### PR TITLE
docs(provider): warn that default complete_stream_async bridge nests io_contexts

### DIFF
--- a/include/neograph/provider.h
+++ b/include/neograph/provider.h
@@ -150,6 +150,22 @@ class NEOGRAPH_API Provider {
      * SHOULD override this to drop the bridging thread and stream
      * tokens straight onto the coroutine's executor.
      *
+     * @warning **This default bridge nests two io_contexts when the
+     * native `complete_stream` is itself implemented via
+     * `neograph::async::run_sync`** — which is the pattern both
+     * `SchemaProvider` and `OpenAIProvider` follow today. Called from
+     * inside an outer engine coroutine (e.g. a node awaiting this
+     * method while the engine is driven by `GraphEngine::run_stream_async`
+     * on the caller's `io_context`), the bridge thread's inner
+     * `run_sync` races against the outer `io_context` on shared
+     * provider state (`ConnPool`, `schema_mutex_`) and can crash.
+     * Native subclasses whose sync streaming path uses `run_sync`
+     * internally MUST override this method directly — do not rely on
+     * the default bridge. The non-streaming `complete` / `complete_async`
+     * pair does not have this problem because that bridge composes
+     * only one layer of `run_sync`, not two. Tracked in #4 (concrete
+     * crash) and #5 (structural Provider single-dispatch direction).
+     *
      * @param params   Completion parameters.
      * @param on_chunk Callback invoked per received token (runs on the
      *                 awaiting coroutine's executor when the default


### PR DESCRIPTION
## Summary

Adds a `@warning` paragraph to `Provider::complete_stream_async`
explaining that the default bridge nests two `io_context`s when the
native `complete_stream` is itself driven by `neograph::async::run_sync`
— which is the pattern both `SchemaProvider` and `OpenAIProvider`
follow. Called from inside an outer engine coroutine, that nesting
races on shared provider state and crashes (#4).

The warning explicitly states that native subclasses whose sync
streaming uses `run_sync` MUST override `complete_stream_async`
directly rather than relying on the default bridge.

## Why docs and not a code fix here

The proper structural fix is in the native subclasses (overriding
`complete_stream_async`) and arguably in the base API shape (#5 —
Provider single-dispatch). This PR is the cheap-and-correct interim:
the trap is now documented in the exact place a future reader
overriding the streaming path would look. No behaviour change.

## Test plan

- [x] No code paths touched — docstring-only change in
      `include/neograph/provider.h`.
- [ ] CI: full build + tests (unchanged behaviour expected).

## Related

- #4 — concrete crash this trap caused
- #5 — Provider single-dispatch (would obviate the bridge entirely)

🤖 Generated with [Claude Code](https://claude.com/claude-code)