### PR TITLE
docs(node): add v0.4.x migration navigator for external node authors

### DIFF
--- a/include/neograph/graph/node.h
+++ b/include/neograph/graph/node.h
@@ -7,6 +7,31 @@
  * - ToolDispatchNode: executes pending tool calls
  * - IntentClassifierNode: LLM-based intent routing
  * - SubgraphNode: hierarchical graph composition
+ *
+ * # v0.4.x migration navigator (external authors)
+ *
+ * Writing a custom node subclass in v0.4.x? **Keep using the legacy
+ * 8-virtual surface** (`execute` / `execute_async` / `execute_full` /
+ * `execute_stream` and their `_async` pairs) — those still work and
+ * the engine drives them on every dispatch path. The new unified
+ * `run(NodeInput) -> awaitable<NodeOutput>` virtual is additive in
+ * v0.4.0 (PR 2 in `ROADMAP_v1.md`): it forwards to the legacy chain
+ * by default, so existing subclasses compile unchanged. PR 4 of the
+ * same plan will mark the legacy virtuals `[[deprecated]]`; v1.0
+ * deletes them.
+ *
+ * The `RunContext` field plumbed through `NodeInput::ctx` is
+ * engine-internal for now — PR 1 (v0.4.0) only carries it through
+ * the dispatch hops. User-overridable virtuals receive it once PR 2
+ * lands. Until then, cancel token / deadline / trace_id propagate
+ * via the legacy paths.
+ *
+ * Example overrides that match the v0.4.x surface:
+ *   - `examples/01_react_agent.cpp` — basic ReAct agent
+ *   - `examples/02_custom_graph.cpp` — custom node subclass
+ *   - `examples/05_parallel_fanout.cpp` — Send / Command pattern
+ *
+ * @see ROADMAP_v1.md for the v0.4 → v1.0 PR sequence
  */
 #pragma once
 


### PR DESCRIPTION
## Summary

Adds a *v0.4.x migration navigator* section to the `graph/node.h`
file-level docstring. The existing per-symbol docs accurately
describe `NodeInput` / `run()` / `NEOGRAPH_DEPRECATED_VIRTUAL` in
terms of internal PR 1..4 work from `ROADMAP_v1.md`, but an external
author opening the header today can't quickly answer the practical
question: *"which signature do I override for my custom node in
this release?"*

The navigator answers it in three short paragraphs:

1. Keep using the legacy 8-virtual surface in v0.4.x; the new
   `run(NodeInput)` is additive and forwards to legacy by default.
2. `RunContext` is plumbed but engine-internal until PR 2 lands —
   cancel token / deadline still propagate via the legacy paths
   until then.
3. Three concrete example files to copy from.

The whole section is intentionally a transient signpost — once
v0.4 ships PR 2/4 and the canonical surface is `run(NodeInput)`,
this navigator naturally gets deleted in the same commit.

## Why a docs-only PR

The structural work (single dispatch flattening for `GraphNode` and
similarly for `Provider` — #5) is the long-running v1.0 plan. This
PR is the cheap interim: external authors reading the header don't
need to also read `ROADMAP_v1.md` to know what's safe to override
right now.

## Test plan

- [x] Docstring-only change in `include/neograph/graph/node.h`.
- [ ] CI: full build + tests (unchanged behaviour expected).

## Related

- `ROADMAP_v1.md` — the PR 1..4 sequence the navigator points at
- #5 — Provider single-dispatch (same shape, one dimension smaller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)