### PR TITLE
docs: close issue #6 thread-safety gaps (engine + checkpoint + schema_provider)

### DIFF
--- a/include/neograph/graph/checkpoint.h
+++ b/include/neograph/graph/checkpoint.h
@@ -167,6 +167,26 @@ struct PendingWrite {
  * returns (flushed to whatever backend the store wraps), because the
  * engine calls `state.apply_writes` only *after* `put_writes` succeeds.
  *
+ * ## Thread safety
+ *
+ * **Individual ops are atomic; cross-op sequencing is the caller's
+ * responsibility.** Every backend in-tree (`InMemoryCheckpointStore`
+ * mutex-guards each call; `PostgresCheckpointStore` /
+ * `SqliteCheckpointStore` use per-call transactions) guarantees that
+ * a single `save_checkpoint` / `load_latest` / `put_writes` /
+ * `delete_thread` call observes a consistent snapshot — no torn
+ * reads, no half-applied writes. They do NOT serialize *sequences*
+ * of calls for the same `thread_id`. Concurrent runs against the same
+ * `thread_id` therefore exhibit last-writer-wins on `save_checkpoint`
+ * and last-saver visibility on subsequent `load_latest` — see
+ * `GraphEngine`'s class-level Thread safety section for the engine-
+ * side contract. Backend authors implementing this interface MUST
+ * preserve the per-call-atomic invariant; callers needing
+ * cross-op atomicity (e.g. compare-and-set on the latest checkpoint)
+ * must wrap the relevant call sequence behind their own external
+ * mutex, or use the engine's `cancel_token` to drain in-flight runs
+ * before issuing an admin op.
+ *
  * @see InMemoryCheckpointStore for a reference implementation.
  */
 /// @note Backend authors: this is a "fat" interface (5 sync core +

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -185,8 +185,20 @@ struct RunResult {
  *   `set_checkpoint_store`, `set_store`, `own_tools`) must be called
  *   before any concurrent `run()` — they are configuration, not runtime.
  * - Concurrent `run()` calls sharing the **same** `thread_id` do not
- *   crash but produce unspecified checkpoint interleaving; serialize
- *   per-thread access yourself if you need deterministic semantics.
+ *   crash but produce unspecified checkpoint interleaving (last-
+ *   writer-wins on `save_checkpoint`, last-saver visible to subsequent
+ *   `load_latest`); serialize per-thread access yourself if you need
+ *   deterministic semantics. Same caveat applies across **multiple
+ *   engines** sharing one `CheckpointStore` for the same `thread_id`
+ *   — e.g. evolving-agent patterns that tear an engine down and
+ *   recompile while a straggler `run_async` is still in flight: the
+ *   store guarantees each individual checkpoint op is atomic, not that
+ *   they sequence in any particular order. Likewise, `update_state` /
+ *   `get_state` / `fork` overlapping a live `run_async` on the same
+ *   `thread_id` race against the engine's own writes; if you need
+ *   "no straggler may overwrite my admin op", cancel the straggler
+ *   via `RunConfig::cancel_token` first and `co_await` its completion
+ *   before issuing the admin call.
  * - Custom `GraphNode` subclasses must be stateless or self-synchronized.
  *   Node instances are owned by the engine and shared across all runs.
  * - User-provided `CheckpointStore` / `Store` / `Provider` / `Tool`

--- a/include/neograph/llm/schema_provider.h
+++ b/include/neograph/llm/schema_provider.h
@@ -106,6 +106,23 @@ class NEOGRAPH_API SchemaProvider : public Provider {
     /// Sync completion is inherited from `Provider::complete()`, which
     /// drives `complete_async` via `neograph::async::run_sync`.
 
+    /// Streaming completion (HTTP/SSE httplib path; WS path dispatched
+    /// to `complete_stream_ws_responses` when `use_websocket=true` and
+    /// the schema is `openai-responses`).
+    ///
+    /// **Locking contract for `on_chunk`**: the callback is invoked
+    /// from inside httplib's content callback (HTTP/SSE) or the
+    /// WebSocket recv loop (WS), in BOTH cases with `schema_mutex_`
+    /// NOT held — the lock is taken only during the per-call body-
+    /// build + per-call response-parse phases at the start of the
+    /// request, then released before the network roundtrip begins.
+    /// Parse state passed through `on_chunk` (accumulated `full_content`,
+    /// tool-call map, etc.) is stack-local to this call and not shared
+    /// with the `schema_mutex_`-protected schema templates. Callers
+    /// can therefore (a) safely call other provider methods from
+    /// inside `on_chunk` without deadlocking, and (b) assume tokens
+    /// emitted by concurrent `complete_stream` calls on the same
+    /// provider do not interleave their parse state.
     ChatCompletion complete_stream(const CompletionParams& params,
                                    const StreamCallback& on_chunk) override;
 


### PR DESCRIPTION
## Summary

Three docstring-only additions to close the documentation gaps surfaced in #6:

- **`graph/engine.h` Thread safety** — expand the existing same-`thread_id` note to spell out last-writer-wins on `save_checkpoint`, last-saver visibility on `load_latest`, and the cross-engine / admin-op interleave case the issue called out via ProjectDatePop's evolving-agent pattern. Recipe for serialize-yourself: drain in-flight runs via `cancel_token` before issuing an admin op.
- **`graph/checkpoint.h` `CheckpointStore`** — adds an explicit Thread safety section pinning the invariant: every in-tree backend (`InMemoryCheckpointStore` mutex / Postgres + SQLite per-call transactions) guarantees individual ops are atomic; cross-op sequences are the caller's responsibility. Backend authors implementing the interface MUST preserve the per-call-atomic invariant.
- **`llm/schema_provider.h` `complete_stream`** — pins the locking contract on `on_chunk`: `schema_mutex_` is NOT held when the callback fires, parse state is stack-local. Callers can therefore invoke other provider methods from inside `on_chunk` without deadlocking, and concurrent `complete_stream` calls don't interleave parse state. The PR #10 fix (worker thread + dispatch onto awaiter executor) makes this provable for the async path too.

Closes #6.

## Test plan

- [x] Docstring-only. No code paths touched.
- [x] Sanity build of `neograph_core` + `neograph_llm` clean.

## Related

- #4 / PR #10 — the async streaming bridge fix; makes the `on_chunk` × `schema_mutex_` invariant provable for the async path.
- #5 — Provider single-dispatch v1.0 architectural; orthogonal to these doc gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)