### PR TITLE
feat(observability): C++ openinference layer (Tracer + tracer + Provider wrapper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- C++ peer of `neograph_engine.openinference` (issue #9). New
+  `neograph::observability` module covers two pieces:
+  - `Tracer` / `Span` — small dep-free abstract interface so NeoGraph
+    itself doesn't pull in opentelemetry-cpp. Downstream provides an
+    adapter wrapping its own backend (OTel SDK, in-memory test fake,
+    logging recorder, etc.). 4 attribute setters (string, int64,
+    double, bool — bool deliberately renamed `set_attribute_bool`
+    so a `const char*` literal can't accidentally resolve to it),
+    plus `add_event` for streamed-token diagnostics, status, and
+    `end()`.
+  - `openinference_tracer(tracer)` — opens a CHAIN-kind root span,
+    returns an `OpenInferenceTracerSession` whose `cb` field plugs
+    into `engine.run_stream()` and opens a CHAIN-kind child span per
+    node, with `NODE_START`/`END` payloads stuffed into
+    `input.value` / `output.value` JSON blobs and `LLM_TOKEN` events
+    recorded as discrete span events.
+  - `OpenInferenceProvider(inner, tracer)` — wraps any `Provider`,
+    attaches the OpenInference LLM-kind attribute set
+    (`llm.model_name`, `llm.invocation_parameters`,
+    `llm.input_messages.{i}.message.{role,content}`,
+    `llm.output_messages.0.message.{role,content}`,
+    `llm.token_count.{prompt,completion,total}`) on every
+    `complete*` call. The streaming overloads also append
+    `llm.token` events and a final assembled `output.value`.
+  - 7 parity tests in `tests/test_openinference_cpp.cpp` driving an
+    `InMemoryTracer` reference adapter — assert root + per-node CHAIN
+    span hierarchy, ERROR / INTERRUPT status surfacing, LLM_TOKEN
+    span-event recording, straggler-span cleanup on session close,
+    LLM provider attribute set, streaming token events, and
+    exception status propagation.
+
 ### Fixed
 
 - `Provider::complete_stream_async` default bridge no longer blocks

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,7 @@ add_library(neograph_core
     src/core/plan_execute_graph.cpp
     src/core/deep_research_graph.cpp
     src/core/store.cpp
+    src/observability/openinference.cpp
 )
 # postgres_checkpoint.cpp is built into a separate target below
 # (neograph_postgres) so projects without libpq can still link

--- a/include/neograph/observability/openinference.h
+++ b/include/neograph/observability/openinference.h
@@ -1,0 +1,157 @@
+/**
+ * @file observability/openinference.h
+ * @brief C++ peer of `neograph_engine.openinference` (issue #9).
+ *
+ * Two pieces, mirroring the Python module:
+ *
+ *   - `openinference_tracer(tracer)` — opens a CHAIN-kind root span,
+ *     returns an `OpenInferenceTracerSession` whose `cb` field plugs
+ *     into `engine.run_stream()` / `engine.run_stream_async()` and
+ *     opens a CHAIN-kind child span per node, with NODE_START / END
+ *     payloads stuffed into `input.value` / `output.value` JSON
+ *     blobs and LLM_TOKEN streamed-chunk events recorded as discrete
+ *     span events. Closing the session ends the root span.
+ *
+ *   - `OpenInferenceProvider(inner, tracer)` — wraps any `Provider`.
+ *     Each `complete*` call opens an LLM-kind child span tagged with
+ *     `llm.model_name`, `llm.invocation_parameters`,
+ *     `llm.input_messages.{i}.message.{role,content}`,
+ *     `llm.output_messages.0.message.{role,content}`, and
+ *     `llm.token_count.{prompt,completion,total}`. The streaming
+ *     overloads (`complete_stream` / `complete_stream_async`) also
+ *     accumulate streamed tokens into the LLM span's `output.value`
+ *     and emit one `llm.token` event per chunk.
+ *
+ * Phoenix / Arize / Langfuse render the resulting trace as a chat
+ * chain with token counts and per-message bubbles — the same UX the
+ * Python wrapper produces.
+ *
+ * Tracer adapter: NeoGraph itself does not link against
+ * opentelemetry-cpp. Downstream provides an adapter implementing
+ * `neograph::observability::Tracer` that wraps its own backend (OTel
+ * SDK, in-memory test fake, logging recorder, etc.). See
+ * `tests/test_openinference_cpp.cpp` for an `InMemoryTracer`
+ * reference impl used by the parity tests.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/graph/types.h>
+#include <neograph/observability/tracer.h>
+#include <neograph/provider.h>
+
+#include <memory>
+#include <string>
+
+namespace neograph::observability {
+
+/**
+ * @brief RAII session returned by `openinference_tracer`.
+ *
+ * Holds the root span (kept alive for the duration of the engine
+ * run) and the GraphStreamCallback wired to record per-node /
+ * streaming events under that root.
+ *
+ * Usage:
+ * @code
+ *   auto session = openinference_tracer(my_tracer);
+ *   engine.run_stream(cfg, session.cb);
+ *   session.close();   // ends the root + any straggler node spans
+ * @endcode
+ *
+ * `close()` is also called by the destructor — explicit close is
+ * recommended only when the user wants to inspect the tracer's
+ * exported spans before the session goes out of scope (e.g. in
+ * tests). Double-close is a no-op.
+ */
+class NEOGRAPH_API OpenInferenceTracerSession {
+public:
+    /// Engine event callback. Pass to `engine.run_stream()`.
+    graph::GraphStreamCallback cb;
+
+    OpenInferenceTracerSession();
+    ~OpenInferenceTracerSession();
+
+    // Non-copyable, movable.
+    OpenInferenceTracerSession(const OpenInferenceTracerSession&) = delete;
+    OpenInferenceTracerSession& operator=(const OpenInferenceTracerSession&) = delete;
+    OpenInferenceTracerSession(OpenInferenceTracerSession&&) noexcept;
+    OpenInferenceTracerSession& operator=(OpenInferenceTracerSession&&) noexcept;
+
+    /// End the root span + any pending node spans. Idempotent.
+    void close();
+
+    /// Internal — exposed so `OpenInferenceProvider` can open LLM
+    /// child spans under the currently-active node span.
+    Span* current_parent() const noexcept;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+
+    friend OpenInferenceTracerSession openinference_tracer(
+        Tracer&, std::string, std::string);
+};
+
+/// Open a CHAIN-kind root span and return a session whose `cb` opens
+/// per-node CHAIN child spans + LLM_TOKEN events under it.
+///
+/// @param tracer            Tracer adapter. Must outlive the session.
+/// @param root_name         Span name for the root (default "graph.run").
+/// @param node_span_prefix  Prefix for per-node spans (default "node.").
+NEOGRAPH_API OpenInferenceTracerSession openinference_tracer(
+    Tracer& tracer,
+    std::string root_name = "graph.run",
+    std::string node_span_prefix = "node.");
+
+/**
+ * @brief Provider wrapper that emits OpenInference LLM spans.
+ *
+ * Pass-through to the inner Provider for all four virtual paths
+ * (complete / complete_async / complete_stream / complete_stream_async).
+ * Each call opens an `llm.complete` child span, attaches the
+ * OpenInference LLM-kind attribute set, runs the inner call, captures
+ * the response + usage onto the span, and ends it. Streaming overloads
+ * additionally append each token to `output.value` and emit a
+ * `llm.token` span event per chunk so Phoenix's timeline view shows
+ * stream cadence.
+ *
+ * Tracing failures are caught and swallowed — observability must
+ * never break the LLM call.
+ */
+class NEOGRAPH_API OpenInferenceProvider : public Provider {
+public:
+    /// @param inner         Provider to delegate to.
+    /// @param tracer        Tracer for span emission. Must outlive `*this`.
+    /// @param parent_lookup Optional callback returning the current node
+    ///                      span the LLM call should nest under (e.g.
+    ///                      bound to an `OpenInferenceTracerSession::current_parent`).
+    ///                      May be null — null parent opens the LLM
+    ///                      span as a root.
+    /// @param span_name     Span name for each LLM call (default "llm.complete").
+    OpenInferenceProvider(std::shared_ptr<Provider> inner,
+                          Tracer& tracer,
+                          std::function<Span*()> parent_lookup = nullptr,
+                          std::string span_name = "llm.complete");
+    ~OpenInferenceProvider() override;
+
+    ChatCompletion complete(const CompletionParams& params) override;
+
+    asio::awaitable<ChatCompletion>
+    complete_async(const CompletionParams& params) override;
+
+    ChatCompletion complete_stream(const CompletionParams& params,
+                                   const StreamCallback& on_chunk) override;
+
+    asio::awaitable<ChatCompletion>
+    complete_stream_async(const CompletionParams& params,
+                          const StreamCallback& on_chunk) override;
+
+    std::string get_name() const override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace neograph::observability

--- a/include/neograph/observability/tracer.h
+++ b/include/neograph/observability/tracer.h
@@ -1,0 +1,112 @@
+/**
+ * @file observability/tracer.h
+ * @brief Dep-free abstract Tracer / Span interface.
+ *
+ * NeoGraph does not link against opentelemetry-cpp directly. The
+ * `openinference_tracer` and `OpenInferenceProvider` helpers in
+ * `observability/openinference.h` drive this small abstract interface
+ * instead, and downstream code provides an adapter wrapping its own
+ * tracing backend (opentelemetry-cpp, a custom recorder, an in-memory
+ * test fake, etc.).
+ *
+ * The interface intentionally stops short of OTel's full surface
+ * (links, resources, span context propagation, sampler hooks). It
+ * covers the minimum the OpenInference attribute-mapping layer needs:
+ * named span open/close, attribute writes, status, and discrete
+ * events for streaming-token diagnostics. Anything richer is the
+ * adapter author's responsibility.
+ */
+#pragma once
+
+#include <neograph/api.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace neograph::observability {
+
+/**
+ * @brief Opaque per-request span; lifetime is unique_ptr.
+ *
+ * Adapters create a Span by wrapping their backend's span handle
+ * (e.g. `opentelemetry::trace::Span`). Calling `end()` is required
+ * before destruction for proper export — the destructor does NOT
+ * call `end()` on its own (an unended span signals "still in flight"
+ * to the OpenInference helpers and lets `_close_all`-style cleanup
+ * paths distinguish active vs. already-ended spans).
+ *
+ * Thread safety: implementations MAY be called from multiple threads
+ * (engine event callback runs on whatever pool worker emitted the
+ * event). Adapter authors must serialize internally if their backend
+ * span isn't thread-safe.
+ */
+class NEOGRAPH_API Span {
+public:
+    virtual ~Span() = default;
+
+    virtual void set_attribute(std::string_view key, std::string_view value) = 0;
+    virtual void set_attribute(std::string_view key, int64_t value) = 0;
+    virtual void set_attribute(std::string_view key, double value) = 0;
+
+    /// Renamed off the `set_attribute` overload set on purpose: a
+    /// `const char*` literal passed as the value would otherwise
+    /// resolve to `(string_view, bool)` (pointer-to-bool standard
+    /// conversion outranks the user-defined string_view conversion),
+    /// silently dropping every string attribute. Keep bool out of the
+    /// overload set entirely.
+    virtual void set_attribute_bool(std::string_view key, bool value) = 0;
+
+    /// Forwarding overload so string literals (`"CHAIN"`) reach the
+    /// string_view sink rather than slipping into a different overload.
+    /// Non-virtual; defined inline.
+    void set_attribute(std::string_view key, const char* value) {
+        set_attribute(key, std::string_view(value ? value : ""));
+    }
+
+    /// Record a discrete time-stamped event on this span (mapped to
+    /// OTel's `Span::AddEvent`). Used by the openinference layer for
+    /// `LLM_TOKEN` events so each streamed chunk is visible in the
+    /// trace timeline without inflating the parent span's attribute
+    /// payload.
+    virtual void add_event(std::string_view name,
+                           std::string_view payload = {}) = 0;
+
+    virtual void set_status_ok() = 0;
+    virtual void set_status_error(std::string_view message) = 0;
+
+    /// Close the span. After end() returns the span is finalized;
+    /// further attribute / event writes are no-ops on most backends.
+    virtual void end() = 0;
+};
+
+/**
+ * @brief Adapter facade for a tracing backend.
+ *
+ * The OpenInference helpers call `start_span` to open named spans
+ * (root + per-node + per-LLM-call). The `parent` argument carries the
+ * span hierarchy — a non-null parent means "open this as a child of
+ * the supplied span", null means "open as a root".
+ *
+ * Adapter authors are free to ignore `parent` if their backend
+ * captures parents implicitly via an OTel context propagation hook;
+ * the OpenInference helpers DO supply the parent explicitly so a
+ * dep-free adapter can link spans without relying on contextvars-
+ * style implicit context.
+ */
+class NEOGRAPH_API Tracer {
+public:
+    virtual ~Tracer() = default;
+
+    /// @param name   Span name (e.g. "graph.run", "node.researcher",
+    ///               "llm.complete").
+    /// @param parent Optional parent span. May be a span this tracer
+    ///               itself returned from a previous `start_span`.
+    ///               Adapters should treat null as "root span".
+    /// @return Owned span; caller must call `end()` before drop.
+    virtual std::unique_ptr<Span> start_span(std::string_view name,
+                                             Span* parent = nullptr) = 0;
+};
+
+} // namespace neograph::observability

--- a/src/observability/openinference.cpp
+++ b/src/observability/openinference.cpp
@@ -1,0 +1,514 @@
+/**
+ * @file observability/openinference.cpp
+ * @brief Implementation of openinference_tracer + OpenInferenceProvider.
+ *
+ * Mirrors `bindings/python/neograph_engine/openinference.py`. The
+ * Python module's Context-attach/detach dance has no C++ analog —
+ * the abstract Tracer interface here is explicit-parent, so the
+ * pending-span stack carries the parent pointer directly.
+ */
+#include <neograph/observability/openinference.h>
+
+#include <neograph/json.h>
+
+#include <atomic>
+#include <exception>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace neograph::observability {
+
+namespace {
+
+constexpr const char* kSpanKind = "openinference.span.kind";
+constexpr const char* kInputValue = "input.value";
+constexpr const char* kInputMime = "input.mime_type";
+constexpr const char* kOutputValue = "output.value";
+constexpr const char* kOutputMime = "output.mime_type";
+constexpr const char* kLlmModel = "llm.model_name";
+constexpr const char* kLlmInvocation = "llm.invocation_parameters";
+constexpr const char* kLlmTokenPrompt = "llm.token_count.prompt";
+constexpr const char* kLlmTokenCompletion = "llm.token_count.completion";
+constexpr const char* kLlmTokenTotal = "llm.token_count.total";
+
+std::string node_input_blob(const std::string& node_name, const json& data) {
+    json blob = json::object();
+    blob["node"] = node_name;
+    if (data.is_object()) {
+        for (auto it = data.begin(); it != data.end(); ++it) {
+            blob[it.key()] = it.value();
+        }
+    }
+    try {
+        return blob.dump();
+    } catch (...) {
+        return node_name;
+    }
+}
+
+std::string node_output_blob(const std::string& node_name, const json& data) {
+    json blob = json::object();
+    if (data.is_object()) {
+        for (auto it = data.begin(); it != data.end(); ++it) {
+            blob[it.key()] = it.value();
+        }
+    } else {
+        blob["node"] = node_name;
+    }
+    try {
+        return blob.dump();
+    } catch (...) {
+        return node_name;
+    }
+}
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// OpenInferenceTracerSession
+// ---------------------------------------------------------------------------
+
+struct OpenInferenceTracerSession::Impl {
+    Tracer* tracer = nullptr;
+    std::string root_name;
+    std::string node_span_prefix;
+    std::unique_ptr<Span> root_span;
+    std::atomic<bool> closed{false};
+
+    // Per-node span stacks. Stack semantics so nested fan-outs (a node
+    // re-entered before its prior NODE_END landed) close in LIFO order.
+    // Mutex-guarded — engine event callback may fire from worker pool
+    // threads.
+    std::mutex pending_mu;
+    std::map<std::string, std::vector<std::unique_ptr<Span>>> pending;
+
+    // The currently-active node span exposed to OpenInferenceProvider
+    // via current_parent(). Tracks the most recently opened, not yet
+    // ended, node span — best-effort under fan-out (single pointer,
+    // not per-thread). For strict per-node-LLM nesting, callers should
+    // capture parent_lookup returning the right span via their own
+    // contextvar / threading.local instead.
+    std::atomic<Span*> active_node{nullptr};
+};
+
+OpenInferenceTracerSession::OpenInferenceTracerSession()
+    : impl_(std::make_unique<Impl>()) {}
+
+OpenInferenceTracerSession::~OpenInferenceTracerSession() {
+    close();
+}
+
+OpenInferenceTracerSession::OpenInferenceTracerSession(
+    OpenInferenceTracerSession&&) noexcept = default;
+OpenInferenceTracerSession& OpenInferenceTracerSession::operator=(
+    OpenInferenceTracerSession&&) noexcept = default;
+
+void OpenInferenceTracerSession::close() {
+    if (!impl_) return;
+    bool expected = false;
+    if (!impl_->closed.compare_exchange_strong(expected, true)) return;
+
+    {
+        std::lock_guard<std::mutex> lock(impl_->pending_mu);
+        for (auto& [node, stack] : impl_->pending) {
+            while (!stack.empty()) {
+                try { stack.back()->end(); } catch (...) {}
+                stack.pop_back();
+            }
+        }
+        impl_->pending.clear();
+    }
+    impl_->active_node.store(nullptr);
+    if (impl_->root_span) {
+        try { impl_->root_span->end(); } catch (...) {}
+        impl_->root_span.reset();
+    }
+}
+
+Span* OpenInferenceTracerSession::current_parent() const noexcept {
+    if (!impl_) return nullptr;
+    Span* node = impl_->active_node.load();
+    return node ? node : impl_->root_span.get();
+}
+
+OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
+                                                std::string root_name,
+                                                std::string node_span_prefix) {
+    OpenInferenceTracerSession session;
+    auto* impl = session.impl_.get();
+    impl->tracer = &tracer;
+    impl->root_name = std::move(root_name);
+    impl->node_span_prefix = std::move(node_span_prefix);
+    impl->root_span = tracer.start_span(impl->root_name);
+    if (impl->root_span) {
+        try {
+            impl->root_span->set_attribute(kSpanKind, "CHAIN");
+        } catch (...) {}
+    }
+
+    // Capture the impl pointer (not the session, which is moved) into
+    // the callback. The session owns impl via unique_ptr; the callback
+    // is owned by std::function inside the session, lifetimes match.
+    session.cb = [impl](const graph::GraphEvent& ev) {
+        if (impl->closed.load()) return;
+        if (!impl->tracer) return;
+
+        const std::string& node = ev.node_name;
+        try {
+            switch (ev.type) {
+            case graph::GraphEvent::Type::NODE_START: {
+                Span* parent = impl->root_span.get();
+                auto span = impl->tracer->start_span(
+                    impl->node_span_prefix + node, parent);
+                if (!span) break;
+                try {
+                    span->set_attribute(kSpanKind, "CHAIN");
+                    span->set_attribute("neograph.node", node);
+                    if (ev.data.is_object()) {
+                        for (auto it = ev.data.begin(); it != ev.data.end(); ++it) {
+                            std::string val;
+                            if (it.value().is_string()) {
+                                val = it.value().get<std::string>();
+                            } else {
+                                try { val = it.value().dump(); }
+                                catch (...) { val = ""; }
+                            }
+                            span->set_attribute(
+                                std::string("neograph.") + it.key(), val);
+                        }
+                    }
+                    span->set_attribute(kInputValue,
+                                        node_input_blob(node, ev.data));
+                    span->set_attribute(kInputMime, "application/json");
+                } catch (...) {}
+
+                impl->active_node.store(span.get());
+                std::lock_guard<std::mutex> lock(impl->pending_mu);
+                impl->pending[node].push_back(std::move(span));
+                break;
+            }
+
+            case graph::GraphEvent::Type::NODE_END: {
+                std::unique_ptr<Span> span;
+                {
+                    std::lock_guard<std::mutex> lock(impl->pending_mu);
+                    auto it = impl->pending.find(node);
+                    if (it == impl->pending.end() || it->second.empty()) break;
+                    span = std::move(it->second.back());
+                    it->second.pop_back();
+                }
+                if (!span) break;
+                try {
+                    if (ev.data.is_object()) {
+                        for (auto kv = ev.data.begin(); kv != ev.data.end(); ++kv) {
+                            std::string val;
+                            if (kv.value().is_string()) {
+                                val = kv.value().get<std::string>();
+                            } else {
+                                try { val = kv.value().dump(); }
+                                catch (...) { val = ""; }
+                            }
+                            span->set_attribute(
+                                std::string("neograph.") + kv.key(), val);
+                        }
+                    }
+                    span->set_attribute(kOutputValue,
+                                        node_output_blob(node, ev.data));
+                    span->set_attribute(kOutputMime, "application/json");
+                    span->set_status_ok();
+                } catch (...) {}
+                try { span->end(); } catch (...) {}
+                // Best-effort: clear active_node if we just closed it.
+                Span* expected = nullptr;
+                impl->active_node.compare_exchange_strong(expected, nullptr);
+                break;
+            }
+
+            case graph::GraphEvent::Type::ERROR: {
+                std::unique_ptr<Span> span;
+                {
+                    std::lock_guard<std::mutex> lock(impl->pending_mu);
+                    auto it = impl->pending.find(node);
+                    if (it == impl->pending.end() || it->second.empty()) break;
+                    span = std::move(it->second.back());
+                    it->second.pop_back();
+                }
+                if (!span) break;
+                std::string msg = ev.data.is_string()
+                    ? ev.data.get<std::string>() : ev.data.dump();
+                try {
+                    span->set_attribute("neograph.error", msg);
+                    span->set_status_error(msg);
+                } catch (...) {}
+                try { span->end(); } catch (...) {}
+                break;
+            }
+
+            case graph::GraphEvent::Type::INTERRUPT: {
+                std::unique_ptr<Span> span;
+                {
+                    std::lock_guard<std::mutex> lock(impl->pending_mu);
+                    auto it = impl->pending.find(node);
+                    if (it == impl->pending.end() || it->second.empty()) break;
+                    span = std::move(it->second.back());
+                    it->second.pop_back();
+                }
+                if (!span) break;
+                try { span->set_attribute_bool("neograph.interrupted", true); }
+                catch (...) {}
+                try { span->end(); } catch (...) {}
+                break;
+            }
+
+            case graph::GraphEvent::Type::LLM_TOKEN: {
+                // Surface streamed tokens as discrete events on the
+                // current node span. Phoenix renders these on the
+                // timeline view; OTel SDK exporters treat them as
+                // span events (not new spans) so cardinality stays
+                // bounded.
+                std::lock_guard<std::mutex> lock(impl->pending_mu);
+                auto it = impl->pending.find(node);
+                if (it == impl->pending.end() || it->second.empty()) break;
+                Span* current = it->second.back().get();
+                if (!current) break;
+                std::string payload = ev.data.is_string()
+                    ? ev.data.get<std::string>() : ev.data.dump();
+                try { current->add_event("llm.token", payload); }
+                catch (...) {}
+                break;
+            }
+
+            case graph::GraphEvent::Type::CHANNEL_WRITE:
+                // Not surfaced as a span event — channel writes are
+                // structural noise in a Phoenix trace view. Users who
+                // want them can wrap the cb themselves.
+                break;
+            }
+        } catch (...) {
+            // Tracing must never break the graph run.
+        }
+    };
+
+    return session;
+}
+
+// ---------------------------------------------------------------------------
+// OpenInferenceProvider
+// ---------------------------------------------------------------------------
+
+struct OpenInferenceProvider::Impl {
+    std::shared_ptr<Provider> inner;
+    Tracer* tracer = nullptr;
+    std::function<Span*()> parent_lookup;
+    std::string span_name;
+};
+
+OpenInferenceProvider::OpenInferenceProvider(
+    std::shared_ptr<Provider> inner,
+    Tracer& tracer,
+    std::function<Span*()> parent_lookup,
+    std::string span_name)
+    : impl_(std::make_unique<Impl>()) {
+    impl_->inner = std::move(inner);
+    impl_->tracer = &tracer;
+    impl_->parent_lookup = std::move(parent_lookup);
+    impl_->span_name = std::move(span_name);
+}
+
+OpenInferenceProvider::~OpenInferenceProvider() = default;
+
+std::string OpenInferenceProvider::get_name() const {
+    try {
+        return std::string("openinference(") + impl_->inner->get_name() + ")";
+    } catch (...) {
+        return "openinference(provider)";
+    }
+}
+
+namespace {
+
+// Drop messages onto an LLM-kind span as input.value + per-message
+// attribute set, matching the Python module's record_input.
+void record_input(Span* span, const CompletionParams& params) {
+    if (!span) return;
+    try {
+        span->set_attribute(kSpanKind, "LLM");
+        if (!params.model.empty()) {
+            span->set_attribute(kLlmModel, params.model);
+        }
+
+        json invocation = json::object();
+        invocation["temperature"] = params.temperature;
+        if (params.max_tokens >= 0) {
+            invocation["max_tokens"] = params.max_tokens;
+        }
+        try {
+            span->set_attribute(kLlmInvocation, invocation.dump());
+        } catch (...) {}
+
+        json messages_blob = json::array();
+        for (size_t i = 0; i < params.messages.size(); ++i) {
+            const auto& m = params.messages[i];
+            std::string base = "llm.input_messages." + std::to_string(i)
+                             + ".message";
+            span->set_attribute(base + ".role", m.role);
+            span->set_attribute(base + ".content", m.content);
+            json one;
+            one["role"] = m.role;
+            one["content"] = m.content;
+            messages_blob.push_back(std::move(one));
+        }
+        if (!params.messages.empty()) {
+            try { span->set_attribute(kInputValue, messages_blob.dump()); }
+            catch (...) {}
+            span->set_attribute(kInputMime, "application/json");
+        }
+    } catch (...) {}
+}
+
+void record_output(Span* span, const ChatCompletion& result) {
+    if (!span) return;
+    try {
+        const auto& m = result.message;
+        span->set_attribute("llm.output_messages.0.message.role", m.role);
+        span->set_attribute("llm.output_messages.0.message.content", m.content);
+        span->set_attribute(kOutputValue, m.content);
+        span->set_attribute(kOutputMime, "text/plain");
+
+        if (result.usage.prompt_tokens > 0) {
+            span->set_attribute(kLlmTokenPrompt,
+                                static_cast<int64_t>(result.usage.prompt_tokens));
+        }
+        if (result.usage.completion_tokens > 0) {
+            span->set_attribute(kLlmTokenCompletion,
+                                static_cast<int64_t>(result.usage.completion_tokens));
+        }
+        if (result.usage.total_tokens > 0) {
+            span->set_attribute(kLlmTokenTotal,
+                                static_cast<int64_t>(result.usage.total_tokens));
+        }
+    } catch (...) {}
+}
+
+} // namespace
+
+ChatCompletion OpenInferenceProvider::complete(const CompletionParams& params) {
+    Span* parent = impl_->parent_lookup ? impl_->parent_lookup() : nullptr;
+    auto span = impl_->tracer->start_span(impl_->span_name, parent);
+    record_input(span.get(), params);
+    try {
+        auto result = impl_->inner->complete(params);
+        record_output(span.get(), result);
+        if (span) { try { span->set_status_ok(); } catch (...) {} }
+        if (span) { try { span->end(); } catch (...) {} }
+        return result;
+    } catch (const std::exception& e) {
+        if (span) {
+            try { span->set_status_error(e.what()); } catch (...) {}
+            try { span->end(); } catch (...) {}
+        }
+        throw;
+    } catch (...) {
+        if (span) {
+            try { span->set_status_error("unknown error"); } catch (...) {}
+            try { span->end(); } catch (...) {}
+        }
+        throw;
+    }
+}
+
+asio::awaitable<ChatCompletion>
+OpenInferenceProvider::complete_async(const CompletionParams& params) {
+    Span* parent = impl_->parent_lookup ? impl_->parent_lookup() : nullptr;
+    auto span = impl_->tracer->start_span(impl_->span_name, parent);
+    record_input(span.get(), params);
+    try {
+        auto result = co_await impl_->inner->complete_async(params);
+        record_output(span.get(), result);
+        if (span) { try { span->set_status_ok(); } catch (...) {} }
+        if (span) { try { span->end(); } catch (...) {} }
+        co_return result;
+    } catch (const std::exception& e) {
+        if (span) {
+            try { span->set_status_error(e.what()); } catch (...) {}
+            try { span->end(); } catch (...) {}
+        }
+        throw;
+    }
+}
+
+ChatCompletion OpenInferenceProvider::complete_stream(
+    const CompletionParams& params,
+    const StreamCallback& on_chunk) {
+    Span* parent = impl_->parent_lookup ? impl_->parent_lookup() : nullptr;
+    auto span = impl_->tracer->start_span(impl_->span_name, parent);
+    record_input(span.get(), params);
+
+    std::string accumulated;
+    StreamCallback wrapped = [&accumulated, &on_chunk, sp = span.get()]
+        (const std::string& chunk) {
+        accumulated += chunk;
+        if (sp) { try { sp->add_event("llm.token", chunk); } catch (...) {} }
+        if (on_chunk) on_chunk(chunk);
+    };
+
+    try {
+        auto result = impl_->inner->complete_stream(params, wrapped);
+        record_output(span.get(), result);
+        if (span) {
+            // Stream-specific: also surface the assembled output for
+            // backends that prefer attributes over events.
+            try { span->set_attribute(kOutputValue, accumulated); }
+            catch (...) {}
+            try { span->set_status_ok(); } catch (...) {}
+            try { span->end(); } catch (...) {}
+        }
+        return result;
+    } catch (const std::exception& e) {
+        if (span) {
+            try { span->set_status_error(e.what()); } catch (...) {}
+            try { span->end(); } catch (...) {}
+        }
+        throw;
+    }
+}
+
+asio::awaitable<ChatCompletion>
+OpenInferenceProvider::complete_stream_async(
+    const CompletionParams& params,
+    const StreamCallback& on_chunk) {
+    Span* parent = impl_->parent_lookup ? impl_->parent_lookup() : nullptr;
+    auto span = impl_->tracer->start_span(impl_->span_name, parent);
+    record_input(span.get(), params);
+
+    auto accumulated = std::make_shared<std::string>();
+    Span* sp = span.get();
+    StreamCallback wrapped = [accumulated, on_chunk, sp]
+        (const std::string& chunk) {
+        *accumulated += chunk;
+        if (sp) { try { sp->add_event("llm.token", chunk); } catch (...) {} }
+        if (on_chunk) on_chunk(chunk);
+    };
+
+    try {
+        auto result = co_await impl_->inner->complete_stream_async(params, wrapped);
+        record_output(span.get(), result);
+        if (span) {
+            try { span->set_attribute(kOutputValue, *accumulated); }
+            catch (...) {}
+            try { span->set_status_ok(); } catch (...) {}
+            try { span->end(); } catch (...) {}
+        }
+        co_return result;
+    } catch (const std::exception& e) {
+        if (span) {
+            try { span->set_status_error(e.what()); } catch (...) {}
+            try { span->end(); } catch (...) {}
+        }
+        throw;
+    }
+}
+
+} // namespace neograph::observability

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,7 @@ add_executable(neograph_tests
     test_node_run_dispatch.cpp
     test_cancel_token_fork.cpp
     test_concurrent_stress.cpp
+    test_openinference_cpp.cpp
 )
 
 if(NEOGRAPH_BUILD_MCP)

--- a/tests/test_openinference_cpp.cpp
+++ b/tests/test_openinference_cpp.cpp
@@ -1,0 +1,365 @@
+// Issue #9 — parity coverage for the C++ OpenInference layer.
+//
+// Mirrors the assertions in `bindings/python/tests/test_openinference.py`:
+//   - openinference_tracer opens a CHAIN root + per-node CHAIN children
+//   - OpenInferenceProvider opens an LLM-kind child span carrying the
+//     full LLM attribute set (model, params, in/out messages, usage)
+//   - Streaming overloads append per-token events on the LLM span
+//   - Provider exceptions surface ERROR status on the span and re-raise
+//
+// The Tracer adapter under test is an in-memory recorder (no
+// opentelemetry-cpp dependency).
+
+#include <gtest/gtest.h>
+
+#include <neograph/observability/openinference.h>
+#include <neograph/observability/tracer.h>
+#include <neograph/provider.h>
+#include <neograph/graph/types.h>
+#include <neograph/json.h>
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using neograph::ChatCompletion;
+using neograph::ChatMessage;
+using neograph::CompletionParams;
+using neograph::Provider;
+using neograph::StreamCallback;
+using neograph::graph::GraphEvent;
+
+namespace obs = neograph::observability;
+
+// ---------------------------------------------------------------------------
+// In-memory tracer adapter.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct RecordedEvent {
+    std::string name;
+    std::string payload;
+};
+
+struct RecordedSpan {
+    std::string name;
+    obs::Span* parent = nullptr;
+    std::unordered_map<std::string, std::string> attrs_str;
+    std::unordered_map<std::string, int64_t> attrs_int;
+    std::unordered_map<std::string, bool> attrs_bool;
+    std::vector<RecordedEvent> events;
+    std::string status = "unset";  // "unset" | "ok" | "error"
+    std::string status_message;
+    bool ended = false;
+};
+
+class InMemorySpan : public obs::Span {
+public:
+    explicit InMemorySpan(RecordedSpan* rec) : rec_(rec) {}
+
+    void set_attribute(std::string_view k, std::string_view v) override {
+        rec_->attrs_str[std::string(k)] = std::string(v);
+    }
+    void set_attribute(std::string_view k, int64_t v) override {
+        rec_->attrs_int[std::string(k)] = v;
+    }
+    void set_attribute(std::string_view k, double v) override {
+        rec_->attrs_str[std::string(k)] = std::to_string(v);
+    }
+    void set_attribute_bool(std::string_view k, bool v) override {
+        rec_->attrs_bool[std::string(k)] = v;
+    }
+    void add_event(std::string_view name, std::string_view payload) override {
+        rec_->events.push_back({std::string(name), std::string(payload)});
+    }
+    void set_status_ok() override { rec_->status = "ok"; }
+    void set_status_error(std::string_view msg) override {
+        rec_->status = "error";
+        rec_->status_message = std::string(msg);
+    }
+    void end() override { rec_->ended = true; }
+
+private:
+    RecordedSpan* rec_;
+};
+
+class InMemoryTracer : public obs::Tracer {
+public:
+    std::unique_ptr<obs::Span> start_span(std::string_view name,
+                                          obs::Span* parent) override {
+        std::lock_guard<std::mutex> lock(mu_);
+        spans_.push_back(std::make_unique<RecordedSpan>());
+        spans_.back()->name = std::string(name);
+        spans_.back()->parent = parent;
+        // Map the underlying record to its handle so the wrapper Span
+        // returned to the caller stays in sync with the recorded one.
+        return std::make_unique<InMemorySpan>(spans_.back().get());
+    }
+
+    std::vector<RecordedSpan*> snapshot() const {
+        std::lock_guard<std::mutex> lock(mu_);
+        std::vector<RecordedSpan*> out;
+        out.reserve(spans_.size());
+        for (const auto& s : spans_) out.push_back(s.get());
+        return out;
+    }
+
+private:
+    mutable std::mutex mu_;
+    std::vector<std::unique_ptr<RecordedSpan>> spans_;
+};
+
+// ---------------------------------------------------------------------------
+// Fake provider — records calls, emits configurable response.
+// ---------------------------------------------------------------------------
+
+class FakeProvider : public Provider {
+public:
+    std::string reply = "ok";
+    int prompt_tokens = 7;
+    int completion_tokens = 3;
+    std::vector<std::string> stream_chunks;
+    std::atomic<int> calls{0};
+
+    ChatCompletion complete(const CompletionParams& /*p*/) override {
+        ++calls;
+        return make_completion();
+    }
+
+    ChatCompletion complete_stream(const CompletionParams& /*p*/,
+                                   const StreamCallback& on_chunk) override {
+        ++calls;
+        std::string acc;
+        for (const auto& c : stream_chunks) {
+            acc += c;
+            if (on_chunk) on_chunk(c);
+        }
+        if (acc.empty()) acc = reply;
+        auto comp = make_completion();
+        comp.message.content = acc;
+        return comp;
+    }
+
+    std::string get_name() const override { return "fake"; }
+
+private:
+    ChatCompletion make_completion() const {
+        ChatCompletion c;
+        c.message.role = "assistant";
+        c.message.content = reply;
+        c.usage.prompt_tokens = prompt_tokens;
+        c.usage.completion_tokens = completion_tokens;
+        c.usage.total_tokens = prompt_tokens + completion_tokens;
+        return c;
+    }
+};
+
+class ThrowingProvider : public Provider {
+public:
+    ChatCompletion complete(const CompletionParams&) override {
+        throw std::runtime_error("boom");
+    }
+    ChatCompletion complete_stream(const CompletionParams&,
+                                   const StreamCallback&) override {
+        return {};
+    }
+    std::string get_name() const override { return "throw"; }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// openinference_tracer — root + per-node spans
+// ---------------------------------------------------------------------------
+
+TEST(OpenInferenceCpp, TracerOpensChainRootAndPerNodeChild) {
+    InMemoryTracer tracer;
+    auto session = obs::openinference_tracer(tracer);
+
+    GraphEvent start{GraphEvent::Type::NODE_START, "researcher", neograph::json::object()};
+    GraphEvent end{GraphEvent::Type::NODE_END, "researcher",
+                   neograph::json{{"summary", "found 3 hits"}}};
+    session.cb(start);
+    session.cb(end);
+    session.close();
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 2u);
+
+    // Root: graph.run, CHAIN, ended
+    EXPECT_EQ(spans[0]->name, "graph.run");
+    EXPECT_EQ(spans[0]->attrs_str["openinference.span.kind"], "CHAIN");
+    EXPECT_TRUE(spans[0]->ended);
+
+    // Node child: name "node.researcher", parent = root, CHAIN
+    EXPECT_EQ(spans[1]->name, "node.researcher");
+    EXPECT_NE(spans[1]->parent, nullptr);
+    EXPECT_EQ(spans[1]->attrs_str["openinference.span.kind"], "CHAIN");
+    EXPECT_EQ(spans[1]->attrs_str["neograph.node"], "researcher");
+    EXPECT_EQ(spans[1]->attrs_str["input.mime_type"], "application/json");
+    EXPECT_EQ(spans[1]->attrs_str["output.mime_type"], "application/json");
+    EXPECT_EQ(spans[1]->status, "ok");
+    EXPECT_TRUE(spans[1]->ended);
+
+    // input.value JSON contains node name; output.value JSON contains the data.
+    auto in_json = neograph::json::parse(spans[1]->attrs_str["input.value"]);
+    EXPECT_EQ(in_json["node"].get<std::string>(), "researcher");
+    auto out_json = neograph::json::parse(spans[1]->attrs_str["output.value"]);
+    EXPECT_EQ(out_json["summary"].get<std::string>(), "found 3 hits");
+}
+
+TEST(OpenInferenceCpp, TracerSurfacesErrorAndInterrupt) {
+    InMemoryTracer tracer;
+    auto session = obs::openinference_tracer(tracer);
+
+    session.cb({GraphEvent::Type::NODE_START, "a", neograph::json::object()});
+    session.cb({GraphEvent::Type::ERROR, "a", neograph::json("kaboom")});
+
+    session.cb({GraphEvent::Type::NODE_START, "b", neograph::json::object()});
+    session.cb({GraphEvent::Type::INTERRUPT, "b", neograph::json::object()});
+
+    session.close();
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 3u);  // root + a + b
+
+    // a: ERROR
+    EXPECT_EQ(spans[1]->name, "node.a");
+    EXPECT_EQ(spans[1]->status, "error");
+    EXPECT_EQ(spans[1]->status_message, "kaboom");
+    EXPECT_EQ(spans[1]->attrs_str["neograph.error"], "kaboom");
+    EXPECT_TRUE(spans[1]->ended);
+
+    // b: INTERRUPT
+    EXPECT_EQ(spans[2]->name, "node.b");
+    EXPECT_TRUE(spans[2]->attrs_bool["neograph.interrupted"]);
+    EXPECT_TRUE(spans[2]->ended);
+}
+
+TEST(OpenInferenceCpp, TracerRecordsLLMTokenAsSpanEvent) {
+    InMemoryTracer tracer;
+    auto session = obs::openinference_tracer(tracer);
+
+    session.cb({GraphEvent::Type::NODE_START, "chat", neograph::json::object()});
+    session.cb({GraphEvent::Type::LLM_TOKEN, "chat", neograph::json("Hello")});
+    session.cb({GraphEvent::Type::LLM_TOKEN, "chat", neograph::json(" world")});
+    session.cb({GraphEvent::Type::NODE_END, "chat", neograph::json::object()});
+
+    session.close();
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 2u);
+    const auto& node_span = *spans[1];
+    ASSERT_EQ(node_span.events.size(), 2u);
+    EXPECT_EQ(node_span.events[0].name, "llm.token");
+    EXPECT_EQ(node_span.events[0].payload, "Hello");
+    EXPECT_EQ(node_span.events[1].payload, " world");
+}
+
+TEST(OpenInferenceCpp, TracerCloseAlsoEndsStragglerNodeSpan) {
+    InMemoryTracer tracer;
+    auto session = obs::openinference_tracer(tracer);
+
+    session.cb({GraphEvent::Type::NODE_START, "a", neograph::json::object()});
+    // No NODE_END before close — close() must still end the open span.
+    session.close();
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 2u);
+    EXPECT_TRUE(spans[0]->ended);  // root
+    EXPECT_TRUE(spans[1]->ended);  // straggler node span
+}
+
+// ---------------------------------------------------------------------------
+// OpenInferenceProvider — LLM span attributes
+// ---------------------------------------------------------------------------
+
+TEST(OpenInferenceCpp, ProviderEmitsLLMSpanWithFullAttributes) {
+    InMemoryTracer tracer;
+    auto inner = std::make_shared<FakeProvider>();
+    inner->reply = "hello world";
+    inner->prompt_tokens = 7;
+    inner->completion_tokens = 3;
+    obs::OpenInferenceProvider wrapped(inner, tracer);
+
+    CompletionParams params;
+    params.model = "fake-model-1";
+    params.temperature = 0.5f;
+    params.max_tokens = 100;
+    params.messages.push_back({"system", "be helpful"});
+    params.messages.push_back({"user", "hi"});
+
+    auto result = wrapped.complete(params);
+    EXPECT_EQ(result.message.content, "hello world");
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 1u);
+    const auto& s = *spans[0];
+    EXPECT_EQ(s.name, "llm.complete");
+    EXPECT_EQ(s.attrs_str.at("openinference.span.kind"), "LLM");
+    EXPECT_EQ(s.attrs_str.at("llm.model_name"), "fake-model-1");
+    EXPECT_EQ(s.attrs_str.at("llm.input_messages.0.message.role"), "system");
+    EXPECT_EQ(s.attrs_str.at("llm.input_messages.0.message.content"), "be helpful");
+    EXPECT_EQ(s.attrs_str.at("llm.input_messages.1.message.role"), "user");
+    EXPECT_EQ(s.attrs_str.at("llm.input_messages.1.message.content"), "hi");
+    EXPECT_EQ(s.attrs_str.at("llm.output_messages.0.message.role"), "assistant");
+    EXPECT_EQ(s.attrs_str.at("llm.output_messages.0.message.content"), "hello world");
+    EXPECT_EQ(s.attrs_int.at("llm.token_count.prompt"), 7);
+    EXPECT_EQ(s.attrs_int.at("llm.token_count.completion"), 3);
+    EXPECT_EQ(s.attrs_int.at("llm.token_count.total"), 10);
+    EXPECT_EQ(s.attrs_str.at("input.mime_type"), "application/json");
+    EXPECT_EQ(s.attrs_str.at("output.mime_type"), "text/plain");
+    EXPECT_EQ(s.status, "ok");
+    EXPECT_TRUE(s.ended);
+}
+
+TEST(OpenInferenceCpp, ProviderStreamAppendsPerTokenEvents) {
+    InMemoryTracer tracer;
+    auto inner = std::make_shared<FakeProvider>();
+    inner->stream_chunks = {"foo", "bar", "baz"};
+    obs::OpenInferenceProvider wrapped(inner, tracer);
+
+    CompletionParams params;
+    params.model = "fake-stream";
+    params.messages.push_back({"user", "hi"});
+
+    std::vector<std::string> user_received;
+    auto result = wrapped.complete_stream(
+        params, [&](const std::string& c) { user_received.push_back(c); });
+
+    EXPECT_EQ(result.message.content, "foobarbaz");
+    EXPECT_EQ(user_received, (std::vector<std::string>{"foo", "bar", "baz"}));
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 1u);
+    const auto& s = *spans[0];
+    EXPECT_EQ(s.events.size(), 3u);
+    EXPECT_EQ(s.events[0].name, "llm.token");
+    EXPECT_EQ(s.events[0].payload, "foo");
+    EXPECT_EQ(s.events[2].payload, "baz");
+    EXPECT_EQ(s.attrs_str.at("output.value"), "foobarbaz");
+    EXPECT_TRUE(s.ended);
+}
+
+TEST(OpenInferenceCpp, ProviderPropagatesExceptionAndMarksSpanError) {
+    InMemoryTracer tracer;
+    auto inner = std::make_shared<ThrowingProvider>();
+    obs::OpenInferenceProvider wrapped(inner, tracer);
+
+    CompletionParams params;
+    params.model = "x";
+    params.messages.push_back({"user", "hi"});
+
+    EXPECT_THROW(wrapped.complete(params), std::runtime_error);
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 1u);
+    EXPECT_EQ(spans[0]->status, "error");
+    EXPECT_NE(spans[0]->status_message.find("boom"), std::string::npos);
+    EXPECT_TRUE(spans[0]->ended);
+}


### PR DESCRIPTION
## Summary

C++ peer of `bindings/python/neograph_engine/openinference.py`. Three new pieces in `neograph::observability`:

- **`Tracer` / `Span`** ([include/neograph/observability/tracer.h](include/neograph/observability/tracer.h)) — small dep-free abstract interface so neograph itself does NOT link against opentelemetry-cpp. Downstream provides an adapter wrapping its own backend (OTel SDK, in-memory test fake, logging recorder, etc.). The bool overload is deliberately renamed `set_attribute_bool` so a `const char*` literal can't silently resolve to it via pointer-to-bool standard conversion (a real bug caught during test development — every `set_attribute("k", "CHAIN")` was dispatching to bool). A `const char*` forwarding overload is added so string literals reach the `string_view` sink directly.
- **`openinference_tracer(tracer)`** ([include/neograph/observability/openinference.h](include/neograph/observability/openinference.h)) — opens a CHAIN-kind root span, returns an `OpenInferenceTracerSession` whose `cb` field plugs into `engine.run_stream()` and opens a CHAIN-kind child span per node. NODE_START/END payloads → `input.value`/`output.value` JSON blobs, LLM_TOKEN → discrete span events. Mutex-guarded pending-span stack handles parallel fan-out. `close()` ends any straggler spans + the root (also called by destructor; idempotent).
- **`OpenInferenceProvider(inner, tracer)`** — wraps any `Provider`. Each `complete*()` call opens an `llm.complete` child span tagged with the OpenInference LLM-kind attribute set (`llm.model_name`, `llm.invocation_parameters`, `llm.input_messages.{i}.message.{role,content}`, `llm.output_messages.0.message.{role,content}`, `llm.token_count.{prompt,completion,total}`). Streaming overloads also append `llm.token` span events plus a final assembled `output.value`. Tracing failures are caught and swallowed — observability never breaks the LLM call.

Wired into `neograph_core` (single library; no new linkage) and `neograph_tests`.

Closes #9.

## Test plan

- [x] **7/7** new parity tests in [`tests/test_openinference_cpp.cpp`](tests/test_openinference_cpp.cpp) driving an `InMemoryTracer` reference adapter:
  - `TracerOpensChainRootAndPerNodeChild` — root + per-node CHAIN spans, parent linkage, attrs.
  - `TracerSurfacesErrorAndInterrupt` — ERROR sets status_error + neograph.error attr; INTERRUPT sets neograph.interrupted bool.
  - `TracerRecordsLLMTokenAsSpanEvent` — LLM_TOKEN events recorded on the active node span.
  - `TracerCloseAlsoEndsStragglerNodeSpan` — close() flushes pending spans.
  - `ProviderEmitsLLMSpanWithFullAttributes` — full LLM attribute set verified.
  - `ProviderStreamAppendsPerTokenEvents` — streaming events + assembled output.value.
  - `ProviderPropagatesExceptionAndMarksSpanError` — inner provider throws → span ERROR + re-raise.
- [x] **460/461** full ctest pass; the one failure (`pybind_smoke`) is an unrelated pre-existing editable-install hijack — same skip we observed against #4 PR.
- [x] Sanity build of `neograph_core` clean; only deprecation warnings from httplib.

## Notes for reviewer

- The `Tracer` interface is intentionally narrower than OTel's full surface — it covers only what the OpenInference attribute layer needs (named span open/close, attributes, status, discrete events). Anything richer is the adapter author's responsibility.
- `OpenInferenceTracerSession::current_parent()` is a best-effort single-pointer for the most-recent active node span, exposed so `OpenInferenceProvider` can nest LLM spans under the right node when the user passes a `parent_lookup` lambda. For strict per-node-LLM nesting under fan-out, callers should provide their own threading.local-style lookup.
- Streaming-token event recording on the engine side (`LLM_TOKEN` → span event) only fires if a node actually emits LLM_TOKEN events — that requires a node body that calls `ctx.stream_cb(...)` with a typed token event. The OpenInferenceProvider handles its own per-call streaming events independently via the wrapped `on_chunk`.

## Related

- #2 (Python openinference shutdown context-detach noise — fixed in PR #3, different surface, same module)
- #4 / PR #10 — the async streaming bridge fix; makes the `OpenInferenceProvider::complete_stream_async` path safe to drive from inside an outer engine coroutine.
- #5 (Provider single-dispatch) — orthogonal v1.0 architectural item.
- #6 (thread-safety doc gaps) — orthogonal docs PR (PR #11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)