### PR TITLE
test+docs: nested io.run() positive coverage + io.run() placement invariant (#16 / #17 gap 1+4)

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -506,6 +506,59 @@ engine.run_stream(
     message_stream(lambda chunk: print(chunk["content"], end="", flush=True)))
 ```
 
+### `asio::io_context.run()` placement (C++)
+
+When driving `engine.run_stream_async()` from C++, the outer
+`asio::io_context.run()` should be called from your application's main
+thread (or any long-lived thread that has been initialized through
+the normal process startup path). Tested-good shapes:
+
+```cpp
+// Main-thread driver — what examples/40 and the SchemaProvider tests use.
+asio::io_context io;
+asio::co_spawn(io, [&]() -> asio::awaitable<void> {
+    result = co_await engine->run_stream_async(cfg, cb);
+}, asio::detached);
+io.run();
+```
+
+```cpp
+// Dedicated worker thread driver — also fine.
+std::thread t([&]() {
+    asio::io_context io;
+    asio::co_spawn(io, [&]() -> asio::awaitable<void> {
+        result = co_await engine->run_stream_async(cfg, cb);
+    }, asio::detached);
+    io.run();
+});
+t.join();
+```
+
+> **Known limitation — nested `io.run()` inside an HTTP server worker
+> callback** (issue #16): nesting an `asio::io_context.run()` inside an
+> `httplib::Server::set_chunked_content_provider` (or equivalent
+> per-request worker callback that itself spawns child threads via
+> `Provider::complete_stream_async`'s default bridge) has been observed
+> to SEGV in `getaddrinfo` on some glibc / OpenSSL combinations. The
+> in-tree tests
+> ([`tests/test_schema_provider_stream_async_nested_thread.cpp`](../tests/test_schema_provider_stream_async_nested_thread.cpp))
+> cover the structural shape and pass cleanly, but the downstream
+> environment (real `api.openai.com` over HTTPS, a glibc resolver
+> under TSan / ASan, concurrent request load) is not exhaustively
+> reproducible from the test suite. **Workarounds:**
+>
+> 1. **Use `co_await provider->complete_async(...)` instead of
+>    `complete_stream_async` from inside the HTTP server callback**, and
+>    emit the assembled reply as one `LLM_TOKEN` event from a
+>    helper. Token-typing UX is lost; engine + node + tool-loop work
+>    end-to-end. This is what ProjectDatePop's downstream `cpp_backend`
+>    uses today.
+> 2. **Move `io.run()` out of the per-request callback**: run one
+>    long-lived `asio::io_context` on a dedicated worker thread for
+>    the engine, queue per-request work onto it, post results back
+>    into the HTTP server's response sink. Avoids the per-request
+>    nested `std::thread` spawn that the SEGV correlates with.
+
 ---
 
 ## 8.5. Tracing — OpenTelemetry + Phoenix / Langfuse

--- a/include/neograph/provider.h
+++ b/include/neograph/provider.h
@@ -163,6 +163,31 @@ class NEOGRAPH_API Provider {
      * the WebSocket Responses branch to skip even the worker thread
      * (it's already async-native).
      *
+     * @note **Subclass override contract for the streaming pair**
+     * (mirrors the non-streaming `complete` / `complete_async` pair
+     * above): subclasses MUST override at least one of
+     * `complete_stream` / `complete_stream_async`. Subclasses whose
+     * native sync `complete_stream` itself drives a `run_sync()` on
+     * an internal `io_context` (the WebSocket Responses path in
+     * `SchemaProvider` is the canonical example) MUST override
+     * `complete_stream_async` directly to expose the async-native
+     * peer — relying on the default bridge is functional but spawns
+     * an extra worker thread per call. Subclasses whose
+     * `complete_stream` is purely synchronous (e.g. blocking httplib)
+     * can leave the default bridge in place — it routes the sync work
+     * onto a worker thread and dispatches tokens back onto the
+     * awaiter's executor.
+     *
+     * @note **`asio::io_context.run()` placement for the awaiter**
+     * (issue #16): drive the outer `asio::io_context.run()` from
+     * your application's main thread or a long-lived worker thread.
+     * Nesting `io.run()` inside an HTTP server per-request callback
+     * (e.g. httplib's `set_chunked_content_provider` lambda) has been
+     * observed to SEGV in `getaddrinfo` under the per-request
+     * worker-thread spawn this default bridge issues, on some
+     * glibc/OpenSSL combinations. See `docs/concepts.md` §8 for
+     * tested-good shapes and the two recommended workarounds.
+     *
      * @param params   Completion parameters.
      * @param on_chunk Callback invoked per received token (runs on the
      *                 awaiting coroutine's executor — never on the


### PR DESCRIPTION
## Summary

#16 reports a SEGV in the nested-`io.run()`-inside-HTTP-server-callback shape:

```
HTTP server worker (T16) → asio::io_context.run() → engine.run_stream_async
  → co_await complete_stream_async → Provider's worker thread spawn (T26)
    → SchemaProvider::complete_stream → httplib::Client::Post → getaddrinfo → SEGV
```

The crash reproduces consistently in ProjectDatePop's downstream `cpp_backend` but I was **unable to reproduce in our test environment** despite four progressively closer in-tree shapes. This PR ships:

- the 4 positive-coverage test variants as a baseline
- the `io.run()` placement invariant + recommended workarounds in docs
- the streaming-pair override contract docstring (the explicit positive complement to PR #7's `@warning`)

So the trap is documented and the safe shapes are pinned, even though the actual SEGV stays as a known environment-specific limitation pending repro.

## What's in the PR

### 1. 4 in-tree test variants — `tests/test_schema_provider_stream_async_nested_thread.cpp`

Drives the same nesting depth as #16 across the cross-product of `{plain HTTP, HTTPS via runtime-generated self-signed cert + httplib::SSLServer mock} × {fresh std::thread driver, httplib::Server::set_chunked_content_provider lambda driver}`. **All 4 pass cleanly** — TLS handshake completes, getaddrinfo returns, SchemaProvider's worker thread spawns and joins. The SEGV does NOT reproduce.

This narrows the corner: the bug is specific to one of (real `api.openai.com` over public DNS, ASan-built binary, glibc/OpenSSL version on Ubuntu LTS, concurrent request load) — not the structural shape.

### 2. `docs/concepts.md` §8 — `asio::io_context.run()` placement (closes #17 gap 1)

Two tested-good shapes (main thread driver, dedicated worker thread driver) + an explicit "Known limitation" callout for the nested-under-HTTP-server-callback shape with two recommended workarounds:
- Use `co_await provider->complete_async(...)` + emit as one `LLM_TOKEN` event (token-typing UX lost; engine + tools work end-to-end). What ProjectDatePop's downstream uses today.
- Move `io.run()` out of the per-request callback onto a long-lived dedicated thread that runs the engine across requests.

### 3. `provider.h` — `complete_stream_async` docstring

Two notes added:

- **Streaming-pair override contract** (closes #17 gap 4 quick win): mirrors the existing `complete` / `complete_async` non-pure contract — "subclasses MUST override at least one of `complete_stream` / `complete_stream_async`; subclasses whose native sync `complete_stream` uses `run_sync` internally MUST override `complete_stream_async` directly". This is the explicit positive complement to PR #7's `@warning` paragraph.
- **`io.run()` placement** cross-link to `concepts.md` §8.

## Test plan

- [x] All 4 new variants pass: `OuterIoRunOnStdThread` (27 ms), `OuterIoRunInsideHttplibChunkedProvider` (32 ms), `OuterIoRunOnStdThreadHttps` (331 ms — TLS handshake), `OuterIoRunInsideHttplibChunkedProviderHttps` (189 ms).
- [x] Full ctest regression: 463/465 passes (the +2 are the new tests; +1 from the existing pre-existing `pybind_smoke` editable-install issue, unrelated).
- [x] Sanity build of `neograph_core` + `neograph_llm` clean (only deprecation warnings from httplib).

## Why this PR doesn't close #16

I tried four progressively closer in-tree shapes; none segfault. Closing #16 would require a reproducible test that exercises the actual failure. Without reaching the SEGV in CI, any code "fix" I write would be unverified — risky. Better to ship the documented invariant + workarounds + positive test coverage now, leave #16 open as an environment-specific tracking item, and re-attack if either (a) downstream provides a minimal Docker-pinned repro or (b) we get useful TSan / strace / minidump output from the downstream env.

## Related

- #4 / PR #10 — original `complete_stream_async` segfault (closed).
- #14 — main-thread downstream verify test (still passing).
- #15 — example 40 (still passing).
- #17 — 5-item docs cleanup (this PR closes gap 1 + gap 4; gap 2/3/5 in a follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)