### PR TITLE
docs: warn about httplib.h macro-inconsistency ODR trap (closes #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,18 @@ Four small things that are easy to miss:
     `target_include_directories(my_agent PRIVATE
     ${neograph_SOURCE_DIR}/deps)` and `#include <cppdotenv/dotenv.hpp>`.
     It's a header-only single file; not part of the public install.
+  - **If you also `#include <httplib.h>` in your own code** (e.g. for
+    your own `httplib::Server` SSE endpoint), every TU that does so
+    MUST `#define CPPHTTPLIB_OPENSSL_SUPPORT` **before** the include —
+    or set it via `target_compile_definitions(your_target PRIVATE
+    CPPHTTPLIB_OPENSSL_SUPPORT)` globally. NeoGraph's SchemaProvider
+    .cpp defines it; if your TUs don't match, the linker silently
+    picks one `httplib::ClientImpl` layout and the mismatched TU
+    reads members at wrong offsets → SEGV inside `getaddrinfo` on the
+    first LLM call. Issue #16 documented the trap end-to-end; see
+    [docs/troubleshooting.md → "C++ consumers — `httplib.h` macro
+    consistency"](docs/troubleshooting.md#c-consumers--httplibh-macro-consistency-load-bearing-issue-16)
+    for the audit recipe and the one-line fix.
 
 ## Python Binding
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -533,6 +533,99 @@ you to manually `release()` and rewrap.
 
 ---
 
+## C++ consumers — `httplib.h` macro consistency (load-bearing, issue #16)
+
+If you build a C++ application that **links against NeoGraph** AND
+also `#include <httplib.h>` in your own translation units (e.g. to
+run your own `httplib::Server` SSE endpoint), every TU that includes
+`<httplib.h>` MUST `#define CPPHTTPLIB_OPENSSL_SUPPORT` **before**
+the include. Missing the macro in even one TU silently produces a
+SEGV inside `getaddrinfo` the first time
+`SchemaProvider::complete_stream` hits the LLM endpoint.
+
+### Why this happens
+
+`cpp-httplib` is header-only. The class `httplib::ClientImpl` is
+**conditionally larger** when `CPPHTTPLIB_OPENSSL_SUPPORT` is defined
+(it gains SSL-related members; layout shifts by ~8 bytes). Because
+the library's functions are all `inline`, the linker keeps one
+instantiation per inline function and discards duplicates. If two
+TUs in your binary compile against different `ClientImpl` layouts
+(because one defined the macro, the other didn't), the linker picks
+one definition; the *other* TU's compile-side accesses members at
+the wrong offsets — classic ODR violation. The corruption lands on
+adjacent fields (e.g. `proxy_host_` ends up reading from offset
+that's actually `path_`'s tail), and `httplib::ClientImpl::create_client_socket`
+branches into the "use proxy" path with a wild `proxy_host_.c_str()`
+→ `getaddrinfo` → `internal_strlen` → SEGV.
+
+### Symptom
+
+Under ASan:
+
+```
+==NNNN==ERROR: AddressSanitizer: SEGV on unknown address
+    #0 internal_strlen (...)
+    #1 getaddrinfo
+    #2 httplib::detail::create_socket
+    #3 httplib::detail::create_client_socket
+    #4 httplib::ClientImpl::create_client_socket
+    #5 httplib::SSLClient::create_and_connect_socket
+    ...
+    #N neograph::llm::SchemaProvider::complete_stream
+```
+
+Without ASan: same stack via gdb, with a wild pointer value that
+*can* look like text (it's whatever bytes were in the wrong-offset
+slot — under ASan it's typically `0xBE` quarantine poison; without
+ASan it can be uninitialized stack content that happens to decode as
+JSON / UTF-8 fragments and *looks* like memory corruption from a
+real culprit — that's the misleading symptom).
+
+### Fix
+
+In every TU that includes `<httplib.h>`:
+
+```cpp
+// your main.cpp / sse_handler.cpp / wherever
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#include <httplib.h>
+```
+
+Or globally in CMake (preferred — guarantees consistency across the
+whole target):
+
+```cmake
+target_compile_definitions(your_target PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
+```
+
+The macro is harmless even if your own httplib use only needs
+`Server` (not `SSLClient`) — it only **adds** members; nothing
+requires you to actually do SSL on your side.
+
+### How to audit without ASan
+
+```bash
+grep -rn 'include.*httplib\.h\|CPPHTTPLIB_OPENSSL_SUPPORT' src/
+```
+
+If any include site of `<httplib.h>` is **not** preceded by a
+`#define CPPHTTPLIB_OPENSSL_SUPPORT` (in the same TU, or via a
+compile-flag definition), that's almost certainly the bug.
+
+### Why NeoGraph can't fix this for you
+
+NeoGraph's own .cpp files all define the macro consistently. The
+violation only happens when a downstream TU also pulls in httplib.h
+*without* the macro. Detecting that at compile time would require
+either (a) NeoGraph exposing `httplib::ClientImpl` in public headers
+(we deliberately don't — httplib stays inside `SchemaProvider.cpp`),
+or (b) link-time `static_assert` of struct size across translation
+units, which C++ doesn't support. Documenting the trap is the best
+we can do; this section is the documentation. Issue #16 closed.
+
+---
+
 ## Reporting a bug
 
 If your symptom isn't above:

--- a/include/neograph/llm/schema_provider.h
+++ b/include/neograph/llm/schema_provider.h
@@ -8,6 +8,20 @@
  *
  * This allows supporting new LLM providers without writing C++ code --
  * just add a new JSON schema file.
+ *
+ * @warning **Downstream `httplib.h` macro consistency** (issue #16). The
+ * SchemaProvider implementation TU defines `CPPHTTPLIB_OPENSSL_SUPPORT`
+ * before including `<httplib.h>`. If your application **also** includes
+ * `<httplib.h>` in any of its own TUs (e.g. to run an `httplib::Server`
+ * SSE endpoint), every such include site MUST `#define CPPHTTPLIB_OPENSSL_SUPPORT`
+ * before the include, OR you must set
+ * `target_compile_definitions(your_target PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)`
+ * globally. cpp-httplib is header-only and `ClientImpl`'s layout differs
+ * between the two macro states; mismatched TUs produce a silent ODR
+ * violation that SEGVs inside `getaddrinfo` on the first LLM call. The
+ * audit recipe and a worked example live in
+ * docs/troubleshooting.md under "C++ consumers — `httplib.h` macro
+ * consistency".
  */
 #pragma once
 


### PR DESCRIPTION
## Summary

#16's downstream segfault root cause turned out to be a plain ODR violation, not the cold-init / nested-context / OpenSSL hypotheses that #18 and #19 covered. Documenting the trap end-to-end so the next downstream consumer that includes \`<httplib.h>\` from their own TU doesn't burn a day chasing the same dead-end paths I did.

## Root cause (one paragraph)

\`cpp-httplib\` is header-only. \`httplib::ClientImpl\` is conditionally larger when \`CPPHTTPLIB_OPENSSL_SUPPORT\` is defined (gains SSL members; layout shifts ~8 bytes). If a binary links a TU that defines the macro before \`#include <httplib.h>\` (NeoGraph's \`SchemaProvider.cpp\`) with a TU that doesn't (downstream's own SSE handler that includes \`<httplib.h>\` only for \`httplib::Server\`), the linker keeps one inline-instantiation per function and the mismatched TU's compile reads members at wrong offsets. \`proxy_host_\` ends up at an ASan-poisoned slot, \`ClientImpl::create_client_socket\` branches into the "use proxy" path with a wild \`proxy_host_.c_str()\`, and \`getaddrinfo\` SEGVs in \`internal_strlen\`.

Verification: byte-level diagnostic prints in a downstream verification build showed the same \`this\` pointer but two different \`&proxy_host_\` offsets between \`ClientImpl\` ctor and \`create_client_socket\` — textbook ODR signature. Adding \`#define CPPHTTPLIB_OPENSSL_SUPPORT\` to the downstream's \`main.cpp\` produced a clean end-to-end run.

## What's in the PR

Three doc surfaces, all read-only:

1. \`docs/troubleshooting.md\` — new section "C++ consumers — \`httplib.h\` macro consistency (load-bearing, issue #16)": why it happens, ASan stack trace signature, the one-line fix, audit recipe (\`grep -rn 'include.*httplib\\.h\\\\|CPPHTTPLIB_OPENSSL_SUPPORT' src/\`), and explanation of why NeoGraph can't catch this at compile time.
2. \`README.md\` — "Using NeoGraph from your CMake project" gains a fifth bullet flagging the trap + cross-link to troubleshooting.
3. \`include/neograph/llm/schema_provider.h\` — file-level \`@warning\` paragraph so anyone reading the SchemaProvider header sees the macro requirement before they even open downstream IDE.

## Why NeoGraph can't fix this for you

The macro consistency is a downstream-build property. NeoGraph's own .cpp files all define it. Detecting the mismatch would require either (a) exposing \`httplib::ClientImpl\` in public headers (we deliberately don't — httplib stays inside SchemaProvider.cpp), or (b) link-time \`static_assert\` of struct size across TUs, which C++ doesn't support. Documentation is the highest-leverage surface; this is it.

## Closes #16

PRs #18 (docs) and #19 (bridge thread) stay merged. Both are architecturally sound — the bridge thread aligns the streaming-path thread topology with the working \`complete_async\` path, and #18's docs pin the \`io.run()\` placement invariant. They're labeled retroactively as "related to #16 but not the actual fix"; the real fix is in the downstream's \`#define\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)