### PR TITLE
examples: API-coverage batch — 9 offline demos + 7 bug candidates surfaced

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -849,6 +849,51 @@ if(NEOGRAPH_BUILD_EXAMPLES)
         add_executable(example_classifier_fanout examples/36_classifier_fanout.cpp)
         target_link_libraries(example_classifier_fanout PRIVATE neograph::core)
 
+        # ─── API-coverage batch (examples 41-50) ───────────────────────
+        # Targeted at API surface that the existing example set did not
+        # exercise. All offline (mock providers / pure orchestration /
+        # in-memory checkpoint backends), exit 0 on success, suitable
+        # for CI smoke-runs and for first-time readers as concrete
+        # docs.
+
+        # Example 41: multi-turn chatbot via RunConfig::resume_if_exists.
+        add_executable(example_resume_if_exists_chat examples/41_resume_if_exists_chat.cpp)
+        target_link_libraries(example_resume_if_exists_chat PRIVATE neograph::core)
+
+        # Example 42: custom reducer + condition via Registry.
+        add_executable(example_custom_reducer_condition examples/42_custom_reducer_condition.cpp)
+        target_link_libraries(example_custom_reducer_condition PRIVATE neograph::core)
+
+        # Example 43: cross-thread Store driving per-user node behaviour.
+        add_executable(example_store_personalization examples/43_store_personalization.cpp)
+        target_link_libraries(example_store_personalization PRIVATE neograph::core)
+
+        # Example 44: RequestQueue backpressure / rejection path.
+        add_executable(example_request_queue_backpressure examples/44_request_queue_backpressure.cpp)
+        target_link_libraries(example_request_queue_backpressure PRIVATE neograph::core neograph::util)
+
+        # Example 46: CancelToken — cooperative cancellation from another thread.
+        add_executable(example_cancel_token examples/46_cancel_token.cpp)
+        target_link_libraries(example_cancel_token PRIVATE neograph::core)
+
+        # Example 47: NodeCache — opt-in result memoization for pure nodes.
+        add_executable(example_node_cache examples/47_node_cache.cpp)
+        target_link_libraries(example_node_cache PRIVATE neograph::core)
+
+        # Example 48: SqliteCheckpointStore — single-file durable runs.
+        if(NEOGRAPH_BUILD_SQLITE)
+            add_executable(example_sqlite_checkpoint examples/48_sqlite_checkpoint.cpp)
+            target_link_libraries(example_sqlite_checkpoint PRIVATE neograph::core neograph::sqlite)
+        endif()
+
+        # Example 49: OpenInference observability — Tracer adapter pattern.
+        add_executable(example_openinference examples/49_openinference.cpp)
+        target_link_libraries(example_openinference PRIVATE neograph::core)
+
+        # Example 50: AsyncTool — coroutine-shaped tool execution.
+        add_executable(example_async_tool examples/50_async_tool.cpp)
+        target_link_libraries(example_async_tool PRIVATE neograph::core)
+
         # Clay + Raylib chatbot (optional — requires Raylib)
         option(NEOGRAPH_BUILD_CLAY_EXAMPLE "Build Clay chatbot example (fetches Raylib)" OFF)
         if(NEOGRAPH_BUILD_CLAY_EXAMPLE)

--- a/examples/41_resume_if_exists_chat.cpp
+++ b/examples/41_resume_if_exists_chat.cpp
@@ -1,0 +1,174 @@
+// NeoGraph Example 41: Multi-turn chat via `resume_if_exists`
+//
+// Demonstrates the LangGraph-style multi-turn pattern called out in the
+// README "Differences from LangGraph" section but not yet shown as a
+// runnable C++ example:
+//
+//     cfg.thread_id        = "session-1";
+//     cfg.input            = {{"messages", [new user turn]}};
+//     cfg.resume_if_exists = true;   // <-- loads prior checkpoint,
+//                                    //     applies input on top
+//
+// Run() with the same thread_id does *not* auto-load the previous
+// turn's state by default (see RunConfig docstring), so without this
+// flag the LangGraph port silently loses history. The example proves:
+//
+//   1. Turn 1 — fresh run (no checkpoint yet).
+//   2. Turn 2 — same thread_id with resume_if_exists=true sees turn 1's
+//      messages plus the new user message, in order.
+//   3. Turn 3 — even with resume_if_exists=false on the same thread_id,
+//      history is NOT carried (verifies the documented default).
+//
+// No API key required — uses a mock provider that just echoes the
+// running conversation length.
+//
+// Usage: ./example_resume_if_exists_chat
+
+#include <neograph/neograph.h>
+
+#include <iostream>
+#include <string>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+// Mock provider — reply names every prior user message back so we can
+// SEE whether history flowed through.
+class EchoProvider : public Provider {
+public:
+    ChatCompletion complete(const CompletionParams& params) override {
+        ChatCompletion r;
+        r.message.role = "assistant";
+
+        std::string reply = "Heard so far: ";
+        int n = 0;
+        for (const auto& m : params.messages) {
+            if (m.role == "user") {
+                if (n++ > 0) reply += " | ";
+                reply += m.content;
+            }
+        }
+        reply += " (total user turns: " + std::to_string(n) + ")";
+
+        r.message.content = reply;
+        return r;
+    }
+    ChatCompletion complete_stream(const CompletionParams& p,
+                                   const StreamCallback&) override {
+        return complete(p);
+    }
+    std::string get_name() const override { return "echo"; }
+};
+
+static void print_messages(const json& state, const std::string& label) {
+    std::cout << "  [" << label << "] channel `messages`:\n";
+    if (!state.contains("channels") || !state["channels"].contains("messages")) {
+        std::cout << "    (no messages channel)\n";
+        return;
+    }
+    auto msgs = state["channels"]["messages"]["value"];
+    if (!msgs.is_array()) {
+        std::cout << "    (not an array)\n";
+        return;
+    }
+    for (const auto& m : msgs) {
+        std::string role    = m.value("role", "?");
+        std::string content = m.value("content", "");
+        std::cout << "      [" << role << "] " << content << "\n";
+    }
+}
+
+int main() {
+    auto provider = std::make_shared<EchoProvider>();
+
+    NodeContext ctx;
+    ctx.provider     = provider;
+    ctx.instructions = "Echo user turn count.";
+
+    json definition = {
+        {"name", "chatbot"},
+        {"channels", {{"messages", {{"reducer", "append"}}}}},
+        {"nodes",    {{"llm",       {{"type", "llm_call"}}}}},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "llm"}},
+            {{"from", "llm"},       {"to", "__end__"}}
+        })}
+    };
+
+    auto store  = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(definition, ctx, store);
+
+    const std::string thread = "session-1";
+
+    // ── Turn 1 ────────────────────────────────────────────────────────
+    std::cout << "── Turn 1 (fresh) ──────────────────────────────\n";
+    {
+        RunConfig cfg;
+        cfg.thread_id        = thread;
+        cfg.resume_if_exists = true;   // No checkpoint exists yet: behaves
+                                       // like a fresh run (per RunConfig docs).
+        cfg.input = {{"messages", json::array({
+            {{"role", "user"}, {"content", "First message"}}
+        })}};
+
+        auto r = engine->run(cfg);
+        print_messages(r.output, "after turn 1");
+    }
+
+    // ── Turn 2 (with resume_if_exists) — should carry turn 1's state ─
+    std::cout << "\n── Turn 2 (resume_if_exists=true) ──────────────\n";
+    {
+        RunConfig cfg;
+        cfg.thread_id        = thread;
+        cfg.resume_if_exists = true;
+        cfg.input = {{"messages", json::array({
+            {{"role", "user"}, {"content", "Second message"}}
+        })}};
+
+        auto r = engine->run(cfg);
+        print_messages(r.output, "after turn 2");
+
+        // Assertion: the assistant's last reply should mention BOTH
+        // user messages because the prior checkpoint loaded their
+        // history into params.messages.
+        // (neograph::json has no .back() — use size()-1 indexing.)
+        auto msgs = r.output["channels"]["messages"]["value"];
+        std::string last = msgs.size() > 0
+                               ? msgs[msgs.size() - 1].value("content", "")
+                               : std::string{};
+        bool sees_first  = last.find("First message") != std::string::npos;
+        bool sees_second = last.find("Second message") != std::string::npos;
+        std::cout << "  assistant saw both turns: "
+                  << std::boolalpha << (sees_first && sees_second) << "\n";
+    }
+
+    // ── Turn 3 (resume_if_exists=false on same thread) — should NOT ─
+    //                                                    carry history.
+    std::cout << "\n── Turn 3 (resume_if_exists=false, same thread) ──\n";
+    {
+        RunConfig cfg;
+        cfg.thread_id        = thread;
+        cfg.resume_if_exists = false;   // Default — fresh start.
+        cfg.input = {{"messages", json::array({
+            {{"role", "user"}, {"content", "Third message"}}
+        })}};
+
+        auto r = engine->run(cfg);
+        print_messages(r.output, "after turn 3");
+
+        auto msgs = r.output["channels"]["messages"]["value"];
+        std::string last = msgs.size() > 0
+                               ? msgs[msgs.size() - 1].value("content", "")
+                               : std::string{};
+        bool sees_first   = last.find("First message")  != std::string::npos;
+        bool sees_third   = last.find("Third message")  != std::string::npos;
+        std::cout << "  assistant saw turn 1 history: "
+                  << std::boolalpha << sees_first << " (expected false)\n";
+        std::cout << "  assistant saw turn 3 input  : "
+                  << std::boolalpha << sees_third << " (expected true)\n";
+    }
+
+    std::cout << "\nResume-if-exists is opt-in; without it, callers must thread\n"
+              << "state through `input` themselves (the LangGraph port pitfall).\n";
+    return 0;
+}

--- a/examples/42_custom_reducer_condition.cpp
+++ b/examples/42_custom_reducer_condition.cpp
@@ -1,0 +1,187 @@
+// NeoGraph Example 42: Custom reducers and conditions from C++
+//
+// The README mentions custom reducers and conditions (and the Python
+// binding shows them), but no existing C++ example actually registers
+// one via `ReducerRegistry::instance().register_reducer(...)` or
+// `ConditionRegistry::instance().register_condition(...)`. The two
+// built-in reducers are `overwrite` and `append`; the two built-in
+// conditions are `has_tool_calls` and `route_channel`.
+//
+// This example demonstrates both:
+//
+//   * A custom "sum" reducer that adds incoming numeric values to the
+//     running channel total — useful for accumulator-style channels
+//     (token counters, rolling cost, score sums).
+//
+//   * A custom "running_total_above_threshold" condition that reads
+//     the accumulator and routes to either a "warn" or "continue"
+//     branch — i.e. a feature flag triggered by a channel value
+//     rather than a tool call.
+//
+// No API key required.
+//
+// Usage: ./example_custom_reducer_condition
+
+#include <neograph/neograph.h>
+#include <neograph/graph/loader.h>
+#include <neograph/graph/state.h>
+
+#include <iostream>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+// Custom node: writes a fixed numeric delta to the "score" channel.
+// Demonstrates the "sum" reducer accumulating across super-steps.
+class IncrementNode : public GraphNode {
+    std::string name_;
+    int         delta_;
+public:
+    IncrementNode(std::string n, int d) : name_(std::move(n)), delta_(d) {}
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"score", json(delta_)});
+        co_return out;
+    }
+    std::string get_name() const override { return name_; }
+};
+
+// Custom terminal nodes — one for each route the condition can take.
+class WarnNode : public GraphNode {
+public:
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        int s = in.state.get("score").is_number()
+                    ? in.state.get("score").get<int>() : 0;
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"verdict",
+            json("WARN: running total " + std::to_string(s) + " exceeded threshold")});
+        co_return out;
+    }
+    std::string get_name() const override { return "warn"; }
+};
+
+class ContinueNode : public GraphNode {
+public:
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        int s = in.state.get("score").is_number()
+                    ? in.state.get("score").get<int>() : 0;
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"verdict",
+            json("OK: running total " + std::to_string(s) + " under threshold")});
+        co_return out;
+    }
+    std::string get_name() const override { return "continue"; }
+};
+
+int main() {
+    // ── Register custom reducer ──────────────────────────────────────
+    //
+    // The `sum` reducer treats `current` as the running total and
+    // adds `incoming` (numeric) to it. Initial value is 0 the first
+    // time anything writes (the engine seeds channels via reducer with
+    // a null `current`, so we explicitly normalise to 0).
+    ReducerRegistry::instance().register_reducer("sum",
+        [](const json& current, const json& incoming) -> json {
+            int cur = current.is_number() ? current.get<int>() : 0;
+            int inc = incoming.is_number() ? incoming.get<int>() : 0;
+            return json(cur + inc);
+        });
+
+    // ── Register custom condition ────────────────────────────────────
+    //
+    // The condition returns a route key matched against the
+    // `routes` map in the JSON edge definition.
+    ConditionRegistry::instance().register_condition(
+        "score_above_5",
+        [](const GraphState& state) -> std::string {
+            int s = state.get("score").is_number()
+                        ? state.get("score").get<int>() : 0;
+            return s > 5 ? "above" : "below";
+        });
+
+    // ── Register custom node types ──────────────────────────────────
+    NodeFactory::instance().register_type("increment",
+        [](const std::string& name, const json& cfg, const NodeContext&) {
+            int delta = cfg.value("delta", 1);
+            return std::make_unique<IncrementNode>(name, delta);
+        });
+    NodeFactory::instance().register_type("warn",
+        [](const std::string&, const json&, const NodeContext&) {
+            return std::make_unique<WarnNode>();
+        });
+    NodeFactory::instance().register_type("continue_node",
+        [](const std::string&, const json&, const NodeContext&) {
+            return std::make_unique<ContinueNode>();
+        });
+
+    // ── Graph: __start__ -> step1 -> step2 -> step3 -> router -> {warn|continue}
+    //   Each step adds to `score` via the `sum` reducer. After three
+    //   steps the running total is 2+3+2 = 7, which crosses the 5
+    //   threshold, so the condition routes to `warn`.
+    //
+    // Channel definition uses `"reducer": "sum"` — the literal string
+    // is what gets passed through to ReducerRegistry::get("sum"). If
+    // the registry name is misspelled, compile() throws — try changing
+    // "sum" to "summ" below to see the failure mode.
+    json def = {
+        {"name", "custom_reducer_demo"},
+        {"channels", {
+            {"score",   {{"reducer", "sum"}}},
+            {"verdict", {{"reducer", "overwrite"}}},
+        }},
+        {"nodes", {
+            {"step1",  {{"type", "increment"}, {"delta", 2}}},
+            {"step2",  {{"type", "increment"}, {"delta", 3}}},
+            {"step3",  {{"type", "increment"}, {"delta", 2}}},
+            {"warn",   {{"type", "warn"}}},
+            {"cont",   {{"type", "continue_node"}}},
+        }},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "step1"}},
+            {{"from", "step1"},     {"to", "step2"}},
+            {{"from", "step2"},     {"to", "step3"}},
+            // After step3 — branch via the custom condition.
+            {{"from", "step3"},
+             {"condition", "score_above_5"},
+             {"routes", {{"above", "warn"}, {"below", "cont"}}}},
+            {{"from", "warn"}, {"to", "__end__"}},
+            {{"from", "cont"}, {"to", "__end__"}},
+        })}
+    };
+
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(def, ctx);
+
+    RunConfig cfg;
+    cfg.thread_id = "t1";
+    cfg.input     = {};   // score starts at 0 (sum reducer normalises null)
+
+    auto r = engine->run(cfg);
+
+    std::cout << "Execution trace: ";
+    for (const auto& n : r.execution_trace) std::cout << n << " -> ";
+    std::cout << "END\n";
+
+    std::cout << "Final score: " << r.output["channels"]["score"]["value"]
+              << "  (2+3+2 = 7 via custom `sum` reducer)\n";
+    std::cout << "Final verdict: "
+              << r.output["channels"]["verdict"]["value"].get<std::string>()
+              << "\n";
+
+    // Sanity assertions:
+    int score = r.output["channels"]["score"]["value"].get<int>();
+    if (score != 7) {
+        std::cerr << "FAIL: expected score=7 but got " << score << "\n";
+        return 1;
+    }
+    auto trace = r.execution_trace;
+    bool went_warn = false;
+    for (const auto& n : trace) if (n == "warn") went_warn = true;
+    if (!went_warn) {
+        std::cerr << "FAIL: expected route via `warn` (score>5)\n";
+        return 1;
+    }
+
+    std::cout << "\nAll assertions passed.\n";
+    return 0;
+}

--- a/examples/43_store_personalization.cpp
+++ b/examples/43_store_personalization.cpp
@@ -1,0 +1,210 @@
+// NeoGraph Example 43: Cross-thread Store driving per-user node behaviour
+//
+// The README touts the cross-thread `Store` (LangGraph's equivalent) for
+// "long-term user preferences, shared knowledge, agent memory" — but
+// example 09 only shows the Store API in isolation. The realistic use
+// case is a node that READS the Store to personalise its output for the
+// current user, and another node that WRITES learned facts back so they
+// survive across sessions and threads.
+//
+// API gap surfaced: there's no `NodeContext::store` field today, so
+// nodes can't access the engine's Store via the standard plumbing.
+// The working pattern is to capture a `shared_ptr<Store>` in the
+// node-factory closure — which is what this example demonstrates.
+// Suggested follow-up: README/concepts.md should call this out
+// explicitly, or `NodeContext` should carry the store the same way
+// it carries the provider.
+//
+// No API key required.
+//
+// Usage: ./example_store_personalization
+
+#include <neograph/neograph.h>
+#include <neograph/graph/loader.h>
+#include <neograph/graph/state.h>
+#include <neograph/graph/store.h>
+
+#include <iostream>
+#include <memory>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+// ── Greet node: reads `user_id` from state, looks up `preferred_name`
+//                and `language` from the Store, emits a personalised
+//                greeting on the `reply` channel.
+//
+// The Store is captured in the closure — there is no
+// NodeContext::store. If you forget to set_store() on the engine and
+// also forget to capture it, the node silently degrades to defaults.
+class GreetNode : public GraphNode {
+    std::shared_ptr<Store> store_;
+public:
+    explicit GreetNode(std::shared_ptr<Store> s) : store_(std::move(s)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        std::string user_id = in.state.get("user_id").is_string()
+                                  ? in.state.get("user_id").get<std::string>()
+                                  : "anonymous";
+
+        std::string preferred_name = "stranger";
+        std::string language       = "en";
+
+        if (store_) {
+            auto name = store_->get({"users", user_id}, "preferred_name");
+            if (name) preferred_name = name->value.get<std::string>();
+
+            auto lang = store_->get({"users", user_id}, "language");
+            if (lang) language = lang->value.get<std::string>();
+        }
+
+        std::string greeting;
+        if      (language == "ko") greeting = "안녕하세요, " + preferred_name + "!";
+        else if (language == "es") greeting = "¡Hola, " + preferred_name + "!";
+        else                       greeting = "Hello, "  + preferred_name + "!";
+
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"reply", json(greeting)});
+        co_return out;
+    }
+    std::string get_name() const override { return "greet"; }
+};
+
+// ── Learn node: at the end of each session, write the `learned_fact`
+//                channel (if any) into the Store, namespaced under
+//                this user. Future sessions on any thread_id can read
+//                it back via Store::search.
+class LearnNode : public GraphNode {
+    std::shared_ptr<Store> store_;
+public:
+    explicit LearnNode(std::shared_ptr<Store> s) : store_(std::move(s)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        std::string user_id = in.state.get("user_id").is_string()
+                                  ? in.state.get("user_id").get<std::string>()
+                                  : "anonymous";
+
+        auto fact = in.state.get("learned_fact");
+        if (store_ && fact.is_string() && !fact.get<std::string>().empty()) {
+            // Append-on-write: store as a list keyed by a counter so
+            // we accumulate across sessions without overwriting.
+            auto existing = store_->search({"users", user_id, "facts"});
+            std::string key = "fact_" + std::to_string(existing.size() + 1);
+            store_->put({"users", user_id, "facts"}, key, fact);
+        }
+
+        NodeOutput out;
+        co_return out;
+    }
+    std::string get_name() const override { return "learn"; }
+};
+
+static json make_graph() {
+    return json{
+        {"name", "personalized"},
+        {"channels", {
+            {"user_id",      {{"reducer", "overwrite"}}},
+            {"learned_fact", {{"reducer", "overwrite"}}},
+            {"reply",        {{"reducer", "overwrite"}}},
+        }},
+        {"nodes", {
+            {"greet", {{"type", "greet"}}},
+            {"learn", {{"type", "learn"}}},
+        }},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "greet"}},
+            {{"from", "greet"},     {"to", "learn"}},
+            {{"from", "learn"},     {"to", "__end__"}},
+        })},
+    };
+}
+
+int main() {
+    // The Store is shared between the engine (for inspection) AND the
+    // node factories (so the running nodes can read/write).
+    auto store = std::make_shared<InMemoryStore>();
+
+    // Seed initial preferences for user alice — typically these would
+    // come from a database or user profile service.
+    store->put({"users", "alice"}, "preferred_name", json("Alice"));
+    store->put({"users", "alice"}, "language",       json("ko"));
+
+    store->put({"users", "bob"},   "preferred_name", json("Bobby"));
+    store->put({"users", "bob"},   "language",       json("es"));
+    // carol intentionally absent — exercise the defaults path.
+
+    // Register node factories that capture the Store by shared_ptr.
+    NodeFactory::instance().register_type("greet",
+        [store](const std::string&, const json&, const NodeContext&) {
+            return std::make_unique<GreetNode>(store);
+        });
+    NodeFactory::instance().register_type("learn",
+        [store](const std::string&, const json&, const NodeContext&) {
+            return std::make_unique<LearnNode>(store);
+        });
+
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(make_graph(), ctx);
+    engine->set_store(store);  // Engine also holds it for get_store().
+
+    // ── Three different user sessions on three different thread_ids ──
+    struct Session {
+        std::string user_id;
+        std::string fact_to_learn;
+    };
+    std::vector<Session> sessions = {
+        {"alice", "Alice prefers tea over coffee."},
+        {"bob",   "Bob's favorite team is Real Madrid."},
+        {"carol", ""},                       // no fact to learn this time
+    };
+
+    for (const auto& s : sessions) {
+        RunConfig cfg;
+        cfg.thread_id = "session-" + s.user_id;
+        cfg.input = {
+            {"user_id",      s.user_id},
+            {"learned_fact", s.fact_to_learn},
+        };
+        auto r = engine->run(cfg);
+        std::cout << "[" << s.user_id << "] "
+                  << r.output["channels"]["reply"]["value"].get<std::string>()
+                  << "\n";
+    }
+
+    // ── Inspect the Store after all sessions: facts learned per user ──
+    std::cout << "\n── Store contents after all sessions ──────────\n";
+    auto all_user_namespaces = store->list_namespaces({"users"});
+    for (const auto& ns : all_user_namespaces) {
+        // Drill into each user's `facts` namespace.
+        if (ns.size() >= 2 && ns[0] == "users") {
+            // skip the bare {"users","x"} prefs entries — print only fact paths
+            if (ns.size() == 3 && ns[2] == "facts") {
+                auto facts = store->search(ns);
+                std::cout << "users/" << ns[1] << "/facts ("
+                          << facts.size() << " items):\n";
+                for (const auto& it : facts) {
+                    std::cout << "  " << it.key << ": " << it.value << "\n";
+                }
+            }
+        }
+    }
+
+    // ── Assertion: carol got the default "Hello, stranger!" path ─────
+    // We re-run carol and check the reply contains "stranger".
+    {
+        RunConfig cfg;
+        cfg.thread_id = "session-carol-check";
+        cfg.input = {{"user_id", "carol"}, {"learned_fact", ""}};
+        auto r = engine->run(cfg);
+        std::string reply = r.output["channels"]["reply"]["value"].get<std::string>();
+        bool defaulted = reply.find("stranger") != std::string::npos;
+        std::cout << "\nUnknown-user fallback: "
+                  << std::boolalpha << defaulted << " (\"" << reply << "\")\n";
+        if (!defaulted) {
+            std::cerr << "FAIL: expected default greeting for unknown user.\n";
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/examples/44_request_queue_backpressure.cpp
+++ b/examples/44_request_queue_backpressure.cpp
@@ -1,0 +1,170 @@
+// NeoGraph Example 44: Fixed-worker pool with backpressure (RequestQueue)
+//
+// The README's "Using the bundled RequestQueue" section advertises this
+// shape for multi-tenant servers that want shed-load semantics instead
+// of unbounded memory growth — but there's no runnable example. Most
+// existing examples use `std::async`, `engine->run_async()` on an
+// io_context, or `set_worker_count(N)` for in-run fan-out; none show
+// the RequestQueue API.
+//
+// What this example shows:
+//
+//   * A graph that simulates per-session work via asio::steady_timer
+//     (no LLM, no API key — the WorkNode itself is the same shape as
+//     in example 27).
+//   * 50 incoming "user sessions" submitted to a tiny RequestQueue
+//     (4 workers, max-queue=8) — far more than the pool can hold.
+//   * Backpressure rejecting sessions when the queue is saturated.
+//   * Stats showing pending / active / completed / rejected.
+//
+// The interesting bit is the `auto [accepted, future] = pool.submit(...)`
+// return — `accepted=false` means the queue refused the task and the
+// future is invalid. The README docstring on submit() warned about
+// this but no example exercised the rejection path.
+//
+// Usage: ./example_request_queue_backpressure
+
+#include <neograph/neograph.h>
+#include <neograph/util/request_queue.h>
+
+#include <asio/io_context.hpp>
+#include <asio/steady_timer.hpp>
+#include <asio/this_coro.hpp>
+#include <asio/use_awaitable.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <vector>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+// Same WorkNode shape as example 27 — sleep on a timer to simulate
+// per-session work without actually blocking the worker thread.
+class WorkNode : public GraphNode {
+    int delay_ms_;
+public:
+    explicit WorkNode(int d) : delay_ms_(d) {}
+    asio::awaitable<std::vector<ChannelWrite>>
+    execute_async(const GraphState&) override {
+        auto ex = co_await asio::this_coro::executor;
+        asio::steady_timer t(ex);
+        t.expires_after(std::chrono::milliseconds(delay_ms_));
+        co_await t.async_wait(asio::use_awaitable);
+        co_return std::vector<ChannelWrite>{
+            ChannelWrite{"result", json("ok")}
+        };
+    }
+    std::string get_name() const override { return "work"; }
+};
+
+static json work_graph() {
+    return {
+        {"name", "single_work"},
+        {"channels", {{"result", {{"reducer", "overwrite"}}}}},
+        {"nodes",    {{"work",   {{"type", "work"}}}}},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "work"}},
+            {{"from", "work"},      {"to", "__end__"}},
+        })},
+    };
+}
+
+int main() {
+    NodeFactory::instance().register_type("work",
+        [](const std::string&, const json& cfg, const NodeContext&) {
+            return std::make_unique<WorkNode>(cfg.value("delay_ms", 80));
+        });
+
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(work_graph(), ctx,
+                                       std::make_shared<InMemoryCheckpointStore>());
+
+    // ── Tiny pool: only 4 workers, only 8 pending allowed ────────────
+    //
+    // With 50 incoming sessions, the queue will saturate quickly and
+    // a chunk of submissions will be rejected — the load-shedding
+    // behaviour the README advertises.
+    util::RequestQueue pool(/*num_workers=*/4, /*max_queue_size=*/8);
+
+    constexpr int N = 50;
+    std::atomic<int> accepted_count{0};
+    std::atomic<int> rejected_count{0};
+    std::vector<std::future<void>> futs;
+    futs.reserve(N);
+
+    auto t0 = std::chrono::steady_clock::now();
+
+    // Fire all 50 submissions back-to-back. Most will be queued; the
+    // ones submitted after the queue saturates get rejected.
+    for (int i = 0; i < N; ++i) {
+        auto [ok, fut] = pool.submit([engine = engine.get(), i]() {
+            RunConfig cfg;
+            cfg.thread_id = "session-" + std::to_string(i);
+            (void) engine->run(cfg);
+        });
+        if (ok) {
+            accepted_count.fetch_add(1, std::memory_order_relaxed);
+            futs.push_back(std::move(fut));
+        } else {
+            rejected_count.fetch_add(1, std::memory_order_relaxed);
+            // Real server would return 503 here.
+        }
+    }
+
+    // Periodically print stats so the user sees the queue draining.
+    for (int tick = 0; tick < 30; ++tick) {
+        auto s = pool.stats();
+        std::cout << "[t+" << tick * 50 << "ms]"
+                  << " pending=" << s.pending
+                  << " active="  << s.active
+                  << " completed=" << s.completed
+                  << " rejected=" << s.rejected
+                  << "\n";
+        if (s.completed >= static_cast<size_t>(accepted_count.load())
+            && s.active == 0 && s.pending == 0) {
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+
+    // Wait on all the accepted futures so we propagate any node
+    // exceptions before final stats.
+    for (auto& f : futs) {
+        try { f.get(); }
+        catch (const std::exception& e) {
+            std::cerr << "task threw: " << e.what() << "\n";
+        }
+    }
+
+    auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+
+    auto s = pool.stats();
+    std::cout << "\n── Final ──────────────────────────────────────\n"
+              << "submitted    : " << N << "\n"
+              << "accepted     : " << accepted_count.load() << "\n"
+              << "rejected (BP): " << rejected_count.load() << "\n"
+              << "completed    : " << s.completed << "\n"
+              << "elapsed      : " << elapsed_ms << " ms (4 workers × 80ms/job)\n"
+              << "\n"
+              << "If accepted_count > workers, the queue absorbed the burst.\n"
+              << "rejected_count > 0 proves backpressure kicked in — those\n"
+              << "would be 503s in a real HTTP server. Sub-`workers` accept\n"
+              << "would mean the test machine drained the queue faster than\n"
+              << "the loop could submit, in which case re-run with a larger\n"
+              << "N or smaller delay_ms.\n";
+
+    // Sanity: at least *some* should have been accepted and processed.
+    if (accepted_count.load() < 4) {
+        std::cerr << "FAIL: expected at least pool size in accepted.\n";
+        return 1;
+    }
+    if (s.completed != static_cast<size_t>(accepted_count.load())) {
+        std::cerr << "FAIL: accepted != completed (worker dropped a task?)\n";
+        return 1;
+    }
+    return 0;
+}

--- a/examples/46_cancel_token.cpp
+++ b/examples/46_cancel_token.cpp
@@ -1,0 +1,122 @@
+// NeoGraph Example 41: Cooperative cancellation via CancelToken
+//
+// Demonstrates how a long-running graph can be aborted from another
+// thread (or signal handler, or HTTP cancel button) by sharing a
+// CancelToken via RunConfig::cancel_token.
+//
+// No API key — uses a sleep-and-increment node so the cancel
+// observably truncates the run mid-flight.
+//
+// Usage:  ./example_cancel_token
+
+#include <neograph/neograph.h>
+#include <neograph/graph/cancel.h>
+
+#include <atomic>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+// Each invocation polls is_cancelled() between 50 ms naps; throws
+// CancelledException so the engine unwinds cleanly.
+class SlowIncNode : public GraphNode {
+public:
+    explicit SlowIncNode(std::string n, std::shared_ptr<CancelToken> tok)
+        : n_(std::move(n)), tok_(std::move(tok)) {}
+
+    std::vector<ChannelWrite> execute(const GraphState& state) override {
+        for (int i = 0; i < 20; ++i) {
+            if (tok_ && tok_->is_cancelled()) {
+                throw CancelledException("aborted inside " + n_);
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+        int cur = 0;
+        auto v = state.get("counter");
+        if (v.is_number()) cur = v.get<int>();
+        return {ChannelWrite{"counter", json(cur + 1)}};
+    }
+    std::string get_name() const override { return n_; }
+
+private:
+    std::string n_;
+    std::shared_ptr<CancelToken> tok_;
+};
+
+int main() {
+    auto tok = std::make_shared<CancelToken>();
+
+    // 4-node chain — each takes ~1s. Total ~4s if uncancelled.
+    NodeFactory::instance().register_type("slow_inc",
+        [tok](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<SlowIncNode>(name, tok);
+        });
+
+    json def = {
+        {"name", "slow_chain"},
+        {"channels", {{"counter", {{"reducer", "overwrite"}}}}},
+        {"nodes", {
+            {"a", {{"type", "slow_inc"}}},
+            {"b", {{"type", "slow_inc"}}},
+            {"c", {{"type", "slow_inc"}}},
+            {"d", {{"type", "slow_inc"}}},
+        }},
+        {"edges", {
+            {{"from", "__start__"}, {"to", "a"}},
+            {{"from", "a"}, {"to", "b"}},
+            {{"from", "b"}, {"to", "c"}},
+            {{"from", "c"}, {"to", "d"}},
+            {{"from", "d"}, {"to", "__end__"}},
+        }},
+    };
+
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(def, ctx);
+
+    RunConfig cfg;
+    cfg.input = {{"counter", 0}};
+    cfg.cancel_token = tok;
+
+    // Fire the cancel from another thread after 250 ms — should land
+    // mid-way through node "a" or "b".
+    std::thread killer([tok]() {
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+        std::cerr << "[killer] requesting cancel...\n";
+        tok->cancel();
+    });
+
+    auto t0 = std::chrono::steady_clock::now();
+    bool cancelled = false;
+    try {
+        auto result = engine->run(cfg);
+        std::cerr << "[run] finished without cancel — counter=" << result.output.dump() << "\n";
+    } catch (const CancelledException& e) {
+        cancelled = true;
+        std::cerr << "[run] cancelled: " << e.what() << "\n";
+    } catch (const std::exception& e) {
+        std::cerr << "[run] unexpected exception: " << e.what() << "\n";
+    }
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0);
+    killer.join();
+
+    std::cout << "elapsed_ms=" << elapsed.count()
+              << " cancelled=" << (cancelled ? "true" : "false")
+              << " token_state=" << (tok->is_cancelled() ? "cancelled" : "active") << "\n";
+
+    // Smoke gate — cancel should land well before the natural 4s
+    // completion. Allow generous slack for CI noise.
+    if (!cancelled) {
+        std::cerr << "FAIL: cancellation did not propagate\n";
+        return 1;
+    }
+    if (elapsed.count() > 2000) {
+        std::cerr << "FAIL: cancel took " << elapsed.count() << "ms (> 2s budget)\n";
+        return 1;
+    }
+    std::cout << "PASS\n";
+    return 0;
+}

--- a/examples/47_node_cache.cpp
+++ b/examples/47_node_cache.cpp
@@ -1,0 +1,111 @@
+// NeoGraph Example 42: Per-node result cache (NodeCache)
+//
+// Demonstrates GraphEngine::set_node_cache_enabled — replays a node's
+// outcome when the input state hash is unchanged. Useful for expensive
+// pure nodes (embedding, deterministic LLM, heavy compute).
+//
+// We instrument a counter node so we can prove the cache short-circuits
+// the second run; hit_count must be 1, miss_count must be 1.
+//
+// Usage: ./example_node_cache
+
+#include <neograph/neograph.h>
+
+#include <atomic>
+#include <iostream>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+// "Expensive" node — bumps a global counter every time its body runs.
+// If the cache works, the counter stays at 1 after two runs.
+std::atomic<int> g_exec_count{0};
+
+class ExpensiveNode : public GraphNode {
+public:
+    std::vector<ChannelWrite> execute(const GraphState& state) override {
+        g_exec_count.fetch_add(1, std::memory_order_relaxed);
+        int x = 0;
+        auto v = state.get("x");
+        if (v.is_number()) x = v.get<int>();
+        // Pretend this is an expensive LLM/embedding/etc.
+        return {ChannelWrite{"y", json(x * x)}};
+    }
+    std::string get_name() const override { return "expensive"; }
+};
+
+int main() {
+    NodeFactory::instance().register_type("expensive",
+        [](const std::string&, const json&, const NodeContext&) {
+            return std::make_unique<ExpensiveNode>();
+        });
+
+    json def = {
+        {"name", "cache_demo"},
+        {"channels", {
+            {"x", {{"reducer", "overwrite"}}},
+            {"y", {{"reducer", "overwrite"}}},
+        }},
+        {"nodes", {{"expensive", {{"type", "expensive"}}}}},
+        {"edges", {
+            {{"from", "__start__"}, {"to", "expensive"}},
+            {{"from", "expensive"}, {"to", "__end__"}},
+        }},
+    };
+
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(def, ctx);
+    engine->set_node_cache_enabled("expensive", true);
+
+    // First run — miss.
+    RunConfig cfg;
+    cfg.input = {{"x", 5}};
+    auto r1 = engine->run(cfg);
+    int exec_after_first = g_exec_count.load();
+    std::cout << "run1 output=" << r1.output.dump()
+              << " exec_count=" << exec_after_first
+              << " cache_size=" << engine->node_cache().size()
+              << " hits=" << engine->node_cache().hit_count()
+              << " misses=" << engine->node_cache().miss_count() << "\n";
+
+    // Second run with identical input — should hit cache, body must NOT run again.
+    auto r2 = engine->run(cfg);
+    int exec_after_second = g_exec_count.load();
+    std::cout << "run2 output=" << r2.output.dump()
+              << " exec_count=" << exec_after_second
+              << " cache_size=" << engine->node_cache().size()
+              << " hits=" << engine->node_cache().hit_count()
+              << " misses=" << engine->node_cache().miss_count() << "\n";
+
+    // Third run with different input — should miss again.
+    RunConfig cfg2;
+    cfg2.input = {{"x", 7}};
+    auto r3 = engine->run(cfg2);
+    int exec_after_third = g_exec_count.load();
+    std::cout << "run3 output=" << r3.output.dump()
+              << " exec_count=" << exec_after_third
+              << " hits=" << engine->node_cache().hit_count()
+              << " misses=" << engine->node_cache().miss_count() << "\n";
+
+    // Gates.
+    bool ok = true;
+    if (exec_after_first != 1) {
+        std::cerr << "FAIL: first run should execute once (got " << exec_after_first << ")\n"; ok = false;
+    }
+    if (exec_after_second != 1) {
+        std::cerr << "FAIL: second run should NOT re-execute (got " << exec_after_second << ")\n"; ok = false;
+    }
+    if (exec_after_third != 2) {
+        std::cerr << "FAIL: third run with new state should re-execute (got " << exec_after_third << ")\n"; ok = false;
+    }
+    if (engine->node_cache().hit_count() != 1) {
+        std::cerr << "FAIL: expected 1 cache hit, got " << engine->node_cache().hit_count() << "\n"; ok = false;
+    }
+    if (engine->node_cache().miss_count() != 2) {
+        std::cerr << "FAIL: expected 2 misses, got " << engine->node_cache().miss_count() << "\n"; ok = false;
+    }
+
+    if (!ok) return 1;
+    std::cout << "PASS\n";
+    return 0;
+}

--- a/examples/48_sqlite_checkpoint.cpp
+++ b/examples/48_sqlite_checkpoint.cpp
@@ -1,0 +1,136 @@
+// NeoGraph Example 43: SqliteCheckpointStore — single-file durable runs
+//
+// Mirror of the Postgres checkpoint example but with SQLite — no DB
+// server, single .db file. Demonstrates the resume_if_exists flow:
+// first run saves a checkpoint, second run resumes from where it left
+// off (HITL pattern), third run reads back history with list().
+//
+// Uses ":memory:" backing so the example is self-contained.
+//
+// Usage: ./example_sqlite_checkpoint
+
+#include <neograph/neograph.h>
+#include <neograph/graph/sqlite_checkpoint.h>
+
+#include <iostream>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+// Simple counter node — increments and tags itself in the history.
+class StampNode : public GraphNode {
+public:
+    explicit StampNode(std::string n) : n_(std::move(n)) {}
+    std::vector<ChannelWrite> execute(const GraphState& state) override {
+        int cur = 0;
+        auto v = state.get("counter");
+        if (v.is_number()) cur = v.get<int>();
+        return {ChannelWrite{"counter", json(cur + 1)},
+                ChannelWrite{"last", json(n_)}};
+    }
+    std::string get_name() const override { return n_; }
+private:
+    std::string n_;
+};
+
+int main() {
+    NodeFactory::instance().register_type("stamp",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<StampNode>(name);
+        });
+
+    // Two-node chain — a → b.
+    json def = {
+        {"name", "checkpoint_demo"},
+        {"channels", {
+            {"counter", {{"reducer", "overwrite"}}},
+            {"last",    {{"reducer", "overwrite"}}},
+        }},
+        {"nodes", {
+            {"a", {{"type", "stamp"}}},
+            {"b", {{"type", "stamp"}}},
+        }},
+        {"edges", {
+            {{"from", "__start__"}, {"to", "a"}},
+            {{"from", "a"}, {"to", "b"}},
+            {{"from", "b"}, {"to", "__end__"}},
+        }},
+    };
+
+    auto store = std::make_shared<SqliteCheckpointStore>(":memory:");
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(def, ctx, store);
+
+    // RunResult::output is the full serialized GraphState. Channel
+    // values live under output["channels"][<name>]["value"] in the
+    // canonical raw shape. Some examples (e.g. example_custom_graph)
+    // see flat top-level keys because their graph compiler stages
+    // (e.g. react_graph) project a synthetic "final_response" channel
+    // out — but the underlying RunResult shape is the channels-wrapper.
+    auto channel_int = [](const json& out, const std::string& ch) -> int {
+        if (out.contains("channels") && out["channels"].contains(ch)
+            && out["channels"][ch].contains("value")
+            && out["channels"][ch]["value"].is_number()) {
+            return out["channels"][ch]["value"].get<int>();
+        }
+        return -1;
+    };
+
+    // First run on thread "alice".
+    RunConfig cfg;
+    cfg.thread_id = "alice";
+    cfg.input = {{"counter", 0}};
+    auto r1 = engine->run(cfg);
+    std::cout << "run1 output=" << r1.output.dump() << "\n";
+
+    // List checkpoints — should have entries for the two steps.
+    auto hist = store->list("alice");
+    std::cout << "alice has " << hist.size() << " checkpoint(s) after run 1\n";
+    if (hist.empty()) {
+        std::cerr << "FAIL: expected checkpoints saved for thread alice\n";
+        return 1;
+    }
+
+    // Second run — same thread_id + resume_if_exists. With this flag the engine
+    // picks up from the last saved state rather than re-running from input.
+    RunConfig cfg2;
+    cfg2.thread_id = "alice";
+    cfg2.input = {{"counter", 0}};   // ignored when resume_if_exists hits
+    cfg2.resume_if_exists = true;
+    auto r2 = engine->run(cfg2);
+    std::cout << "run2 (resumed) output=" << r2.output.dump() << "\n";
+
+    // Independent thread "bob" — own state, own history.
+    RunConfig cfg3;
+    cfg3.thread_id = "bob";
+    cfg3.input = {{"counter", 100}};
+    auto r3 = engine->run(cfg3);
+    std::cout << "run3 (bob) output=" << r3.output.dump() << "\n";
+
+    auto bob_hist = store->list("bob");
+    auto alice_hist = store->list("alice");
+    std::cout << "alice=" << alice_hist.size()
+              << " bob=" << bob_hist.size()
+              << " blobs=" << store->blob_count() << "\n";
+
+    // Gates.
+    bool ok = true;
+    if (alice_hist.size() < 2) {
+        std::cerr << "FAIL: expected at least 2 alice checkpoints (got " << alice_hist.size() << ")\n";
+        ok = false;
+    }
+    if (bob_hist.size() < 2) {
+        std::cerr << "FAIL: expected at least 2 bob checkpoints (got " << bob_hist.size() << ")\n";
+        ok = false;
+    }
+    // resume_if_exists should not have re-counted from 0.
+    int r2_counter = channel_int(r2.output, "counter");
+    if (r2_counter < 2) {
+        std::cerr << "FAIL: resume_if_exists did not pick up prior state (counter="
+                  << r2_counter << ")\n";
+        ok = false;
+    }
+    if (!ok) return 1;
+    std::cout << "PASS\n";
+    return 0;
+}

--- a/examples/49_openinference.cpp
+++ b/examples/49_openinference.cpp
@@ -1,0 +1,215 @@
+// NeoGraph Example 44: OpenInference observability (v0.6.0 feature)
+//
+// Wires a minimal Tracer adapter (prints spans to stderr) into the
+// engine via openinference_tracer() and wraps a mock Provider in
+// OpenInferenceProvider so each LLM call shows up as a child span.
+//
+// In a real deployment the Tracer would forward to opentelemetry-cpp →
+// OTLP → Phoenix / Arize / Langfuse. Here we just print the recorded
+// span tree so the example stays dep-free.
+//
+// Usage: ./example_openinference
+
+#include <neograph/neograph.h>
+#include <neograph/observability/openinference.h>
+#include <neograph/observability/tracer.h>
+
+#include <iostream>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+using namespace neograph;
+using namespace neograph::graph;
+namespace obs = neograph::observability;
+
+// ── Minimal stderr-printing tracer ──────────────────────────────────
+//
+// IMPORTANT pattern: the data record (RecordedSpan) is owned by the
+// tracer, NOT by the wrapper returned to the OpenInference layer.
+// OpenInferenceTracerSession::close() releases its
+// `unique_ptr<obs::Span>` over the root span — the same applies to
+// pending node spans. If the tracer adapter handed out raw pointers
+// into caller-owned span storage, those raw pointers become
+// dangling after close(), and any post-close introspection
+// (printing, attribute inspection in tests) reads freed memory and
+// either crashes or hangs.
+//
+// The shape below splits the data (`RecordedSpan`, owned by the
+// tracer in `unique_ptr`s, lifetime = tracer's lifetime) from the
+// wrapper (`PrintedSpan`, owned by the OpenInference layer,
+// destruction is harmless because the data lives elsewhere). This
+// is the same pattern used by `tests/test_openinference_cpp.cpp`'s
+// InMemoryTracer — copy it for any tracer adapter you write.
+
+struct RecordedSpan {
+    std::string name;
+    RecordedSpan* parent = nullptr;
+    std::map<std::string, std::string> attrs;
+    int event_count = 0;
+    std::string status = "unset";
+    bool ended = false;
+};
+
+class PrintedSpan : public obs::Span {
+public:
+    explicit PrintedSpan(RecordedSpan* rec) : rec_(rec) {}
+    void set_attribute(std::string_view k, std::string_view v) override {
+        rec_->attrs[std::string(k)] = std::string(v);
+    }
+    void set_attribute(std::string_view k, int64_t v) override {
+        rec_->attrs[std::string(k)] = std::to_string(v);
+    }
+    void set_attribute(std::string_view k, double v) override {
+        rec_->attrs[std::string(k)] = std::to_string(v);
+    }
+    void set_attribute_bool(std::string_view k, bool v) override {
+        rec_->attrs[std::string(k)] = v ? "true" : "false";
+    }
+    void add_event(std::string_view, std::string_view) override { ++rec_->event_count; }
+    void set_status_ok() override { rec_->status = "ok"; }
+    void set_status_error(std::string_view m) override { rec_->status = "error: " + std::string(m); }
+    void end() override { rec_->ended = true; }
+private:
+    RecordedSpan* rec_;
+};
+
+class PrintTracer : public obs::Tracer {
+public:
+    std::unique_ptr<obs::Span> start_span(std::string_view name, obs::Span* parent) override {
+        std::lock_guard<std::mutex> lk(mu_);
+        auto rec = std::make_unique<RecordedSpan>();
+        rec->name = std::string(name);
+        if (parent) {
+            auto it = wrapper_to_record_.find(parent);
+            if (it != wrapper_to_record_.end()) rec->parent = it->second;
+        }
+        auto wrap = std::make_unique<PrintedSpan>(rec.get());
+        wrapper_to_record_[wrap.get()] = rec.get();
+        records_.push_back(std::move(rec));
+        return wrap;
+    }
+    void print_tree() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        std::cerr << "─── span tree ──────────────────────\n";
+        std::map<RecordedSpan*, std::vector<RecordedSpan*>> children;
+        std::vector<RecordedSpan*> roots;
+        for (auto& r : records_) {
+            if (r->parent) children[r->parent].push_back(r.get());
+            else roots.push_back(r.get());
+        }
+        for (auto* r : roots) print_one(r, children, 0);
+    }
+    size_t span_count() const {
+        std::lock_guard<std::mutex> lk(mu_);
+        return records_.size();
+    }
+private:
+    void print_one(RecordedSpan* s,
+                   const std::map<RecordedSpan*, std::vector<RecordedSpan*>>& children,
+                   int depth) const {
+        std::cerr << std::string(depth * 2, ' ') << "• " << s->name
+                  << " [" << s->status << (s->ended ? ", ended" : "") << "]";
+        if (s->event_count) std::cerr << " events=" << s->event_count;
+        std::cerr << "\n";
+        for (auto& [k, v] : s->attrs) {
+            std::string short_v = v.size() > 60 ? v.substr(0, 57) + "..." : v;
+            std::cerr << std::string(depth * 2 + 2, ' ') << k << " = " << short_v << "\n";
+        }
+        auto it = children.find(s);
+        if (it != children.end()) {
+            for (auto* c : it->second) print_one(c, children, depth + 1);
+        }
+    }
+    mutable std::mutex mu_;
+    std::vector<std::unique_ptr<RecordedSpan>> records_;
+    std::map<obs::Span*, RecordedSpan*> wrapper_to_record_;
+};
+
+// ── Mock LLM provider ───────────────────────────────────────────────
+
+class MockProvider : public Provider {
+public:
+    ChatCompletion complete(const CompletionParams&) override {
+        ChatCompletion c;
+        c.message.role = "assistant";
+        c.message.content = "Hello from the observed provider!";
+        return c;
+    }
+    ChatCompletion complete_stream(const CompletionParams& p,
+                                    const StreamCallback& on_chunk) override {
+        auto c = complete(p);
+        if (on_chunk) on_chunk(c.message.content);
+        return c;
+    }
+    std::string get_name() const override { return "mock"; }
+};
+
+// ── Simple non-streaming LLM node ───────────────────────────────────
+
+class TalkNode : public GraphNode {
+public:
+    explicit TalkNode(std::shared_ptr<Provider> p) : prov_(std::move(p)) {}
+    std::vector<ChannelWrite> execute(const GraphState&) override {
+        CompletionParams params;
+        params.messages = {{"user", "say hi"}};
+        params.model = "gpt-mock";
+        auto c = prov_->complete(params);
+        return {ChannelWrite{"reply", json(c.message.content)}};
+    }
+    std::string get_name() const override { return "talk"; }
+private:
+    std::shared_ptr<Provider> prov_;
+};
+
+int main() {
+    PrintTracer tracer;
+
+    // The session opens the CHAIN root span at construction. It must
+    // outlive the run; we hold it in a shared_ptr so the
+    // OpenInferenceProvider's parent_lookup lambda can grab it.
+    auto session = std::make_shared<obs::OpenInferenceTracerSession>(
+        obs::openinference_tracer(tracer));
+
+    auto inner = std::make_shared<MockProvider>();
+    auto traced = std::make_shared<obs::OpenInferenceProvider>(
+        inner, tracer,
+        [session]() -> obs::Span* { return session->current_parent(); });
+
+    NodeFactory::instance().register_type("talk",
+        [traced](const std::string&, const json&, const NodeContext&) {
+            return std::make_unique<TalkNode>(traced);
+        });
+
+    json def = {
+        {"name", "obs_demo"},
+        {"channels", {{"reply", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"talk", {{"type", "talk"}}}}},
+        {"edges", {
+            {{"from", "__start__"}, {"to", "talk"}},
+            {{"from", "talk"}, {"to", "__end__"}},
+        }},
+    };
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(def, ctx);
+
+    // Use run_stream so the session's cb fires NODE_START/END events.
+    RunConfig cfg;
+    cfg.input = {{"reply", ""}};
+    cfg.stream_mode = StreamMode::ALL;
+    engine->run_stream(cfg, session->cb);
+    session->close();
+
+    tracer.print_tree();
+    auto total = tracer.span_count();
+    std::cout << "total spans=" << total << "\n";
+
+    if (total < 3) {
+        std::cerr << "FAIL: expected ≥ 3 spans (root + node + llm), got " << total << "\n";
+        return 1;
+    }
+    std::cout << "PASS\n";
+    return 0;
+}

--- a/examples/50_async_tool.cpp
+++ b/examples/50_async_tool.cpp
@@ -1,0 +1,96 @@
+// NeoGraph Example 45: AsyncTool — coroutine-shaped tool execution
+//
+// Tools that fetch over the network, RPC into MCP, or query an async
+// DB are naturally awaitable. AsyncTool gives them a coroutine slot
+// (`execute_async`) and adapts to the sync `Tool::execute` contract
+// automatically — so the Agent / ToolDispatchNode that expects a
+// blocking call still works without touching the tool surface.
+//
+// Demonstrates:
+//   - subclass AsyncTool, override execute_async
+//   - call sync execute() — driver fires up a private io_context
+//   - and (optional) await execute_async directly from a coroutine
+//
+// No API key. Uses asio::steady_timer to fake "I/O latency" so the
+// awaitable nature is observable in the timing.
+//
+// Usage: ./example_async_tool
+
+#include <neograph/neograph.h>
+#include <neograph/tool.h>
+#include <neograph/async/run_sync.h>
+
+#include <asio/steady_timer.hpp>
+#include <asio/this_coro.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <string>
+
+using namespace neograph;
+
+class FakeFetchTool : public AsyncTool {
+public:
+    ChatTool get_definition() const override {
+        return {"fetch", "Fetch a URL (mocked)", json{{"type", "object"}}};
+    }
+    std::string get_name() const override { return "fetch"; }
+
+    asio::awaitable<std::string> execute_async(const json& args) override {
+        auto ex = co_await asio::this_coro::executor;
+        asio::steady_timer t(ex);
+        t.expires_after(std::chrono::milliseconds(80));
+        co_await t.async_wait(asio::use_awaitable);
+
+        std::string url = args.value("url", "<missing>");
+        co_return std::string("fetched: ") + url;
+    }
+};
+
+int main() {
+    FakeFetchTool tool;
+
+    // ── A. Sync facade ─────────────────────────────────────────────
+    // AsyncTool::execute(...) wraps execute_async in run_sync so the
+    // Tool consumer (Agent / ToolDispatchNode) doesn't have to know
+    // anything is async.
+    auto t0 = std::chrono::steady_clock::now();
+    std::string r1 = tool.execute({{"url", "https://example.com"}});
+    auto el_sync = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+    std::cout << "sync   result=\"" << r1 << "\" elapsed_ms=" << el_sync << "\n";
+
+    // ── B. Native async ────────────────────────────────────────────
+    // Drive execute_async on a private io_context via the public
+    // run_sync helper — this is the same machinery AsyncTool::execute
+    // uses internally, exposed so user code can mix the two styles.
+    //
+    // (A second co_await on top of execute_async via co_spawn was the
+    // ideal shape here, but GCC 13's coroutine front-end ICEs on it —
+    // bug filed in this repo's toolchain notes. run_sync gives the
+    // same observable behaviour without the front-end hit.)
+    auto t1 = std::chrono::steady_clock::now();
+    std::string r2 = neograph::async::run_sync(
+        tool.execute_async({{"url", "https://other.example"}}));
+    auto el_async = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t1).count();
+    std::cout << "async  result=\"" << r2 << "\" elapsed_ms=" << el_async << "\n";
+
+    // Both should report the latency (~80 ms) and produce identical content.
+    bool ok = true;
+    if (r1.find("https://example.com") == std::string::npos) {
+        std::cerr << "FAIL: sync path lost arg\n"; ok = false;
+    }
+    if (r2.find("https://other.example") == std::string::npos) {
+        std::cerr << "FAIL: async path lost arg\n"; ok = false;
+    }
+    if (el_sync < 70 || el_async < 70) {
+        std::cerr << "FAIL: I/O delay swallowed (sync=" << el_sync
+                  << "ms async=" << el_async << "ms)\n"; ok = false;
+    }
+    // No upper-bound gate — CI noise can spike timer wakes.
+
+    if (!ok) return 1;
+    std::cout << "PASS\n";
+    return 0;
+}


### PR DESCRIPTION
## Summary

- **9 new offline (no-key) examples** filling API surface gaps the existing example set didn't exercise: cancel/cache/observability/sqlite-checkpoint/async-tool/Store-live/custom-reducer/request-queue-backpressure/resume-if-exists-chat
- All 9 build cleanly and `rc=0` from a fresh worktree on master HEAD
- **7 bug candidates / DX friction items surfaced** while writing them — listed in the commit body for follow-up issues

## Motivation

Downstream consumers (most recently `ProjectDatePop` → issue #16's
ODR macro trap) keep finding bugs in code paths the existing example
set didn't exercise. Pre-emptively covering more surface should catch
the next batch of #16-shaped bugs before any user does.

API-class coverage diff showed **27/53 `NEOGRAPH_API` classes** had
zero example references by name. This PR prioritized the highest-value
user-facing gaps. Two parallel passes — coverage-gap driven (5 examples
46-50) and neutral-developer perspective (4 examples 41-44) —
produced complementary additions.

## Examples added

See commit body for the per-example surface-exercised table.

## Bug candidates surfaced (7 items)

These came up *while writing* the examples and are not fixed by this
PR. The commit body has the full list; high-impact ones:

- `Provider::complete_stream` pure-virtual → every mock provider has to stub it
- GCC 13 coroutine ICE on simple `co_await x.foo_async(...)` → undocumented
- `OpenInferenceTracerSession::close()` resets root-span `unique_ptr` → tracer adapters with raw pointers get UAF on post-close inspection (manifested as hang on first attempt)
- `RunResult::output` shape inconsistency (flat-key vs channels-wrapped)
- `neograph::json` arrays missing `.back()` / `.front()`
- No `NodeContext::store` / `RunContext::store` — Store API plumbing into nodes requires factory-closure workaround
- Example 09 Store demo never reads Store from inside a running node

If we agree these are worth tracking I can split each into a GitHub
issue under the existing milestone scheme.

## Test plan

- [x] All 9 build with `cmake --build build-coverage -j --target example_*`
- [x] All 9 run to `rc=0` from a fresh worktree on master HEAD
- [ ] CI build green (relies on the standard CI matrix; no source-file changes outside `examples/` + CMakeLists glue)
- [ ] Reviewer reads the bug-candidate list and decides which become follow-up issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)