### PR TITLE
docs: GCC 13 coroutine ICE + Tracer adapter UAF on close (closes #23, #24)

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -427,7 +427,120 @@ ImportError fires on first use only, with a one-line install hint::
 Add `opentelemetry-exporter-otlp` if you want to push spans to
 Phoenix / Langfuse / Tempo via OTLP.
 
+### My custom `Tracer` adapter hangs / crashes / prints garbage after `session.close()` (issue #24)
+
+You wrote a `neograph::observability::Tracer` adapter (C++) that
+records spans into an in-memory list, then walked the list **after**
+calling `OpenInferenceTracerSession::close()`. The walk reads
+freed memory.
+
+`close()` resets the internal `unique_ptr<Span>` over the root
+span (and the per-node-span stacks). If your adapter handed out
+**raw pointers** into the wrapper objects it returned from
+`start_span`, those pointers are dangling the moment `close()`
+returns — the wrappers were owned by the caller, and the caller
+just released them.
+
+**Fix:** the adapter must own the recorded span data itself, not
+just track raw pointers into caller-owned wrappers. The shape:
+
+```cpp
+// Owned by the tracer (lives until tracer drops):
+struct RecordedSpan {
+    std::string name;
+    RecordedSpan* parent = nullptr;
+    std::map<std::string, std::string> attrs;
+    // ...status, events, ended flag...
+};
+
+// Owned by the OpenInference layer (may be reset on close):
+class WrapperSpan : public obs::Span {
+    RecordedSpan* rec_;        // pointer into the tracer-owned data
+public:
+    void set_attribute(...) override { rec_->attrs[...] = ...; }
+    // ...
+};
+
+class MyTracer : public obs::Tracer {
+    std::vector<std::unique_ptr<RecordedSpan>> records_;  // ← owns data
+    // start_span builds a fresh RecordedSpan, returns a Wrapper
+    // pointing at it. Walk records_ for inspection — never the
+    // wrappers.
+};
+```
+
+References: `tests/test_openinference_cpp.cpp::InMemoryTracer`
+(canonical test fixture) and `examples/49_openinference.cpp::PrintTracer`
+(stderr-printing demo) both use this exact pattern. The same
+warning is in the `@warning` blocks on `Tracer` and
+`OpenInferenceTracerSession::close()` in the headers.
+
+**How the bug shows up:** observable failure modes include a clean
+crash inside the inspection loop (best case), a hang in the middle
+of printing a span name (the freed buffer happened to contain
+something that loops a string formatter), or just incorrect
+attribute values. All three are the same root cause.
+
 ---
+
+## Build errors
+
+### GCC 13 internal compiler error: `build_special_member_call`, `cp/call.cc:11096` (issue #23)
+
+You're on Ubuntu 24.04's stock GCC 13 (or any GCC 13.x). The build
+dies with:
+
+```
+internal compiler error: in build_special_member_call, at cp/call.cc:11096
+```
+
+…on a line that does `co_await x.foo_async(...)` inside a coroutine
+(typically a lambda body passed to `asio::co_spawn` from `main()`).
+This is a GCC 13 front-end bug, not your code. GCC 14+, Clang 18+,
+and MSVC 19.40+ all compile the same source unchanged.
+
+**Three escapes**, in order of preference:
+
+1. **Upgrade the compiler** — `sudo apt install gcc-14 g++-14` on
+   Ubuntu 24.04 (24.10 ships GCC 14 by default), then
+   `cmake -DCMAKE_CXX_COMPILER=g++-14 ...`. Cleanest fix; lets
+   you write the code the natural way.
+
+2. **Drive the coroutine via `neograph::async::run_sync`** instead of
+   `asio::co_spawn` from `main()`. Same observable behaviour, no
+   front-end ICE:
+
+   ```cpp
+   // Instead of:
+   asio::co_spawn(io,
+       [&]() -> asio::awaitable<void> {
+           result = co_await tool.execute_async(args);   // ← GCC 13 ICEs here
+       },
+       asio::detached);
+   io.run();
+
+   // Do:
+   #include <neograph/async/run_sync.h>
+   result = neograph::async::run_sync(tool.execute_async(args));
+   ```
+
+   `run_sync` builds its own private `io_context` and drives the
+   awaitable to completion — internally identical to what
+   `co_spawn + io.run()` does, but the call site is sync from the
+   compiler's point of view, so the ICE never fires.
+
+3. **Restructure the coroutine** so the `co_await` happens inside a
+   member function of a regular class, not a free function or lambda
+   body. This works in some cases but the diagnostic doesn't always
+   point at the right shape change — option 1 or 2 is more reliable.
+
+**Where this bites in this repo:** the CMakeLists has a per-example
+toolchain gate around `example_03` (the original ICE site), and
+`examples/50_async_tool.cpp` works around the issue by using
+`run_sync` instead of `co_spawn` from `main()`. New coroutine
+examples / tests that follow the natural `co_spawn`-from-main shape
+will hit the same ICE on the same toolchain — just apply option 1
+or 2.
 
 ## Python type identity (v0.5.0+)
 

--- a/include/neograph/observability/openinference.h
+++ b/include/neograph/observability/openinference.h
@@ -79,6 +79,24 @@ public:
     OpenInferenceTracerSession& operator=(OpenInferenceTracerSession&&) noexcept;
 
     /// End the root span + any pending node spans. Idempotent.
+    ///
+    /// @warning **Adapter authors:** `close()` resets the internal
+    /// `unique_ptr<Span>` over the root span (and the corresponding
+    /// pending-node-span stacks). If your `Tracer` adapter handed
+    /// out raw pointers into caller-owned span storage and stored
+    /// them for post-close inspection, those pointers become
+    /// dangling — any walk of \"all spans I've recorded\" after
+    /// `close()` reads freed memory and may crash, hang, or print
+    /// garbage (issue #24).
+    ///
+    /// The adapter must own the span DATA itself (not just the
+    /// wrapper). Pattern: split a `RecordedSpan` (owned by the
+    /// adapter in `unique_ptr`s) from the `Span` wrapper handed
+    /// back to the OpenInference layer. The wrapper's destruction
+    /// is then harmless — the recorded data lives in the adapter
+    /// and survives `close()`. See `tests/test_openinference_cpp.cpp`
+    /// (`InMemoryTracer`) and `examples/49_openinference.cpp`
+    /// (`PrintTracer`) for the canonical shape.
     void close();
 
     /// Internal — exposed so `OpenInferenceProvider` can open LLM

--- a/include/neograph/observability/tracer.h
+++ b/include/neograph/observability/tracer.h
@@ -94,6 +94,22 @@ public:
  * the OpenInference helpers DO supply the parent explicitly so a
  * dep-free adapter can link spans without relying on contextvars-
  * style implicit context.
+ *
+ * @warning **Span lifetime contract.** The OpenInference layer owns
+ * the `unique_ptr<Span>` your `start_span` returns and may release
+ * it (e.g. inside `OpenInferenceTracerSession::close()`). If your
+ * adapter stores **raw pointers into the wrapper objects** to allow
+ * post-close inspection (printing, test asserts, attribute audit),
+ * those pointers become dangling at close time — see issue #24.
+ *
+ * The supported pattern is: own the recorded span DATA in your
+ * adapter (a `RecordedSpan`-style struct held in
+ * `unique_ptr<RecordedSpan>` inside the tracer), and have the
+ * `Span` wrapper your `start_span` returns merely point at that
+ * recorded struct. The wrapper's destruction is then harmless. See
+ * `tests/test_openinference_cpp.cpp::InMemoryTracer` and
+ * `examples/49_openinference.cpp::PrintTracer` for the reference
+ * shape.
  */
 class NEOGRAPH_API Tracer {
 public:


### PR DESCRIPTION
## 한 줄 요약

PR #21 에서 발견한 7개 이슈 중 **문서만 추가하면 되는 두 항목** 을 한 PR 로 묶었습니다 — 이슈 #23 (GCC 13 코루틴 컴파일러 버그) + 이슈 #24 (Tracer 어댑터를 잘못 만들면 메모리 오류 나는 함정).

## 변경 내용

### #23 — GCC 13 코루틴 ICE
- `docs/troubleshooting.md` 의 `## Build errors` 섹션 신설 + 항목 추가
  - 정확한 오류 메시지 (`internal compiler error: in build_special_member_call, at cp/call.cc:11096`) 로 검색해서 바로 닿게
  - 우선순위 순 3가지 회피책: (1) GCC 14 업그레이드, (2) `run_sync` 로 sync-bridge, (3) 멤버 함수로 재배치
  - 이미 `examples/50_async_tool.cpp` 가 (2) 회피책 적용한 상태 — 사례로 인용
- 같은 함정에 대한 EDDSkills 컴패니언 스킬 (`gcc13-coroutine-co-await-ice`) 별도 커밋

### #24 — Tracer 어댑터 raw-pointer 함정
- `include/neograph/observability/tracer.h` 의 `Tracer` base 클래스 docstring 에 `@warning` 블록 — 어댑터 작성자가 가장 먼저 보는 곳
- `include/neograph/observability/openinference.h` 의 `OpenInferenceTracerSession::close()` docstring 에 `@warning` 블록
- `docs/troubleshooting.md` 의 `## OpenTelemetry` 섹션에 증상 우선 항목 — "내 Tracer 어댑터가 `session.close()` 후에 hang / crash / 가비지 출력"
- 셋 모두 정답 패턴 (`RecordedSpan` 데이터를 어댑터가 소유 + `Span` 래퍼는 그 데이터를 가리킴) 을 명시하고 기존 참조 (`tests/test_openinference_cpp.cpp::InMemoryTracer`, `examples/49_openinference.cpp::PrintTracer`) 를 인용

## 코드 변경 0

`@warning` 블록은 doxygen 주석이라 빌드 영향 없음. 헤더 변경이 ABI 영향 0 인지 확인 — `cmake --build` clean.

## 테스트 방법

- [x] `neograph_core` 재빌드 (헤더 변경) — green
- [x] doxygen 주석 문법 OK (빌드 경고 없음)
- [ ] CI: `docs:` 접두 PR 이라 build/test job 그대로 통과해야 함

## 남은 것 — 별도 PR

- **#25** RunResult.output 모양 일관성 — `RunResult::channel<T>("name")` 도우미 추가 (PR 2)
- **#27** RunContext::store 필드 추가 (PR 3)
- **#5** v1.0 ROADMAP — 사이클 시작 전까지 그대로 둠

🤖 Generated with [Claude Code](https://claude.com/claude-code)