### PR TITLE
feat(engine): RunResult::channel<T>(name) accessor + canonical shape doc (closes #25)

### DIFF
--- a/examples/48_sqlite_checkpoint.cpp
+++ b/examples/48_sqlite_checkpoint.cpp
@@ -61,20 +61,10 @@ int main() {
     NodeContext ctx;
     auto engine = GraphEngine::compile(def, ctx, store);
 
-    // RunResult::output is the full serialized GraphState. Channel
-    // values live under output["channels"][<name>]["value"] in the
-    // canonical raw shape. Some examples (e.g. example_custom_graph)
-    // see flat top-level keys because their graph compiler stages
-    // (e.g. react_graph) project a synthetic "final_response" channel
-    // out — but the underlying RunResult shape is the channels-wrapper.
-    auto channel_int = [](const json& out, const std::string& ch) -> int {
-        if (out.contains("channels") && out["channels"].contains(ch)
-            && out["channels"][ch].contains("value")
-            && out["channels"][ch]["value"].is_number()) {
-            return out["channels"][ch]["value"].get<int>();
-        }
-        return -1;
-    };
+    // RunResult::channel<T>(name) handles both shapes — channels-wrapper
+    // (canonical) and flat-key projections (e.g. react_graph's
+    // final_response). See engine.h's RunResult docstring for the full
+    // shape contract. Issue #25.
 
     // First run on thread "alice".
     RunConfig cfg;
@@ -124,7 +114,7 @@ int main() {
         ok = false;
     }
     // resume_if_exists should not have re-counted from 0.
-    int r2_counter = channel_int(r2.output, "counter");
+    int r2_counter = r2.has_channel("counter") ? r2.channel<int>("counter") : -1;
     if (r2_counter < 2) {
         std::cerr << "FAIL: resume_if_exists did not pick up prior state (counter="
                   << r2_counter << ")\n";

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -183,14 +183,91 @@ struct RunContext {
 
 /**
  * @brief Result of a graph execution run.
+ *
+ * ## ``output`` shape (issue #25)
+ *
+ * The canonical shape of ``output`` is **channels-wrapped**: each
+ * channel value lives at ``output["channels"][<name>]["value"]``,
+ * with sibling metadata such as ``["version"]`` recording how many
+ * times the channel was written. ``output["global_version"]`` carries
+ * the super-step counter.
+ *
+ * Some compiled flows project additional **flat top-level keys** for
+ * ergonomic access — e.g. ``react_graph`` exposes a synthetic
+ * ``output["final_response"]`` so the README quickstart can read the
+ * model's last reply with one bracket. These projections coexist with
+ * the channels wrapper; the wrapper is always present and is the
+ * source of truth.
+ *
+ * Use the ``channel<T>(name)`` accessor below to read a channel value
+ * without committing to either shape — it checks the channels wrapper
+ * first, then falls back to a flat top-level key with the same name.
+ * That way the same call site works against ``GraphEngine::compile``-
+ * built graphs (channels-wrapped only) and ``react_graph``-built
+ * graphs (channels-wrapped + flat-key projections) alike.
  */
 struct RunResult {
-    json        output;                             ///< Final serialized graph state.
+    json        output;                             ///< Final serialized graph state. See struct docstring for shape details.
     bool        interrupted       = false;          ///< True if execution was interrupted (HITL).
     std::string interrupt_node;                     ///< Name of the node that triggered the interrupt.
     json        interrupt_value;                    ///< Value associated with the interrupt.
     std::string checkpoint_id;                      ///< ID of the last checkpoint saved.
     std::vector<std::string> execution_trace;       ///< Ordered list of executed node names.
+
+    /// @brief Read a channel value as type ``T`` (issue #25).
+    ///
+    /// Looks up the value in ``output``. Tries the canonical
+    /// channels-wrapped path first
+    /// (``output["channels"][name]["value"]``); falls back to a flat
+    /// top-level key (``output[name]``) for graphs that project flat
+    /// keys such as ``react_graph``'s ``final_response``.
+    ///
+    /// @throws json::out_of_range if no channel with that name exists
+    /// in either shape.
+    /// @throws json::type_error if the channel exists but its value
+    /// cannot be converted to ``T`` (delegated to ``json::get<T>``).
+    ///
+    /// @tparam T One of the types ``json::get<T>`` is specialised for
+    ///         — ``int``, ``long``, ``double``, ``std::string``,
+    ///         ``bool``, ``json``, etc. See ``json.h``.
+    template <typename T>
+    T channel(const std::string& name) const {
+        return channel_raw(name).get<T>();
+    }
+
+    /// @brief Read a channel value as a raw ``json`` node (issue #25).
+    ///
+    /// Same lookup rules as ``channel<T>`` — channels-wrapped first,
+    /// flat top-level key as fallback. Returns the underlying json so
+    /// the caller can walk arrays / objects without committing to a
+    /// scalar conversion.
+    ///
+    /// @throws json::out_of_range if no channel with that name exists
+    /// in either shape.
+    json channel_raw(const std::string& name) const {
+        if (output.contains("channels") && output["channels"].contains(name)) {
+            const auto wrapped = output["channels"][name];
+            if (wrapped.contains("value")) return wrapped["value"];
+        }
+        if (output.contains(name)) return output[name];
+        throw json::out_of_range(
+            "RunResult::channel: no such channel '" + name + "' in output "
+            "(checked output[\"channels\"][\"" + name + "\"][\"value\"] and output[\"" + name + "\"])");
+    }
+
+    /// @brief Test whether a channel value exists in either shape.
+    ///
+    /// True if either the channels-wrapped path or a flat top-level
+    /// key with the same name resolves. Useful as a guard before
+    /// ``channel<T>`` when the graph may or may not have written the
+    /// channel (e.g. early HITL interrupt before a node ran).
+    bool has_channel(const std::string& name) const noexcept {
+        if (output.contains("channels") && output["channels"].contains(name)
+            && output["channels"][name].contains("value")) {
+            return true;
+        }
+        return output.contains(name);
+    }
 };
 
 /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(neograph_tests
     test_async_http_options.cpp
     test_provider_async_default.cpp
     test_run_context_store.cpp
+    test_run_result_channel.cpp
     test_openai_provider_async.cpp
     test_checkpoint_async_default.cpp
     test_node_async_default.cpp

--- a/tests/test_run_result_channel.cpp
+++ b/tests/test_run_result_channel.cpp
@@ -1,0 +1,128 @@
+// Issue #25 — RunResult::channel<T>(name) / channel_raw / has_channel
+//
+// Two coexisting output shapes:
+//   * canonical channels-wrapped: output["channels"][name]["value"]
+//   * flat-key projection:        output[name]
+// The accessor must handle both transparently.
+//
+// Tests construct RunResult directly with hand-built output JSON to
+// keep the assertions focused on the accessor; engine end-to-end is
+// covered in test_graph_engine.cpp.
+
+#include <gtest/gtest.h>
+
+#include <neograph/graph/engine.h>
+#include <neograph/json.h>
+
+using neograph::json;
+using neograph::graph::RunResult;
+
+namespace {
+
+RunResult make_wrapped(const std::string& name, const json& value, int version = 1) {
+    RunResult r;
+    r.output = json{
+        {"channels", {
+            {name, {{"value", value}, {"version", version}}}
+        }},
+        {"global_version", version}
+    };
+    return r;
+}
+
+RunResult make_flat(const std::string& name, const json& value) {
+    RunResult r;
+    r.output = json{{name, value}};
+    return r;
+}
+
+RunResult make_both(const std::string& name, const json& wrapped_value, const json& flat_value) {
+    // Channels wrapper + flat-key projection (react_graph-style coexistence).
+    RunResult r;
+    r.output = json{
+        {"channels", {
+            {name, {{"value", wrapped_value}, {"version", 1}}}
+        }},
+        {"global_version", 1},
+        {name, flat_value},
+    };
+    return r;
+}
+
+}  // namespace
+
+TEST(RunResultChannel, ChannelWrappedScalar) {
+    auto r = make_wrapped("counter", json(42));
+    EXPECT_EQ(r.channel<int>("counter"), 42);
+    EXPECT_TRUE(r.has_channel("counter"));
+}
+
+TEST(RunResultChannel, FlatKeyScalar) {
+    auto r = make_flat("final_response", json("hello"));
+    EXPECT_EQ(r.channel<std::string>("final_response"), "hello");
+    EXPECT_TRUE(r.has_channel("final_response"));
+}
+
+TEST(RunResultChannel, ChannelWrappedTakesPrecedenceOverFlatKey) {
+    // When both shapes coexist (react_graph), the wrapper is the
+    // source of truth. Flat-key would shadow it if we read flat first.
+    auto r = make_both("counter", json(7), json(99));
+    EXPECT_EQ(r.channel<int>("counter"), 7);
+}
+
+TEST(RunResultChannel, MissingChannelThrowsOutOfRange) {
+    RunResult r;
+    r.output = json::object();
+    EXPECT_THROW(r.channel<int>("nope"), json::out_of_range);
+    EXPECT_FALSE(r.has_channel("nope"));
+}
+
+TEST(RunResultChannel, MissingChannelEmptyChannelsBlockThrows) {
+    // channels exists but the named one isn't there → out_of_range.
+    RunResult r;
+    r.output = json{{"channels", json::object()}, {"global_version", 0}};
+    EXPECT_THROW(r.channel<int>("nope"), json::out_of_range);
+    EXPECT_FALSE(r.has_channel("nope"));
+}
+
+TEST(RunResultChannel, ChannelRawReturnsJsonNode) {
+    // Channel value is itself a compound (array of strings).
+    json arr = json::array();
+    arr.push_back(json("alpha"));
+    arr.push_back(json("beta"));
+    auto r = make_wrapped("tags", arr);
+
+    json got = r.channel_raw("tags");
+    ASSERT_TRUE(got.is_array());
+    ASSERT_EQ(got.size(), 2u);
+    EXPECT_EQ(got[0].get<std::string>(), "alpha");
+    EXPECT_EQ(got[1].get<std::string>(), "beta");
+}
+
+TEST(RunResultChannel, ChannelRawFlatFallback) {
+    auto r = make_flat("payload", json{{"k", "v"}});
+    json got = r.channel_raw("payload");
+    ASSERT_TRUE(got.is_object());
+    EXPECT_EQ(got["k"].get<std::string>(), "v");
+}
+
+TEST(RunResultChannel, WrongTypeConversionPropagates) {
+    // Channel exists but its value is a string; asking for int via
+    // channel<int> should propagate json::type_error from get<int>.
+    auto r = make_wrapped("text", json("not a number"));
+    EXPECT_THROW(r.channel<int>("text"), json::type_error);
+}
+
+TEST(RunResultChannel, WrappedWithoutValueKeyFallsThroughToFlatLookup) {
+    // Edge case: channels wrapper exists for the name but has no
+    // ["value"] sub-key. Should fall through to flat-key check; if
+    // neither, throw.
+    RunResult r;
+    r.output = json{
+        {"channels", {
+            {"weird", {{"version", 1}}}      // no "value" key
+        }},
+        {"weird", json("from-flat")}
+    };
+    EXPECT_EQ(r.channel<std::string>("weird"), "from-flat");
+}


### PR DESCRIPTION
## 한 줄 요약

`RunResult::output` 의 두 모양 (한 겹 들어간 표준 모양 + `react_graph` 가 추가하는 평탄한 키) 을 모두 받아주는 도우미 함수 `channel<T>(name)` / `channel_raw(name)` / `has_channel(name)` 를 추가하고, 어느 모양이 정식인지 헤더 docstring 에 못 박았습니다.

## 배경

PR #21 작업 중 발견한 함정 (이슈 #25):
- 예제 02 (`react_graph` 사용) 는 `output["final_response"]` 평탄 키로 바로 꺼냄 → 동작
- 예제 48 (raw `GraphEngine::compile` 사용) 은 같은 패턴 시도 → 크래시 (`json::type_error: get<int>: not a number`)

원인: `RunResult::output` 의 정식 모양은 한 겹 들어간 `output["channels"][name]["value"]` 형태인데, `react_graph` 가 사용자 편의로 평탄 키를 한 번 더 추가해주는 것. 둘 다 존재하니 사용자는 어느 모양이 정식인지 모름.

## 결정

**한 겹 들어간 모양이 정식.** 이유:
- version 메타 정보 (`output["channels"][name]["version"]`) 까지 같이 담겨 있음 — 정보 손실 없음
- 평탄 키는 `react_graph` 같은 도우미가 더해주는 보조 — 항상 있는 게 아님
- 기존 사용자 코드 (한 겹 모양 의존) 안 깨짐

## 변경 내용

### 1. `include/neograph/graph/engine.h`
- `RunResult` 구조체 docstring 에 모양 계약 명시 — 한 겹 모양이 정식, 평탄 키는 일부 그래프 빌더의 부가 투영
- `RunResult::channel<T>(name)` — 두 모양 모두에서 값 한 줄로 꺼냄. 한 겹 우선, 평탄 폴백
- `RunResult::channel_raw(name)` — 같은 조회, 원시 `json` 노드 반환 (배열·객체 채널용)
- `RunResult::has_channel(name)` — 두 모양 어디든 있는지 boolean

### 2. `tests/test_run_result_channel.cpp` (신규, +9 ctest)
- 한 겹 모양 / 평탄 모양 / 두 모양 공존 / 둘 다 없음 / 빈 channels 블록 / 원시 json 접근 / 잘못된 타입 / 엣지 케이스

### 3. `examples/48_sqlite_checkpoint.cpp`
- PR #21 에서 임시로 박아둔 인라인 `channel_int` 람다 제거 → 새 도우미 사용

## 검증

- **478/478 ctest green** (이전 469 + 새 9개)
- 예제 02 / 09 / 41-50 모두 rc=0 — 회귀 0
- 헤더 변경은 더하기만 — 기존 사용자 코드 안 깨짐. `RunResult::output` 필드는 그대로 public, 새 메서드가 그걸 읽음

## 별도 작업 (이 PR 범위 밖)

- 예제 02 자체는 여전히 `output["final_response"]` 평탄 키 직접 사용 — 동작은 정상이고 도우미 사용으로 바꾸는 건 정합성/문서 정리이지 버그 수정 아님. 리뷰어가 같은 PR 에서 정리하길 원하면 추가 가능
- Python 바인딩의 `RunResult` 미러에도 같은 함정이 있다면 별도 이슈 / PR

## 테스트 방법

- [x] `cmake --build build --target neograph_tests` — clean 빌드
- [x] `ctest -R RunResultChannel` — 9/9 green
- [x] `ctest` 풀 — 478/478 green
- [x] 예제 48 재실행 — rc=0
- [ ] CI: 표준 build + test job 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)