### PR TITLE
feat(engine): RunContext::store — node-side Store access via in.ctx.store (closes #27)

### DIFF
--- a/examples/43_store_personalization.cpp
+++ b/examples/43_store_personalization.cpp
@@ -7,13 +7,23 @@
 // current user, and another node that WRITES learned facts back so they
 // survive across sessions and threads.
 //
-// API gap surfaced: there's no `NodeContext::store` field today, so
-// nodes can't access the engine's Store via the standard plumbing.
-// The working pattern is to capture a `shared_ptr<Store>` in the
-// node-factory closure — which is what this example demonstrates.
-// Suggested follow-up: README/concepts.md should call this out
-// explicitly, or `NodeContext` should carry the store the same way
-// it carries the provider.
+// ## Two ways to reach the Store from a node
+//
+// 1. **`in.ctx.store`** (recommended, available since issue #27).
+//    `RunContext::store` mirrors `GraphEngine::get_store()` so any
+//    node body can read/write through `in.ctx.store->get(...)` /
+//    `->put(...)` directly. No factory-closure plumbing needed.
+//
+// 2. **Capture `shared_ptr<Store>` in the `NodeFactory` closure**
+//    (what this example shows). Pre-#27 this was the only working
+//    shape; it still works and is left in place during the
+//    deprecation window so older examples / downstream code keeps
+//    compiling unchanged.
+//
+// New code should prefer (1) — fewer captures, less boilerplate, and
+// the engine guarantees `in.ctx.store` is the same Store instance
+// `set_store(...)` was called with. This example sticks with (2) so
+// the contrast with example 09 (Store-in-main-only) stays direct.
 //
 // No API key required.
 //

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -142,6 +142,43 @@ struct RunContext {
 
     /// Mirrors ``RunConfig::stream_mode``.
     StreamMode stream_mode = StreamMode::ALL;
+
+    /**
+     * @brief Cross-thread shared memory (issue #27).
+     *
+     * Mirrors ``GraphEngine::get_store()``. Populated by the engine
+     * at the top of every run so node bodies can read / write
+     * Store-backed state through ``in.ctx.store`` without a
+     * separate plumbing channel.
+     *
+     * Default ``nullptr``. The engine sets this to whatever the
+     * caller previously passed to ``GraphEngine::set_store(...)``;
+     * if no Store is configured, ``in.ctx.store`` stays ``nullptr``
+     * and node bodies should guard accordingly.
+     *
+     * Before this field existed, the only way for a node body to
+     * reach the Store was to capture a ``shared_ptr<Store>`` in the
+     * ``NodeFactory`` registration closure. That pattern still
+     * works and is left undisturbed during the deprecation window —
+     * use whichever shape fits your code best:
+     *
+     * @code
+     * // New shape (post-#27):
+     * asio::awaitable<NodeOutput> run(NodeInput in) override {
+     *     if (in.ctx.store) {
+     *         auto v = in.ctx.store->get(ns, "user.fact");
+     *     }
+     *     ...
+     * }
+     *
+     * // Legacy factory-closure shape — still supported:
+     * NodeFactory::instance().register_type("my_node",
+     *     [store](const std::string& name, const json&, const NodeContext&) {
+     *         return std::make_unique<MyNode>(name, store);  // ← capture
+     *     });
+     * @endcode
+     */
+    std::shared_ptr<Store> store;
 };
 
 /**

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -421,6 +421,7 @@ GraphEngine::execute_graph_async(const RunConfig& config,
     ctx.cancel_token = config.cancel_token;
     ctx.thread_id    = config.thread_id;
     ctx.stream_mode  = stream_mode;
+    ctx.store        = store_;   // issue #27 — node bodies reach Store via in.ctx.store
     // ctx.deadline / ctx.trace_id stay default-constructed for now —
     // RunConfig has no source field for either. Future PRs add them.
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(neograph_tests
     test_async_http_stream.cpp
     test_async_http_options.cpp
     test_provider_async_default.cpp
+    test_run_context_store.cpp
     test_openai_provider_async.cpp
     test_checkpoint_async_default.cpp
     test_node_async_default.cpp

--- a/tests/test_run_context_store.cpp
+++ b/tests/test_run_context_store.cpp
@@ -1,0 +1,170 @@
+// Issue #27 — RunContext::store plumbing.
+//
+// The engine populates ctx.store from GraphEngine::set_store(...) at
+// the top of every run, so node bodies can reach the Store through
+// in.ctx.store without the factory-closure capture workaround.
+//
+// Validates: (a) ctx.store is the same shared_ptr the engine was
+// configured with, (b) reads inside a running node see whatever the
+// caller put into the Store before run(), (c) ctx.store is nullptr
+// when no Store is configured (back-compat).
+
+#include <gtest/gtest.h>
+
+#include <neograph/neograph.h>
+#include <neograph/graph/store.h>
+
+#include <asio/awaitable.hpp>
+#include <atomic>
+#include <memory>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+// Records what it saw on ctx.store during execute. Test asserts on
+// the recorded values after run() returns.
+struct StoreProbe {
+    std::atomic<bool> ctx_store_was_null{true};
+    std::atomic<bool> read_succeeded{false};
+    std::string       read_value;
+    std::mutex        mu;
+};
+
+class ProbeNode : public GraphNode {
+public:
+    ProbeNode(std::string n, std::shared_ptr<StoreProbe> probe,
+              std::string ns, std::string key)
+        : n_(std::move(n)), probe_(std::move(probe)),
+          ns_{std::move(ns)}, key_(std::move(key)) {}
+
+    // Use the v0.4 unified run() entry so we receive NodeInput
+    // (which carries RunContext via in.ctx).
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        probe_->ctx_store_was_null.store(in.ctx.store == nullptr,
+                                         std::memory_order_release);
+        if (in.ctx.store) {
+            auto v = in.ctx.store->get(ns_, key_);
+            if (v) {
+                std::lock_guard<std::mutex> lk(probe_->mu);
+                probe_->read_value = v->value.is_string()
+                    ? v->value.get<std::string>()
+                    : v->value.dump();
+                probe_->read_succeeded.store(true, std::memory_order_release);
+            }
+        }
+        NodeOutput out;
+        out.writes.push_back({"hits", json(1)});
+        co_return out;
+    }
+
+    std::string get_name() const override { return n_; }
+
+private:
+    std::string n_;
+    std::shared_ptr<StoreProbe> probe_;
+    Namespace   ns_;
+    std::string key_;
+};
+
+json make_def() {
+    return {
+        {"name", "probe_graph"},
+        {"channels", {{"hits", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"probe", {{"type", "probe"}}}}},
+        {"edges", {
+            {{"from", "__start__"}, {"to", "probe"}},
+            {{"from", "probe"},     {"to", "__end__"}},
+        }},
+    };
+}
+
+}  // namespace
+
+TEST(RunContextStore, NullByDefaultWhenEngineHasNoStore) {
+    auto probe = std::make_shared<StoreProbe>();
+    NodeFactory::instance().register_type("probe",
+        [probe](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<ProbeNode>(name, probe, "users", "alice");
+        });
+
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(make_def(), ctx);
+    // No set_store call.
+
+    RunConfig cfg;
+    cfg.input = {{"hits", 0}};
+    engine->run(cfg);
+
+    EXPECT_TRUE(probe->ctx_store_was_null.load());
+    EXPECT_FALSE(probe->read_succeeded.load());
+}
+
+TEST(RunContextStore, PopulatedFromEngineSetStore) {
+    auto probe = std::make_shared<StoreProbe>();
+    auto store = std::make_shared<InMemoryStore>();
+    store->put(Namespace{"users"}, "alice",
+        json{{"role", "admin"}, {"city", "Seoul"}});
+
+    NodeFactory::instance().register_type("probe",
+        [probe](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<ProbeNode>(name, probe, "users", "alice");
+        });
+
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(make_def(), ctx);
+    engine->set_store(store);
+
+    RunConfig cfg;
+    cfg.input = {{"hits", 0}};
+    engine->run(cfg);
+
+    EXPECT_FALSE(probe->ctx_store_was_null.load());
+    EXPECT_TRUE(probe->read_succeeded.load());
+    EXPECT_NE(probe->read_value.find("Seoul"), std::string::npos);
+}
+
+TEST(RunContextStore, MultipleRunsSeeSameStore) {
+    // Repeat the populated case three times — same engine, same Store
+    // configured. Reading through ctx.store across runs should be
+    // stable.
+    //
+    // GraphEngine::compile() resolves the node factory once and reuses
+    // the same node instance across runs, so the probe captured by the
+    // factory closure is shared. We reset its flags between iterations
+    // and assert per-iteration that the most-recent run populated them
+    // again — that proves ctx.store is repopulated every dispatch.
+    auto store = std::make_shared<InMemoryStore>();
+    store->put(Namespace{"k"}, "v", json("stable"));
+
+    auto probe = std::make_shared<StoreProbe>();
+    NodeFactory::instance().register_type("probe",
+        [probe](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<ProbeNode>(name, probe, "k", "v");
+        });
+
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(make_def(), ctx);
+    engine->set_store(store);
+
+    for (int i = 0; i < 3; ++i) {
+        // Reset probe state so the assertion at the end of this
+        // iteration is about THIS run, not a stale value from i-1.
+        probe->ctx_store_was_null.store(true, std::memory_order_release);
+        probe->read_succeeded.store(false, std::memory_order_release);
+        {
+            std::lock_guard<std::mutex> lk(probe->mu);
+            probe->read_value.clear();
+        }
+
+        RunConfig cfg;
+        cfg.input = {{"hits", 0}};
+        engine->run(cfg);
+
+        EXPECT_FALSE(probe->ctx_store_was_null.load()) << "iter " << i;
+        EXPECT_TRUE(probe->read_succeeded.load()) << "iter " << i;
+        std::lock_guard<std::mutex> lk(probe->mu);
+        EXPECT_EQ(probe->read_value, "stable") << "iter " << i;
+    }
+}


### PR DESCRIPTION
## 한 줄 요약

`RunContext` 에 `store` 필드를 더해서 노드 본문이 `in.ctx.store->get(...)` 한 줄로 Store 에 닿게 했습니다. 이미 같은 자리에 흐르는 `cancel_token` 과 똑같은 모양 — 더하기만 하는 변경이라 기존 코드 안 깨집니다.

## 배경

PR #21 에서 발견한 비대칭 (이슈 #27):
- `RunContext` 는 이미 `cancel_token`, `deadline`, `trace_id`, `thread_id`, `stream_mode` 를 노드 본문까지 흘려보냄 (`NodeInput::ctx`)
- 그런데 cross-thread `Store` 는 노드 안에서 닿을 길이 없어서 — `engine.set_store(...)` 로 엔진에 박아놔도 노드 안에서는 못 씀
- 유일한 해법은 `NodeFactory` 등록 람다에서 `shared_ptr<Store>` 를 잡아두는 것 → 매번 같은 보일러플레이트
- 새 예제 43 (`store_personalization`) 이 이 보일러플레이트를 그대로 보여줘야 했음

## 결정

`cancel_token` 모양을 그대로 따라감 — `RunContext::store` 필드 추가. 엔진이 매 run 시작에서 `set_store(...)` 의 값을 채워줌. 노드는 `in.ctx.store->get(...)` 한 줄로 끝.

기존 람다 캡처 패턴은 그대로 동작 — deprecation 없음, 사용자가 원할 때 옮기면 됨.

## 변경 내용

### 1. `include/neograph/graph/engine.h`
- `RunContext::store` 필드 (`shared_ptr<Store>`) + `@brief` 블록
  - 언제 채워지는지 / 언제 nullptr 인지 / 기존 람다 캡처 패턴과 어떻게 공존하는지
  - 두 패턴 코드 예제 나란히 넣음 (마이그레이션 가이드)

### 2. `src/core/graph_engine.cpp`
- `execute_graph_async` 의 `RunContext` 생성 부분에 한 줄: `ctx.store = store_;`
- 단일 생성 지점 — fresh run 과 resume 경로 모두 여기 거침

### 3. `tests/test_run_context_store.cpp` (신규, +3 ctest)
- `NullByDefaultWhenEngineHasNoStore` — `set_store` 안 부르면 `ctx.store` 가 nullptr (기존 동작 유지)
- `PopulatedFromEngineSetStore` — 노드 본문이 엔진에 박아둔 값 읽음 (왕복 검증)
- `MultipleRunsSeeSameStore` — 매 dispatch 마다 다시 채워짐 (3회 연속 실행, probe 리셋해서 stale 감지)

### 4. `examples/43_store_personalization.cpp`
- 파일 머리 주석에 두 길 명시: `in.ctx.store` (권장) + 람다 캡처 (legacy/동작)
- 본문은 그대로 — 예제 09 (Store-in-main-only) 와의 대비를 유지하기 위해

## 검증

- **472/472 ctest green** (이전 469 + 새 3개)
- 기존 예제/테스트 동작 변화 0 — 헤더 필드는 기본 nullptr, 엔진 할당은 더하기만
- 마이그레이션은 선택 사항 — 람다 캡처는 계속 동작

## 별도 작업 (이 PR 범위 밖)

- **`RunConfig::store` override** (이슈 옵션 B) — multi-tenant 에서 같은 엔진 인스턴스로 thread_id 마다 다른 Store 라우팅. 필요 생기면 이 PR 계약 안 건드리고 그 위에 얹을 수 있음
- **Python 바인딩 미러** (`ctx.store` 노출) — 별도 PR
- 예제 43 본문도 새 패턴으로 바꾸기 — 본문 단순화는 좋지만 예제 09 와의 대비 약해짐. 리뷰어가 정합성 우선이면 같은 PR 에서 가능

## 테스트 방법

- [x] `cmake --build build --target neograph_tests` — clean 빌드
- [x] `ctest -R RunContextStore` — 3/3 green
- [x] `ctest` 풀 — 472/472 green
- [x] 예제 43 회귀 확인 — rc=0
- [ ] CI: 표준 build + test job 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)