### PR TITLE
dx: 5-항목 폴리시 배치 — 친절한 에러, ODR 가드, 입문 예제, 함정 5선, v1.0 마이그레이션 가이드

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -894,6 +894,12 @@ if(NEOGRAPH_BUILD_EXAMPLES)
         add_executable(example_async_tool examples/50_async_tool.cpp)
         target_link_libraries(example_async_tool PRIVATE neograph::core)
 
+        # Example 51: 가장 작은 동작하는 NeoGraph 프로그램. LLM·tool·mock
+        # provider 다 없는, 노드 1개짜리 5분 입문용. README 의 "first program"
+        # 자리에 인용되는 코드.
+        add_executable(example_minimal examples/51_minimal.cpp)
+        target_link_libraries(example_minimal PRIVATE neograph::core)
+
         # Clay + Raylib chatbot (optional — requires Raylib)
         option(NEOGRAPH_BUILD_CLAY_EXAMPLE "Build Clay chatbot example (fetches Raylib)" OFF)
         if(NEOGRAPH_BUILD_CLAY_EXAMPLE)

--- a/README.md
+++ b/README.md
@@ -138,6 +138,35 @@ cookbook](examples/cookbook/ai-assembly/) for a 600-line demo built
 this way (4 personas, A2A multi-process, OpenAI-backed) — including
 a friction journal of what a fresh user trips over.
 
+### 흔한 함정 5선 — 신참이 첫 30분에 부딪치는 것들
+
+NeoGraph 처음 쓰는 사람이 가장 자주 막히는 5 가지. 미리 한 번 훑어두면 디버깅 30분 절약됩니다.
+
+1. **결과는 `result.channel<T>("name")` 으로 꺼내세요** ([example 51](examples/51_minimal.cpp))
+   `result.output["counter"]` 식 직접 접근은 `react_graph` 같은 일부 빌더에서만 통합니다. raw `GraphEngine::compile` 그래프는 `output["channels"]["counter"]["value"]` 한 겹 더 들어간 모양이라 직접 접근하면 깨집니다. 도우미 함수 `result.channel<T>("counter")` 는 두 모양 모두 처리.
+
+2. **노드 안에서 `Store` 는 `in.ctx.store` 로** ([example 43](examples/43_store_personalization.cpp))
+   `engine->set_store(...)` 로 `Store` 박으면 v0.7+ 부터는 노드 본문에서 `in.ctx.store->get(ns, key)` 한 줄로 닿습니다. 옛 패턴 (`NodeFactory` 람다에서 `shared_ptr<Store>` 캡처) 도 계속 동작하지만 새 코드는 `in.ctx.store` 가 깔끔.
+
+3. **`neograph::graph::` 서브네임스페이스** — `GraphEngine`, `GraphNode`, `RunConfig`, `RunResult` 는 모두 `neograph::graph::` 안에 있습니다. 매번 풀 경로로 쓰기 싫으면 파일 위에 `using namespace neograph::graph;` 한 줄. `Provider`, `Tool`, `json` 같은 것들은 `neograph::` 바로 아래.
+
+4. **`<httplib.h>` 직접 쓰는 TU 는 `CPPHTTPLIB_OPENSSL_SUPPORT` 정의 필수** ([issue #16](https://github.com/fox1245/NeoGraph/issues/16))
+   여러분 코드에서 `httplib::Server` 같은 걸 직접 쓴다면, `<httplib.h>` 를 include 하기 전에 반드시 매크로를 정의하세요. 안 하면 NeoGraph 의 cpp-httplib 와 ABI 가 안 맞아서 (One Definition Rule 위반) 런타임에 `getaddrinfo` 안에서 SEGV. v0.8+ 부터는 컴파일 타임에 자동 검출됩니다 (`<neograph/api.h>` 의 `#error` 가드).
+
+   ```cpp
+   #define CPPHTTPLIB_OPENSSL_SUPPORT   // ← 반드시 먼저
+   #include <httplib.h>
+   ```
+
+   또는 CMake 측에서:
+   ```cmake
+   target_compile_definitions(your_target PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)
+   ```
+
+5. **GCC 13 코루틴 ICE** — Ubuntu 24.04 기본 GCC 13.3 에서 `co_await x.foo_async(...)` 형태가 `internal compiler error: in build_special_member_call, at cp/call.cc:11096` 으로 죽습니다. 컴파일러 버그라 코드는 멀쩡. 회피: GCC 14 업그레이드, 또는 `co_spawn` 대신 `neograph::async::run_sync(awaitable)` 로 sync-bridge. 자세한 안내는 [troubleshooting.md "Build errors"](docs/troubleshooting.md).
+
+각 항목의 더 깊은 내용은 [troubleshooting.md](docs/troubleshooting.md) 와 링크된 예제 / 이슈에 있습니다.
+
 ### A minimal LLM-only chatbot (no tools, no streaming)
 
 The shortest C++ that runs a real OpenAI multi-turn chatbot —

--- a/docs/migration-v0.4-to-v1.0.md
+++ b/docs/migration-v0.4-to-v1.0.md
@@ -1,0 +1,290 @@
+# Migration: 옛 8-virtual chain → 새 `run(NodeInput)` (v0.4 → v1.0)
+
+NeoGraph v0.4 가 노드의 dispatch 진입점을 `run(NodeInput) ->
+awaitable<NodeOutput>` 하나로 통합했습니다. 옛 8개 virtual
+(`execute` / `execute_async` / `execute_stream` /
+`execute_stream_async` 와 그 `_full` 짝꿍) 은 `[[deprecated]]` 마킹돼
+있고 v1.0 에서 삭제됩니다. 이 문서가 옮기는 절차.
+
+> v0.4 ~ v0.x 동안에는 옛 virtual 들이 그대로 동작합니다 — 한 번에
+> 다 옮길 필요 없고, 새 노드만 새 모양으로 짜도 무방. 이 문서는
+> v1.0 직전 (또는 v0.x 사이클에서 컴파일러 경고가 거슬리기 시작할
+> 때) 보면 됩니다.
+
+## 왜 옮기나
+
+옛 모양 — `(sync/async) × (writes/full) × (stream/non-stream)` =
+8 virtual cross-product. 어느 하나만 override 하면 다른 7 개에서
+default 가 fallback chain 을 타고 호출됨. 안전한 조합도 있고
+런타임 함정 (예: sync `execute_full` + async dispatch → nested
+`run_sync` race) 도 있어서 사용자가 어느 함수를 override 해야 하는지
+명확하지 않음.
+
+새 모양 — `run(NodeInput) -> awaitable<NodeOutput>` 한 개. 하나만
+override. sync vs async 는 호출자 안 신경 씀 (사용자가 코루틴 안에
+`co_await` 으로 async 호출하든, 그냥 동기 코드 쓰든 자유). Command /
+Send 는 `NodeOutput` 에 들어 있어서 추가 virtual 필요 없음. 스트리밍
+콜백은 `NodeInput::stream_cb` (포인터, null 가능) 로 들어옴.
+
+## 8 virtual → 새 `run()` 매핑표
+
+| 옛 virtual | 옮긴 모양 |
+|---|---|
+| `execute(state)` | `co_return NodeOutput{ .writes = {...} };` (sync 본문) |
+| `execute_async(state)` | `co_return co_await provider->complete_async(...);` 같은 native async |
+| `execute_stream(state, cb)` | `if (in.stream_cb) (*in.stream_cb)(event); co_return NodeOutput{...};` |
+| `execute_stream_async(state, cb)` | 위 + native async (`co_await ...`) |
+| `execute_full(state)` | `NodeOutput out; out.writes=...; out.command=...; co_return out;` |
+| `execute_full_async(state)` | 위 + native async |
+| `execute_full_stream(state, cb)` | `execute_full` + `in.stream_cb` 사용 |
+| `execute_full_stream_async(state, cb)` | 위 + native async |
+
+핵심: **8 갈래가 `NodeOutput` 의 어느 필드를 채우느냐 + `in.stream_cb`
+사용 유무 + `co_await` 사용 유무 의 조합**으로 표현 가능. virtual 은 1개.
+
+## 케이스별 변환 예제
+
+### 케이스 1 — 가장 단순한 sync 노드
+
+**옛:**
+```cpp
+class MyNode : public GraphNode {
+public:
+    std::vector<ChannelWrite> execute(const GraphState& state) override {
+        int n = state.get("counter").get<int>();
+        return {ChannelWrite{"counter", json(n + 1)}};
+    }
+    std::string get_name() const override { return "my_node"; }
+};
+```
+
+**새:**
+```cpp
+class MyNode : public GraphNode {
+public:
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        int n = in.state.get("counter").get<int>();
+        NodeOutput out;
+        out.writes.push_back({"counter", json(n + 1)});
+        co_return out;
+    }
+    std::string get_name() const override { return "my_node"; }
+};
+```
+
+차이:
+- `state` → `in.state`
+- 반환값을 `NodeOutput` 에 담음 (`writes` 필드)
+- 함수가 `asio::awaitable<NodeOutput>` 이고 마지막에 `co_return`
+
+### 케이스 2 — async LLM 노드 (`execute_async` 옮기기)
+
+**옛:**
+```cpp
+class TalkNode : public GraphNode {
+    std::shared_ptr<Provider> prov_;
+public:
+    asio::awaitable<std::vector<ChannelWrite>>
+    execute_async(const GraphState& state) override {
+        auto reply = co_await prov_->complete_async({
+            .messages = state.get_messages(),
+            .model    = "gpt-mock",
+        });
+        co_return std::vector<ChannelWrite>{
+            {"reply", json(reply.message.content)}
+        };
+    }
+    std::string get_name() const override { return "talk"; }
+};
+```
+
+**새:**
+```cpp
+class TalkNode : public GraphNode {
+    std::shared_ptr<Provider> prov_;
+public:
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto reply = co_await prov_->complete_async({
+            .messages = in.state.get_messages(),
+            .model    = "gpt-mock",
+        });
+        NodeOutput out;
+        out.writes.push_back({"reply", json(reply.message.content)});
+        co_return out;
+    }
+    std::string get_name() const override { return "talk"; }
+};
+```
+
+### 케이스 3 — 스트리밍 노드 (`execute_stream` 옮기기)
+
+**옛:**
+```cpp
+std::vector<ChannelWrite>
+execute_stream(const GraphState& state, const GraphStreamCallback& cb) override {
+    auto reply = prov_->complete_stream(params, [&](const std::string& chunk) {
+        cb({GraphEvent::Type::LLM_TOKEN, "talk", json(chunk)});
+    });
+    return {ChannelWrite{"reply", json(reply.message.content)}};
+}
+```
+
+**새:**
+```cpp
+asio::awaitable<NodeOutput> run(NodeInput in) override {
+    // in.stream_cb 는 포인터 — null 이면 호출자가 streaming 안 원함.
+    auto on_chunk = [&](const std::string& chunk) {
+        if (in.stream_cb) {
+            (*in.stream_cb)({GraphEvent::Type::LLM_TOKEN, "talk", json(chunk)});
+        }
+    };
+    auto reply = prov_->complete_stream(params, on_chunk);
+    NodeOutput out;
+    out.writes.push_back({"reply", json(reply.message.content)});
+    co_return out;
+}
+```
+
+### 케이스 4 — Command / Send 쓰는 노드 (`execute_full` 옮기기)
+
+**옛:**
+```cpp
+NodeResult execute_full(const GraphState& state) override {
+    NodeResult r;
+    r.writes.push_back({"step", json("dispatched")});
+    r.command = Command{.goto_node = "next_router"};   // 라우팅 강제
+    return r;
+}
+```
+
+**새:**
+```cpp
+asio::awaitable<NodeOutput> run(NodeInput in) override {
+    NodeOutput out;   // NodeOutput == NodeResult — 같은 타입의 alias
+    out.writes.push_back({"step", json("dispatched")});
+    out.command = Command{.goto_node = "next_router"};
+    co_return out;
+}
+```
+
+`NodeOutput` 은 `NodeResult` 의 별명 — 옛 코드의 `NodeResult` 도
+그대로 컴파일됩니다.
+
+## 자주 하는 실수
+
+### `NodeInput in` 은 by-value
+
+```cpp
+// ❌ 잘못 — 코루틴 ref-param UAF, pybind async path 에서 SEGV
+asio::awaitable<NodeOutput> run(const NodeInput& in) override { ... }
+
+// ✅ 맞음
+asio::awaitable<NodeOutput> run(NodeInput in) override { ... }
+```
+
+이유: 코루틴 frame 이 인자 사본을 가져야 안전. 참조로 받으면
+호출자 stack frame 이 사라진 뒤 `in.state` 가 dangling. PR 2 작업
+중 실제로 발생한 버그.
+
+### cancel / store / stream_cb 는 모두 `in.ctx` 에서
+
+옛 노드는 cancel token 을 `state.run_cancel_token_` 같은 smuggling
+채널로 받았는데, v0.4 부터는 `RunContext` 가 정식 plumbing:
+
+```cpp
+asio::awaitable<NodeOutput> run(NodeInput in) override {
+    // 취소 신호 확인
+    if (in.ctx.cancel_token && in.ctx.cancel_token->is_cancelled()) {
+        throw CancelledException("user cancelled");
+    }
+
+    // Store 접근 (issue #27)
+    if (in.ctx.store) {
+        auto user_pref = in.ctx.store->get({"users", in.ctx.thread_id}, "lang");
+        // ...
+    }
+
+    // Streaming sink (null 가능)
+    if (in.stream_cb) {
+        (*in.stream_cb)({GraphEvent::Type::NODE_END, "my_node", json(...)});
+    }
+
+    co_return NodeOutput{};
+}
+```
+
+`in.ctx` 의 다른 필드: `deadline`, `trace_id`, `thread_id`, `step`,
+`stream_mode` — 노드가 자기 컨텍스트를 알고 행동을 바꿀 때 활용.
+
+### `_full` virtual 옮기는 사람 — `co_return out;` 한 줄로 끝
+
+옛 `execute_full` 사용자가 가장 자주 헤매는 부분:
+"`NodeResult` 는 옛 타입인데 `NodeOutput` 을 반환해야 하나?"
+→ 둘은 같은 타입의 별명입니다. `NodeOutput out; out.writes=...;
+out.command=...; out.sends=...; co_return out;` 만 하면 됨.
+
+### 옛 virtual 도 같이 두는 transitional 패턴
+
+마이그레이션 중간에 새 `run()` 도 박고 옛 `execute()` 도 그대로
+두면, **새 `run()` 이 우선**되어서 호출됩니다 (engine 의 PR 2
+dispatch). 옛 본문은 dead code — 안전하게 지우면 됩니다.
+
+```cpp
+class MyNode : public GraphNode {
+public:
+    // 새 진입점 — 우선됨
+    asio::awaitable<NodeOutput> run(NodeInput in) override { ... }
+
+    // 옛 진입점 — 호출 안 됨 (dead). 지워도 됨.
+    std::vector<ChannelWrite> execute(const GraphState&) override {
+        // ...
+    }
+};
+```
+
+## 마이그레이션 안 하면
+
+v0.4 ~ v0.x 동안:
+- 옛 virtual override 는 그대로 동작
+- `[[deprecated]]` 컴파일러 경고가 뜸 (`-Wdeprecated-declarations`)
+- 컴파일 / 런타임 모두 멀쩡 — 그냥 시끄러울 뿐
+
+v1.0 에서:
+- 옛 8 virtual 전부 삭제
+- 옛 모양 노드는 컴파일 안 됨 (`'execute' marked override but doesn't
+  override anything in the base class`)
+- 그 시점에 옮겨야 함
+
+선제 마이그레이션 추천 — 노드 개수가 많을수록 v1.0 직후 한꺼번에
+옮기는 게 부담. 새 노드부터 새 모양으로 짜고, 옛 노드는 시간 날 때
+하나씩.
+
+## 일괄 옮기는 스크립트가 있나?
+
+없습니다 — virtual 시그니처가 8 가지로 다양해서 정규식 변환이 깔끔하지
+않습니다. 케이스별 변환 (위 4 가지 예제) 을 사용자가 보고 손으로
+옮기는 게 안전.
+
+가장 자주 쓰이는 패턴 (`execute(state)` 만 override) 의 경우 다음
+정도의 sed/awk 한 줄이면 1차 변환 가능 — 검토는 사람이 해야 합니다:
+
+```bash
+# 매우 거친 1차 변환 — 한 줄짜리 execute 만 override 하는 노드 한정.
+# 절대 -i 없이 dry-run 부터.
+grep -lE 'execute\(const GraphState' src/**/*.cpp
+# 결과 파일 하나씩 열어서 새 모양으로 손편집.
+```
+
+복잡한 노드 (`execute_full`, `execute_stream_async` 등) 는 무조건
+손편집. 쇼트컷 없습니다.
+
+## 관련 문서 / 이슈
+
+- [`include/neograph/graph/node.h`](../include/neograph/graph/node.h) —
+  새 `run(NodeInput)` virtual 의 인라인 docstring (예제 포함)
+- [ROADMAP_v1.md](../ROADMAP_v1.md) — Candidate 1 (GraphNode 8-virtual
+  flattening) 의 상세 설계 메모
+- [troubleshooting.md](troubleshooting.md) — 실제 옮기다 부딪치는
+  컴파일 에러 / 런타임 차이 정리
+- [Issue #5](https://github.com/fox1245/NeoGraph/issues/5) — 같은 패턴
+  을 `Provider` 에도 적용하는 v1.0 Candidate 6 추적용

--- a/examples/51_minimal.cpp
+++ b/examples/51_minimal.cpp
@@ -1,0 +1,61 @@
+// NeoGraph Example 51: 가장 작은 동작하는 프로그램
+//
+// LLM 없음, mock provider 없음, tool 없음, API key 없음 — 노드 하나가
+// 채널 하나의 값을 변환하고 끝나는 그래프. NeoGraph 가 어떤 모양으로
+// 돌아가는지 5분 안에 이해하고 싶은 사람에게.
+//
+// 흐름:
+//   1) 그래프를 JSON 으로 기술 — 채널 1개 + 노드 1개 + 엣지
+//   2) 노드 타입을 등록
+//   3) compile → run → 결과를 result.channel<T>(name) 으로 꺼냄
+//
+// 실행: ./example_minimal     출력: "HELLO"
+
+#include <neograph/neograph.h>
+
+#include <cctype>
+#include <iostream>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+// 노드 한 개. 채널 "text" 를 읽어서 대문자로 바꿔 다시 같은 채널에 씀.
+class UpperNode : public GraphNode {
+public:
+    std::vector<ChannelWrite> execute(const GraphState& state) override {
+        std::string s = state.get("text").get<std::string>();
+        for (auto& c : s) c = static_cast<char>(std::toupper(c));
+        return {ChannelWrite{"text", json(s)}};
+    }
+    std::string get_name() const override { return "upper"; }
+};
+
+int main() {
+    // (2) JSON 노드 type → 실제 GraphNode 만드는 함수 등록.
+    NodeFactory::instance().register_type("upper",
+        [](const std::string&, const json&, const NodeContext&) {
+            return std::make_unique<UpperNode>();
+        });
+
+    // (1) 그래프 정의 — 채널 1, 노드 1, 엣지 2 (start→upper→end).
+    json def = {
+        {"name", "minimal"},
+        {"channels", {{"text", {{"reducer", "overwrite"}}}}},
+        {"nodes",    {{"upper", {{"type", "upper"}}}}},
+        {"edges", {
+            {{"from", "__start__"}, {"to", "upper"}},
+            {{"from", "upper"},     {"to", "__end__"}},
+        }},
+    };
+
+    // (3) 컴파일 → 실행 → 결과 꺼냄.
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(def, ctx);
+
+    RunConfig cfg;
+    cfg.input = {{"text", "hello"}};
+    auto result = engine->run(cfg);
+
+    std::cout << result.channel<std::string>("text") << "\n";   // → HELLO
+    return 0;
+}

--- a/include/neograph/api.h
+++ b/include/neograph/api.h
@@ -79,3 +79,40 @@
     #define NEOGRAPH_PUSH_IGNORE_DEPRECATED
     #define NEOGRAPH_POP_IGNORE_DEPRECATED
 #endif
+
+// =========================================================================
+// Issue #16 — silent ODR-trap detection for cpp-httplib + OpenSSL.
+//
+// NeoGraph's bundled cpp-httplib is built with `CPPHTTPLIB_OPENSSL_SUPPORT`
+// defined (TLS ON). cpp-httplib's `ClientImpl` class adds extra members
+// when this macro is set, so a downstream TU that includes `<httplib.h>`
+// WITHOUT the macro sees a different class layout — a One Definition Rule
+// violation. The linker keeps a single inline-function instantiation
+// arbitrarily, so callers compiled against the wrong layout read members
+// at the wrong offsets and SEGV inside the resolver
+// (`getaddrinfo` / `internal_strlen`) the first time the LLM endpoint
+// is hit.
+//
+// This guard catches the ordering case where the user's TU includes
+// `<httplib.h>` BEFORE the first NeoGraph header (the natural order in
+// many builds — system headers first, project headers second). The
+// cpp-httplib include guard `CPPHTTPLIB_HTTPLIB_H` is already defined
+// at this point, and we can compare macro state.
+//
+// Caveat: this guard does NOT fire when the user includes any NeoGraph
+// header BEFORE `<httplib.h>` — at that point cpp-httplib hasn't been
+// processed yet, its include guard isn't visible, so we have nothing to
+// check against. For that ordering, the docstring on
+// `include/neograph/llm/schema_provider.h` and
+// `docs/troubleshooting.md` "C++ consumers — httplib.h macro
+// consistency" explain the symptom and the fix.
+//
+// Disable the guard with `-DNEOGRAPH_SKIP_HTTPLIB_MACRO_GUARD=1` in
+// build flags — last-resort escape for downstream TUs that have a
+// genuine reason to mismatch (vanishingly rare; the canonical fix is
+// to define the macro consistently).
+#if defined(CPPHTTPLIB_HTTPLIB_H)                            \
+    && !defined(CPPHTTPLIB_OPENSSL_SUPPORT)                  \
+    && !defined(NEOGRAPH_SKIP_HTTPLIB_MACRO_GUARD)
+#  error "NeoGraph: <httplib.h> was included before this NeoGraph header without CPPHTTPLIB_OPENSSL_SUPPORT defined. NeoGraph's bundled cpp-httplib is built with TLS support ON; a mismatched macro state between TUs is an ODR violation that silently SEGVs inside getaddrinfo at runtime (issue #16). Fix: `#define CPPHTTPLIB_OPENSSL_SUPPORT` BEFORE `#include <httplib.h>` in this TU, OR add `target_compile_definitions(<your_target> PRIVATE CPPHTTPLIB_OPENSSL_SUPPORT)` to your CMakeLists. See docs/troubleshooting.md \"C++ consumers — httplib.h macro consistency\". Last-resort opt-out: `-DNEOGRAPH_SKIP_HTTPLIB_MACRO_GUARD=1`."
+#endif

--- a/include/neograph/graph/node.h
+++ b/include/neograph/graph/node.h
@@ -99,12 +99,15 @@ using NodeOutput = NodeResult;
 /// Centralised so the message stays consistent across every override
 /// point. v0.4.x emits ``-Wdeprecated-declarations`` warnings; v1.0
 /// removes the marked methods entirely. See ROADMAP_v1.md PR 9.
-#define NEOGRAPH_DEPRECATED_VIRTUAL                              \
-    [[deprecated(                                                \
-        "v0.4: override run(NodeInput) -> awaitable<NodeOutput> " \
-        "instead. The legacy 8-virtual chain is preserved for "   \
-        "back-compat through v0.5 and removed in v1.0. See "      \
-        "ROADMAP_v1.md.")]]
+///
+/// Migration recipe with case-by-case before/after examples:
+/// docs/migration-v0.4-to-v1.0.md
+#define NEOGRAPH_DEPRECATED_VIRTUAL                                  \
+    [[deprecated(                                                    \
+        "v0.4: override run(NodeInput) -> awaitable<NodeOutput> "    \
+        "instead. The legacy 8-virtual chain is preserved for "      \
+        "back-compat through v0.5 and removed in v1.0. "             \
+        "Migration recipe: docs/migration-v0.4-to-v1.0.md")]]
 
 /**
  * @brief Thrown by the GraphNode default-execute chain when none of

--- a/src/core/graph_loader.cpp
+++ b/src/core/graph_loader.cpp
@@ -2,8 +2,10 @@
 #include <neograph/graph/node.h>
 #include <neograph/graph/engine.h>
 #include <neograph/graph/state.h>
+#include <algorithm>
 #include <stdexcept>
 #include <fstream>
+#include <vector>
 
 namespace neograph::graph {
 
@@ -43,10 +45,34 @@ void ReducerRegistry::register_reducer(const std::string& name, ReducerFn fn) {
     registry_[name] = std::move(fn);
 }
 
+// DX helper: comma-separated sorted names from a registry map. Used by the
+// "Unknown <thing>: foo" error messages so users see what IS available
+// without having to grep the source. Defined as a template so the same
+// shape works for ReducerRegistry / ConditionRegistry / NodeFactory's
+// different value types.
+template <typename Map>
+static std::string registry_name_list(const Map& m) {
+    std::vector<std::string> names;
+    names.reserve(m.size());
+    for (const auto& kv : m) names.push_back(kv.first);
+    std::sort(names.begin(), names.end());
+    std::string out;
+    for (size_t i = 0; i < names.size(); ++i) {
+        if (i) out += ", ";
+        out += names[i];
+    }
+    return out;
+}
+
 ReducerFn ReducerRegistry::get(const std::string& name) const {
     auto it = registry_.find(name);
     if (it == registry_.end()) {
-        throw std::runtime_error("Unknown reducer: " + name);
+        throw std::runtime_error(
+            "Unknown reducer: '" + name + "'. "
+            "Available: " + registry_name_list(registry_) + ". "
+            "Register a custom reducer before compile via "
+            "ReducerRegistry::instance().register_reducer(name, fn). "
+            "See docs/troubleshooting.md \"Unknown reducer\".");
     }
     return it->second;
 }
@@ -91,7 +117,12 @@ void ConditionRegistry::register_condition(const std::string& name, ConditionFn 
 ConditionFn ConditionRegistry::get(const std::string& name) const {
     auto it = registry_.find(name);
     if (it == registry_.end()) {
-        throw std::runtime_error("Unknown condition: " + name);
+        throw std::runtime_error(
+            "Unknown condition: '" + name + "'. "
+            "Available: " + registry_name_list(registry_) + ". "
+            "Register a custom condition before compile via "
+            "ConditionRegistry::instance().register_condition(name, fn). "
+            "See docs/troubleshooting.md \"Unknown condition\".");
     }
     return it->second;
 }
@@ -195,7 +226,12 @@ std::unique_ptr<GraphNode> NodeFactory::create(
 
     auto it = registry_.find(type);
     if (it == registry_.end()) {
-        throw std::runtime_error("Unknown node type: " + type);
+        throw std::runtime_error(
+            "Unknown node type: '" + type + "' (referenced by node '" + name + "'). "
+            "Available: " + registry_name_list(registry_) + ". "
+            "Register a custom type before compile via "
+            "NodeFactory::instance().register_type(type, factory). "
+            "See docs/troubleshooting.md \"Unknown node type\".");
     }
     return it->second(name, config, ctx);
 }

--- a/src/core/graph_state.cpp
+++ b/src/core/graph_state.cpp
@@ -1,8 +1,27 @@
 #include <neograph/graph/state.h>
 #include <neograph/graph/cancel.h>
+#include <algorithm>
 #include <stdexcept>
+#include <vector>
 
 namespace neograph::graph {
+
+// DX helper: comma-separated sorted list of declared channel names. Used by
+// the "Write to unknown channel" error so the user immediately sees what
+// IS declared, instead of having to compare against the JSON definition.
+// Caller already holds the mutex.
+static std::string declared_channel_list(
+    const std::map<std::string, Channel>& channels) {
+    if (channels.empty()) return "(none — no channels declared in the graph definition)";
+    std::string out;
+    bool first = true;
+    for (const auto& kv : channels) {  // std::map iterates sorted by key
+        if (!first) out += ", ";
+        first = false;
+        out += kv.first;
+    }
+    return out;
+}
 
 void GraphState::init_channel(const std::string& name,
                                ReducerType type,
@@ -41,7 +60,12 @@ void GraphState::write(const std::string& channel, const json& value) {
     std::unique_lock lock(mutex_);
     auto it = channels_.find(channel);
     if (it == channels_.end()) {
-        throw std::runtime_error("Write to unknown channel: " + channel);
+        throw std::runtime_error(
+            "Write to unknown channel: '" + channel + "'. "
+            "Declared channels: " + declared_channel_list(channels_) + ". "
+            "Channel names are case-sensitive; add it to the graph "
+            "definition's \"channels\" block before writing. "
+            "See docs/troubleshooting.md \"Write to unknown channel\".");
     }
     auto& ch  = it->second;
     ch.value   = ch.reducer(ch.value, value);
@@ -53,7 +77,12 @@ void GraphState::apply_writes(const std::vector<ChannelWrite>& writes) {
     for (const auto& w : writes) {
         auto it = channels_.find(w.channel);
         if (it == channels_.end()) {
-            throw std::runtime_error("Write to unknown channel: " + w.channel);
+            throw std::runtime_error(
+                "Write to unknown channel: '" + w.channel + "'. "
+                "Declared channels: " + declared_channel_list(channels_) + ". "
+                "Channel names are case-sensitive; add it to the graph "
+                "definition's \"channels\" block before writing. "
+                "See docs/troubleshooting.md \"Write to unknown channel\".");
         }
         auto& ch  = it->second;
         ch.value   = ch.reducer(ch.value, w.value);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(neograph_tests
     test_provider_async_default.cpp
     test_run_context_store.cpp
     test_run_result_channel.cpp
+    test_error_messages_friendly.cpp
     test_openai_provider_async.cpp
     test_checkpoint_async_default.cpp
     test_node_async_default.cpp

--- a/tests/test_error_messages_friendly.cpp
+++ b/tests/test_error_messages_friendly.cpp
@@ -1,0 +1,125 @@
+// DX batch — error message regression tests.
+//
+// The four registry / channel "Unknown <thing>: foo" errors now carry
+// the available names + the next-action hint inline. This file locks
+// the contract so the next refactor doesn't accidentally regress the
+// message back to the bare-name shape.
+//
+// Why test the message text: the messages are surfaced to humans
+// (CMake build error output, exception what(), tracer span errors).
+// If the hint text disappears, downstream onboarding breaks but no
+// behavioural test catches it.
+
+#include <gtest/gtest.h>
+
+#include <neograph/neograph.h>
+
+#include <stdexcept>
+#include <string>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+// Tiny helper — substring-match wrapper so failure output is clearer
+// than EXPECT_TRUE(s.find(...) != npos).
+static bool contains(const std::string& haystack, const char* needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+// ── ReducerRegistry::get ──
+
+TEST(ErrorMessagesFriendly, UnknownReducerListsAvailableAndHint) {
+    try {
+        ReducerRegistry::instance().get("nonexistent_reducer_xyz");
+        FAIL() << "expected throw on unknown reducer";
+    } catch (const std::runtime_error& e) {
+        std::string msg = e.what();
+        EXPECT_TRUE(contains(msg, "'nonexistent_reducer_xyz'")) << msg;
+        EXPECT_TRUE(contains(msg, "Available:")) << msg;
+        // Built-in reducers must show up in the list.
+        EXPECT_TRUE(contains(msg, "append")) << msg;
+        EXPECT_TRUE(contains(msg, "overwrite")) << msg;
+        EXPECT_TRUE(contains(msg, "register_reducer")) << msg;
+        EXPECT_TRUE(contains(msg, "troubleshooting")) << msg;
+    }
+}
+
+// ── ConditionRegistry::get ──
+
+TEST(ErrorMessagesFriendly, UnknownConditionListsAvailableAndHint) {
+    try {
+        ConditionRegistry::instance().get("nonexistent_condition_xyz");
+        FAIL() << "expected throw on unknown condition";
+    } catch (const std::runtime_error& e) {
+        std::string msg = e.what();
+        EXPECT_TRUE(contains(msg, "'nonexistent_condition_xyz'")) << msg;
+        EXPECT_TRUE(contains(msg, "Available:")) << msg;
+        EXPECT_TRUE(contains(msg, "has_tool_calls")) << msg;
+        EXPECT_TRUE(contains(msg, "register_condition")) << msg;
+    }
+}
+
+// ── NodeFactory::create ──
+
+TEST(ErrorMessagesFriendly, UnknownNodeTypeListsAvailableAndHint) {
+    NodeContext ctx;
+    try {
+        NodeFactory::instance().create("nonexistent_type_xyz", "my_node", json::object(), ctx);
+        FAIL() << "expected throw on unknown node type";
+    } catch (const std::runtime_error& e) {
+        std::string msg = e.what();
+        EXPECT_TRUE(contains(msg, "'nonexistent_type_xyz'")) << msg;
+        EXPECT_TRUE(contains(msg, "my_node")) << msg;  // node name reference
+        EXPECT_TRUE(contains(msg, "Available:")) << msg;
+        // Built-in node types must show up.
+        EXPECT_TRUE(contains(msg, "llm_call")) << msg;
+        EXPECT_TRUE(contains(msg, "register_type")) << msg;
+    }
+}
+
+// ── GraphState::write — Write to unknown channel ──
+
+TEST(ErrorMessagesFriendly, WriteToUnknownChannelListsDeclaredAndHint) {
+    GraphState state;
+    state.init_channel("counter", ReducerType::OVERWRITE,
+                       ReducerRegistry::instance().get("overwrite"),
+                       json(0));
+    state.init_channel("messages", ReducerType::APPEND,
+                       ReducerRegistry::instance().get("append"),
+                       json::array());
+
+    try {
+        state.write("nonexistent_channel_xyz", json("anything"));
+        FAIL() << "expected throw on unknown channel";
+    } catch (const std::runtime_error& e) {
+        std::string msg = e.what();
+        EXPECT_TRUE(contains(msg, "'nonexistent_channel_xyz'")) << msg;
+        EXPECT_TRUE(contains(msg, "Declared channels:")) << msg;
+        EXPECT_TRUE(contains(msg, "counter")) << msg;
+        EXPECT_TRUE(contains(msg, "messages")) << msg;
+        EXPECT_TRUE(contains(msg, "case-sensitive")) << msg;
+    }
+}
+
+// ── apply_writes path takes the same code shape — guard separately ──
+
+TEST(ErrorMessagesFriendly, ApplyWritesUnknownChannelListsDeclaredAndHint) {
+    GraphState state;
+    state.init_channel("only_one", ReducerType::OVERWRITE,
+                       ReducerRegistry::instance().get("overwrite"),
+                       json(0));
+
+    std::vector<ChannelWrite> writes = {
+        {"only_one",   json(1)},
+        {"missing_xyz", json(2)},
+    };
+    try {
+        state.apply_writes(writes);
+        FAIL() << "expected throw on unknown channel in apply_writes";
+    } catch (const std::runtime_error& e) {
+        std::string msg = e.what();
+        EXPECT_TRUE(contains(msg, "'missing_xyz'")) << msg;
+        EXPECT_TRUE(contains(msg, "only_one")) << msg;
+        EXPECT_TRUE(contains(msg, "Declared channels:")) << msg;
+    }
+}


### PR DESCRIPTION
## 한 줄 요약

v0.8 직전 사이클의 신참 마찰면 5 가지를 한 PR 에 모음. 모두 더하기만 하는 변경 (additive) 이라 기존 사용자 코드는 안 깨집니다.

## 변경 내용

### (1) RuntimeError 4 종 메시지 친절화
`Unknown reducer/condition/node type` + `Write to unknown channel` 의 메시지에 **사용 가능한 이름 목록 + 다음 행동 + 트러블슈팅 링크** 를 본문에 박았습니다.

```
Before: "Unknown reducer: foo"
After:  "Unknown reducer: 'foo'. Available: append, overwrite.
         Register a custom reducer before compile via
         ReducerRegistry::instance().register_reducer(name, fn).
         See docs/troubleshooting.md \"Unknown reducer\"."
```

신참이 메시지만 보고도 다음 단계 알 수 있음. 5 신규 ctest (`ErrorMessagesFriendly.*`) 가 메시지 contract 잠금.

### (2) compile-time `#error` 가드 — cpp-httplib ODR (#16)
`include/neograph/api.h` 에 조건부 `#error` 블록. 사용자 TU 에서 `<httplib.h>` 가 NeoGraph 헤더보다 먼저 include 되면서 `CPPHTTPLIB_OPENSSL_SUPPORT` 가 정의 안 돼 있으면 **컴파일 타임에 명확한 메시지** 와 함께 fail. 옛 #16 이 런타임 SEGV 였던 걸 컴파일 타임에 잡습니다. opt-out: `-DNEOGRAPH_SKIP_HTTPLIB_MACRO_GUARD=1`.

3 케이스 검증 (가드 발동 / 정상 / `<httplib.h>` 안 씀) — 의도대로 동작.

### (3) `examples/51_minimal.cpp` — 가장 작은 동작 예제
LLM·tool·mock provider·API key 다 없는, 노드 1 개짜리 30 줄 입문 예제. 기존 가장 작은 예제 (02_custom_graph) 가 mock provider + 50 줄이라 처음 보는 사람한테 무거웠던 점을 보완.

### (4) README "흔한 함정 5선" 섹션
"Using NeoGraph from your CMake project" 다음 자리. 신참이 첫 30 분에 부딪치는 5 가지를 한 곳에:
1. `result.channel<T>("name")` 으로 출력 꺼내기 (#25)
2. `Store` 는 `in.ctx.store` 로 (#27)
3. `neograph::graph::` 서브네임스페이스
4. `<httplib.h>` 매크로 정의 필수 (#16)
5. Ubuntu 24.04 GCC 13 코루틴 ICE (#23)

각 항목에 fix 한 줄 + 관련 예제·이슈·문서 링크.

### (5) `docs/migration-v0.4-to-v1.0.md` — 마이그레이션 가이드
`[[deprecated]]` 마킹된 옛 8-virtual chain (`execute` / `execute_async` / 등) → 새 `run(NodeInput) -> awaitable<NodeOutput>` 으로 옮기는 케이스별 before/after 예제 4 개. 자주 하는 실수 (`NodeInput in` by-value, `ctx` 통한 cancel/store 접근, `NodeOutput == NodeResult` alias) 와 마이그레이션 안 했을 때 v1.0 에서 무엇이 일어나는지. `NEOGRAPH_DEPRECATED_VIRTUAL` 매크로 메시지에도 이 문서 링크 박음.

## 검증

- **ctest 486/486 green** (이전 481 + 5 신규)
- **10 예제 (41-50 + 51) 전부 rc=0** — 회귀 0
- ODR 가드: 발동 / 정상 / no-httplib 3 케이스 manual 검증

## 다운스트림 영향

- **에러 메시지 텍스트가 길어짐** — 정확 매칭 의존하던 사용자 코드는 부분-매칭으로 옮기면 됨. 기존 `grep "Unknown reducer:"` 패턴은 그대로 매칭됨.
- **ODR 가드**: 현재 cpp-httplib + NeoGraph 같이 쓰면서 매크로 안 정의한 다운스트림이 있다면 컴파일 fail. 하지만 그건 이미 런타임 SEGV 였으므로 컴파일 타임 fail 이 더 친절한 결과. opt-out 매크로 제공.
- 다른 변경은 모두 additive (새 예제, 새 README 섹션, 새 doc 파일).

## 테스트 방법

- [x] `ctest -R ErrorMessagesFriendly` — 5/5 green
- [x] `ctest` 풀 — 486/486 green
- [x] `example_minimal` 실행 → "HELLO" 출력
- [x] ODR 가드 3 케이스 (wrong_order / right_order / no_httplib) manual 검증
- [ ] CI: `dx:` 접두 PR — 표준 build/test 통과 확인

## 다음 사이클

이 PR 머지되면 v0.8.0 릴리스 컷 가능 — `RunResult::channel<T>` (#25 PR #30) + `RunContext::store` (#27 PR #31) + 이 PR 의 폴리시 묶어서.

🤖 Generated with [Claude Code](https://claude.com/claude-code)