### PR TITLE
fix(schema_provider): extra_fields 적용 범위 + temperature_path opt-out (closes #34, closes #35)

### DIFF
--- a/include/neograph/llm/schema_provider.h
+++ b/include/neograph/llm/schema_provider.h
@@ -42,6 +42,8 @@ namespace neograph::async { class ConnPool; class CurlH2Pool; }
 
 namespace neograph::llm {
 
+namespace test_access { class SchemaProviderTestAccess; }  // fwd-decl for friend
+
 /**
  * @brief LLM provider that adapts to any API via a JSON schema.
  *
@@ -383,6 +385,29 @@ class NEOGRAPH_API SchemaProvider : public Provider {
     static std::pair<std::string, std::string> parse_data_url(const std::string& url);
     static json substitute(const json& tmpl, const std::map<std::string, json>& vars);
     static std::string generate_tool_call_id();
+
+    // Test-only access to private internals. The helper class lives in a
+    // separate `test_access` namespace to discourage accidental use; tests
+    // that need to inspect build_body / serialize_messages output for
+    // contract verification (e.g. issue #34, #35 regression coverage)
+    // pull it in explicitly. NOT a public API surface — may change without
+    // notice between versions.
+    friend class neograph::llm::test_access::SchemaProviderTestAccess;
 };
+
+namespace test_access {
+
+/// Test-only friend of `SchemaProvider`. See the `friend class` line
+/// inside `SchemaProvider` for the rationale. Static methods only —
+/// stateless wrapper.
+class SchemaProviderTestAccess {
+  public:
+    static json build_body(const SchemaProvider& sp,
+                           const CompletionParams& params) {
+        return sp.build_body(params);
+    }
+};
+
+}  // namespace test_access
 
 } // namespace neograph::llm

--- a/src/llm/schema_provider.cpp
+++ b/src/llm/schema_provider.cpp
@@ -136,7 +136,29 @@ void SchemaProvider::parse_schema()
     req_.model_field = r.value("model_field", "model");
     req_.messages_field = r.value("messages_field", "messages");
     req_.tools_field = r.value("tools_field", "tools");
-    req_.temperature_path = r.value("temperature_path", "temperature");
+    // temperature_path: schema-side opt-out via JSON null (issue #35).
+    //
+    // Reasoning models (OpenAI gpt-5.x, o-series) treat `temperature`
+    // and `reasoning.effort` as mutually exclusive; sending both is
+    // undefined behaviour. A schema for those models needs to declare
+    // "this provider doesn't accept temperature" so build_body skips
+    // the field entirely.
+    //
+    // Convention:
+    //   - `"temperature_path": "temperature"`  → write at body.temperature
+    //   - `"temperature_path": "some.nested.path"` → json_path::set_path
+    //   - `"temperature_path": null`           → opt out (don't write at all)
+    //   - field omitted entirely               → defaults to "temperature"
+    //                                            (back-compat for existing
+    //                                             schemas)
+    //
+    // Internally an empty string is the opt-out sentinel; build_body
+    // checks `!req_.temperature_path.empty()` before writing.
+    if (r.contains("temperature_path") && r["temperature_path"].is_null()) {
+        req_.temperature_path.clear();   // opt-out
+    } else {
+        req_.temperature_path = r.value("temperature_path", "temperature");
+    }
     req_.max_tokens_path = r.value("max_tokens_path", "max_tokens");
     req_.max_tokens_required = r.value("max_tokens_required", false);
     req_.max_tokens_default = r.value("max_tokens_default", -1);
@@ -883,18 +905,45 @@ json SchemaProvider::build_body(const CompletionParams& params) const {
         }
     }
 
-    // Tools
+    // Tools — only stamp the tools field when the caller actually passed
+    // tools. Empty tools means "this call doesn't expose any to the
+    // model"; sending an empty array silently changes some providers'
+    // behaviour (especially OpenAI Responses), so omit it.
     if (!params.tools.empty()) {
         body[req_.tools_field] = serialize_tools(params.tools);
-
-        // Add tool-related extra fields (like tool_choice) only when tools present
-        for (const auto& [k, v] : req_.extra_fields.items()) {
-            body[k] = v;
-        }
     }
 
-    // Temperature
-    if (params.temperature >= 0.0f) {
+    // Schema-declared static body fields (issue #34).
+    //
+    // These are vendor-specific fields a schema author wants stamped
+    // into every request body — not just when tools are present. The
+    // pre-#34 code accidentally gated this on `params.tools.empty()`
+    // because the original use case was `tool_choice` (tool-specific).
+    // But schemas declare reasoning-grade fields here too:
+    // `reasoning: {effort: "medium"}`, `response_format`, vendor knobs.
+    // Gating on tools silently dropped all of them whenever the caller
+    // didn't pass tools — observable only by inspecting the outgoing
+    // HTTP body. Now applied unconditionally.
+    //
+    // Tool-specific keys (`tool_choice`) ARE harmless to send without
+    // tools — most providers ignore them when there's nothing to
+    // choose from. Schema authors who want a key gated on tool
+    // presence can move it to a per-call binding once that surface
+    // exists (issue #33).
+    for (const auto& [k, v] : req_.extra_fields.items()) {
+        body[k] = v;
+    }
+
+    // Temperature.
+    //
+    // Two opt-out paths combined:
+    //   - Per-call: caller passes `params.temperature < 0` (sentinel).
+    //   - Per-schema: schema declares `"temperature_path": null`, which
+    //     leaves `req_.temperature_path` empty (issue #35).
+    // Either disables the write. Reasoning-model schemas typically use
+    // the per-schema path so node code doesn't have to negate
+    // `params.temperature` at every call site.
+    if (params.temperature >= 0.0f && !req_.temperature_path.empty()) {
         json_path::set_path(body, req_.temperature_path, params.temperature);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(neograph_tests
     test_run_context_store.cpp
     test_run_result_channel.cpp
     test_error_messages_friendly.cpp
+    test_schema_provider_extra_fields_temperature.cpp
     test_openai_provider_async.cpp
     test_checkpoint_async_default.cpp
     test_node_async_default.cpp

--- a/tests/test_schema_provider_extra_fields_temperature.cpp
+++ b/tests/test_schema_provider_extra_fields_temperature.cpp
@@ -1,0 +1,238 @@
+// Issue #34 — RequestConfig::extra_fields applied unconditionally,
+//              not only when params.tools is non-empty.
+// Issue #35 — temperature_path: null in schema disables the temperature
+//              field entirely; reasoning models don't get an unwanted
+//              temperature: 0.7 stamped on every body.
+//
+// Both fixes live in src/llm/schema_provider.cpp::build_body. Tests
+// drive build_body directly via the test_access friend helper.
+
+#include <gtest/gtest.h>
+
+#include <neograph/llm/schema_provider.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+
+using neograph::CompletionParams;
+using neograph::ChatMessage;
+using neograph::json;
+using neograph::llm::SchemaProvider;
+using neograph::llm::test_access::SchemaProviderTestAccess;
+
+namespace {
+
+// Write a JSON schema to a temp file so SchemaProvider::create can
+// load it. Returns the absolute path; caller is responsible for the
+// fixture's TearDown removing the file.
+std::string write_temp_schema(const json& schema_doc) {
+    char tmpl[] = "/tmp/neograph_schema_XXXXXX.json";
+    int fd = mkstemps(tmpl, 5);
+    if (fd < 0) {
+        ADD_FAILURE() << "mkstemps failed";
+        return "";
+    }
+    std::string path = tmpl;
+    close(fd);
+    std::ofstream out(path);
+    out << schema_doc.dump();
+    out.close();
+    return path;
+}
+
+// Minimal valid OpenAI-Responses-shaped schema. Each test starts from
+// this and patches the bits it cares about (extra_fields entries,
+// temperature_path).
+json base_schema() {
+    return json{
+        {"name", "test_schema"},
+        {"connection", {
+            {"base_url", "http://localhost:9999"},
+            {"endpoint", "/v1/responses"},
+            {"auth_header", "Authorization"},
+            {"auth_prefix", "Bearer "},
+            {"api_key_env", "TEST_API_KEY"},
+        }},
+        {"request", {
+            {"model_field", "model"},
+            {"messages_field", "input"},
+            {"tools_field", "tools"},
+            {"temperature_path", "temperature"},
+            {"max_tokens_path", "max_output_tokens"},
+            {"stream_field", "stream"},
+        }},
+        {"system_prompt", {
+            {"strategy", "in_messages"},
+        }},
+        {"messages", {
+            {"role_user", "user"},
+            {"role_assistant", "assistant"},
+            {"role_system", "system"},
+        }},
+        {"tool_call", {
+            {"strategy", "tool_calls_array"},
+        }},
+        {"tool_result", {
+            {"strategy", "flat"},
+        }},
+        {"image", {
+            {"strategy", "none"},
+        }},
+        {"response", {
+            {"strategy", "choices_message"},
+            {"message_path", "choices.0.message"},
+            {"content_path", "content"},
+        }},
+        {"stream", {
+            {"format", "sse_data"},
+        }},
+    };
+}
+
+std::unique_ptr<SchemaProvider> make_provider_from(const json& schema) {
+    auto path = write_temp_schema(schema);
+    if (path.empty()) return nullptr;
+
+    SchemaProvider::Config cfg;
+    cfg.schema_path = path;
+    cfg.api_key = "test-key";
+    cfg.default_model = "gpt-test";
+
+    auto sp = SchemaProvider::create(cfg);
+    std::remove(path.c_str());
+    return sp;
+}
+
+CompletionParams basic_params() {
+    CompletionParams p;
+    p.model = "gpt-test";
+    p.messages.push_back({"user", "hello"});
+    p.temperature = 0.7f;   // default-equivalent; let the schema decide
+    return p;
+}
+
+}  // namespace
+
+// ─── #34: extra_fields applied without tools ───
+
+TEST(SchemaExtraFields, AppliedWhenToolsAbsent) {
+    auto schema = base_schema();
+    schema["request"]["extra_fields"] = json{
+        {"reasoning", {{"effort", "medium"}}},
+        {"response_format", {{"type", "json_object"}}},
+    };
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    ASSERT_TRUE(p.tools.empty());
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+
+    ASSERT_TRUE(body.contains("reasoning")) << body.dump();
+    EXPECT_EQ(body["reasoning"]["effort"].get<std::string>(), "medium");
+    ASSERT_TRUE(body.contains("response_format")) << body.dump();
+    EXPECT_EQ(body["response_format"]["type"].get<std::string>(), "json_object");
+}
+
+TEST(SchemaExtraFields, AppliedWhenToolsPresent) {
+    auto schema = base_schema();
+    schema["request"]["extra_fields"] = json{
+        {"reasoning", {{"effort", "high"}}},
+    };
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    p.tools.push_back({"my_tool", "demo", json::object()});
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+
+    ASSERT_TRUE(body.contains("reasoning")) << body.dump();
+    EXPECT_EQ(body["reasoning"]["effort"].get<std::string>(), "high");
+    EXPECT_TRUE(body.contains("tools"));   // tools also there
+}
+
+TEST(SchemaExtraFields, EmptyExtraFieldsNoOp) {
+    auto schema = base_schema();
+    // request.extra_fields omitted entirely → defaults to {}; no body keys.
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    json body = SchemaProviderTestAccess::build_body(*sp, basic_params());
+    EXPECT_FALSE(body.contains("reasoning"));
+    EXPECT_FALSE(body.contains("tools"));
+}
+
+// ─── #35: temperature_path opt-out via JSON null ───
+
+TEST(SchemaTemperatureOptOut, NullPathSkipsField) {
+    auto schema = base_schema();
+    schema["request"]["temperature_path"] = nullptr;
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    p.temperature = 0.7f;   // would normally be written
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+    EXPECT_FALSE(body.contains("temperature")) << body.dump();
+}
+
+TEST(SchemaTemperatureOptOut, OmittedFieldDefaultsToTemperatureKey) {
+    auto schema = base_schema();
+    // Rebuild request block without the temperature_path key — schema
+    // doesn't declare it. neograph::json doesn't expose erase(), so we
+    // copy field-by-field via the structured-binding range loop.
+    json req_no_temp;
+    for (const auto& [k, v] : schema["request"].items()) {
+        if (k != "temperature_path") req_no_temp[k] = v;
+    }
+    schema["request"] = req_no_temp;
+
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    p.temperature = 0.7f;
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+    ASSERT_TRUE(body.contains("temperature")) << body.dump();
+    EXPECT_NEAR(body["temperature"].get<double>(), 0.7, 1e-5);
+}
+
+TEST(SchemaTemperatureOptOut, NullPathRespectsCallerSentinelToo) {
+    // Combination case: schema opts out via null AND caller passes
+    // negative sentinel. Should still be skipped (both opt-out paths
+    // active), no surprises.
+    auto schema = base_schema();
+    schema["request"]["temperature_path"] = nullptr;
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    p.temperature = -1.0f;   // caller-side opt-out as well
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+    EXPECT_FALSE(body.contains("temperature"));
+}
+
+TEST(SchemaTemperatureOptOut, NestedTemperaturePathStillWorks) {
+    // Sanity — the opt-out path doesn't break the existing nested-path
+    // case (e.g. a future schema with `sampling.temperature` etc).
+    auto schema = base_schema();
+    schema["request"]["temperature_path"] = "sampling.temperature";
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    p.temperature = 0.5f;
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+    ASSERT_TRUE(body.contains("sampling")) << body.dump();
+    ASSERT_TRUE(body["sampling"].contains("temperature")) << body.dump();
+    EXPECT_NEAR(body["sampling"]["temperature"].get<double>(), 0.5, 1e-5);
+}


### PR DESCRIPTION
## 한 줄 요약

ProjectDatePop downstream 에서 발견된 SchemaProvider 버그 두 개 — 둘 다 `src/llm/schema_provider.cpp::build_body` 의 작은 변경. 회귀 0, 488/488 ctest green.

## #34 — `extra_fields` 가 tools 없을 때 silent drop

**증상**: schema 의 `request.extra_fields` 에 `reasoning: {effort: "medium"}` 같은 핵심 필드가 박혀 있어도, 호출자가 `params.tools` 없이 부르면 그 필드 전체가 body 에서 사라짐. 출력 HTTP body 까봐야 알 수 있는 silent drop.

**원인**: 옛 코드가 `extra_fields` 적용을 `if (!params.tools.empty())` 안에 가둬뒀음. 의도는 `tool_choice` 만 가두는 거였는데 같은 loop 가 모든 키를 가둠.

**Fix**: `extra_fields` 적용을 tools 분기 밖으로 빼서 항상 적용. tools 필드 자체만 분기 안에. tool_choice 같은 키는 tools 없을 때 대부분 provider 가 무시하므로 무해.

```cpp
// Before
if (!params.tools.empty()) {
    body[req_.tools_field] = serialize_tools(params.tools);
    for (const auto& [k, v] : req_.extra_fields.items()) {  // ← 여기 갇혀 있었음
        body[k] = v;
    }
}

// After
if (!params.tools.empty()) {
    body[req_.tools_field] = serialize_tools(params.tools);
}
for (const auto& [k, v] : req_.extra_fields.items()) {       // ← 항상 적용
    body[k] = v;
}
```

## #35 — schema 가 `temperature` 안 쓴다고 선언할 수 없음

**증상**: reasoning model (gpt-5.x, o-series) 은 `temperature` 와 `reasoning.effort` 가 서로 배타. 그런데 schema 가 "temperature 안 받음" 을 선언할 표면이 없어서 항상 `temperature: 0.7` 가 body 에 박힘. 다운스트림은 매 call site 마다 `params.temperature = -1.0f` 로 우회 (메모리 추적 어려운 hack).

**Fix**: schema 가 `"temperature_path": null` 로 명시적 opt-out 가능.

```jsonc
// schemas/openai_responses_reasoning.json (예)
"request": {
    ...
    "temperature_path": null,           // ← 새 옵션 — 아예 안 씀
    "extra_fields": {
        "reasoning": { "effort": "medium" }
    }
}
```

규칙:
- `"temperature_path": "temperature"` → 기본 동작
- `"temperature_path": "nested.path"` → 중첩 경로
- `"temperature_path": null` → **아예 안 씀 (NEW)**
- 필드 omit → `"temperature"` default (기존 호환)

## 테스트

새 7 ctest (`test_schema_provider_extra_fields_temperature.cpp`):

- `SchemaExtraFields.AppliedWhenToolsAbsent` — #34 핵심
- `SchemaExtraFields.AppliedWhenToolsPresent` — tools 있을 때도 동시 동작
- `SchemaExtraFields.EmptyExtraFieldsNoOp` — 선언 안 한 schema 는 추가 키 없음
- `SchemaTemperatureOptOut.NullPathSkipsField` — #35 핵심
- `SchemaTemperatureOptOut.OmittedFieldDefaultsToTemperatureKey` — back-compat
- `SchemaTemperatureOptOut.NullPathRespectsCallerSentinelToo` — 두 opt-out 같이 써도 OK
- `SchemaTemperatureOptOut.NestedTemperaturePathStillWorks` — sanity

`build_body` 가 private 이라 외부 검증 못함. `friend class neograph::llm::test_access::SchemaProviderTestAccess` 로 access 만 노출 — public surface 안 늘림.

## 검증

- **488/488 ctest green** (이전 481 + 7 신규)
- **ProjectDatePop 다운스트림 우회 코드 (`params.temperature = -1.0f` 박은 모든 call site) 제거 가능** — schema 측에서 한 번만 `temperature_path: null` 선언

## 다운스트림 영향

- **#34 fix**: tool 없이 SchemaProvider 쓰던 다운스트림은 이제 schema 의 `extra_fields` 가 정상 적용됨. 이전엔 silent drop 이었으니 동작 복원이지 회귀 아님.
- **#35 fix**: 새 schema 옵션 추가만 — 옛 schema 그대로 동작.

## 남은 관련 항목

- **#33** `CompletionParams::extra_fields` per-call binding — 디자인 토론 필요. 별도 PR.
- **#36** 메타 패턴 관찰 — ROADMAP_v1.md 보강 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)