### PR TITLE
feat(provider): CompletionParams::extra_fields + schema per_call_fields (closes #33)

### DIFF
--- a/include/neograph/llm/schema_provider.h
+++ b/include/neograph/llm/schema_provider.h
@@ -34,6 +34,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <string>
 #include <thread>
 #include <map>
@@ -201,6 +202,16 @@ class NEOGRAPH_API SchemaProvider : public Provider {
         int max_tokens_default = -1;
         std::string stream_field;
         json extra_fields;
+
+        /// Issue #33: which body paths a schema declares as bindable
+        /// per-call via `CompletionParams::extra_fields`. Schema:
+        ///   "request.per_call_fields": ["reasoning.effort", "thinking.budget"]
+        /// build_body iterates the caller's `params.extra_fields` map
+        /// and only stamps keys present in this set — unknown keys
+        /// are dropped (schema owns the contract). Empty set = no
+        /// per-call bindings honoured (legacy default; back-compat
+        /// for schemas that don't declare the key).
+        std::set<std::string> per_call_fields;
     };
 
     struct SystemPromptConfig {

--- a/include/neograph/provider.h
+++ b/include/neograph/provider.h
@@ -75,6 +75,44 @@ struct CompletionParams {
      * abort across multiple completions.
      */
     std::shared_ptr<graph::CancelToken> cancel_token;
+
+    /**
+     * @brief Per-call body field bindings (issue #33, v0.8+).
+     *
+     * Map of `path → value` overrides that the provider stamps into
+     * the outgoing request body for THIS call only. Companion to
+     * the schema-static `request.extra_fields` block that ships
+     * with every body — `extra_fields` here is the dynamic per-call
+     * side of the same hook.
+     *
+     * For ``SchemaProvider``: the schema author declares which paths
+     * are bindable per-call via `"request.per_call_fields": [...]`.
+     * Only listed paths are honoured; unknown paths are silently
+     * dropped (the schema, not the caller, owns the contract). This
+     * keeps the per-call surface declarative and matches how
+     * `temperature_path` / `max_tokens_path` already address specific
+     * paths.
+     *
+     * Native ``Provider`` subclasses (e.g. ``OpenAIProvider``) may
+     * choose to honour or ignore individual keys per their own
+     * documented surface — the field is generic, the contract is
+     * provider-defined.
+     *
+     * @code
+     * // Reasoning model — high effort for hard call, low for cheap call.
+     * CompletionParams hard;
+     * hard.extra_fields = {{"reasoning.effort", "high"}};
+     * auto deep = co_await provider->complete_async(hard);
+     *
+     * CompletionParams cheap;
+     * cheap.extra_fields = {{"reasoning.effort", "low"}};
+     * auto fast = co_await provider->complete_async(cheap);
+     * @endcode
+     *
+     * Default: empty json. Same lifecycle shape as the existing
+     * schema-static `request.extra_fields` block.
+     */
+    json extra_fields;
 };
 
 /**

--- a/src/llm/schema_provider.cpp
+++ b/src/llm/schema_provider.cpp
@@ -165,6 +165,17 @@ void SchemaProvider::parse_schema()
     req_.stream_field = r.value("stream_field", "stream");
     req_.extra_fields = r.value("extra_fields", json::object());
 
+    // Per-call body field allowlist (issue #33). Schema declares which
+    // body paths a caller can override per-call via
+    // CompletionParams::extra_fields. Built once at parse time so
+    // build_body's per-call check is an O(log n) set lookup, not a
+    // re-parse.
+    if (r.contains("per_call_fields") && r["per_call_fields"].is_array()) {
+        for (const auto& path : r["per_call_fields"]) {
+            if (path.is_string()) req_.per_call_fields.insert(path.get<std::string>());
+        }
+    }
+
     // --- System Prompt ---
     auto s = schema_["system_prompt"];
     std::string sys_strategy = s.value("strategy", "in_messages");
@@ -932,6 +943,34 @@ json SchemaProvider::build_body(const CompletionParams& params) const {
     // exists (issue #33).
     for (const auto& [k, v] : req_.extra_fields.items()) {
         body[k] = v;
+    }
+
+    // Per-call body field bindings (issue #33).
+    //
+    // The schema declares which paths a caller can override per-call
+    // via `"request.per_call_fields": [path1, path2, ...]`. Caller
+    // passes the values in `params.extra_fields` as a `path -> value`
+    // map. Build_body applies them AFTER the schema-static
+    // extra_fields above, so a per-call value wins when both bind the
+    // same key — which is what the caller wants ("I'm overriding the
+    // default for THIS call").
+    //
+    // Path is a json_path expression (dot-separated, like
+    // `temperature_path` / `max_tokens_path`), so caller can target
+    // nested structure (`reasoning.effort`, `thinking.budget_tokens`).
+    //
+    // Unknown paths (not in `req_.per_call_fields`) are silently
+    // dropped. The schema, not the caller, owns the contract — same
+    // discipline as `temperature_path` and `max_tokens_path`. This
+    // also means a typo in caller code (`reasonin.effort`) silently
+    // does nothing instead of stamping a malformed key, which is
+    // safer for production.
+    if (params.extra_fields.is_object()) {
+        for (const auto& [path, value] : params.extra_fields.items()) {
+            if (req_.per_call_fields.count(path)) {
+                json_path::set_path(body, path, value);
+            }
+        }
     }
 
     // Temperature.

--- a/tests/test_schema_provider_extra_fields_temperature.cpp
+++ b/tests/test_schema_provider_extra_fields_temperature.cpp
@@ -236,3 +236,109 @@ TEST(SchemaTemperatureOptOut, NestedTemperaturePathStillWorks) {
     ASSERT_TRUE(body["sampling"].contains("temperature")) << body.dump();
     EXPECT_NEAR(body["sampling"]["temperature"].get<double>(), 0.5, 1e-5);
 }
+
+// ─── #33: per-call extra_fields binding via schema's per_call_fields ───
+
+TEST(SchemaPerCallFields, BoundPathLandsInBody) {
+    auto schema = base_schema();
+    // Schema declares: only reasoning.effort is bindable per-call.
+    schema["request"]["per_call_fields"] = json::array({"reasoning.effort"});
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    p.extra_fields = json{{"reasoning.effort", "high"}};
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+    ASSERT_TRUE(body.contains("reasoning")) << body.dump();
+    ASSERT_TRUE(body["reasoning"].contains("effort")) << body.dump();
+    EXPECT_EQ(body["reasoning"]["effort"].get<std::string>(), "high");
+}
+
+TEST(SchemaPerCallFields, UnknownPathSilentlyDropped) {
+    // Caller passes a path the schema didn't declare — should be a no-op,
+    // not an error. Schema owns the contract; typo silently drops rather
+    // than stamping a malformed key.
+    auto schema = base_schema();
+    schema["request"]["per_call_fields"] = json::array({"reasoning.effort"});
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    p.extra_fields = json{
+        {"reasoning.effort", "low"},        // declared
+        {"reasonin.effort",  "typo"},       // typo — not in allowlist
+        {"random.knob",      "ignore me"},  // never declared
+    };
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+    EXPECT_EQ(body["reasoning"]["effort"].get<std::string>(), "low");
+    EXPECT_FALSE(body.contains("reasonin"));
+    EXPECT_FALSE(body.contains("random"));
+}
+
+TEST(SchemaPerCallFields, PerCallOverridesSchemaStatic) {
+    // Both schema-static (request.extra_fields) and per-call bind the
+    // same path. Per-call wins — caller is overriding the default for
+    // THIS call.
+    auto schema = base_schema();
+    schema["request"]["extra_fields"] = json{
+        {"reasoning", {{"effort", "medium"}}},   // static default
+    };
+    schema["request"]["per_call_fields"] = json::array({"reasoning.effort"});
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    p.extra_fields = json{{"reasoning.effort", "high"}};
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+    EXPECT_EQ(body["reasoning"]["effort"].get<std::string>(), "high");
+}
+
+TEST(SchemaPerCallFields, OmittedPerCallFieldsNoOp) {
+    // Caller passes extra_fields but schema didn't declare any per_call_fields
+    // → all caller keys silently dropped (back-compat for schemas that
+    // predate the feature).
+    auto schema = base_schema();
+    // No per_call_fields key in schema.
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    p.extra_fields = json{{"reasoning.effort", "high"}};
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+    EXPECT_FALSE(body.contains("reasoning"));
+}
+
+TEST(SchemaPerCallFields, EmptyExtraFieldsNoOpEvenWithDeclaration) {
+    // Schema declares per_call_fields but caller doesn't bind anything
+    // → no body change.
+    auto schema = base_schema();
+    schema["request"]["per_call_fields"] = json::array({"reasoning.effort"});
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    // p.extra_fields stays default-constructed (empty json).
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+    EXPECT_FALSE(body.contains("reasoning"));
+}
+
+TEST(SchemaPerCallFields, NestedPathBindsCorrectly) {
+    // Sanity — per-call binding uses the same json_path::set_path
+    // machinery, so deep paths (4+ segments) just work.
+    auto schema = base_schema();
+    schema["request"]["per_call_fields"] = json::array({"a.b.c.d"});
+    auto sp = make_provider_from(schema);
+    ASSERT_NE(sp, nullptr);
+
+    CompletionParams p = basic_params();
+    p.extra_fields = json{{"a.b.c.d", "deep"}};
+
+    json body = SchemaProviderTestAccess::build_body(*sp, p);
+    ASSERT_TRUE(body.contains("a")) << body.dump();
+    EXPECT_EQ(body["a"]["b"]["c"]["d"].get<std::string>(), "deep");
+}


### PR DESCRIPTION
## 한 줄 요약

Schema-driven Provider 가 새 body 필드를 *선언*할 표면 (`request.extra_fields`) 은 있지만 *per-call 값을 바인딩*할 표면이 없었던 갭을 닫음. Schema 가 `per_call_fields` 로 바인딩 가능한 path 를 명시하고, 호출자는 `CompletionParams::extra_fields` 로 값을 넘김.

## 디자인 — Option A (명시 허용 목록)

이슈 본문에서 본인이 추천한 옵션. `temperature_path` / `max_tokens_path` 처럼 path 기반 declarative 와 일관, 새 mini-language 안 만듦.

### 사용

**Schema 측** — 어느 path 가 per-call override 가능한지 선언:
```jsonc
"request": {
    "extra_fields": { "tool_choice": "auto" },
    "per_call_fields": ["reasoning.effort", "thinking.budget_tokens"]
}
```

**호출자 측** — `CompletionParams.extra_fields` 에 path → value 맵:
```cpp
CompletionParams hard;
hard.extra_fields = {{"reasoning.effort", "high"}};
auto deep = co_await provider->complete_async(hard);

CompletionParams cheap;
cheap.extra_fields = {{"reasoning.effort", "low"}};
auto fast = co_await provider->complete_async(cheap);
```

### 우선순위 (충돌 시)

`build_body` 가 schema-static `extra_fields` 적용 → 그 다음 per-call `extra_fields` 적용. **per-call 이 win** — "이 호출에선 default 를 덮어쓴다" 가 호출자 의도.

### 알 수 없는 path

호출자가 schema 에 선언 안 된 path (오타 등) 를 보내면 **silent drop**. Schema 가 contract 소유. 오타가 malformed 키를 body 에 박는 것보다 안전.

## 변경 내용

- **`include/neograph/provider.h`** — `CompletionParams::extra_fields` 필드 (json, default empty) + 사용 예시 docstring
- **`include/neograph/llm/schema_provider.h`** — `RequestConfig::per_call_fields` `std::set<std::string>` 필드
- **`src/llm/schema_provider.cpp`**:
  - `parse_schema`: `per_call_fields` 배열 → set 으로 한 번 빌드
  - `build_body`: `params.extra_fields` 순회 → 허용 목록에 있는 path 만 `json_path::set_path` 로 적용
- **`tests/test_schema_provider_extra_fields_temperature.cpp`** — 6 신규 ctest:
  - `BoundPathLandsInBody` — happy path
  - `UnknownPathSilentlyDropped` — 오타 / 미선언 path silent no-op
  - `PerCallOverridesSchemaStatic` — 충돌 시 per-call win
  - `OmittedPerCallFieldsNoOp` — 옛 schema (필드 미선언) back-compat
  - `EmptyExtraFieldsNoOpEvenWithDeclaration` — 빈 caller-side
  - `NestedPathBindsCorrectly` — 깊은 path 동작 sanity

## 검증

- **499/499 ctest green** (이전 493 + 6 신규)
- 헤더 변경은 additive — `extra_fields` default 빈 json, `per_call_fields` default 빈 set. 기존 `CompletionParams` 호출자 / 기존 schema: 동작 변화 0.

## 다운스트림 영향

ProjectDatePop 의 "reasoning effort 별 SchemaProvider 인스턴스 여러 개" 패턴이 **하나의 인스턴스 + per-call binding** 으로 축소 가능. Schema 패치에 `per_call_fields` 추가, 노드 코드는 call site 에서 값 넘김.

## 별도 작업 (이 PR 범위 밖)

- **Python 바인딩** 의 `params.extra_fields` 노출 — 별도 PR 필요 시
- **`OpenAIProvider` 의 native `extra_fields` 해석** — 이 PR 은 SchemaProvider 전용. Native provider 는 필드를 보지만 자체 contract 가 없으면 무시.

🤖 Generated with [Claude Code](https://claude.com/claude-code)