### PR TITLE
feat(provider): Provider::invoke() — v1.0 single-dispatch additive (ROADMAP Candidate 6 PR1)

### DIFF
--- a/include/neograph/provider.h
+++ b/include/neograph/provider.h
@@ -244,6 +244,53 @@ class NEOGRAPH_API Provider {
                           const StreamCallback& on_chunk);
 
     /**
+     * @brief Single-dispatch async-streaming completion (v1.0 canonical).
+     *
+     * The unified entry point that future v1.0+ Provider subclasses
+     * override. Replaces the current `(sync/async) × (stream/non-stream)`
+     * 4-virtual cross-product (`complete` / `complete_async` /
+     * `complete_stream` / `complete_stream_async`) with one async-
+     * streaming-superset method. ROADMAP_v1.md Candidate 6.
+     *
+     * Semantics:
+     *   - `on_chunk == nullptr` → caller wants the full assembled
+     *     completion only; provider may skip streaming framing.
+     *   - `on_chunk != nullptr` → caller wants tokens incrementally;
+     *     provider invokes `on_chunk` on each chunk AND returns the
+     *     full assembled completion when the stream ends.
+     *
+     * The returned awaitable resolves on the caller's executor; the
+     * `on_chunk` callback runs there too (single-threaded with the
+     * awaiter, same invariant `complete_stream_async` already provides).
+     *
+     * **Deprecation strategy** (Candidate 6 PR sequence):
+     *   - This PR (additive): `invoke()` lands as a new virtual; default
+     *     forwards to the legacy 4-virtual chain (`complete_stream_async`
+     *     when `on_chunk` is set, `complete_async` otherwise) so every
+     *     existing Provider subclass keeps working unchanged.
+     *   - Subsequent PR: native subclasses (`OpenAIProvider`,
+     *     `SchemaProvider`, `RateLimitedProvider`) override `invoke()`
+     *     directly; their old 4 overrides become thin adapters.
+     *   - Subsequent PR: 4 legacy virtuals get `[[deprecated]]` markers.
+     *   - v1.0.0: 4 legacy virtuals removed; `invoke()` becomes the
+     *     only Provider virtual besides `get_name()`.
+     *
+     * **Override contract**: subclasses overriding `invoke()` MUST NOT
+     * call any of the 4 legacy `complete_*` methods on themselves —
+     * those default to forwarding to `invoke()` (in a future PR), which
+     * would recurse infinitely. New code: override `invoke()` and only
+     * `invoke()`. Old code: keep overriding the 4 legacy methods; the
+     * default `invoke()` here delegates to them.
+     *
+     * @param params   Completion parameters (model, messages, tools, ...).
+     * @param on_chunk Optional per-chunk callback. `nullptr` for non-
+     *                 streaming use.
+     * @return Awaitable yielding the full assembled completion.
+     */
+    virtual asio::awaitable<ChatCompletion>
+    invoke(const CompletionParams& params, StreamCallback on_chunk = nullptr);
+
+    /**
      * @brief Get the provider name (e.g., "openai", "claude").
      *
      * **Opaque debug identifier**, not a typed dispatch key. Different

--- a/src/core/provider.cpp
+++ b/src/core/provider.cpp
@@ -128,4 +128,31 @@ Provider::complete_stream_async(const CompletionParams& params,
     co_return std::move(*shared->result);
 }
 
+// v1.0 unified invoke() — additive virtual that future-proofs the
+// Provider dispatch surface. New providers override THIS one method;
+// legacy providers (OpenAIProvider's complete_async + complete_stream_async
+// overrides, SchemaProvider's same pair, RateLimitedProvider's 4-method
+// delegation, every user-written Provider subclass) keep working
+// unchanged because the default body below forwards to the legacy
+// 4-virtual chain — preserving the current cross-product fallback.
+//
+// Subsequent Candidate 6 PRs migrate native subclasses to override
+// invoke() directly; the 4 legacy virtuals then gain [[deprecated]]
+// markers; v1.0 deletes them. See ROADMAP_v1.md Candidate 6.
+//
+// No recursion guard needed in this PR: the 4 legacy virtuals' defaults
+// don't yet route back through invoke(), so the chain terminates at
+// either complete_async (which co_returns complete()) or
+// complete_stream_async (which spawns a worker thread). When a future
+// PR flips the legacy defaults to forward INTO invoke() — closing the
+// loop — a guard analogous to ExecuteDefaultGuard (graph_node.cpp) will
+// be added then, not now.
+asio::awaitable<ChatCompletion>
+Provider::invoke(const CompletionParams& params, StreamCallback on_chunk) {
+    if (on_chunk) {
+        co_return co_await complete_stream_async(params, on_chunk);
+    }
+    co_return co_await complete_async(params);
+}
+
 } // namespace neograph

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(neograph_tests
     test_async_http_stream.cpp
     test_async_http_options.cpp
     test_provider_async_default.cpp
+    test_provider_invoke_default.cpp
     test_run_context_store.cpp
     test_run_result_channel.cpp
     test_error_messages_friendly.cpp

--- a/tests/test_provider_invoke_default.cpp
+++ b/tests/test_provider_invoke_default.cpp
@@ -1,0 +1,199 @@
+// ROADMAP_v1.md Candidate 6 — `Provider::invoke()` regression coverage.
+//
+// `invoke(params, on_chunk)` is the v1.0 canonical single-dispatch
+// entry point that replaces the 4-virtual cross-product
+// (`complete` / `complete_async` / `complete_stream` /
+// `complete_stream_async`). This first additive PR adds `invoke()`
+// with a default body that forwards to the legacy chain so existing
+// Provider subclasses keep working unchanged. These tests pin the
+// forwarding semantics and the new override surface.
+
+#include <gtest/gtest.h>
+#include <neograph/provider.h>
+#include <neograph/async/run_sync.h>
+
+#include <asio/awaitable.hpp>
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <asio/io_context.hpp>
+#include <asio/use_awaitable.hpp>
+
+#include <atomic>
+#include <string>
+#include <vector>
+
+using neograph::ChatCompletion;
+using neograph::CompletionParams;
+using neograph::Provider;
+using neograph::StreamCallback;
+using neograph::async::run_sync;
+
+namespace {
+
+ChatCompletion make_completion(const std::string& text) {
+    ChatCompletion c;
+    c.message.role = "assistant";
+    c.message.content = text;
+    return c;
+}
+
+// Legacy provider — overrides only complete_async() and complete_stream(),
+// the two pieces of the existing chain. Default invoke() must route to
+// the right one based on on_chunk presence.
+class LegacyChainProvider : public Provider {
+  public:
+    std::atomic<int> async_calls{0};
+    std::atomic<int> stream_sync_calls{0};
+
+    asio::awaitable<ChatCompletion>
+    complete_async(const CompletionParams& /*params*/) override {
+        ++async_calls;
+        co_return make_completion("legacy-async");
+    }
+
+    ChatCompletion complete_stream(const CompletionParams& /*params*/,
+                                   const StreamCallback& on_chunk) override {
+        ++stream_sync_calls;
+        if (on_chunk) on_chunk("chunk-1");
+        return make_completion("legacy-stream");
+    }
+
+    std::string get_name() const override { return "legacy-chain"; }
+};
+
+// New-style provider — overrides invoke() directly. Legacy 4 virtuals
+// are NOT overridden. Engine code that already calls the legacy methods
+// gets the base-class default, which (in this PR) forwards through the
+// chain — but if the user calls invoke() directly, the override fires.
+class InvokeNativeProvider : public Provider {
+  public:
+    std::atomic<int> invoke_calls{0};
+    std::atomic<int> chunks_emitted{0};
+
+    asio::awaitable<ChatCompletion>
+    invoke(const CompletionParams& /*params*/, StreamCallback on_chunk) override {
+        ++invoke_calls;
+        if (on_chunk) {
+            on_chunk("native-chunk-A");
+            on_chunk("native-chunk-B");
+            chunks_emitted += 2;
+        }
+        co_return make_completion("native-invoke");
+    }
+
+    // Required: get_name is the only other pure virtual on Provider.
+    std::string get_name() const override { return "invoke-native"; }
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// Default invoke() routes to the legacy chain — no on_chunk → complete_async.
+// ---------------------------------------------------------------------------
+
+TEST(ProviderInvokeDefault, NoCallbackRoutesToCompleteAsync) {
+    LegacyChainProvider p;
+    CompletionParams params;
+
+    auto result = run_sync(p.invoke(params, nullptr));
+
+    EXPECT_EQ(result.message.content, "legacy-async");
+    EXPECT_EQ(p.async_calls.load(), 1);
+    EXPECT_EQ(p.stream_sync_calls.load(), 0);
+}
+
+TEST(ProviderInvokeDefault, EmptyCallbackTreatedAsNoCallback) {
+    // StreamCallback is std::function — a default-constructed instance is
+    // falsy, so the `if (on_chunk)` branch in the default invoke() must
+    // route to complete_async, not complete_stream_async.
+    LegacyChainProvider p;
+    CompletionParams params;
+
+    auto result = run_sync(p.invoke(params, StreamCallback{}));
+
+    EXPECT_EQ(result.message.content, "legacy-async");
+    EXPECT_EQ(p.async_calls.load(), 1);
+    EXPECT_EQ(p.stream_sync_calls.load(), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Default invoke() routes to the legacy chain — on_chunk present →
+// complete_stream_async (which itself bridges to complete_stream on a
+// worker thread per the existing default).
+// ---------------------------------------------------------------------------
+
+TEST(ProviderInvokeDefault, WithCallbackRoutesToCompleteStreamAsync) {
+    LegacyChainProvider p;
+    CompletionParams params;
+
+    std::vector<std::string> chunks;
+    auto result = run_sync(p.invoke(
+        params,
+        [&](const std::string& c) { chunks.push_back(c); }));
+
+    // The legacy default complete_stream_async spawns a worker thread that
+    // invokes the sync complete_stream and dispatches chunks back onto the
+    // awaiter's executor — same path as the established #4 fix. After
+    // run_sync drains the io_context the chunk MUST have landed.
+    EXPECT_EQ(result.message.content, "legacy-stream");
+    EXPECT_EQ(p.stream_sync_calls.load(), 1);
+    EXPECT_EQ(p.async_calls.load(), 0);
+    ASSERT_EQ(chunks.size(), 1u);
+    EXPECT_EQ(chunks.front(), "chunk-1");
+}
+
+// ---------------------------------------------------------------------------
+// New-style: subclass overrides invoke() directly. Calling invoke() must
+// hit the override, not the legacy chain.
+// ---------------------------------------------------------------------------
+
+TEST(ProviderInvokeDefault, OverriddenInvokeFires) {
+    InvokeNativeProvider p;
+    CompletionParams params;
+
+    auto result = run_sync(p.invoke(params, nullptr));
+
+    EXPECT_EQ(result.message.content, "native-invoke");
+    EXPECT_EQ(p.invoke_calls.load(), 1);
+    EXPECT_EQ(p.chunks_emitted.load(), 0);
+}
+
+TEST(ProviderInvokeDefault, OverriddenInvokeDeliversChunks) {
+    InvokeNativeProvider p;
+    CompletionParams params;
+
+    std::vector<std::string> chunks;
+    auto result = run_sync(p.invoke(
+        params,
+        [&](const std::string& c) { chunks.push_back(c); }));
+
+    EXPECT_EQ(result.message.content, "native-invoke");
+    EXPECT_EQ(p.invoke_calls.load(), 1);
+    EXPECT_EQ(p.chunks_emitted.load(), 2);
+    ASSERT_EQ(chunks.size(), 2u);
+    EXPECT_EQ(chunks[0], "native-chunk-A");
+    EXPECT_EQ(chunks[1], "native-chunk-B");
+}
+
+// ---------------------------------------------------------------------------
+// invoke() composes under co_spawn on the caller's io_context — the
+// production case where a node body co_awaits the provider directly.
+// ---------------------------------------------------------------------------
+
+TEST(ProviderInvokeDefault, AwaitableComposesOnCallerIoContext) {
+    InvokeNativeProvider p;
+    CompletionParams params;
+    asio::io_context io;
+
+    ChatCompletion out;
+    asio::co_spawn(
+        io,
+        [&]() -> asio::awaitable<void> {
+            out = co_await p.invoke(params, nullptr);
+        },
+        asio::detached);
+    io.run();
+
+    EXPECT_EQ(out.message.content, "native-invoke");
+    EXPECT_EQ(p.invoke_calls.load(), 1);
+}


### PR DESCRIPTION
## 요약

ROADMAP_v1.md **Candidate 6 (Provider 4→1 단일 dispatch)** 의 첫 PR — 새 `virtual asio::awaitable<ChatCompletion> Provider::invoke(params, on_chunk)` 메서드 추가.

기존 `Provider` 의 4 virtual cross-product (`complete` / `complete_async` / `complete_stream` / `complete_stream_async`) 를 한 async-streaming-superset 메서드로 모음. v0.4.0 의 `GraphNode::run(NodeInput)` 추가 패턴과 동일한 모양.

## 이 PR 의 범위 — 추가만 (additive)

- `invoke()` 새 virtual 추가
- default 구현: `on_chunk != nullptr` 면 `complete_stream_async()`, 아니면 `complete_async()` 로 forward (= 기존 4 virtual chain 그대로 사용)
- 새 ctest 6개 (`tests/test_provider_invoke_default.cpp`)
- **기존 Provider subclass 모두 무변경 동작** — native subclass 마이그레이션, internal call site 변경, `[[deprecated]]` 마커는 후속 PR

## 후속 PR 시퀀스 (Candidate 6)

| # | 작업 | 이 PR |
|---|---|---|
| PR1 | `invoke()` 추가 + default forward 4 virtual | **이 PR** |
| PR2 | OpenAI, Schema, RateLimited 가 invoke() 직접 override | 다음 |
| PR3 | graph_node, agent, deep_research_graph 의 호출 사이트가 invoke() 사용 | 그 다음 |
| PR4 | 4 legacy virtual 에 `[[deprecated]]` 마커 + PUSH_IGNORE 가드 | 그 다음 |
| v1.0 | legacy virtual 4개 삭제 | release moment |

## 테스트

- 새 ctest 6/6 green:
  - `NoCallbackRoutesToCompleteAsync`
  - `EmptyCallbackTreatedAsNoCallback`
  - `WithCallbackRoutesToCompleteStreamAsync`
  - `OverriddenInvokeFires`
  - `OverriddenInvokeDeliversChunks`
  - `AwaitableComposesOnCallerIoContext`
- 전체 ctest 505/505 green (pybind_smoke fail 1건은 사전 환경 — `openinference` python 모듈 install 갭, master HEAD 동일 상태)

## Test plan

- [x] 새 ctest 통과
- [x] 전체 ctest 회귀 없음
- [ ] CI green (build-and-test, sanitizer, tsan, macos, arm64)

ROADMAP_v1.md Candidate 6 section + Issue #5 컨텍스트 참조.

🤖 Generated with [Claude Code](https://claude.com/claude-code)