### PR TITLE
feat(engine): LLMCallNode + IntentClassifierNode dispatch via Provider::invoke() (Candidate 6 PR2)

### DIFF
--- a/src/core/graph_node.cpp
+++ b/src/core/graph_node.cpp
@@ -353,23 +353,27 @@ asio::awaitable<NodeOutput> LLMCallNode::run(NodeInput in) {
     // the in-flight HTTPS socket.
     params.cancel_token = in.ctx.cancel_token;
 
-    json msg_json;
+    // ROADMAP_v1.md Candidate 6 PR2: dispatch through Provider::invoke()
+    // — the v1.0 unified entry point. Same semantic as the previous
+    // `if (in.stream_cb) complete_stream_async else complete_async` pair,
+    // but the stream/non-stream branch lives inside the provider's own
+    // default invoke() body (or its native override), not at every call
+    // site. Native providers that override invoke() get one dispatch
+    // path; legacy 4-virtual subclasses get the chain via the additive
+    // default. See PR #40.
+    StreamCallback on_token;
     if (in.stream_cb) {
-        // Bridge per-token events to GraphEvent::LLM_TOKEN on the
-        // engine's stream callback.
         const GraphStreamCallback& cb = *in.stream_cb;
         std::string node_name = name_;
-        auto on_token = [&cb, &node_name](const std::string& token) {
+        on_token = [&cb, node_name](const std::string& token) {
             cb(GraphEvent{GraphEvent::Type::LLM_TOKEN,
                           node_name, json(token)});
         };
-        auto completion = co_await provider_->complete_stream_async(
-            params, on_token);
-        to_json(msg_json, completion.message);
-    } else {
-        auto completion = co_await provider_->complete_async(params);
-        to_json(msg_json, completion.message);
     }
+    auto completion = co_await provider_->invoke(params, on_token);
+
+    json msg_json;
+    to_json(msg_json, completion.message);
 
     NodeOutput out;
     out.writes.push_back(
@@ -503,20 +507,17 @@ asio::awaitable<NodeOutput> IntentClassifierNode::run(NodeInput in) {
     auto params = build_params(in.state);
     params.cancel_token = in.ctx.cancel_token;
 
-    ChatMessage reply;
+    // Candidate 6 PR2: same invoke() unification as LLMCallNode above.
+    StreamCallback on_token;
     if (in.stream_cb) {
         const GraphStreamCallback& cb = *in.stream_cb;
         std::string node_name = name_;
-        auto on_token = [&cb, &node_name](const std::string& token) {
+        on_token = [&cb, node_name](const std::string& token) {
             cb(GraphEvent{GraphEvent::Type::LLM_TOKEN, node_name, json(token)});
         };
-        auto completion = co_await provider_->complete_stream_async(
-            params, on_token);
-        reply = std::move(completion.message);
-    } else {
-        auto completion = co_await provider_->complete_async(params);
-        reply = std::move(completion.message);
     }
+    auto completion = co_await provider_->invoke(params, on_token);
+    ChatMessage reply = std::move(completion.message);
 
     NodeOutput out;
     out.writes = route_from(reply.content);


### PR DESCRIPTION
## 요약

ROADMAP_v1.md **Candidate 6 PR2** — engine 의 built-in LLM-호출 노드 (`LLMCallNode`, `IntentClassifierNode`) 가 v1.0 의 통합 dispatch `Provider::invoke(params, on_chunk)` 통해 호출하도록 변경.

기존 패턴 (call site 마다 stream/non-stream 분기):
```cpp
if (in.stream_cb) {
    co_await provider_->complete_stream_async(params, on_token);
} else {
    co_await provider_->complete_async(params);
}
```

새 패턴:
```cpp
StreamCallback on_token; // null = non-streaming
if (in.stream_cb) on_token = ...;
co_await provider_->invoke(params, on_token);
```

분기 로직이 provider 의 `invoke()` 안으로 이동. native invoke override (Candidate 6 PR4) 가 들어오면 engine 코드 수정 없이 single dispatch 경로 활성화.

## 동작 동등성

PR #40 의 default `invoke()` 가:
- `on_chunk != nullptr` → `complete_stream_async()`
- `on_chunk == nullptr` → `complete_async()`

이게 정확히 기존 두 분기. 모든 기존 Provider subclass 무변경 동작.

## 람다 capture 트랩

기존 `[&cb, &node_name]` 양쪽 ref capture 는 worker-thread bridge 가 람다를 코루틴 프레임 pop 후 발화시키면 UAF. 이번 PR 에서 `node_name` 은 by-value (std::string copy), `cb` 는 by-ref (생명주기는 `NodeInput in` = by-value 코루틴 프레임에 묶임 = awaitable 보다 오래 살아 있음 보장).

## 의도적으로 좁게 잡은 범위

- `agent.cpp` / `deep_research_graph.cpp` 는 sync `complete()` / `complete_stream()` 사용. `run_sync(invoke(...))` 로 옮기면 현재 `Provider::complete()` 가 읽는 `current_cancel_token()` thread-local 우회 — cancel propagation 검토 필요. **PR3 으로 미룸.**
- native subclass invoke override + 4 legacy virtual `[[deprecated]]` 마커 → **PR4.**

## 테스트

- 478/478 ctest green (env 의존 제외: pybind_smoke / Postgres / live LLM). 같은 셋이 PR 전 동일 통과.

## Stacking

PR #40 (Candidate 6 PR1) 위에 쌓인 stacked PR. PR #40 머지 후 base 자동 변경 또는 rebase.

## Test plan

- [x] 새 ctest 통과 / 회귀 0
- [ ] CI green

ROADMAP_v1.md Candidate 6 + Issue #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)