### PR TITLE
feat: agent + deep_research → Provider::invoke() + thread_local cancel parity (Candidate 6 PR3)

### DIFF
--- a/src/core/deep_research_graph.cpp
+++ b/src/core/deep_research_graph.cpp
@@ -4,6 +4,7 @@
 #include <neograph/graph/node.h>
 #include <neograph/graph/state.h>
 #include <neograph/graph/types.h>
+#include <neograph/async/run_sync.h>
 
 #include <algorithm>
 #include <memory>
@@ -216,7 +217,7 @@ public:
         params.temperature = 0.3f;
         params.max_tokens = 2048;
 
-        auto completion = provider_->complete(params);
+        auto completion = neograph::async::run_sync(provider_->invoke(params, nullptr));
 
         json asst;
         to_json(asst, completion.message);
@@ -529,7 +530,7 @@ public:
             params.temperature = 0.3f;
             params.max_tokens = 2048;
 
-            auto completion = provider_->complete(params);
+            auto completion = neograph::async::run_sync(provider_->invoke(params, nullptr));
             auto& msg = completion.message;
             convo.push_back(msg);
 
@@ -609,7 +610,7 @@ private:
         cp.max_tokens = 2048;
 
         try {
-            auto completion = provider_->complete(cp);
+            auto completion = neograph::async::run_sync(provider_->invoke(cp, nullptr));
             std::string out = completion.message.content;
             // Hard cap regardless of what the model produced. Protects the
             // supervisor's accumulated context from unbounded growth across
@@ -732,7 +733,7 @@ public:
             params.max_tokens = 4096;
 
             try {
-                auto completion = provider_->complete(params);
+                auto completion = neograph::async::run_sync(provider_->invoke(params, nullptr));
                 return {
                     ChannelWrite{"final_report", json(completion.message.content)}
                 };
@@ -827,7 +828,7 @@ Output ONLY the brief, in plain markdown. No preamble. Keep it under 200 words.)
             params.temperature = 0.2f;
             params.max_tokens = 800;
 
-            auto completion = provider_->complete(params);
+            auto completion = neograph::async::run_sync(provider_->invoke(params, nullptr));
             std::string brief = completion.message.content;
             if (brief.empty()) brief = user_query;  // pass-through guard
             return {ChannelWrite{"research_brief", json(std::move(brief))}};
@@ -928,7 +929,7 @@ Bias toward PROCEED — only ASK when the question would clearly fork the resear
             params.temperature = 0.0f;
             params.max_tokens = 200;
 
-            verdict = provider_->complete(params).message.content;
+            verdict = neograph::async::run_sync(provider_->invoke(params, nullptr)).message.content;
         } catch (const std::exception&) {
             // Provider failure — degrade to PROCEED so the run isn't sunk.
             return NodeResult{};

--- a/src/core/provider.cpp
+++ b/src/core/provider.cpp
@@ -140,6 +140,18 @@ Provider::complete_stream_async(const CompletionParams& params,
 // invoke() directly; the 4 legacy virtuals then gain [[deprecated]]
 // markers; v1.0 deletes them. See ROADMAP_v1.md Candidate 6.
 //
+// **Cancel propagation parity with sync complete()** (Candidate 6 PR3):
+// the legacy sync `Provider::complete()` reads
+// `neograph::graph::current_cancel_token()` from the engine's thread-
+// local scope so a node body calling `provider->complete(params)`
+// without explicitly pinning `params.cancel_token` still gets cancel
+// propagation. As internal call sites migrate from
+// `provider->complete(params)` to `co_await provider->invoke(params, ...)`,
+// invoke() must mirror that fallback or the cancel signal is silently
+// lost. We pull the same thread_local at invoke entry and stamp the
+// effective params; explicit `params.cancel_token` (set by the caller)
+// always wins.
+//
 // No recursion guard needed in this PR: the 4 legacy virtuals' defaults
 // don't yet route back through invoke(), so the chain terminates at
 // either complete_async (which co_returns complete()) or
@@ -149,10 +161,34 @@ Provider::complete_stream_async(const CompletionParams& params,
 // be added then, not now.
 asio::awaitable<ChatCompletion>
 Provider::invoke(const CompletionParams& params, StreamCallback on_chunk) {
-    if (on_chunk) {
-        co_return co_await complete_stream_async(params, on_chunk);
+    // Fast path: caller already pinned cancel_token (or there's no
+    // engine scope on this thread). Forward const& to avoid the
+    // CompletionParams copy.
+    if (params.cancel_token) {
+        if (on_chunk) {
+            co_return co_await complete_stream_async(params, on_chunk);
+        }
+        co_return co_await complete_async(params);
     }
-    co_return co_await complete_async(params);
+    auto* tok = neograph::graph::current_cancel_token();
+    if (!tok) {
+        if (on_chunk) {
+            co_return co_await complete_stream_async(params, on_chunk);
+        }
+        co_return co_await complete_async(params);
+    }
+    // Stamp engine's thread_local token onto a copy of params. The
+    // token is owned by the engine's CurrentCancelTokenScope (lifetime
+    // strictly outlives this awaitable), so a non-owning shared_ptr
+    // alias suffices — no extra ref-count contention with the engine's
+    // own shared_ptr.
+    CompletionParams effective = params;
+    effective.cancel_token = std::shared_ptr<neograph::graph::CancelToken>(
+        tok, [](neograph::graph::CancelToken*){});
+    if (on_chunk) {
+        co_return co_await complete_stream_async(effective, on_chunk);
+    }
+    co_return co_await complete_async(effective);
 }
 
 } // namespace neograph

--- a/src/llm/agent.cpp
+++ b/src/llm/agent.cpp
@@ -1,4 +1,5 @@
 #include <neograph/llm/agent.h>
+#include <neograph/async/run_sync.h>
 #include <algorithm>
 #include <iostream>
 #include <stdexcept>
@@ -60,7 +61,10 @@ Agent::complete(const std::vector<ChatMessage>& messages)
     CompletionParams params;
     params.model = model_;
     params.messages = messages;
-    return provider_->complete(params);
+    // Candidate 6 PR3: dispatch via invoke() so the v1.0 single-
+    // dispatch surface is end-to-end. run_sync drives the awaitable
+    // synchronously (Agent::complete is the public sync API).
+    return neograph::async::run_sync(provider_->invoke(params, nullptr));
 }
 
 std::string
@@ -75,7 +79,7 @@ Agent::run(std::vector<ChatMessage>& messages, int max_iterations)
         params.messages = messages;
         params.tools = tool_defs;
 
-        auto completion = provider_->complete(params);
+        auto completion = neograph::async::run_sync(provider_->invoke(params, nullptr));
         auto& msg = completion.message;
 
         // Append assistant message to history
@@ -131,7 +135,8 @@ Agent::run_stream(std::vector<ChatMessage>& messages,
 
         // After tool execution, use streaming for the final response
         if (has_done_tool_calls) {
-            auto completion = provider_->complete_stream(params, on_chunk);
+            auto completion = neograph::async::run_sync(
+                provider_->invoke(params, on_chunk));
             messages.push_back(completion.message);
 
             if (completion.message.tool_calls.empty()) {
@@ -140,14 +145,16 @@ Agent::run_stream(std::vector<ChatMessage>& messages,
             // Rare: another tool call after streaming — fall through to execute
         } else {
             // Non-streaming: reliable tool call detection
-            auto completion = provider_->complete(params);
+            auto completion = neograph::async::run_sync(
+                provider_->invoke(params, nullptr));
             messages.push_back(completion.message);
 
             if (completion.message.tool_calls.empty()) {
                 // No tools needed at all — stream the response
                 // Remove the non-streamed message, re-do with streaming
                 messages.pop_back();
-                auto streamed = provider_->complete_stream(params, on_chunk);
+                auto streamed = neograph::async::run_sync(
+                    provider_->invoke(params, on_chunk));
                 messages.push_back(streamed.message);
                 return streamed.message.content;
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(neograph_tests
     test_async_http_options.cpp
     test_provider_async_default.cpp
     test_provider_invoke_default.cpp
+    test_provider_invoke_cancel_propagation.cpp
     test_run_context_store.cpp
     test_run_result_channel.cpp
     test_error_messages_friendly.cpp

--- a/tests/test_provider_invoke_cancel_propagation.cpp
+++ b/tests/test_provider_invoke_cancel_propagation.cpp
@@ -1,0 +1,115 @@
+// ROADMAP_v1.md Candidate 6 PR3 — Provider::invoke() cancel propagation
+// parity with the legacy sync `Provider::complete()`.
+//
+// `Provider::complete()` (legacy sync) reads the engine's
+// thread-local `current_cancel_token()` so a node calling
+// `provider->complete(params)` without explicitly setting
+// `params.cancel_token` still gets the running graph's cancel signal.
+// `Provider::invoke()` MUST mirror that fallback because PR3 migrates
+// internal sync call sites (agent.cpp, deep_research_graph.cpp) from
+// `complete()` to `run_sync(invoke())` — losing the thread-local would
+// silently drop cancel propagation on every node-side LLM call.
+//
+// Coverage:
+//   1. thread_local set, params.cancel_token unset → invoke() stamps
+//      effective.cancel_token from the thread_local
+//   2. thread_local set, params.cancel_token set → params.cancel_token
+//      wins (explicit overrides implicit)
+//   3. thread_local unset, params.cancel_token unset → fast path,
+//      effective.cancel_token stays nullptr (no copy needed)
+
+#include <gtest/gtest.h>
+#include <neograph/provider.h>
+#include <neograph/graph/cancel.h>
+#include <neograph/async/run_sync.h>
+
+#include <asio/awaitable.hpp>
+
+#include <atomic>
+#include <memory>
+
+using neograph::ChatCompletion;
+using neograph::CompletionParams;
+using neograph::Provider;
+using neograph::StreamCallback;
+using neograph::async::run_sync;
+using neograph::graph::CancelToken;
+using neograph::graph::CurrentCancelTokenScope;
+using neograph::graph::current_cancel_token;
+
+namespace {
+
+// Records which cancel_token (if any) reached complete_async — proxy
+// for "what did invoke() stamp into effective.cancel_token before
+// forwarding". Provider override chain bottoms out at complete_async
+// when on_chunk == nullptr (matches PR1 default routing).
+class TokenInspectingProvider : public Provider {
+  public:
+    std::shared_ptr<CancelToken> seen_token;
+    bool was_called = false;
+
+    asio::awaitable<ChatCompletion>
+    complete_async(const CompletionParams& params) override {
+        was_called = true;
+        seen_token = params.cancel_token;
+        ChatCompletion c;
+        c.message.role = "assistant";
+        c.message.content = "ok";
+        co_return c;
+    }
+
+    std::string get_name() const override { return "token-inspect"; }
+};
+
+} // namespace
+
+TEST(InvokeCancelPropagation, ThreadLocalStampedWhenParamsUnset) {
+    TokenInspectingProvider p;
+    auto engine_token = std::make_shared<CancelToken>();
+    CurrentCancelTokenScope scope(engine_token.get());
+    ASSERT_EQ(current_cancel_token(), engine_token.get());
+
+    CompletionParams params;
+    ASSERT_FALSE(params.cancel_token);
+
+    auto result = run_sync(p.invoke(params, nullptr));
+
+    EXPECT_TRUE(p.was_called);
+    EXPECT_EQ(result.message.content, "ok");
+    ASSERT_TRUE(p.seen_token);
+    // The engine's thread_local raw pointer was wrapped into a
+    // non-owning shared_ptr inside invoke(). The .get() must point
+    // back to the engine token (same instance).
+    EXPECT_EQ(p.seen_token.get(), engine_token.get());
+}
+
+TEST(InvokeCancelPropagation, ExplicitParamsTokenWinsOverThreadLocal) {
+    TokenInspectingProvider p;
+    auto engine_token = std::make_shared<CancelToken>();
+    auto explicit_token = std::make_shared<CancelToken>();
+    CurrentCancelTokenScope scope(engine_token.get());
+
+    CompletionParams params;
+    params.cancel_token = explicit_token;
+
+    auto result = run_sync(p.invoke(params, nullptr));
+
+    EXPECT_TRUE(p.was_called);
+    ASSERT_TRUE(p.seen_token);
+    EXPECT_EQ(p.seen_token.get(), explicit_token.get());
+    EXPECT_NE(p.seen_token.get(), engine_token.get());
+}
+
+TEST(InvokeCancelPropagation, NoThreadLocalFastPathLeavesTokenNull) {
+    TokenInspectingProvider p;
+    // No CurrentCancelTokenScope on this thread.
+    ASSERT_EQ(current_cancel_token(), nullptr);
+
+    CompletionParams params;
+    ASSERT_FALSE(params.cancel_token);
+
+    auto result = run_sync(p.invoke(params, nullptr));
+
+    EXPECT_TRUE(p.was_called);
+    EXPECT_FALSE(p.seen_token);
+}


### PR DESCRIPTION
## 요약

ROADMAP_v1.md **Candidate 6 PR3** — engine-내부의 sync LLM 호출 사이트를 전부 `Provider::invoke()` 로 이동. NeoGraph 내부의 LLM 호출이 모두 v1.0 단일 dispatch 진입점 (`Provider::invoke`) 을 통과.

마이그레이션 대상:
- `src/llm/agent.cpp` — `Agent::complete()` + `Agent::run_stream()` 의 5 사이트 (sync + streaming)
- `src/core/deep_research_graph.cpp` — SupervisorLLMNode / ResearcherLLMNode / CompressNotesNode / FinalReportNode 의 6 사이트

각 사이트가 `neograph::async::run_sync(provider_->invoke(params, on_chunk_or_nullptr))` 통과.

## 핵심: cancel propagation parity

기존 sync `Provider::complete()` 는 `neograph::graph::current_cancel_token()` thread-local 을 읽어서 노드 본문이 자동으로 running graph 의 cancel signal 받음. 단순히 `run_sync(invoke(...))` 로 옮기면 thread-local 우회 → cancel propagation silent drop (deep_research 6 노드는 engine dispatch 하에 도는 실제 production path).

해결: `Provider::invoke()` 의 default 가 같은 fallback 수행. `params.cancel_token` 이 set 안 됐으면 `current_cancel_token()` 읽어서 non-owning `shared_ptr` alias 로 effective copy 에 stamp. 명시적 `params.cancel_token` 가 항상 우선. fast path (이미 pin 됐거나 engine scope 없을 때) 는 `CompletionParams` copy 안 함.

## 새 ctest (`InvokeCancelPropagation`)

3개:
- `ThreadLocalStampedWhenParamsUnset` — engine scope 있음 + params 미설정 → invoke() 가 thread-local 포인터를 effective.cancel_token 에 stamp
- `ExplicitParamsTokenWinsOverThreadLocal` — 둘 다 set → explicit 우선, thread-local 무시
- `NoThreadLocalFastPathLeavesTokenNull` — 둘 다 unset → fast path, copy 안 함

검증용 provider 가 `complete_async` 까지 도달한 token 을 기록 → invoke 가 forward 전에 stamping 한 것 검증.

## 검증

- 479/479 ctest green (env-dependent 제외)
- 회귀 0

## Test plan

- [x] 새 cancel propagation ctest 3개 통과
- [x] 전체 ctest 회귀 0
- [ ] CI green

ROADMAP_v1.md Candidate 6 + Issue #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)