### PR TITLE
feat(provider): 4 legacy virtuals [[deprecated]] + plan_execute → invoke() + decorator guards (Candidate 6 PR4)

### DIFF
--- a/include/neograph/provider.h
+++ b/include/neograph/provider.h
@@ -138,7 +138,16 @@ class NEOGRAPH_API Provider {
      *
      * @param params Completion parameters including model, messages, and tools.
      * @return The full completion response with message and usage statistics.
+     *
+     * @deprecated v1.0 collapses the 4-virtual cross-product into the
+     * single async-streaming-superset `invoke(params, on_chunk)`. New
+     * code: `co_await provider->invoke(params, nullptr)` (async) or
+     * `neograph::async::run_sync(provider->invoke(params, nullptr))`
+     * (sync). The legacy `complete()` keeps working through the
+     * deprecation window and is removed in v1.0.0. See ROADMAP_v1.md
+     * Candidate 6.
      */
+    [[deprecated("v1.0 single-dispatch: use invoke(params, nullptr) — see ROADMAP_v1.md Candidate 6")]]
     virtual ChatCompletion complete(const CompletionParams& params);
 
     /**
@@ -160,7 +169,10 @@ class NEOGRAPH_API Provider {
      *
      * @param params Completion parameters.
      * @return An awaitable yielding the full completion response.
+     *
+     * @deprecated Use `invoke(params, nullptr)`. v1.0 removes this.
      */
+    [[deprecated("v1.0 single-dispatch: use invoke(params, nullptr) — see ROADMAP_v1.md Candidate 6")]]
     virtual asio::awaitable<ChatCompletion>
     complete_async(const CompletionParams& params);
 
@@ -180,7 +192,12 @@ class NEOGRAPH_API Provider {
      * @param params Completion parameters.
      * @param on_chunk Callback invoked per received token.
      * @return The full completion response after streaming is complete.
+     *
+     * @deprecated Use `invoke(params, on_chunk)` (or
+     * `neograph::async::run_sync(invoke(params, on_chunk))` for a
+     * sync caller). v1.0 removes this.
      */
+    [[deprecated("v1.0 single-dispatch: use invoke(params, on_chunk) — see ROADMAP_v1.md Candidate 6")]]
     virtual ChatCompletion complete_stream(const CompletionParams& params,
                                            const StreamCallback& on_chunk);
 
@@ -238,7 +255,10 @@ class NEOGRAPH_API Provider {
      *                 awaiting coroutine's executor — never on the
      *                 internal worker thread).
      * @return Awaitable resolving to the full completion response.
+     *
+     * @deprecated Use `invoke(params, on_chunk)`. v1.0 removes this.
      */
+    [[deprecated("v1.0 single-dispatch: use invoke(params, on_chunk) — see ROADMAP_v1.md Candidate 6")]]
     virtual asio::awaitable<ChatCompletion>
     complete_stream_async(const CompletionParams& params,
                           const StreamCallback& on_chunk);

--- a/src/core/plan_execute_graph.cpp
+++ b/src/core/plan_execute_graph.cpp
@@ -4,6 +4,7 @@
 #include <neograph/graph/node.h>
 #include <neograph/graph/state.h>
 #include <neograph/graph/types.h>
+#include <neograph/async/run_sync.h>
 
 #include <algorithm>
 #include <cctype>
@@ -119,7 +120,7 @@ public:
         params.model = model_;
         params.messages = std::move(prompt_msgs);
 
-        auto completion = provider_->complete(params);
+        auto completion = neograph::async::run_sync(provider_->invoke(params, nullptr));
         auto plan_items = extract_plan(completion.message.content);
 
         json plan_json = json::array();
@@ -187,7 +188,7 @@ public:
             params.messages = convo;
             params.tools = tool_defs;
 
-            auto completion = provider_->complete(params);
+            auto completion = neograph::async::run_sync(provider_->invoke(params, nullptr));
             auto& msg = completion.message;
             convo.push_back(msg);
 
@@ -292,7 +293,7 @@ public:
         params.model = model_;
         params.messages = std::move(convo);
 
-        auto completion = provider_->complete(params);
+        auto completion = neograph::async::run_sync(provider_->invoke(params, nullptr));
 
         json asst_json;
         to_json(asst_json, completion.message);

--- a/src/core/provider.cpp
+++ b/src/core/provider.cpp
@@ -26,6 +26,17 @@
 
 namespace neograph {
 
+// Candidate 6 PR4: the 4 legacy virtuals (complete / complete_async /
+// complete_stream / complete_stream_async) are now [[deprecated]]; this
+// TU is the canonical default-chain implementation that legitimately
+// calls them on behalf of legacy subclasses + the new invoke() default
+// (which forwards into the 4-virtual chain through the deprecation
+// window). Bracket the whole namespace body so internal forwarders
+// don't drown the build in self-warnings; user code overriding the
+// 4 virtuals or calling them externally still sees the marker on its
+// own override / call site.
+NEOGRAPH_PUSH_IGNORE_DEPRECATED
+
 ChatCompletion Provider::complete(const CompletionParams& params) {
     // v0.3: thread cancel propagation through the sync path. The
     // engine sets a thread-local CancelToken before invoking each
@@ -190,5 +201,7 @@ Provider::invoke(const CompletionParams& params, StreamCallback on_chunk) {
     }
     co_return co_await complete_async(effective);
 }
+
+NEOGRAPH_POP_IGNORE_DEPRECATED
 
 } // namespace neograph

--- a/src/llm/rate_limited_provider.cpp
+++ b/src/llm/rate_limited_provider.cpp
@@ -11,6 +11,14 @@
 
 namespace neograph::llm {
 
+// Candidate 6 PR4: inner Provider's 4 legacy virtuals are now
+// [[deprecated]]. RateLimitedProvider is a delegating decorator that
+// wraps the legacy surface for retry/backoff; it MUST keep forwarding
+// to the inner's legacy methods through the deprecation window.
+// Bracket the whole TU so internal forwarders don't drown in self-
+// warnings; v1.0 collapses these to a single invoke() override.
+NEOGRAPH_PUSH_IGNORE_DEPRECATED
+
 RateLimitedProvider::RateLimitedProvider(std::shared_ptr<Provider> inner,
                                          Config cfg)
     : inner_(std::move(inner)), cfg_(cfg) {
@@ -115,5 +123,7 @@ RateLimitedProvider::complete_stream(const CompletionParams& params,
         }
     }
 }
+
+NEOGRAPH_POP_IGNORE_DEPRECATED
 
 } // namespace neograph::llm

--- a/src/observability/openinference.cpp
+++ b/src/observability/openinference.cpp
@@ -394,6 +394,16 @@ void record_output(Span* span, const ChatCompletion& result) {
 
 } // namespace
 
+// Candidate 6 PR4: inner Provider's 4 legacy virtuals are now
+// [[deprecated]]. OpenInferenceProvider is a tracing decorator that
+// MUST keep wrapping all 4 surfaces through the deprecation window so
+// downstream code calling any legacy method on a wrapped provider
+// still gets a span. The 4 overrides below legitimately forward to
+// `impl_->inner->complete*()` — bracket the region so the build
+// doesn't drown in self-warnings. v1.0 collapses these to a single
+// `invoke()` override.
+NEOGRAPH_PUSH_IGNORE_DEPRECATED
+
 ChatCompletion OpenInferenceProvider::complete(const CompletionParams& params) {
     Span* parent = impl_->parent_lookup ? impl_->parent_lookup() : nullptr;
     auto span = impl_->tracer->start_span(impl_->span_name, parent);
@@ -510,5 +520,7 @@ OpenInferenceProvider::complete_stream_async(
         throw;
     }
 }
+
+NEOGRAPH_POP_IGNORE_DEPRECATED
 
 } // namespace neograph::observability


### PR DESCRIPTION
## 요약

ROADMAP_v1.md **Candidate 6 PR4** — `Provider` 의 4 legacy virtual (`complete` / `complete_async` / `complete_stream` / `complete_stream_async`) 에 `[[deprecated(\"v1.0 single-dispatch: use invoke(...)\")]]` 마커. v1.0 single dispatch 가 모든 downstream consumer 에게 visible deprecation 신호. legacy method 는 deprecation window 동안 그대로 동작; v1.0.0 에서 삭제.

## Internal forwarder cleanup

PR3 후 남아있던 3 cluster:

- **`src/core/plan_execute_graph.cpp`** — PlannerNode + ExecutorNode 의 3 sync `provider_->complete(params)` 사이트. **invoke() 로 마이그레이션** (PR3 의 deep_research 와 동일 패턴, cancel-propagation parity 상속).

- **`src/observability/openinference.cpp`** — `OpenInferenceProvider` 는 tracing decorator. 4 virtual override 가 inner provider 의 legacy method forward 해야 함 (downstream code 가 legacy 호출해도 span 유지). **PUSH_IGNORE 가드** 로 4-override 블록 감쌈; v1.0 에서 single invoke() override 로 collapse.

- **`src/llm/rate_limited_provider.cpp`** — `RateLimitedProvider` 는 retry/backoff 데코레이터. OpenInference 와 동일 패턴. **PUSH_IGNORE 가드** TU 전체.

`src/core/provider.cpp` (base default-chain TU) 도 동일 — invoke() default 가 legacy chain forward, 4 legacy default 끼리 호출. namespace-wide PUSH/POP 으로 internal forwarder 모두 커버.

User code 가 4 virtual override 하거나 외부에서 호출하면 그 override / call site 에 marker visible — 마이그레이션 필요한 곳에 정확히 warning.

## 검증

- 479/479 ctest green (env-dependent 제외)
- internal deprecation warning 0 (post-build grep 으로 확인)

## 남은 작업

- **Native subclass invoke() override** (Schema, OpenAI, RateLimited): 오늘은 trivial forward; native impl 통합은 post-deprecation 사이클로 미룸. PR5 후보.
- **Examples 마이그레이션**: 의도적으로 이 PR 에서 안 함 — examples 는 user-facing 데모 표면이라 일괄 rewrite 는 별도 docs pass. v0.9.0 ship 시 CHANGELOG 에 메모.
- **v1.0.0**: 4 legacy virtual 삭제 + internal PUSH_IGNORE 가드 제거.

## Test plan

- [x] ctest 479/479 green
- [x] internal deprecation warning 0
- [ ] CI green

ROADMAP_v1.md Candidate 6 + Issue #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)