### PR TITLE
docs(examples): C++ examples migrate to Provider::invoke() (Candidate 6 PR5)

### DIFF
--- a/examples/31_local_transformer.cpp
+++ b/examples/31_local_transformer.cpp
@@ -31,6 +31,7 @@
 // up a real agent graph.
 
 #include <neograph/llm/openai_provider.h>
+#include <neograph/async/run_sync.h>
 
 #include <algorithm>
 #include <chrono>
@@ -77,7 +78,7 @@ int main(int argc, char** argv) {
         p.max_tokens = 4;
         neograph::ChatMessage m; m.role = "user"; m.content = "hi";
         p.messages = {m};
-        try { (void)provider->complete(p); }
+        try { (void)neograph::async::run_sync(provider->invoke(p, nullptr)); }
         catch (const std::exception& e) {
             std::cerr << "[bench] warmup failed: " << e.what()
                       << "\n[bench] is the server up on " << base_url << " ?\n";
@@ -111,7 +112,7 @@ int main(int argc, char** argv) {
         };
 
         try {
-            (void)provider->complete_stream(p, on_tok);
+            (void)neograph::async::run_sync(provider->invoke(p, on_tok));
         } catch (const std::exception& e) {
             std::cerr << "[bench] iter " << i << " failed: " << e.what() << "\n";
             return 2;

--- a/examples/cookbook/ai-assembly/member_server.cpp
+++ b/examples/cookbook/ai-assembly/member_server.cpp
@@ -17,6 +17,7 @@
 #include <neograph/neograph.h>
 #include <neograph/a2a/server.h>
 #include <neograph/llm/openai_provider.h>
+#include <neograph/async/run_sync.h>
 #include <neograph/graph/node.h>
 #include <neograph/graph/loader.h>
 
@@ -78,7 +79,7 @@ class PersonaNode : public GraphNode {
         p.messages.push_back({"system", system_prompt_});
         p.messages.push_back({"user", user_text});
 
-        auto reply = provider_->complete(p);
+        auto reply = neograph::async::run_sync(provider_->invoke(p, nullptr));
         std::string text = reply.message.content;
 
         // Tag with party + name so the Speaker's transcript is readable.


### PR DESCRIPTION
## 요약

ROADMAP_v1.md **Candidate 6 PR5** — `[[deprecated]]` 가 박힌 4 legacy method 를 부르던 C++ examples 2개를 새 `Provider::invoke()` 로 마이그레이션. 사용자 빌드에서 deprecation warning 안 뜨게.

| 파일 | 변경 사이트 |
|---|---|
| `examples/31_local_transformer.cpp` | warmup `complete()` + per-iter `complete_stream()` 2개 → `neograph::async::run_sync(provider->invoke(p, on_chunk_or_nullptr))` |
| `examples/cookbook/ai-assembly/member_server.cpp` | 1 sync `complete()` 사이트 → 동일 패턴 |

각각 `#include <neograph/async/run_sync.h>` 추가.

## 의도적으로 안 건드린 것

- **`examples/40_react_async_streaming.cpp`** — `complete_stream_async` 가 코멘트 narrative 에만 등장 (실제 호출 X)
- **`tests/*`** — 다수 test fixture 가 의도적으로 4 legacy virtual override 해서 default chain 검증. 이 tests 는 deprecation window 동안 legacy 동작 exercise 가 존재 이유. invoke() 로 rewrite 하면 목적 무효화 — v1.0 에서 4 virtual 삭제할 때 같은 sub-PR 에서 tests 도 삭제
- **`bindings/python/examples/*`** — Python 의 `Provider.complete()` 는 별도 sync wrapper layer (사용자 관점에서 C++ 4 deprecated virtual 중 하나가 아님). v1.0 에서 Python sync `complete()` API 유지

## 검증

- 479/479 ctest green, 회귀 0
- `example_local_transformer` 빌드 clean, provider 호출 사이트에 deprecation warning 0

## Test plan

- [x] ctest 회귀 0
- [x] 마이그레이션 후 deprecation warning 0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)