### PR TITLE
docs: Candidate 6 landing log + migration guide (v0.9.0 candidate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,71 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
-## [Unreleased]
+## [Unreleased] — Candidate 6: Provider 단일 dispatch (v1.0 prep)
+
+ROADMAP_v1.md 의 **Candidate 6** (Provider 4-virtual cross-product →
+1-virtual `invoke()`) 5 PR landing. v0.4.0 의 `GraphNode::run(NodeInput)`
+에 이은 두 번째 v1.0 single-dispatch surface 통합. 모든 변화는 추가
++ deprecation 단계 — 기존 사용자 코드 그대로 동작, deprecation
+window 동안 마이그레이션 안내만 visible.
+
+### Added
+
+- **`Provider::invoke(params, on_chunk = nullptr)`** — v1.0 의
+  표준 단일 dispatch 진입점. 비스트리밍 (`on_chunk == nullptr`) 과
+  스트리밍 (`on_chunk` 전달) 을 한 메서드가 처리. 기존 4 virtual
+  cross-product (`complete` / `complete_async` / `complete_stream` /
+  `complete_stream_async`) 를 한 async-streaming-superset 으로 모음.
+  default impl 은 4 legacy virtual 로 forward 하므로 기존 Provider
+  subclass 무변경 동작. 6 신규 ctest (`ProviderInvokeDefault`).
+  (PR #40)
+- **`invoke()` cancel propagation parity** — `params.cancel_token` 미설정
+  + engine thread-local scope 활성 → `current_cancel_token()` 자동 stamp.
+  legacy sync `complete()` 의 동작과 동등 (engine 안의 노드 본문이
+  `provider->invoke(params, ...)` 부르면 running graph 의 cancel signal
+  자동 받음). 3 신규 ctest (`InvokeCancelPropagation`). (PR #43)
+
+### Changed
+
+- **engine 내부 모든 LLM 호출이 `invoke()` 통과** — `LLMCallNode`,
+  `IntentClassifierNode` (PR #41/#42), `Agent::complete` /
+  `Agent::run_stream` (PR #43), `SupervisorLLMNode` /
+  `ResearcherLLMNode` / `CompressNotesNode` / `FinalReportNode`
+  (PR #43), `PlannerNode` / `ExecutorNode` (PR #44). NeoGraph
+  내부의 LLM dispatch 가 한 표면으로 통일.
+- **C++ examples 마이그레이션 (2 file)** — `31_local_transformer.cpp`,
+  `cookbook/ai-assembly/member_server.cpp` 가 새 `invoke()` 사용.
+  사용자 빌드에서 deprecation warning 안 뜸. (PR #45)
+
+### Deprecated
+
+- **`Provider::complete` / `complete_async` / `complete_stream` /
+  `complete_stream_async`** — 4 legacy virtual 모두
+  `[[deprecated("v1.0 single-dispatch: use invoke(...)")]]` 마커.
+  legacy method 는 deprecation window 동안 그대로 동작. v1.0.0
+  에서 삭제. internal forwarder 는 `NEOGRAPH_PUSH/POP_IGNORE_DEPRECATED`
+  로 감싸서 user-facing override / 호출 사이트에만 warning. (PR #44)
+
+### Migration (사용자 코드)
+
+새 코드:
+```cpp
+// 비스트리밍
+auto completion = co_await provider->invoke(params, nullptr);
+
+// 스트리밍
+auto completion = co_await provider->invoke(params, on_chunk);
+
+// sync 사이트 (옛 complete() 자리)
+auto completion = neograph::async::run_sync(provider->invoke(params, nullptr));
+```
+
+기존 4 virtual override 는 deprecation window 동안 그대로 동작하지만,
+`-Wdeprecated-declarations` warning 이 user override 사이트에 visible.
+v1.0.0 직전에 제거되니 deprecation window 안에 마이그레이션 권장.
+
+`docs/migration-v0.4-to-v1.0.md` 의 Provider 섹션 (다음 docs sweep
+에서 추가 예정) 가 케이스별 before/after 안내.
 
 ## [0.8.0] — 2026-05-13 — DX 폴리시 + downstream-driven API gaps 정리
 

--- a/ROADMAP_v1.md
+++ b/ROADMAP_v1.md
@@ -373,7 +373,7 @@ the class. Candidate 1 + 6 do.
 | 3 | Hierarchical CancelToken | **Landed in v0.4** (`CancelToken::fork()` + cascade) | v0.3.2 hooks, v0.3.2 emit-vs-bind |
 | 4 | Self-evolving graph runtime hooks | Research | TODO_v0.3.md #8 |
 | 5 | pgvector RAG example | Cookbook | TODO_v0.3.md #9 |
-| 6 | Provider single dispatch | Proposed (concrete crash #4 closed by PR #10; architectural cleanup deferred) | #4 (closed v0.7), #5 (open as v1.0 tracking item), pattern reinforced by #36 |
+| 6 | Provider single dispatch | **Landed (additive + deprecation)** v0.9.0 candidate — PR #40 / #41+#42 / #43 / #44 / #45. Phase B (legacy 4 virtual 제거) v1.0.0 대기. | #4 (closed v0.7), #5 (open as v1.0 tracking item), pattern reinforced by #36 |
 
 ---
 
@@ -842,3 +842,32 @@ split if the work happens in different PRs.
 Issue #5 — surfaced while debugging #4. Concrete crash closed by
 PR #10; architectural cleanup deferred to v1.0 alongside
 Candidate 1.
+
+### Landing log (v0.9.0 candidate cycle)
+
+5 PR landed sequentially on master, mid-2026-05-13:
+
+| PR | Scope | Lands in |
+|---|---|---|
+| **#40 (PR1)** | `Provider::invoke(params, on_chunk = nullptr)` 새 virtual 추가. default impl 이 4 legacy virtual chain 으로 forward (모든 기존 Provider subclass 무변경 동작). 6 신규 ctest. | v0.9.0 |
+| **#41+#42 (PR2)** | engine 의 built-in LLM 노드 (`LLMCallNode`, `IntentClassifierNode`) 가 `provider->invoke(params, on_chunk)` 통해 dispatch. PR #41 가 stacked base 에만 머지되어 PR #42 로 master 재적용. | v0.9.0 |
+| **#43 (PR3)** | engine-내부 sync LLM 호출 사이트 모두 마이그레이션 — `agent.cpp` (5 사이트), `deep_research_graph.cpp` (6 사이트). `Provider::invoke()` default 에 thread-local cancel propagation parity 추가 (legacy `complete()` 의 `current_cancel_token()` 동작 재현). 3 신규 ctest. | v0.9.0 |
+| **#44 (PR4)** | 4 legacy virtual 모두 `[[deprecated]]` 마커. `plan_execute_graph.cpp` 3 사이트 invoke() 마이그레이션. `OpenInferenceProvider` 와 `RateLimitedProvider` (decorator 들) 의 4 virtual override 블록을 `NEOGRAPH_PUSH/POP_IGNORE_DEPRECATED` 로 감쌈 — internal forwarder warning 차단, user-facing override / 호출 사이트만 warning. | v0.9.0 |
+| **#45 (PR5)** | C++ examples 마이그레이션 (`31_local_transformer.cpp`, `cookbook/ai-assembly/member_server.cpp`). | v0.9.0 |
+
+### v1.0 destructive removal (deferred)
+
+`SchemaProvider` / `OpenAIProvider` / `RateLimitedProvider` /
+`OpenInferenceProvider` 는 4 legacy virtual override 와 새 invoke()
+의 default forward 를 함께 갖고 있는 상태. v1.0.0 sub-PR 시퀀스 (Candidate 1
+의 9b–9e mirror):
+
+  - **6b**: native subclass 가 invoke() native override (4 virtual
+    override 의 코드를 invoke 안으로 통합). 기존 4 override 는 thin
+    adapter 또는 제거.
+  - **6c**: 4 legacy virtual 자체 삭제 from `Provider`. internal
+    forwarder PUSH_IGNORE 가드 제거. v1.0.0 에서 `Provider` 가 단일
+    pure-virtual `invoke()` + `get_name()` 만.
+  - **adjacent**: `schema_provider.cpp` (1800 LoC) 의 `SchemaParser` /
+    `SchemaWireBuilder` / `SchemaProviderImpl` 분할 (위 6b 와 같은
+    PR 또는 별도 — 구현 시 결정).

--- a/docs/migration-v0.4-to-v1.0.md
+++ b/docs/migration-v0.4-to-v1.0.md
@@ -278,6 +278,149 @@ grep -lE 'execute\(const GraphState' src/**/*.cpp
 복잡한 노드 (`execute_full`, `execute_stream_async` 등) 는 무조건
 손편집. 쇼트컷 없습니다.
 
+---
+
+# Migration 2: 옛 4 `Provider` virtual → 새 `Provider::invoke()` (v0.9 → v1.0)
+
+GraphNode 8 virtual → `run(NodeInput)` 와 같은 모양의 두 번째 통합.
+ROADMAP_v1.md **Candidate 6** 에 해당. v0.9.0 에서 새 `invoke()` 가
+landing + 옛 4 virtual 이 `[[deprecated]]` 마킹됨. v1.0.0 에서 옛
+4 virtual 삭제.
+
+## 시그니처 매핑
+
+| 옛 virtual | 새 모양 |
+|---|---|
+| `complete(params)` | `co_await invoke(params, nullptr)` (코루틴) 또는 `neograph::async::run_sync(invoke(params, nullptr))` (sync) |
+| `complete_async(params)` | `co_await invoke(params, nullptr)` |
+| `complete_stream(params, on_chunk)` | `neograph::async::run_sync(invoke(params, on_chunk))` |
+| `complete_stream_async(params, on_chunk)` | `co_await invoke(params, on_chunk)` |
+
+**핵심 규칙**: `on_chunk == nullptr` 이면 비스트리밍, `on_chunk` 가 있으면
+스트리밍. 한 메서드가 두 케이스 다 처리.
+
+## 케이스별 변환
+
+### Provider 호출하는 사용자 코드
+
+```cpp
+// 옛 — async 컨텍스트에서
+auto completion = co_await provider->complete_async(params);
+
+// 새 — 같은 의미
+auto completion = co_await provider->invoke(params, nullptr);
+```
+
+```cpp
+// 옛 — sync 함수 안에서
+auto completion = provider->complete(params);
+
+// 새 — async 어웨이트할 io_context 가 없으면 run_sync 로 brige
+auto completion = neograph::async::run_sync(provider->invoke(params, nullptr));
+```
+
+```cpp
+// 옛 — 스트리밍
+auto completion = co_await provider->complete_stream_async(params, on_chunk);
+
+// 새 — invoke 가 같은 분기를 자기 안에서 함
+auto completion = co_await provider->invoke(params, on_chunk);
+```
+
+### 사용자 정의 Provider subclass
+
+옛: 4 virtual 중 하나 이상 override. 새: `invoke()` 하나만 override
+하면 됨.
+
+```cpp
+// 옛 모양 — async-native provider
+class MyProvider : public neograph::Provider {
+public:
+    asio::awaitable<ChatCompletion>
+    complete_async(const CompletionParams& params) override {
+        // ... HTTP call ...
+        co_return result;
+    }
+
+    ChatCompletion complete_stream(const CompletionParams& params,
+                                   const StreamCallback& on_chunk) override {
+        // ... SSE call ...
+        return result;
+    }
+
+    std::string get_name() const override { return "my"; }
+};
+```
+
+```cpp
+// 새 모양 — 한 메서드가 두 케이스 다 처리
+class MyProvider : public neograph::Provider {
+public:
+    asio::awaitable<ChatCompletion>
+    invoke(const CompletionParams& params, StreamCallback on_chunk) override {
+        if (on_chunk) {
+            // ... SSE call, 토큰마다 on_chunk(token) ...
+        } else {
+            // ... HTTP call ...
+        }
+        co_return result;
+    }
+
+    std::string get_name() const override { return "my"; }
+};
+```
+
+v0.9 deprecation window 동안: 옛 4 virtual override 가 그대로 동작.
+새 invoke() 안 만들면 base default 가 4 virtual chain 으로 forward —
+즉 두 모양 공존 가능.
+
+## cancel 자동 propagation
+
+옛 sync `complete()` 가 `current_cancel_token()` 을 thread-local 에서
+읽어서 자동 cancel propagation 함. **새 `invoke()` 도 같은 동작 유지**:
+caller 가 `params.cancel_token` 을 set 안 했으면 thread-local 에서
+자동 stamp. 명시적 `params.cancel_token` 가 항상 우선.
+
+```cpp
+// engine 안 노드 본문 — 둘 다 동일하게 cancel 됨
+co_await provider->invoke(params, nullptr);                    // OK
+neograph::async::run_sync(provider->invoke(params, nullptr));  // OK
+```
+
+graph 밖에서 직접 호출하는 케이스 (`Agent` user code 등) 도 동일 —
+explicit cancel_token 안 주면 그냥 cancel 못 받음 (예전과 동일).
+
+## 마이그레이션 안 하면
+
+v0.9 ~ v0.x:
+- 옛 4 virtual override 그대로 동작
+- `-Wdeprecated-declarations` warning 이 user override / 호출 사이트에 visible
+- engine 내부 forwarder 는 `NEOGRAPH_PUSH_IGNORE_DEPRECATED` 가드 됨 — internal warning 0
+
+v1.0:
+- 옛 4 virtual 삭제
+- override 한 모든 user code 가 컴파일 fail (`'complete_async' marked
+  override but doesn't override anything in the base class`)
+- 호출하는 user code 도 compile fail (메서드 자체가 없음)
+
+선제 마이그레이션 추천 — Provider subclass 가 적어도 invoke() 하나만
+override 하면 v1.0 호환. 사용자 정의 Provider 가 많으면 일찍 옮기는
+게 부담 적음.
+
+## 자동 변환 가능?
+
+호출 사이트는 패턴 단순:
+
+```bash
+# dry-run 으로 검토
+grep -rnE '->complete(_async|_stream|_stream_async)?\(' your/code
+
+# 그 다음 케이스별로 손편집 (위 매핑표 참고).
+```
+
+Provider subclass 의 4 virtual override → invoke() 통합은 로직이 섞여
+있어서 손편집 필수.
+
 ## 관련 문서 / 이슈
 
 - [`include/neograph/graph/node.h`](../include/neograph/graph/node.h) —


### PR DESCRIPTION
## 요약

ROADMAP_v1.md **Candidate 6** (Provider 4-virtual → 1-virtual `invoke()`) 의 5 PR landing 정리. **v0.9.0 candidate cycle**.

코드 변경 0 — 문서만 (CHANGELOG / ROADMAP / migration guide 3개).

## CHANGELOG.md — [Unreleased] 섹션 신설

- **Added**: `Provider::invoke(params, on_chunk = nullptr)` + cancel propagation parity (PR #40 + #43)
- **Changed**: engine 내부 모든 LLM 호출 사이트가 invoke() 통과 (PR #41/#42 + #43 + #44) + C++ examples 2개 (PR #45)
- **Deprecated**: 4 legacy virtual `[[deprecated]]` 마커 + before/after 마이그레이션 코드 예제 (PR #44)

## ROADMAP_v1.md

- Status table: Candidate 6 = "Landed (additive + deprecation)" 5 PR. Candidate 1 행도 "Landed (additive)" 로 명시 (Phase B 만 v1.0 대기).
- Candidate 6 section 끝에 5 PR landing log 표 + v1.0 destructive removal 서브섹션 추가 (sub-PR 6b, 6c, schema split adjacent).

## docs/migration-v0.4-to-v1.0.md

새 섹션 **"Migration 2: 옛 4 Provider virtual → 새 invoke()"**:

- 시그니처 매핑표 (4 → 1)
- 케이스별 변환 — 호출 코드 + Provider subclass override
- cancel propagation parity 설명 (`current_cancel_token()` 자동 stamp)
- 자동 변환 limit + grep 명령 예제
- v1.0 에서 마이그레이션 안 하면 컴파일 fail 안내

## Test plan

- [x] 문서만 — 코드 영향 없음
- [ ] CI green (md 변경이라 build 영향 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)