### PR TITLE
refactor(examples): 9 C++ examples → GraphNode::run() (C-pre step 1)

### DIFF
--- a/examples/05_parallel_fanout.cpp
+++ b/examples/05_parallel_fanout.cpp
@@ -47,8 +47,8 @@ public:
     ResearcherNode(const std::string& name, const std::string& topic, int delay_ms)
         : name_(name), topic_(topic), delay_ms_(delay_ms) {}
 
-    asio::awaitable<std::vector<neograph::graph::ChannelWrite>>
-    execute_async(const neograph::graph::GraphState& /*state*/) override {
+    asio::awaitable<neograph::graph::NodeOutput>
+    run(neograph::graph::NodeInput /*in*/) override {
         auto start = std::chrono::steady_clock::now();
 
         auto ex = co_await asio::this_coro::executor;
@@ -68,26 +68,18 @@ public:
             + ". (" + std::to_string(elapsed) + "ms)";
         result["elapsed_ms"] = elapsed;
 
-        co_return std::vector<neograph::graph::ChannelWrite>{
-            neograph::graph::ChannelWrite{
-                "findings", neograph::json::array({result})}};
+        neograph::graph::NodeOutput out;
+        out.writes.push_back(neograph::graph::ChannelWrite{
+            "findings", neograph::json::array({result})});
+        co_return out;
     }
 
-    // Override the full_stream peer so the engine doesn't invoke our
-    // (already finished) work twice per super-step. The default
-    // GraphNode::execute_full_stream_async wraps execute_full_async
-    // *and then* replaces the writes with execute_stream_async's
-    // output if no Command/Send was emitted — that works for real
-    // streaming LLM nodes (where the token stream is what produces
-    // the writes) but for a node whose execute_async already did all
-    // the work it's a redundant second run. Short-circuit to a single
-    // execute_async call.
-    asio::awaitable<neograph::graph::NodeResult>
-    execute_full_stream_async(const neograph::graph::GraphState& state,
-                              const neograph::graph::GraphStreamCallback& /*cb*/) override {
-        auto writes = co_await execute_async(state);
-        co_return neograph::graph::NodeResult{std::move(writes)};
-    }
+    // Note: v0.4 unified `run()` replaces the old 8-virtual cross-product.
+    // The previous version of this node overrode `execute_full_stream_async`
+    // to avoid double-running its already-async body; with `run(NodeInput)`
+    // that's no longer needed — engine dispatches `run()` exactly once per
+    // super-step regardless of stream mode (the stream_cb just lives in
+    // `in.stream_cb`, which we don't use here).
 
     std::string get_name() const override { return name_; }
 };
@@ -95,10 +87,10 @@ public:
 // Custom node: Summarizer
 class SummarizerNode : public neograph::graph::GraphNode {
 public:
-    std::vector<neograph::graph::ChannelWrite> execute(
-        const neograph::graph::GraphState& state) override {
+    asio::awaitable<neograph::graph::NodeOutput>
+    run(neograph::graph::NodeInput in) override {
 
-        auto findings = state.get("findings");
+        auto findings = in.state.get("findings");
         std::string summary = "=== Research Summary ===\n";
 
         if (findings.is_array()) {
@@ -109,7 +101,10 @@ public:
             summary += "\nTotal " + std::to_string(findings.size()) + " research findings collected.";
         }
 
-        return {neograph::graph::ChannelWrite{"summary", neograph::json(summary)}};
+        neograph::graph::NodeOutput out;
+        out.writes.push_back(
+            neograph::graph::ChannelWrite{"summary", neograph::json(summary)});
+        co_return out;
     }
 
     std::string get_name() const override { return "summarizer"; }

--- a/examples/27_async_concurrent_runs.cpp
+++ b/examples/27_async_concurrent_runs.cpp
@@ -46,14 +46,15 @@ public:
     WorkNode(std::string name, int delay_ms)
         : name_(std::move(name)), delay_ms_(delay_ms) {}
 
-    asio::awaitable<std::vector<ng::ChannelWrite>>
-    execute_async(const ng::GraphState&) override {
+    asio::awaitable<ng::NodeOutput> run(ng::NodeInput) override {
         auto ex = co_await asio::this_coro::executor;
         asio::steady_timer t(ex);
         t.expires_after(std::chrono::milliseconds(delay_ms_));
         co_await t.async_wait(asio::use_awaitable);
-        co_return std::vector<ng::ChannelWrite>{
-            ng::ChannelWrite{"result", neograph::json("done by " + name_)}};
+        ng::NodeOutput out;
+        out.writes.push_back(
+            ng::ChannelWrite{"result", neograph::json("done by " + name_)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 };

--- a/examples/44_request_queue_backpressure.cpp
+++ b/examples/44_request_queue_backpressure.cpp
@@ -47,15 +47,14 @@ class WorkNode : public GraphNode {
     int delay_ms_;
 public:
     explicit WorkNode(int d) : delay_ms_(d) {}
-    asio::awaitable<std::vector<ChannelWrite>>
-    execute_async(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         auto ex = co_await asio::this_coro::executor;
         asio::steady_timer t(ex);
         t.expires_after(std::chrono::milliseconds(delay_ms_));
         co_await t.async_wait(asio::use_awaitable);
-        co_return std::vector<ChannelWrite>{
-            ChannelWrite{"result", json("ok")}
-        };
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"result", json("ok")});
+        co_return out;
     }
     std::string get_name() const override { return "work"; }
 };

--- a/examples/46_cancel_token.cpp
+++ b/examples/46_cancel_token.cpp
@@ -27,7 +27,7 @@ public:
     explicit SlowIncNode(std::string n, std::shared_ptr<CancelToken> tok)
         : n_(std::move(n)), tok_(std::move(tok)) {}
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
         for (int i = 0; i < 20; ++i) {
             if (tok_ && tok_->is_cancelled()) {
                 throw CancelledException("aborted inside " + n_);
@@ -35,9 +35,11 @@ public:
             std::this_thread::sleep_for(std::chrono::milliseconds(50));
         }
         int cur = 0;
-        auto v = state.get("counter");
+        auto v = in.state.get("counter");
         if (v.is_number()) cur = v.get<int>();
-        return {ChannelWrite{"counter", json(cur + 1)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"counter", json(cur + 1)});
+        co_return out;
     }
     std::string get_name() const override { return n_; }
 

--- a/examples/47_node_cache.cpp
+++ b/examples/47_node_cache.cpp
@@ -23,13 +23,15 @@ std::atomic<int> g_exec_count{0};
 
 class ExpensiveNode : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
         g_exec_count.fetch_add(1, std::memory_order_relaxed);
         int x = 0;
-        auto v = state.get("x");
+        auto v = in.state.get("x");
         if (v.is_number()) x = v.get<int>();
         // Pretend this is an expensive LLM/embedding/etc.
-        return {ChannelWrite{"y", json(x * x)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"y", json(x * x)});
+        co_return out;
     }
     std::string get_name() const override { return "expensive"; }
 };

--- a/examples/48_sqlite_checkpoint.cpp
+++ b/examples/48_sqlite_checkpoint.cpp
@@ -21,12 +21,14 @@ using namespace neograph::graph;
 class StampNode : public GraphNode {
 public:
     explicit StampNode(std::string n) : n_(std::move(n)) {}
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
         int cur = 0;
-        auto v = state.get("counter");
+        auto v = in.state.get("counter");
         if (v.is_number()) cur = v.get<int>();
-        return {ChannelWrite{"counter", json(cur + 1)},
-                ChannelWrite{"last", json(n_)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"counter", json(cur + 1)});
+        out.writes.push_back(ChannelWrite{"last", json(n_)});
+        co_return out;
     }
     std::string get_name() const override { return n_; }
 private:

--- a/examples/49_openinference.cpp
+++ b/examples/49_openinference.cpp
@@ -152,12 +152,14 @@ public:
 class TalkNode : public GraphNode {
 public:
     explicit TalkNode(std::shared_ptr<Provider> p) : prov_(std::move(p)) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         CompletionParams params;
         params.messages = {{"user", "say hi"}};
         params.model = "gpt-mock";
-        auto c = prov_->complete(params);
-        return {ChannelWrite{"reply", json(c.message.content)}};
+        auto c = co_await prov_->invoke(params, nullptr);
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"reply", json(c.message.content)});
+        co_return out;
     }
     std::string get_name() const override { return "talk"; }
 private:

--- a/examples/51_minimal.cpp
+++ b/examples/51_minimal.cpp
@@ -22,10 +22,12 @@ using namespace neograph::graph;
 // 노드 한 개. 채널 "text" 를 읽어서 대문자로 바꿔 다시 같은 채널에 씀.
 class UpperNode : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        std::string s = state.get("text").get<std::string>();
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        std::string s = in.state.get("text").get<std::string>();
         for (auto& c : s) c = static_cast<char>(std::toupper(c));
-        return {ChannelWrite{"text", json(s)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"text", json(s)});
+        co_return out;
     }
     std::string get_name() const override { return "upper"; }
 };

--- a/examples/cookbook/ai-assembly/member_server.cpp
+++ b/examples/cookbook/ai-assembly/member_server.cpp
@@ -69,8 +69,8 @@ class PersonaNode : public GraphNode {
           party_(std::move(party)),
           system_prompt_(std::move(system_prompt)) {}
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        auto raw = state.get("prompt");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto raw = in.state.get("prompt");
         std::string user_text = raw.is_string() ? raw.get<std::string>() : raw.dump();
 
         CompletionParams p;
@@ -79,12 +79,14 @@ class PersonaNode : public GraphNode {
         p.messages.push_back({"system", system_prompt_});
         p.messages.push_back({"user", user_text});
 
-        auto reply = neograph::async::run_sync(provider_->invoke(p, nullptr));
+        auto reply = co_await provider_->invoke(p, nullptr);
         std::string text = reply.message.content;
 
         // Tag with party + name so the Speaker's transcript is readable.
         std::string framed = "[" + party_ + " " + persona_name_ + "]\n" + text;
-        return {{"response", framed}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"response", json(framed)});
+        co_return out;
     }
 
     std::string get_name() const override { return name_; }


### PR DESCRIPTION
## 요약

**C-pre 단계 1** — 9 C++ examples 가 `[[deprecated]]` 인 옛 8-virtual `execute*` chain 에서 새 통합 `run(NodeInput) -> awaitable<NodeOutput>` 으로 마이그레이션. Candidate 1 Phase B sub-PR 9b (옛 8 virtual 자체 삭제) 진입 전 무대 정리.

## 마이그레이션 패턴

```cpp
// Before
std::vector<ChannelWrite> execute(const GraphState& state) override {
    return {ChannelWrite{"out", v}};
}

// After
asio::awaitable<NodeOutput> run(NodeInput in) override {
    NodeOutput out;
    out.writes.push_back(ChannelWrite{"out", v});
    co_return out;
}
```

`state` → `in.state`, `vector` literal 직접 return → `NodeOutput` 명시 build, `return` → `co_return`. async 노드는 시그니처만 바꾸면 됨 (`execute_async` → `run`, `awaitable<vector<...>>` → `awaitable<NodeOutput>`).

## 9 file

| 파일 | 노드 모양 |
|---|---|
| `51_minimal.cpp` | sync 단일 노드 |
| `46_cancel_token.cpp` | sync + CancelToken |
| `47_node_cache.cpp` | sync + cache demo |
| `48_sqlite_checkpoint.cpp` | sync + 두 write |
| `49_openinference.cpp` | sync + provider call |
| `44_request_queue_backpressure.cpp` | async timer |
| `27_async_concurrent_runs.cpp` | async timer |
| `05_parallel_fanout.cpp` | async + 옛 `execute_full_stream_async` workaround 삭제 (run 통합으로 불필요) |
| `cookbook/ai-assembly/member_server.cpp` | sync wrapper → 코루틴 본체로 옮김 |

## 검증

- 9 example binary 모두 build + 실행 — 기존 출력과 동일 (회귀 0)
- 479/479 ctest green

## NOT in this PR

- **`tests/*`** — 26 test file 이 옛 8-virtual 사용 (일부 의도적). 다음 PR (C-pre step 2) 에서 마이그레이션 + `tests/test_node_default_dispatch.cpp` / `test_node_async_default.cpp` 는 9e 에서 삭제 명시.
- **Python examples** — 확인 완료. `def run(self, input)` 이미 사용 중.

## Test plan

- [x] 9 example 모두 정상 출력
- [x] ctest 479/479
- [ ] CI green

ROADMAP_v1.md Candidate 1 Phase B 진입 준비.

🤖 Generated with [Claude Code](https://claude.com/claude-code)