### PR TITLE
refactor(tests): 7 single-site tests → GraphNode::run() (C-pre step 2 batch 1)

### DIFF
--- a/tests/test_a2a_server.cpp
+++ b/tests/test_a2a_server.cpp
@@ -30,16 +30,20 @@ using neograph::graph::GraphNode;
 using neograph::graph::GraphState;
 using neograph::graph::NodeContext;
 using neograph::graph::NodeFactory;
+using neograph::graph::NodeInput;
+using neograph::graph::NodeOutput;
 
 namespace {
 
 class EchoNode : public GraphNode {
   public:
     EchoNode(std::string name) : name_(std::move(name)) {}
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        auto raw = state.get("prompt");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto raw = in.state.get("prompt");
         std::string prompt = raw.is_string() ? raw.get<std::string>() : raw.dump();
-        return {{"response", "echo:" + prompt}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"response", json("echo:" + prompt)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
   private:

--- a/tests/test_admin_api_barrier_preservation.cpp
+++ b/tests/test_admin_api_barrier_preservation.cpp
@@ -21,7 +21,7 @@ namespace {
 // step loop, so the graph structure just has to compile.
 class Noop : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState&) override { return {}; }
+    asio::awaitable<NodeOutput> run(NodeInput) override { co_return NodeOutput{}; }
     std::string get_name() const override { return "noop"; }
 };
 

--- a/tests/test_barrier_persistence.cpp
+++ b/tests/test_barrier_persistence.cpp
@@ -31,9 +31,11 @@ class HitCounter : public GraphNode {
 public:
     HitCounter(std::string n, std::atomic<int>* counter)
         : name_(std::move(n)), counter_(counter) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         counter_->fetch_add(1, std::memory_order_relaxed);
-        return {ChannelWrite{name_ + "_done", json(true)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{name_ + "_done", json(true)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 private:

--- a/tests/test_compiler.cpp
+++ b/tests/test_compiler.cpp
@@ -21,7 +21,7 @@ namespace {
 class NoopNode : public GraphNode {
 public:
     explicit NoopNode(std::string n) : name_(std::move(n)) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override { return {}; }
+    asio::awaitable<NodeOutput> run(NodeInput) override { co_return NodeOutput{}; }
     std::string get_name() const override { return name_; }
 private:
     std::string name_;

--- a/tests/test_multi_node_resume.cpp
+++ b/tests/test_multi_node_resume.cpp
@@ -18,11 +18,13 @@ namespace {
 class HitCounter : public GraphNode {
 public:
     explicit HitCounter(std::string n) : n_(std::move(n)) {}
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
         int cur = 0;
-        auto v = state.get(n_ + "_hits");
+        auto v = in.state.get(n_ + "_hits");
         if (v.is_number()) cur = static_cast<int>(v.get<double>());
-        return {ChannelWrite{n_ + "_hits", json(cur + 1)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{n_ + "_hits", json(cur + 1)});
+        co_return out;
     }
     std::string get_name() const override { return n_; }
 private:

--- a/tests/test_node_cache.cpp
+++ b/tests/test_node_cache.cpp
@@ -23,9 +23,11 @@ public:
 
     std::string get_name() const override { return name_; }
 
-    std::vector<ChannelWrite> execute(const GraphState& /*state*/) override {
+    asio::awaitable<NodeOutput> run(NodeInput /*in*/) override {
         counter_->fetch_add(1, std::memory_order_relaxed);
-        return {ChannelWrite{"out", json("hit")}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"out", json("hit")});
+        co_return out;
     }
 
 private:

--- a/tests/test_resume_if_exists.cpp
+++ b/tests/test_resume_if_exists.cpp
@@ -18,8 +18,8 @@ namespace {
 // channel. One run = one assistant turn appended.
 class EchoNode : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        auto msgs = state.get("messages");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto msgs = in.state.get("messages");
         std::string last_user = "";
         if (msgs.is_array()) {
             for (const auto& m : msgs) {
@@ -30,7 +30,9 @@ public:
         }
         json reply = {{"role", "assistant"},
                       {"content", "echo: " + last_user}};
-        return {ChannelWrite{"messages", json::array({reply})}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"messages", json::array({reply})});
+        co_return out;
     }
     std::string get_name() const override { return "echo"; }
 };


### PR DESCRIPTION
## 요약

**C-pre 단계 2 batch 1** — 7 test file (각 1 site) 가 옛 `execute(GraphState)` override 에서 새 `run(NodeInput) -> awaitable<NodeOutput>` 으로 마이그레이션. 다음 batch 들이 multi-site 파일 처리한 후 Phase B sub-PR 9b 가 옛 8 virtual 자체 삭제할 수 있게.

## 마이그레이션 파일

| 파일 | 노드 |
|---|---|
| test_compiler.cpp | NoopNode |
| test_a2a_server.cpp | EchoNode (+ `NodeInput/Output` using 추가) |
| test_admin_api_barrier_preservation.cpp | Noop placeholder |
| test_barrier_persistence.cpp | HitCounter |
| test_multi_node_resume.cpp | HitCounter (다른 모양) |
| test_node_cache.cpp | CountingNode |
| test_resume_if_exists.cpp | EchoNode (chat resume) |

## 후속 batch (예정)

| 카테고리 | 파일 |
|---|---|
| multi-site (4+ override) | test_acp_server, test_cancel_token_propagation, test_multi_send_events (12), test_multi_send_routing (11), test_pending_writes (6, `NodeResult`), test_sends_interrupt_order (5), test_signal_dispatch (14) |
| medium (2–3 site) | test_concurrent_stress, test_executor_async_parallel, test_executor_async_retry, test_graph_engine, test_graph_engine_async_api, test_live_llm_cancel_fanout_cpp, test_node, test_node_execution |
| **9e 에서 삭제** (의도적 옛 chain 검증) | test_node_default_dispatch, test_node_async_default, test_node_run_dispatch (LegacyExecuteOnlyNode case), test_execute_stream_only_dispatch |

## 검증

- 479/479 ctest green
- 회귀 0

## Test plan

- [x] ctest 479/479
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)