### PR TITLE
refactor(tests): 7 medium-complexity tests → run() (C-pre step 2 batch 2)

### DIFF
--- a/tests/test_concurrent_stress.cpp
+++ b/tests/test_concurrent_stress.cpp
@@ -60,15 +60,15 @@ long read_rss_kb() {
 class Worker : public GraphNode {
 public:
     std::string get_name() const override { return "worker"; }
-    asio::awaitable<std::vector<ChannelWrite>>
-    execute_async(const GraphState& state) override {
-        int i = state.get("i").get<int>();
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        int i = in.state.get("i").get<int>();
         auto ex = co_await asio::this_coro::executor;
         asio::steady_timer t(ex);
         t.expires_after(std::chrono::milliseconds(1));
         co_await t.async_wait(asio::use_awaitable);
-        co_return std::vector<ChannelWrite>{
-            ChannelWrite{"results", json::array({i * i})}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"results", json::array({i * i})});
+        co_return out;
     }
 };
 
@@ -78,12 +78,12 @@ public:
 class Planner : public GraphNode {
 public:
     std::string get_name() const override { return "planner"; }
-    NodeResult execute_full(const GraphState&) override {
-        NodeResult r;
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
         for (int i = 0; i < 3; ++i) {
-            r.sends.emplace_back(Send{"worker", json{{"i", i}}});
+            out.sends.emplace_back(Send{"worker", json{{"i", i}}});
         }
-        return r;
+        co_return out;
     }
 };
 

--- a/tests/test_executor_async_parallel.cpp
+++ b/tests/test_executor_async_parallel.cpp
@@ -46,27 +46,22 @@ public:
     AsyncWorkerNode(std::string name, int delay_ms)
         : name_(std::move(name)), delay_ms_(delay_ms) {}
 
-    asio::awaitable<std::vector<ChannelWrite>>
-    execute_async(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         auto ex = co_await asio::this_coro::executor;
         asio::steady_timer t(ex);
         t.expires_after(std::chrono::milliseconds(delay_ms_));
         co_await t.async_wait(asio::use_awaitable);
         json append = json::array();
         append.push_back("done-by-" + name_);
-        co_return std::vector<ChannelWrite>{ChannelWrite{"findings", append}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"findings", append});
+        co_return out;
     }
 
-    // 3.0: execute_full_async default bridges to sync execute_full
-    // (for Command/Send preservation), which would serialize this
-    // node's async timer under a fresh io_context per call. Override
-    // here to keep the non-blocking timer on the caller's executor —
-    // the contract documented on GraphNode::execute_full_async.
-    asio::awaitable<NodeResult>
-    execute_full_async(const GraphState& state) override {
-        auto writes = co_await execute_async(state);
-        co_return NodeResult{std::move(writes)};
-    }
+    // Note: under unified run() the old execute_full_async override
+    // (which used to short-circuit the legacy bridge to avoid double-
+    // dispatch through sync execute_full) is unnecessary — run() is
+    // dispatched exactly once per super-step.
 
     std::string get_name() const override { return name_; }
 };
@@ -75,8 +70,9 @@ class InterruptingNode : public GraphNode {
     std::string name_;
 public:
     explicit InterruptingNode(std::string name) : name_(std::move(name)) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         throw NodeInterrupt("human input required: " + name_);
+        co_return NodeOutput{};  // unreachable
     }
     std::string get_name() const override { return name_; }
 };

--- a/tests/test_executor_async_retry.cpp
+++ b/tests/test_executor_async_retry.cpp
@@ -31,12 +31,14 @@ public:
     FlakyNode(std::string name, int fail_remaining)
         : name_(std::move(name)), fail_remaining_(fail_remaining) {}
 
-    std::vector<ChannelWrite> execute(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         int remaining = fail_remaining_.fetch_sub(1, std::memory_order_acq_rel);
         if (remaining > 0) {
             throw std::runtime_error("flaky: injected failure in " + name_);
         }
-        return {ChannelWrite{"result", json("ok from " + name_)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"result", json("ok from " + name_)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 private:
@@ -47,8 +49,10 @@ private:
 class AlwaysSuccessNode : public GraphNode {
 public:
     explicit AlwaysSuccessNode(std::string name) : name_(std::move(name)) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override {
-        return {ChannelWrite{"result", json("ok")}};
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"result", json("ok")});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 private:
@@ -58,8 +62,9 @@ private:
 class AlwaysInterruptNode : public GraphNode {
 public:
     explicit AlwaysInterruptNode(std::string name) : name_(std::move(name)) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         throw NodeInterrupt("needs human");
+        co_return NodeOutput{};  // unreachable, keeps it a coroutine
     }
     std::string get_name() const override { return name_; }
 private:

--- a/tests/test_graph_engine.cpp
+++ b/tests/test_graph_engine.cpp
@@ -56,8 +56,10 @@ public:
     EchoNode(const std::string& name, const std::string& value)
         : name_(name), value_(value) {}
 
-    std::vector<ChannelWrite> execute(const GraphState& /*state*/) override {
-        return {ChannelWrite{"result", json(value_)}};
+    asio::awaitable<NodeOutput> run(NodeInput /*in*/) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"result", json(value_)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 private:
@@ -72,8 +74,10 @@ public:
     RouterNode(const std::string& name, const std::string& route)
         : name_(name), route_(route) {}
 
-    std::vector<ChannelWrite> execute(const GraphState& /*state*/) override {
-        return {ChannelWrite{"__route__", json(route_)}};
+    asio::awaitable<NodeOutput> run(NodeInput /*in*/) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"__route__", json(route_)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 private:
@@ -238,12 +242,14 @@ public:
     DoublerNode(const std::string& name, std::atomic<int>* counter)
         : name_(name), counter_(counter) {}
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        json v = state.get("input_val");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        json v = in.state.get("input_val");
         int input = v.is_number_integer() ? v.get<int>() : 0;
         std::this_thread::sleep_for(std::chrono::milliseconds(2));
         if (counter_) counter_->fetch_add(1, std::memory_order_relaxed);
-        return {ChannelWrite{"result", json(input * 2)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"result", json(input * 2)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 private:

--- a/tests/test_graph_engine_async_api.cpp
+++ b/tests/test_graph_engine_async_api.cpp
@@ -53,8 +53,10 @@ class WriteNode : public GraphNode {
 public:
     WriteNode(const std::string& name, std::string value)
         : name_(name), value_(std::move(value)) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override {
-        return {ChannelWrite{"result", json(value_)}};
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"result", json(value_)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 private:
@@ -65,8 +67,9 @@ private:
 class ThrowingNode : public GraphNode {
 public:
     explicit ThrowingNode(const std::string& name) : name_(name) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         throw std::runtime_error("intentional failure");
+        co_return NodeOutput{};  // unreachable
     }
     std::string get_name() const override { return name_; }
 private:

--- a/tests/test_live_llm_cancel_fanout_cpp.cpp
+++ b/tests/test_live_llm_cancel_fanout_cpp.cpp
@@ -61,8 +61,8 @@ public:
                    LiveTimings* t)
         : name_(std::move(name)), provider_(std::move(provider)), t_(t) {}
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        auto i_v = state.get("i");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto i_v = in.state.get("i");
         int i = i_v.is_number_integer() ? i_v.get<int>() : 0;
         if (i < 0 || i >= WIDTH) i = 0;
 
@@ -85,12 +85,11 @@ public:
         params.messages = {msg};
 
         // This is the call that should abort at the socket layer when
-        // the parent cancel_token fires. v0.3.2 wires the parent's
-        // cancel into provider.complete() via add_cancel_hook + a
-        // local cancellation_signal — concurrent siblings each get
-        // their own slot, no last-writer-wins.
+        // the parent cancel_token fires. v1.0 invoke() picks up
+        // in.ctx.cancel_token (or the engine's thread-local cancel scope)
+        // and stamps it into the underlying HTTP call.
         try {
-            auto result = provider_->complete(params);
+            auto result = co_await provider_->invoke(params, nullptr);
             (void)result;
         } catch (...) {
             // CancelledException / asio operation_aborted unwind here.
@@ -103,7 +102,7 @@ public:
             std::lock_guard<std::mutex> lk(t_->mu);
             t_->finished[i] = now_seconds();
         }
-        return {};
+        co_return NodeOutput{};
     }
 
     std::string get_name() const override { return name_; }
@@ -118,14 +117,14 @@ class DispatcherNode : public GraphNode {
 public:
     explicit DispatcherNode(std::string name) : name_(std::move(name)) {}
 
-    NodeResult execute_full(const GraphState&) override {
-        NodeResult r;
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
         for (int i = 0; i < WIDTH; ++i) {
             json input;
             input["i"] = i;
-            r.sends.push_back(Send{"worker", input});
+            out.sends.push_back(Send{"worker", input});
         }
-        return r;
+        co_return out;
     }
 
     std::string get_name() const override { return name_; }

--- a/tests/test_node_execution.cpp
+++ b/tests/test_node_execution.cpp
@@ -34,12 +34,14 @@ public:
     FlakyNode(std::string n, std::atomic<int>* attempts, std::atomic<int>* fail_remaining)
         : name_(std::move(n)), attempts_(attempts), fail_remaining_(fail_remaining) {}
 
-    std::vector<ChannelWrite> execute(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         attempts_->fetch_add(1, std::memory_order_relaxed);
         if (fail_remaining_->fetch_sub(1, std::memory_order_relaxed) > 0) {
             throw std::runtime_error("flaky: injected failure in " + name_);
         }
-        return {ChannelWrite{name_ + "_done", json(true)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{name_ + "_done", json(true)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 
@@ -56,12 +58,14 @@ public:
     InterruptOnceNode(std::string n, std::atomic<int>* attempts, std::atomic<bool>* should_interrupt)
         : name_(std::move(n)), attempts_(attempts), should_interrupt_(should_interrupt) {}
 
-    std::vector<ChannelWrite> execute(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         attempts_->fetch_add(1, std::memory_order_relaxed);
         if (should_interrupt_->load(std::memory_order_relaxed)) {
             throw NodeInterrupt("needs approval");
         }
-        return {ChannelWrite{name_ + "_done", json(true)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{name_ + "_done", json(true)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 
@@ -110,8 +114,10 @@ json make_single_flaky_graph(int global_max_retries = 0, int initial_delay_ms = 
 // fan-out failures downstream have somewhere to attach pending writes.
 class SetupNode : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState&) override {
-        return {ChannelWrite{"setup_done", json(true)}};
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"setup_done", json(true)});
+        co_return out;
     }
     std::string get_name() const override { return "setup"; }
 };


### PR DESCRIPTION
## 요약

**C-pre 단계 2 batch 2** — 7 multi-site (2–3 override) test file 마이그레이션.

| 파일 | sites | 패턴 |
|---|---|---|
| test_executor_async_retry.cpp | 3 | sync execute + throw |
| test_graph_engine.cpp | 3 | sync execute |
| test_graph_engine_async_api.cpp | 2 | sync + throw |
| test_node_execution.cpp | 3 | sync + interrupt |
| test_concurrent_stress.cpp | 2 | async timer + execute_full → sends |
| test_executor_async_parallel.cpp | 3 | async timer + 옛 `execute_full_async` 워크어라운드 삭제 (run() 가 자동 single-dispatch 라 불필요) |
| test_live_llm_cancel_fanout_cpp.cpp | 2 | sync `complete()` → `co_await invoke()` + dispatcher execute_full → sends |

## 패턴 변종

- **async timer 노드**: `execute_async` → `run` with awaitable timer 본체 그대로
- **`execute_full` + Send fan-out**: `NodeResult` writes/sends → `NodeOutput::sends`
- **throwing 노드** (NodeInterrupt / runtime_error): `co_return NodeOutput{}; // unreachable` 줄 추가 (코루틴 유지)

## 검증

- 479/479 ctest green
- 회귀 0

## 남은 batch 3

multi-site (4+) 파일 8개 — test_acp_server, test_cancel_token_propagation, test_multi_send_events (12!), test_multi_send_routing (11), test_node, test_pending_writes (`NodeResult execute_full`), test_sends_interrupt_order, test_signal_dispatch (14!). 그 다음 9b 가 destructive removal 안전.

## Test plan

- [x] ctest 479/479
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)