### PR TITLE
refactor(tests): 3 multi-site tests → run() (C-pre step 2 batch 3a)

### DIFF
--- a/tests/test_acp_server.cpp
+++ b/tests/test_acp_server.cpp
@@ -33,16 +33,20 @@ using neograph::graph::GraphNode;
 using neograph::graph::GraphState;
 using neograph::graph::NodeContext;
 using neograph::graph::NodeFactory;
+using neograph::graph::NodeInput;
+using neograph::graph::NodeOutput;
 
 namespace {
 
 class EchoNode : public GraphNode {
   public:
     EchoNode(std::string n) : name_(std::move(n)) {}
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        auto raw = state.get("prompt");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto raw = in.state.get("prompt");
         std::string p = raw.is_string() ? raw.get<std::string>() : raw.dump();
-        return {{"response", "echo:" + p}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"response", neograph::json("echo:" + p)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
   private:
@@ -327,11 +331,13 @@ class ReadFileNode : public GraphNode {
   public:
     ReadFileNode(std::string n, std::shared_ptr<ACPClient> client, std::string path)
         : name_(std::move(n)), client_(std::move(client)), path_(std::move(path)) {}
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        auto sid_v = state.get("_acp_session_id");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto sid_v = in.state.get("_acp_session_id");
         std::string sid = sid_v.is_string() ? sid_v.get<std::string>() : "";
         auto contents = client_->read_text_file(sid, path_);
-        return {{"response", "got:" + contents}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"response", neograph::json("got:" + contents)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
   private:
@@ -446,8 +452,8 @@ class GatedNode : public GraphNode {
   public:
     GatedNode(std::string n, std::shared_ptr<ACPClient> client)
         : name_(std::move(n)), client_(std::move(client)) {}
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        auto sid_v = state.get("_acp_session_id");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto sid_v = in.state.get("_acp_session_id");
         std::string sid = sid_v.is_string() ? sid_v.get<std::string>() : "";
 
         acp::ToolCallUpdate tc;
@@ -465,7 +471,9 @@ class GatedNode : public GraphNode {
         std::string answer = (outcome.kind == PermissionOutcomeKind::Selected)
                              ? outcome.option_id
                              : "(cancelled)";
-        return {{"response", answer}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"response", neograph::json(answer)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
   private:
@@ -616,11 +624,13 @@ class WriteFileNode : public GraphNode {
                   std::string path, std::string body)
         : name_(std::move(n)), client_(std::move(client)),
           path_(std::move(path)), body_(std::move(body)) {}
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        auto sid_v = state.get("_acp_session_id");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto sid_v = in.state.get("_acp_session_id");
         std::string sid = sid_v.is_string() ? sid_v.get<std::string>() : "";
         client_->write_text_file(sid, path_, body_);
-        return {{"response", "wrote:" + path_}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"response", neograph::json("wrote:" + path_)});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
   private:
@@ -758,11 +768,13 @@ TEST(ACPServer, RejectsSecondPromptOnSameSession) {
       public:
         StallNode(std::string n, std::shared_ptr<std::atomic<bool>> stall)
             : name_(std::move(n)), stall_(std::move(stall)) {}
-        std::vector<ChannelWrite> execute(const GraphState&) override {
+        asio::awaitable<NodeOutput> run(NodeInput) override {
             while (stall_->load(std::memory_order_acquire)) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(5));
             }
-            return {{"response", "done"}};
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{"response", neograph::json("done")});
+            co_return out;
         }
         std::string get_name() const override { return name_; }
       private:

--- a/tests/test_cancel_token_propagation.cpp
+++ b/tests/test_cancel_token_propagation.cpp
@@ -33,16 +33,21 @@ public:
                                 CancelToken* expected)
         : n_(std::move(n)), count_(observed_count), expected_(expected) {}
 
-    NodeResult execute_full(const GraphState& state) override {
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
         // Read the token pointer; record only if it matches the parent
         // run's token. A null or mismatched pointer is the actual bug
         // — if the test sees that, count_ stays unchanged and the
         // assertion below fails.
-        if (state.run_cancel_token() == expected_ && expected_ != nullptr) {
+        // NOTE: this still reads the legacy state.run_cancel_token() smuggling
+        // channel — 9d will switch it to in.ctx.cancel_token.get() (or this
+        // whole test gets superseded by the in.ctx.cancel_token coverage).
+        if (in.state.run_cancel_token() == expected_ && expected_ != nullptr) {
             count_->fetch_add(1, std::memory_order_relaxed);
         }
         // Emit a small write so the engine has something to commit.
-        return NodeResult{{ChannelWrite{"saw_token", json::array({n_})}}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"saw_token", json::array({n_})});
+        co_return out;
     }
 
     std::string get_name() const override { return n_; }
@@ -59,14 +64,14 @@ public:
     explicit SendFanOutNode(std::string n, std::string target, int width)
         : n_(std::move(n)), target_(std::move(target)), width_(width) {}
 
-    NodeResult execute_full(const GraphState&) override {
-        NodeResult res;
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
         for (int i = 0; i < width_; ++i) {
             json input;
             input["i"] = i;
-            res.sends.push_back(Send{target_, input});
+            out.sends.push_back(Send{target_, input});
         }
-        return res;
+        co_return out;
     }
 
     std::string get_name() const override { return n_; }
@@ -213,7 +218,7 @@ TEST(CancelTokenPropagation, CancelMidFanOutHaltsLoop) {
         SlowObserver(std::string n, std::atomic<int>* started,
                      std::shared_ptr<CancelToken> tok)
             : n_(std::move(n)), started_(started), tok_(std::move(tok)) {}
-        NodeResult execute_full(const GraphState& state) override {
+        asio::awaitable<NodeOutput> run(NodeInput in) override {
             started_->fetch_add(1, std::memory_order_relaxed);
             // First node: trip the cancel before returning, so the
             // engine's super-step boundary observes it before the
@@ -223,11 +228,13 @@ TEST(CancelTokenPropagation, CancelMidFanOutHaltsLoop) {
             } else {
                 // Cooperative: if cancel is set, throw the same way
                 // the engine does at super-step boundaries.
-                if (auto* t = state.run_cancel_token()) {
+                if (auto* t = in.state.run_cancel_token()) {
                     t->throw_if_cancelled("worker " + n_);
                 }
             }
-            return NodeResult{{ChannelWrite{"saw_token", json::array({n_})}}};
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{"saw_token", json::array({n_})});
+            co_return out;
         }
         std::string get_name() const override { return n_; }
     private:
@@ -321,7 +328,7 @@ TEST(CancelTokenPropagation, MidFlightCancelAbortsSendSiblings) {
               entered_(entered), completed_(completed),
               first_done_(first_done) {}
 
-        NodeResult execute_full(const GraphState& state) override {
+        asio::awaitable<NodeOutput> run(NodeInput in) override {
             entered_->fetch_add(1, std::memory_order_relaxed);
 
             // The first worker to win the race trips cancel. Use a CAS
@@ -336,7 +343,9 @@ TEST(CancelTokenPropagation, MidFlightCancelAbortsSendSiblings) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(5));
                 tok_->cancel();
                 completed_->fetch_add(1, std::memory_order_relaxed);
-                return NodeResult{{ChannelWrite{"saw_token", json::array({n_})}}};
+                NodeOutput out;
+                out.writes.push_back(ChannelWrite{"saw_token", json::array({n_})});
+                co_return out;
             }
 
             // Siblings: simulate "in-flight long work" by polling cancel
@@ -347,7 +356,7 @@ TEST(CancelTokenPropagation, MidFlightCancelAbortsSendSiblings) {
             // null on the isolated send_state and the loop polls
             // forever (until the deadline) → completed_ bumps as if
             // nothing happened.
-            auto* t = state.run_cancel_token();
+            auto* t = in.state.run_cancel_token();
             const auto deadline =
                 std::chrono::steady_clock::now() +
                 std::chrono::milliseconds(200);
@@ -361,7 +370,9 @@ TEST(CancelTokenPropagation, MidFlightCancelAbortsSendSiblings) {
             // Reaching here means we never observed the cancel within
             // the 200 ms window — the propagation is broken.
             completed_->fetch_add(1, std::memory_order_relaxed);
-            return NodeResult{{ChannelWrite{"saw_token", json::array({n_})}}};
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{"saw_token", json::array({n_})});
+            co_return out;
         }
         std::string get_name() const override { return n_; }
     private:

--- a/tests/test_sends_interrupt_order.cpp
+++ b/tests/test_sends_interrupt_order.cpp
@@ -32,15 +32,10 @@ namespace {
 // No retries, no state writes — just dispatches fan-out.
 class SinglePlanner : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState&) override { return {}; }
-    NodeResult execute_full(const GraphState&) override {
-        NodeResult nr;
-        nr.sends.push_back(Send{"worker", json{{"payload", 7}}});
-        return nr;
-    }
-    asio::awaitable<NodeResult>
-    execute_full_async(const GraphState& state) override {
-        co_return execute_full(state);
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.sends.push_back(Send{"worker", json{{"payload", 7}}});
+        co_return out;
     }
     std::string get_name() const override { return "planner"; }
 };
@@ -50,11 +45,13 @@ public:
 class Worker : public GraphNode {
 public:
     explicit Worker(std::atomic<int>* counter) : counter_(counter) {}
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
         counter_->fetch_add(1, std::memory_order_relaxed);
-        json p = state.get("payload");
+        json p = in.state.get("payload");
         int v = p.is_number_integer() ? p.get<int>() : -1;
-        return {ChannelWrite{"results", json(v)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"results", json(v)});
+        co_return out;
     }
     std::string get_name() const override { return "worker"; }
 private:


### PR DESCRIPTION
## 요약

**C-pre 단계 2 batch 3a** — 3 multi-site tests 마이그레이션.

| 파일 | sites | 패턴 |
|---|---|---|
| test_acp_server.cpp | 5 | sync `execute` + ACP client call. `NodeInput/Output` using 추가 |
| test_cancel_token_propagation.cpp | 4 | `NodeResult execute_full` + `state.run_cancel_token()` 옛 thread-local (9d 에서 ctx 로 옮길 예정) |
| test_sends_interrupt_order.cpp | 3 | SinglePlanner 의 옛 3-override workaround (`execute` + `execute_full` + `execute_full_async`) 한 `run()` 로 collapse + Worker (1 sync) |

## NOT in this PR

- **test_node.cpp** — `DefaultExecuteFullWrapsExecute` test 가 의도적으로 옛 chain 검증. 이미 `NEOGRAPH_PUSH/POP_IGNORE_DEPRECATED` 로 감쌈. 9b 에서 test 자체 삭제 (execute_full virtual 삭제와 함께).

## 검증

- 479/479 ctest green
- 회귀 0

## 남은 batch 3b–3c

| 파일 | sites | 비고 |
|---|---|---|
| test_pending_writes | 6 | `NodeResult execute_full` + `node.execute_full(state)` 직접 호출 |
| test_multi_send_events | 12 | 다수 노드, 일부 NodeResult |
| test_multi_send_routing | 11 | 다수 노드 |
| test_signal_dispatch | 14 | 다수 노드 |

그 다음 9b destructive removal.

## Test plan

- [x] ctest 479/479
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)