### PR TITLE
refactor(tests): test_pending_writes + test_multi_send_events → run() (C-pre step 2 batch 3b)

### DIFF
--- a/tests/test_multi_send_events.cpp
+++ b/tests/test_multi_send_events.cpp
@@ -31,20 +31,15 @@ namespace {
 class FanoutPlannerNode : public GraphNode {
 public:
     explicit FanoutPlannerNode(int fanout) : fanout_(fanout) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override { return {}; }
-    NodeResult execute_full(const GraphState&) override {
-        NodeResult nr;
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
         for (int i = 0; i < fanout_; ++i) {
             Send s;
             s.target_node = "worker";
             s.input = {{"task_idx", i}};
-            nr.sends.push_back(std::move(s));
+            out.sends.push_back(std::move(s));
         }
-        return nr;
-    }
-    asio::awaitable<NodeResult>
-    execute_full_async(const GraphState& state) override {
-        co_return execute_full(state);
+        co_return out;
     }
     std::string get_name() const override { return "planner"; }
 private:
@@ -54,10 +49,12 @@ private:
 // Worker node: writes result. Stateless, thread-safe.
 class WorkerNode : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        json v = state.get("task_idx");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        json v = in.state.get("task_idx");
         int idx = v.is_number_integer() ? v.get<int>() : -1;
-        return {ChannelWrite{"results", json::array({idx})}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"results", json::array({idx})});
+        co_return out;
     }
     std::string get_name() const override { return "worker"; }
 };
@@ -189,15 +186,17 @@ class FlakyWorkerNode : public GraphNode {
 public:
     FlakyWorkerNode(std::atomic<int>* attempts, int fail_until)
         : attempts_(attempts), fail_until_(fail_until) {}
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
         int n = attempts_->fetch_add(1, std::memory_order_relaxed) + 1;
         if (n <= fail_until_) {
             throw std::runtime_error(
                 "simulated transient failure #" + std::to_string(n));
         }
-        json v = state.get("task_idx");
+        json v = in.state.get("task_idx");
         int idx = v.is_number_integer() ? v.get<int>() : -1;
-        return {ChannelWrite{"results", json::array({idx})}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"results", json::array({idx})});
+        co_return out;
     }
     std::string get_name() const override { return "worker"; }
 private:
@@ -217,25 +216,20 @@ private:
 // updates make it into the merged state.
 class CommandUpdateSendTarget : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState&) override { return {}; }
-    NodeResult execute_full(const GraphState& state) override {
-        NodeResult nr;
-        json v = state.get("task_idx");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        NodeOutput out;
+        json v = in.state.get("task_idx");
         int idx = v.is_number_integer() ? v.get<int>() : -1;
         // A normal write (baseline) and a Command.updates entry. If the
         // engine drops command->updates, `side_effects` will stay empty
         // even though `results` accumulates normally.
-        nr.writes.push_back(ChannelWrite{"results", json::array({idx})});
+        out.writes.push_back(ChannelWrite{"results", json::array({idx})});
         Command cmd;
         cmd.goto_node = "__end__";
         cmd.updates.push_back(
             ChannelWrite{"side_effects", json::array({idx * 100})});
-        nr.command = std::move(cmd);
-        return nr;
-    }
-    asio::awaitable<NodeResult>
-    execute_full_async(const GraphState& state) override {
-        co_return execute_full(state);
+        out.command = std::move(cmd);
+        co_return out;
     }
     std::string get_name() const override { return "worker"; }
 };

--- a/tests/test_pending_writes.cpp
+++ b/tests/test_pending_writes.cpp
@@ -29,21 +29,15 @@ class PlannerNode : public GraphNode {
 public:
     explicit PlannerNode(int fanout) : fanout_(fanout) {}
 
-    std::vector<ChannelWrite> execute(const GraphState&) override { return {}; }
-
-    NodeResult execute_full(const GraphState&) override {
-        NodeResult nr;
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
         for (int i = 0; i < fanout_; ++i) {
             Send s;
             s.target_node = "executor";
             s.input = {{"task_idx", i}};
-            nr.sends.push_back(std::move(s));
+            out.sends.push_back(std::move(s));
         }
-        return nr;
-    }
-    asio::awaitable<NodeResult>
-    execute_full_async(const GraphState& state) override {
-        co_return execute_full(state);
+        co_return out;
     }
     std::string get_name() const override { return "planner"; }
 private:
@@ -56,8 +50,8 @@ public:
     CrashyExecutorNode(std::atomic<int>* counter, std::atomic<int>* fail_on)
         : counter_(counter), fail_on_(fail_on) {}
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        json v = state.get("task_idx");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        json v = in.state.get("task_idx");
         int idx = v.is_number_integer() ? v.get<int>() : -999;
         counter_->fetch_add(1, std::memory_order_relaxed);
 
@@ -67,7 +61,9 @@ public:
         }
         // Write a result entry. The main-state "results" channel is
         // append-reduced, so all successful sends accumulate.
-        return {ChannelWrite{"results", json(idx * 10)}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"results", json(idx * 10)});
+        co_return out;
     }
     std::string get_name() const override { return "executor"; }
 
@@ -81,8 +77,10 @@ private:
 // to; without this, crash recovery on the first super-step has no anchor.
 class SetupNode : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState&) override {
-        return {ChannelWrite{"setup_done", json(true)}};
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"setup_done", json(true)});
+        co_return out;
     }
     std::string get_name() const override { return "setup"; }
 };


### PR DESCRIPTION
## 요약

**C-pre 단계 2 batch 3b** — 2 large multi-site tests 마이그레이션.

| 파일 | sites | 패턴 |
|---|---|---|
| test_pending_writes.cpp | 6 | PlannerNode 의 3-override workaround (`execute` + `NodeResult execute_full` + `execute_full_async`) → 한 `run()`. CrashyExecutor + Setup 단순 |
| test_multi_send_events.cpp | 12 | FanoutPlanner + CommandUpdateSendTarget 같은 3-override workaround → 한 `run()`. CommandUpdateSendTarget 의 `NodeResult::command`/`writes` → `NodeOutput::command`/`writes` (alias) |

## 검증

- 479/479 ctest green
- 회귀 0

## 남은 batch 3c

| 파일 | sites |
|---|---|
| test_multi_send_routing | 11 |
| test_signal_dispatch | 14 |

그 다음 9b destructive removal.

## Test plan

- [x] ctest 479/479
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)