### PR TITLE
refactor(tests): test_multi_send_routing + test_signal_dispatch → run() (C-pre step 2 batch 3c, FINAL)

### DIFF
--- a/tests/test_multi_send_routing.cpp
+++ b/tests/test_multi_send_routing.cpp
@@ -34,20 +34,15 @@ namespace {
 class RoutingPlannerNode : public GraphNode {
 public:
     explicit RoutingPlannerNode(int fanout) : fanout_(fanout) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override { return {}; }
-    NodeResult execute_full(const GraphState&) override {
-        NodeResult nr;
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
         for (int i = 0; i < fanout_; ++i) {
             Send s;
             s.target_node = "worker";
             s.input = {{"task_idx", i}};
-            nr.sends.push_back(std::move(s));
+            out.sends.push_back(std::move(s));
         }
-        return nr;
-    }
-    asio::awaitable<NodeResult>
-    execute_full_async(const GraphState& state) override {
-        co_return execute_full(state);
+        co_return out;
     }
     std::string get_name() const override { return "planner"; }
 private:
@@ -60,20 +55,15 @@ class RoutingWorkerWithGoto : public GraphNode {
 public:
     explicit RoutingWorkerWithGoto(std::string goto_target)
         : goto_target_(std::move(goto_target)) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override { return {}; }
-    NodeResult execute_full(const GraphState& state) override {
-        NodeResult nr;
-        json v = state.get("task_idx");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        NodeOutput out;
+        json v = in.state.get("task_idx");
         int idx = v.is_number_integer() ? v.get<int>() : -1;
-        nr.writes.push_back(ChannelWrite{"results", json::array({idx})});
+        out.writes.push_back(ChannelWrite{"results", json::array({idx})});
         Command cmd;
         cmd.goto_node = goto_target_;
-        nr.command = std::move(cmd);
-        return nr;
-    }
-    asio::awaitable<NodeResult>
-    execute_full_async(const GraphState& state) override {
-        co_return execute_full(state);
+        out.command = std::move(cmd);
+        co_return out;
     }
     std::string get_name() const override { return "worker"; }
 private:
@@ -84,10 +74,12 @@ private:
 // "worker" is what should drive the post-fan-in routing.
 class RoutingWorkerNoCommand : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        json v = state.get("task_idx");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        json v = in.state.get("task_idx");
         int idx = v.is_number_integer() ? v.get<int>() : -1;
-        return {ChannelWrite{"results", json::array({idx})}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"results", json::array({idx})});
+        co_return out;
     }
     std::string get_name() const override { return "worker"; }
 };
@@ -96,8 +88,10 @@ public:
 // so the test can verify the engine actually transitioned here.
 class FinalizeMarkerNode : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState&) override {
-        return {ChannelWrite{"finalized", true}};
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"finalized", json(true)});
+        co_return out;
     }
     std::string get_name() const override { return "finalize"; }
 };
@@ -107,8 +101,10 @@ public:
 // graph in the default-edge test.
 class BridgeNode : public GraphNode {
 public:
-    std::vector<ChannelWrite> execute(const GraphState&) override {
-        return {ChannelWrite{"bridged", true}};
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"bridged", json(true)});
+        co_return out;
     }
     std::string get_name() const override { return "bridge"; }
 };

--- a/tests/test_signal_dispatch.cpp
+++ b/tests/test_signal_dispatch.cpp
@@ -23,11 +23,13 @@ public:
     ScriptedRouter(std::string name, std::vector<std::string> script)
         : name_(std::move(name)), script_(std::move(script)) {}
 
-    std::vector<ChannelWrite> execute(const GraphState&) override {
+    asio::awaitable<NodeOutput> run(NodeInput) override {
         std::string r = idx_ < script_.size() ? script_[idx_] : "end";
         ++idx_;
-        return {ChannelWrite{"__route__", json(r)},
-                ChannelWrite{name_ + "_count", json(static_cast<int>(idx_))}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"__route__", json(r)});
+        out.writes.push_back(ChannelWrite{name_ + "_count", json(static_cast<int>(idx_))});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 
@@ -40,8 +42,10 @@ private:
 class Collector : public GraphNode {
 public:
     explicit Collector(std::string name) : name_(std::move(name)) {}
-    std::vector<ChannelWrite> execute(const GraphState&) override {
-        return {ChannelWrite{"hits", json::array({name_})}};
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"hits", json::array({name_})});
+        co_return out;
     }
     std::string get_name() const override { return name_; }
 private:
@@ -180,19 +184,12 @@ TEST(SignalDispatch, CommandGotoOverridesEdgeRouting) {
     class GotoNode : public GraphNode {
     public:
         explicit GotoNode(std::string target) : target_(std::move(target)) {}
-        std::vector<ChannelWrite> execute(const GraphState&) override {
-            return {};
-        }
-        NodeResult execute_full(const GraphState&) override {
-            NodeResult nr;
+        asio::awaitable<NodeOutput> run(NodeInput) override {
+            NodeOutput out;
             Command c;
             c.goto_node = target_;
-            nr.command = c;
-            return nr;
-        }
-        asio::awaitable<NodeResult>
-        execute_full_async(const GraphState& state) override {
-            co_return execute_full(state);
+            out.command = c;
+            co_return out;
         }
         std::string get_name() const override { return "a"; }
     private:
@@ -202,8 +199,10 @@ TEST(SignalDispatch, CommandGotoOverridesEdgeRouting) {
     class SinkNode : public GraphNode {
     public:
         explicit SinkNode(std::string n) : n_(std::move(n)) {}
-        std::vector<ChannelWrite> execute(const GraphState&) override {
-            return {ChannelWrite{"hit_" + n_, json(true)}};
+        asio::awaitable<NodeOutput> run(NodeInput) override {
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{"hit_" + n_, json(true)});
+            co_return out;
         }
         std::string get_name() const override { return n_; }
     private:
@@ -272,8 +271,10 @@ TEST(SignalDispatch, ParallelFanInRunsOnce) {
     class LeafNode : public GraphNode {
     public:
         explicit LeafNode(std::string n) : n_(std::move(n)) {}
-        std::vector<ChannelWrite> execute(const GraphState&) override {
-            return {ChannelWrite{"leaf_" + n_, json(true)}};
+        asio::awaitable<NodeOutput> run(NodeInput) override {
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{"leaf_" + n_, json(true)});
+            co_return out;
         }
         std::string get_name() const override { return n_; }
     private:
@@ -281,9 +282,11 @@ TEST(SignalDispatch, ParallelFanInRunsOnce) {
     };
     class JoinNode : public GraphNode {
     public:
-        std::vector<ChannelWrite> execute(const GraphState&) override {
+        asio::awaitable<NodeOutput> run(NodeInput) override {
             join_hits.fetch_add(1, std::memory_order_relaxed);
-            return {ChannelWrite{"joined", json(true)}};
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{"joined", json(true)});
+            co_return out;
         }
         std::string get_name() const override { return "join"; }
     };
@@ -362,8 +365,10 @@ TEST(SignalDispatch, AsymmetricSerialFanInFiresJoinPerPath) {
     class PassThrough : public GraphNode {
     public:
         explicit PassThrough(std::string n) : n_(std::move(n)) {}
-        std::vector<ChannelWrite> execute(const GraphState&) override {
-            return {ChannelWrite{n_ + "_ran", json(true)}};
+        asio::awaitable<NodeOutput> run(NodeInput) override {
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{n_ + "_ran", json(true)});
+            co_return out;
         }
         std::string get_name() const override { return n_; }
     private:
@@ -371,17 +376,21 @@ TEST(SignalDispatch, AsymmetricSerialFanInFiresJoinPerPath) {
     };
     class JoinCounter : public GraphNode {
     public:
-        std::vector<ChannelWrite> execute(const GraphState&) override {
+        asio::awaitable<NodeOutput> run(NodeInput) override {
             join_hits.fetch_add(1, std::memory_order_relaxed);
-            return {ChannelWrite{"join_ran", json(true)}};
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{"join_ran", json(true)});
+            co_return out;
         }
         std::string get_name() const override { return "join"; }
     };
     class FinishCounter : public GraphNode {
     public:
-        std::vector<ChannelWrite> execute(const GraphState&) override {
+        asio::awaitable<NodeOutput> run(NodeInput) override {
             finish_hits.fetch_add(1, std::memory_order_relaxed);
-            return {ChannelWrite{"finish_ran", json(true)}};
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{"finish_ran", json(true)});
+            co_return out;
         }
         std::string get_name() const override { return "finish"; }
     };
@@ -460,8 +469,10 @@ TEST(SignalDispatch, DeclaredBarrierCoalescesAsymmetricFanIn) {
     class PassThrough : public GraphNode {
     public:
         explicit PassThrough(std::string n) : n_(std::move(n)) {}
-        std::vector<ChannelWrite> execute(const GraphState&) override {
-            return {ChannelWrite{n_ + "_ran", json(true)}};
+        asio::awaitable<NodeOutput> run(NodeInput) override {
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{n_ + "_ran", json(true)});
+            co_return out;
         }
         std::string get_name() const override { return n_; }
     private:
@@ -469,9 +480,11 @@ TEST(SignalDispatch, DeclaredBarrierCoalescesAsymmetricFanIn) {
     };
     class BarrierJoinCounter : public GraphNode {
     public:
-        std::vector<ChannelWrite> execute(const GraphState&) override {
+        asio::awaitable<NodeOutput> run(NodeInput) override {
             b_join_hits.fetch_add(1, std::memory_order_relaxed);
-            return {ChannelWrite{"bjoin_ran", json(true)}};
+            NodeOutput out;
+            out.writes.push_back(ChannelWrite{"bjoin_ran", json(true)});
+            co_return out;
         }
         std::string get_name() const override { return "join"; }
     };


### PR DESCRIPTION
## 요약

**C-pre 단계 2 batch 3c — 마지막** — 25 sites 마이그레이션, C-pre tests 마이그레이션 arc 완료.

| 파일 | sites | 패턴 |
|---|---|---|
| test_multi_send_routing.cpp | 11 | RoutingPlanner + RoutingWorkerWithGoto 의 3-override workaround → 한 `run()`. RoutingWorkerNoCommand + FinalizeMarker + BridgeNode 단순 |
| test_signal_dispatch.cpp | 14 | 9 단순 `execute` (ScriptedRouter, Collector, SinkNode, LeafNode, JoinNode, PassThrough, JoinCounter, FinishCounter, BarrierJoinCounter) + 1 inline 3-override (GotoNode) collapse |

## C-pre 완료 후 상태

남은 옛 chain 사용자 5 file **모두 의도적** (9b/9e 에서 처리):

- `test_node.cpp` (`DefaultExecuteFullWrapsExecute`) — `NEOGRAPH_PUSH/POP_IGNORE_DEPRECATED` 박힘. 9b 에서 virtual 삭제와 함께 test 삭제.
- `test_node_default_dispatch.cpp` — 전체 파일이 옛 chain 검증. **9e 에서 파일 삭제** (ROADMAP 명시).
- `test_node_async_default.cpp` — 같음. **9e 에서 삭제**.
- `test_node_run_dispatch.cpp` (`LegacyExecuteOnlyNode` case) — run() 가 옛 chain 통해 raw 노드 부르는 거 검증. 9b 에서 업데이트/제거.
- `test_execute_stream_only_dispatch.cpp` — streaming-only fallback. 9b 에서 업데이트/제거.

## 검증

- 479/479 ctest green
- 회귀 0
- 의도된 PUSH_IGNORE 브래킷 밖에서 deprecation warning 0

## 다음 — Phase B 진입 준비

이제 **9b** 가 가능:
1. `node.h` 의 8 virtual 선언 삭제
2. `graph_node.cpp` 의 default chain + ExecuteDefaultGuard 삭제
3. `deep_research_graph.cpp` + `plan_execute_graph.cpp` 내부 노드 마이그레이션
4. 위 4 의도적 legacy-coverage test 들 업데이트/삭제

## Test plan

- [x] ctest 479/479
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)