### PR TITLE
feat(tooling): 스키마 export CLI + 파이썬 export_schema() + 문서 (issue #56 2·3차)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **토폴로지 JSON Schema export — `NodeFactory::export_schema()`
+  (issue #56, 코드 없는 비주얼 블록 에디터의 선결 과제).** 엔진이
+  먹는 토폴로지 JSON 형식을 기계가독 스키마(JSON Schema Draft
+  2020-12) 한 덩어리로 내보낸다: `{ neograph_version, $schema,
+  topology(고정 봉투), node_types, reducers, conditions }`. 별도
+  리포의 블록 에디터가 이 스키마로 팔레트를 자동 생성 → 에디터와
+  엔진이 버전 간 표류(drift)하지 않음. 전부 additive:
+    - `NodeFactory::register_type(type, fn, json config_schema)`
+      3-인자 변형 추가. 기존 2-인자는 permissive 기본 스키마로
+      위임 — 기존 사용자 노드/호출 안 깨짐.
+    - `ReducerRegistry::names()` / `ConditionRegistry::names()` /
+      `NodeFactory::registered_types()` 조회 접근자 신설.
+    - 내장 4타입(`llm_call`/`tool_dispatch`/`intent_classifier`/
+      `subgraph`)에 설정 스키마 선언. `NEOGRAPH_VERSION` 을
+      컴파일 정의로 노출(pyproject.toml 단일 진실) → 스키마 버전
+      도장.
+    - `examples/52_export_schema.cpp` (`example_export_schema`):
+      `./example_export_schema > schema.json` — 에디터 리포 CI 가
+      고정 NeoGraph 버전으로 산출물을 뽑는 표준 경로.
+    - 파이썬: `neograph_engine.export_schema()` → dict (에디터 리포
+      CI 가 `pip install neograph-engine` 후 덤프).
+    - `tests/test_schema_export.cpp` 8건 + `test_export_schema.py`
+      4건. 핵심: top-level `conditional_edges` 가 loader→compile
+      왕복에서 살아남는지 회귀 가드(v0.1.0~0.1.7 silent-drop
+      재발 방지).
+
 ### Fixed
 
 - **v0.9.0 ship 시 누락된 신 API 마이그레이션 3건 보완.** v1.0 prep PR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1095,6 +1095,14 @@ if(NEOGRAPH_BUILD_EXAMPLES)
         add_executable(example_minimal examples/51_minimal.cpp)
         target_link_libraries(example_minimal PRIVATE neograph::core)
 
+        # Schema dump tool — prints NodeFactory::export_schema() as JSON.
+        # The drift-proof artifact source for external tooling (the
+        # visual block editor, issue #56): `./example_export_schema >
+        # schema.json` in CI keeps an editor's palette pinned to the
+        # exact engine version it was built against.
+        add_executable(example_export_schema examples/52_export_schema.cpp)
+        target_link_libraries(example_export_schema PRIVATE neograph::core)
+
         # Clay + Raylib chatbot (optional — requires Raylib)
         option(NEOGRAPH_BUILD_CLAY_EXAMPLE "Build Clay chatbot example (fetches Raylib)" OFF)
         if(NEOGRAPH_BUILD_CLAY_EXAMPLE)

--- a/bindings/python/neograph_engine/__init__.py
+++ b/bindings/python/neograph_engine/__init__.py
@@ -88,6 +88,11 @@ from ._neograph import (
     ReducerRegistry,
     ConditionRegistry,
 
+    # Topology schema export (issue #56) — drift-proof palette source
+    # for external tooling (the visual block editor). Reflects whatever
+    # is registered in NodeFactory at call time.
+    export_schema,
+
     # Engine
     GraphEngine,
     RunConfig,
@@ -373,6 +378,7 @@ __all__ = [
     "NodeFactory",
     "ReducerRegistry",
     "ConditionRegistry",
+    "export_schema",
     "node",
     "GraphEngine",
     "RunConfig",

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -202,6 +202,24 @@ void resolve_future_async(std::shared_ptr<py::object> future,
 void init_graph(py::module_& m) {
     using namespace neograph::graph;
 
+    // ── Topology schema export (issue #56) ───────────────────────────────
+    //
+    // Lets a Python-side tool build (the visual block editor's CI
+    // typically does: `pip install neograph-engine` then dump this to
+    // schema.json) a palette pinned to the exact engine version. The
+    // returned dict is the same document as the C++
+    // NodeFactory::export_schema() / `example_export_schema`:
+    // {neograph_version, $schema, topology, node_types, reducers,
+    // conditions}. Reflects whatever is registered in NodeFactory at
+    // call time, so register custom node types/reducers/conditions
+    // first if you want them in the palette.
+    m.def("export_schema",
+        []() {
+            return json_to_py(NodeFactory::instance().export_schema());
+        },
+        "Return the engine's topology JSON Schema (Draft 2020-12) as a "
+        "dict. Drift-proof palette source for external tooling.");
+
     // ── Async-bridge safe-resolve helpers ────────────────────────────────
     //
     // Hand these to `loop.call_soon_threadsafe` instead of raw

--- a/bindings/python/tests/test_export_schema.py
+++ b/bindings/python/tests/test_export_schema.py
@@ -1,0 +1,75 @@
+"""Python side of the topology schema export (issue #56).
+
+`neograph_engine.export_schema()` returns the same document the C++
+`NodeFactory::export_schema()` / `example_export_schema` emits — the
+drift-proof palette source the visual block editor consumes. These
+tests pin the shape, the built-in catalog, and that custom node types
+registered from Python show up (so an embedder's palette is complete).
+"""
+from __future__ import annotations
+
+import neograph_engine as ng
+
+
+def test_document_shape():
+    doc = ng.export_schema()
+    assert isinstance(doc, dict)
+
+    assert isinstance(doc["neograph_version"], str)
+    assert doc["neograph_version"]                       # non-empty
+    assert doc["neograph_version"] != "unknown"          # CMake stamp reached the TU
+    assert doc["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+
+    topo = doc["topology"]
+    assert topo["type"] == "object"
+    assert "nodes" in topo["required"]
+    for k in ("name", "channels", "nodes", "edges",
+              "conditional_edges", "interrupt_before",
+              "interrupt_after", "retry_policy"):
+        assert k in topo["properties"], k
+
+    for t in ("llm_call", "tool_dispatch", "intent_classifier", "subgraph"):
+        assert t in doc["node_types"], t
+
+    assert "overwrite" in doc["reducers"]
+    assert "append" in doc["reducers"]
+    assert "has_tool_calls" in doc["conditions"]
+    assert "route_channel" in doc["conditions"]
+
+
+def test_builtin_intent_classifier_schema():
+    nt = ng.export_schema()["node_types"]
+    assert "routes" in nt["intent_classifier"]["required"]
+    assert "prompt" in nt["intent_classifier"]["properties"]
+    assert "definition" in nt["subgraph"]["required"]
+
+
+def test_matches_cpp_version():
+    # The dict is produced by the same C++ call as __version__'s source
+    # (both read pyproject.toml via CMake). They must agree.
+    assert ng.export_schema()["neograph_version"] == ng.__version__
+
+
+def test_python_registered_node_appears_in_palette():
+    # A custom node registered from Python must surface in the editor
+    # palette — otherwise an embedder's blocks would be invisible.
+    class _Probe(ng.GraphNode):
+        def __init__(self, name):
+            super().__init__()
+            self._name = name
+
+        def get_name(self):
+            return self._name
+
+        def run(self, input):
+            return []
+
+    ng.NodeFactory.register_type(
+        "py_palette_probe",
+        lambda name, config, ctx: _Probe(name),
+    )
+
+    nt = ng.export_schema()["node_types"]
+    assert "py_palette_probe" in nt
+    # Registered without a declared schema -> permissive default object.
+    assert nt["py_palette_probe"]["type"] == "object"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -739,6 +739,42 @@ we can do; this section is the documentation. Issue #16 closed.
 
 ---
 
+## A tool/editor that builds topology JSON drifts from the engine
+
+### Symptom
+
+You wrote (or use) a generator, GUI, or visual block editor that emits
+NeoGraph topology JSON. It offered a node type, reducer, or condition
+that the engine then rejects at `compile()` with `Unknown node type:`
+/ `Unknown reducer:` / `Unknown condition:` — or a branch you drew
+silently never fires.
+
+### Why this happens
+
+The tool's palette was hand-maintained and fell behind the NeoGraph
+version actually linked. The branch case is the classic top-level
+`conditional_edges` regression (silently dropped in v0.1.0–v0.1.7,
+fixed v0.1.8) — a tool that emits that block must verify it survives a
+loader→compile round-trip.
+
+### Fix
+
+Don't hand-maintain the palette. The engine emits a machine-readable
+schema of exactly what it accepts — pin the tool to it:
+
+- C++: `neograph::graph::NodeFactory::instance().export_schema()`.
+- CLI: `./example_export_schema > schema.json`
+  (`examples/52_export_schema.cpp`).
+- Python: `neograph_engine.export_schema()` → dict.
+
+The document carries `neograph_version`; have the tool compare it to
+its cached schema and warn on mismatch. `node_types` reflects whatever
+is registered in `NodeFactory` at call time, so register your custom
+node types/reducers/conditions *before* exporting, exactly as you do
+before `compile()`. (Background: issue #56.)
+
+---
+
 ## Reporting a bug
 
 If your symptom isn't above:

--- a/examples/52_export_schema.cpp
+++ b/examples/52_export_schema.cpp
@@ -1,0 +1,41 @@
+// NeoGraph Example 52: Export the topology JSON Schema
+//
+// NeoGraph runs a graph that is *described in JSON* — swap the JSON and
+// the same engine becomes a different harness. That makes a code-free
+// visual editor possible (see issue #56: a block-coding topology
+// editor in a separate repo). For the editor's palette to never drift
+// from the engine, the engine itself emits a machine-readable schema:
+//
+//   { "neograph_version": "...",
+//     "$schema": "https://json-schema.org/draft/2020-12/schema",
+//     "topology":   { ...JSON Schema for the top-level envelope... },
+//     "node_types": { "<type>": { ...config schema... }, ... },
+//     "reducers":   [ ... ],
+//     "conditions": [ ... ] }
+//
+// `node_types` reflects whatever is registered in NodeFactory at call
+// time, so an embedder's custom node types appear here too — register
+// them before calling, exactly as you would before compile().
+//
+// Usage:
+//   ./example_export_schema > schema.json
+//
+// A separate editor repo's CI runs this against the pinned NeoGraph
+// version and ships the resulting schema.json as the palette source —
+// the editor and the engine cannot fall out of sync.
+
+#include <neograph/graph/loader.h>
+
+#include <iostream>
+
+int main() {
+    // (Register any custom node types / reducers / conditions here
+    //  first if you want them in the exported palette, e.g.:
+    //    NodeFactory::instance().register_type("my_node", factory, schema);)
+
+    std::cout << neograph::graph::NodeFactory::instance()
+                     .export_schema()
+                     .dump(2)
+              << "\n";
+    return 0;
+}


### PR DESCRIPTION
issue #56 비주얼 블록 에디터(별도 리포 `fox1245/NeoGraph-Studio` 로 추출 완료)가 NeoGraph 와 표류 없이 팔레트를 자동 생성하도록 `export_schema()` 소비 경로를 마련. 엔진측 본체(`53895f9`, `NodeFactory::export_schema()`)는 이미 master 에 있고, 이 PR 은 그 후속 2·3차.

### 포함 (fac963c, 전부 additive)
- `examples/52_export_schema.cpp` + `example_export_schema`: `./example_export_schema > schema.json` — 에디터 리포 CI 표준 산출 경로.
- 파이썬 `neograph_engine.export_schema()` → dict (bind_graph.cpp + __init__ 재노출).
- `bindings/python/tests/test_export_schema.py` 4건.
- CHANGELOG [Unreleased] Added + docs/troubleshooting.md symptom-first 엔트리.

### 검증
- ctest **505/505 green** (pybind_smoke 가 새 pytest 수집 포함).
- end-to-end: NeoGraph-Studio 에디터로 intent 라우팅 하네스 블록 코딩 → JSON → 실제 OpenAI gpt-4o-mini 로 정확히 라우팅 실행 확인. 의미보존 왕복 + 스키마 린트 통과.

Refs #56 (트래킹 이슈 — 별도 리포·문서 후속 남아 auto-close 안 함).

🤖 Generated with [Claude Code](https://claude.com/claude-code)