### PR TITLE
docs(reference): export_schema() 정식 섹션 (en+ko §10) — issue #56

### DIFF
--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -1963,6 +1963,7 @@ public:
 
     void register_reducer(const std::string& name, ReducerFn fn);
     ReducerFn get(const std::string& name) const;
+    std::vector<std::string> names() const;
 };
 ```
 
@@ -1971,6 +1972,7 @@ public:
 | `instance()` | Returns the singleton instance |
 | `register_reducer(name, fn)` | Registers a custom reducer function |
 | `get(name)` | Looks up a reducer by name. Throws if not found |
+| `names()` | Sorted list of all registered reducer names (introspection for external tooling) |
 
 ### ConditionRegistry
 
@@ -1983,6 +1985,7 @@ public:
 
     void register_condition(const std::string& name, ConditionFn fn);
     ConditionFn get(const std::string& name) const;
+    std::vector<std::string> names() const;
 };
 ```
 
@@ -1991,6 +1994,7 @@ public:
 | `instance()` | Returns the singleton instance |
 | `register_condition(name, fn)` | Registers a custom condition function |
 | `get(name)` | Looks up a condition by name. Throws if not found |
+| `names()` | Sorted list of all registered condition names (introspection for external tooling) |
 
 ### NodeFactory
 
@@ -2007,18 +2011,25 @@ public:
     static NodeFactory& instance();
 
     void register_type(const std::string& type, NodeFactoryFn fn);
+    void register_type(const std::string& type, NodeFactoryFn fn,
+                       json config_schema);
     std::unique_ptr<GraphNode> create(const std::string& type,
                                        const std::string& name,
                                        const json& config,
                                        const NodeContext& ctx) const;
+    std::vector<std::string> registered_types() const;
+    json export_schema() const;
 };
 ```
 
 | Method | Description |
 |--------|-------------|
 | `instance()` | Returns the singleton instance |
-| `register_type(type, fn)` | Registers a node factory function for the given type string |
+| `register_type(type, fn)` | Registers a node factory. Config schema defaults to a permissive `{"type":"object"}` |
+| `register_type(type, fn, config_schema)` | As above, with a declared JSON Schema (Draft 2020-12) for the node's `config`. Additive — the 2-arg overload still works unchanged. Used only by `export_schema()`; the engine does not validate config against it |
 | `create(type, name, config, ctx)` | Creates a node of the given type. Throws if the type is not registered |
+| `registered_types()` | Sorted list of all registered node type names |
+| `export_schema()` | Machine-readable description of the topology JSON this engine accepts (see [Topology Schema Export](#topology-schema-export-issue-56)) |
 
 ### Built-in Registrations
 
@@ -2046,6 +2057,63 @@ The library pre-registers the following components:
 | `"tool_dispatch"` | `ToolDispatchNode` | Dispatches tool calls from the latest assistant message |
 | `"intent_classifier"` | `IntentClassifierNode` | LLM-based intent classification. Reads `prompt` and `valid_routes` from `config` |
 | `"subgraph"` | `SubgraphNode` | Runs a compiled subgraph. Reads `input_map` and `output_map` from `config` |
+
+### Topology Schema Export (issue #56)
+
+NeoGraph runs a graph that is *described in JSON*; swap the JSON and the
+same engine becomes a different harness. `NodeFactory::export_schema()`
+emits a machine-readable description of exactly what topology JSON this
+engine version accepts, so external tooling — notably a code-free
+visual block editor ([NeoGraph Studio](https://github.com/fox1245/NeoGraph-Studio),
+issue #56) — can generate its palette from the engine and never drift
+out of sync.
+
+**Three access paths, one document:**
+
+| From | How |
+|------|-----|
+| C++ | `neograph::graph::NodeFactory::instance().export_schema()` → `json` |
+| CLI | `./example_export_schema > schema.json` (`examples/52_export_schema.cpp`) |
+| Python | `neograph_engine.export_schema()` → `dict` |
+
+**Document shape:**
+
+```jsonc
+{
+  "neograph_version": "0.9.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "topology":   { /* JSON Schema for the top-level envelope:
+                     name, channels, nodes (type + config + barrier),
+                     edges, conditional_edges, interrupt_before,
+                     interrupt_after, retry_policy */ },
+  "node_types": { "<type>": { /* config JSON Schema */ }, ... },
+  "reducers":   ["append", "overwrite", ...],
+  "conditions": ["has_tool_calls", "route_channel", ...]
+}
+```
+
+- **`neograph_version`** is stamped at compile time from
+  `pyproject.toml` (single source of truth). A tool compares it to its
+  cached schema and warns when its palette is older than the engine.
+- **`node_types`** reflects whatever is registered in `NodeFactory` at
+  call time, so an embedder's custom node types appear too — register
+  them (and any custom reducers/conditions) *before* exporting, exactly
+  as you would before `compile()`. A type registered via the 3-arg
+  `register_type` carries its declared config schema; the 2-arg form
+  yields a permissive `{"type":"object"}`.
+- **Round-trip contract.** A tool that emits topology JSON should
+  round-trip it through the loader and assert structure is preserved.
+  In particular the top-level `conditional_edges` block was silently
+  dropped by the compiler in v0.1.0–v0.1.7 (fixed v0.1.8); the engine
+  test suite (`tests/test_schema_export.cpp`) guards this regression,
+  and tooling should too.
+
+```cpp
+#include <neograph/graph/loader.h>
+// register custom node types first if you want them in the palette …
+auto schema = neograph::graph::NodeFactory::instance().export_schema();
+std::cout << schema.dump(2) << "\n";
+```
 
 ---
 

--- a/docs/reference-ko.md
+++ b/docs/reference-ko.md
@@ -1794,6 +1794,7 @@ public:
 
     void register_reducer(const std::string& name, ReducerFn fn);
     ReducerFn get(const std::string& name) const;
+    std::vector<std::string> names() const;   // 등록된 이름 목록(정렬)
 };
 ```
 
@@ -1826,6 +1827,7 @@ public:
 
     void register_condition(const std::string& name, ConditionFn fn);
     ConditionFn get(const std::string& name) const;
+    std::vector<std::string> names() const;   // 등록된 이름 목록(정렬)
 };
 ```
 
@@ -1875,12 +1877,22 @@ public:
     static NodeFactory& instance();
 
     void register_type(const std::string& type, NodeFactoryFn fn);
+    void register_type(const std::string& type, NodeFactoryFn fn,
+                       json config_schema);     // 설정 스키마 동반(추가형)
     std::unique_ptr<GraphNode> create(const std::string& type,
                                        const std::string& name,
                                        const json& config,
                                        const NodeContext& ctx) const;
+    std::vector<std::string> registered_types() const;  // 타입 이름 목록
+    json export_schema() const;                 // 아래 10.4 참고
 };
 ```
+
+> `register_type` 의 3-인자 변형은 그 노드 타입의 `config` 가 받는
+> 필드를 JSON Schema(Draft 2020-12)로 같이 선언한다. 기존 2-인자는
+> 그대로 동작(기존 코드 안 깨짐) — 미지정 시 `{"type":"object"}`
+> (아무 객체나 허용). 이 스키마는 `export_schema()` 용이고 엔진이
+> compile 시 검증에 쓰지는 않는다.
 
 **내장 노드 타입:**
 
@@ -1911,6 +1923,64 @@ factory.register_type("my_node",
     "processor": { "type": "my_node", "config": { "threshold": 0.5 } }
   }
 }
+```
+
+---
+
+### 10.4 토폴로지 스키마 export (issue #56)
+
+NeoGraph 는 그래프를 **JSON 으로 기술**한다 — JSON 만 갈아끼우면 같은
+엔진이 다른 하네스가 된다. `NodeFactory::export_schema()` 는 *이 엔진
+버전이 받는 토폴로지 JSON 형식*을 기계가 읽을 수 있는 한 덩어리로
+내보낸다. 덕분에 외부 도구 — 특히 코드 없는 비주얼 블록 에디터
+([NeoGraph Studio](https://github.com/fox1245/NeoGraph-Studio),
+issue #56) — 가 팔레트를 엔진에서 자동 생성해 **버전 간 표류(drift)가
+구조적으로 불가능**하다.
+
+**같은 문서, 가져오는 경로 3가지:**
+
+| 경로 | 방법 |
+|------|------|
+| C++ | `neograph::graph::NodeFactory::instance().export_schema()` → `json` |
+| CLI | `./example_export_schema > schema.json` (`examples/52_export_schema.cpp`) |
+| 파이썬 | `neograph_engine.export_schema()` → `dict` |
+
+**문서 모양:**
+
+```jsonc
+{
+  "neograph_version": "0.9.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "topology":   { /* 최상위 봉투의 JSON Schema: name, channels,
+                     nodes(type+config+barrier), edges,
+                     conditional_edges, interrupt_before,
+                     interrupt_after, retry_policy */ },
+  "node_types": { "<타입>": { /* config JSON Schema */ }, ... },
+  "reducers":   ["append", "overwrite", ...],
+  "conditions": ["has_tool_calls", "route_channel", ...]
+}
+```
+
+- **`neograph_version`** 은 컴파일 시 `pyproject.toml`(버전 단일
+  진실)에서 박힌다. 도구는 캐시한 스키마와 이 값을 비교해 자기
+  팔레트가 엔진보다 구버전이면 경고할 수 있다.
+- **`node_types`** 는 호출 시점에 `NodeFactory` 에 등록돼 있는 것을
+  그대로 반영한다. 임베더가 만든 커스텀 노드 타입도 나오니, 팔레트에
+  넣고 싶으면 `compile()` 전과 똑같이 export 전에 먼저 등록하라.
+  3-인자 `register_type` 으로 등록한 타입은 선언한 설정 스키마를,
+  2-인자는 `{"type":"object"}`(아무 객체나 허용)를 갖는다.
+- **왕복 계약.** 토폴로지 JSON 을 뽑는 도구는 그걸 loader 에 다시
+  넣어 구조가 보존되는지 확인해야 한다. 특히 최상위
+  `conditional_edges` 블록은 v0.1.0~v0.1.7 에서 컴파일러가 조용히
+  버린 회귀가 있었다(v0.1.8 수정). 엔진 테스트
+  (`tests/test_schema_export.cpp`)가 이 회귀를 막고, 도구도 막아야
+  한다.
+
+```cpp
+#include <neograph/graph/loader.h>
+// 팔레트에 넣을 커스텀 노드 타입이 있으면 먼저 등록 …
+auto schema = neograph::graph::NodeFactory::instance().export_schema();
+std::cout << schema.dump(2) << "\n";
 ```
 
 ---


### PR DESCRIPTION
issue #56 후속 — `NodeFactory::export_schema()` 정식 문서화.

reference-en.md / reference-ko.md §10(Loader/로더·레지스트리)에:
- Reducer/Condition `names()`, NodeFactory `registered_types()` /
  `export_schema()` / 3-인자 `register_type` 시그니처+표 갱신
- 새 하위섹션 'Topology Schema Export (issue #56)' / '10.4 토폴로지
  스키마 export': 문서 모양, 3 접근 경로(C++/CLI/파이썬), 버전
  도장 표류 감지, conditional_edges 왕복 회귀 계약, NeoGraph-Studio
  링크.

순수 문서 변경(코드·빌드 무관). Refs #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)