### PR TITLE
docs: README + examples 매니페스트 기능 폭 최신화 (additive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,11 @@ target_link_libraries(my_app PRIVATE neograph::core neograph::llm)
 - **Intent routing** — LLM-based classification + dynamic routing
 - **Cross-thread Store** — Namespace-based shared memory across threads
 - **Custom nodes** — Register via `NodeFactory` with zero framework changes
+- **Async-native engine** — `run_async()` / `run_stream_async()` host thousands of agents on one `asio::io_context`, no thread per run
+- **Cooperative cancellation** — hierarchical `CancelToken` with `fork()`; `cancel()` cascades to in-flight children and aborts open sockets
+- **Conversation history compaction** — bounded message history with LLM summarisation of the dropped prefix ([example 56](examples/56_history_compaction.cpp))
+- **Per-node result cache** — `NodeCache` keyed on node + input, skips recompute ([example 47](examples/47_node_cache.cpp))
+- **Topology schema export** — `NodeFactory::export_schema()` emits the engine's JSON Schema (Draft 2020-12), machine-readable so a codeless visual editor stays version-locked to the engine ([example 52](examples/52_export_schema.cpp), issue #56)
 
 ### LLM Providers (`neograph::llm`)
 
@@ -487,9 +492,39 @@ target_link_libraries(my_app PRIVATE neograph::core neograph::llm)
 - **Tool discovery** — `get_tools()` auto-discovers tools from either
   transport; returned `MCPTool`s plug straight into `Agent` / `GraphEngine`
 
+### Async HTTP/WS (`neograph::async`)
+
+- **asio::ssl client** — HTTP / HTTPS / WebSocket on the engine's coroutine runtime; connection pooling, SSE streaming, timeout, redirect, typed error classification. This is the layer every provider and MCP transport sits on.
+
+### Agent-to-Agent (`neograph::a2a`)
+
+- **A2A server** — expose any compiled NeoGraph as an Agent-to-Agent endpoint (HTTP, dual v0.3 / v1 method dispatch, streaming SSE)
+- **A2A client + caller node** — drive a *remote* agent as if it were a local node; `A2ACallerNode` drops straight into a graph ([examples 37–38](examples/37_a2a_client.cpp))
+
+### Agent Client Protocol (`neograph::acp`)
+
+- **ACP server** — bidirectional JSON-RPC over stdio so editors (Zed-style) drive a NeoGraph agent: `session/{new,prompt,cancel}` client→agent, `fs/{read,write}_text_file` + `session/request_permission` agent→client, official Zed `StopReason` schema ([example 39](examples/39_acp_server.cpp))
+
+### gRPC service (`neograph::grpc`, opt-in)
+
+- **GraphService** — run a graph over gRPC; per-distinct-graph engines compiled lazily and cached (same multi-tenant pattern as the cookbook)
+- **GrpcCheckpointStore** — a remote `CheckpointStore` reachable over gRPC (restart-surviving state across a network boundary)
+- **Remote tool adapter** — a tool living in another process exposed as a local `neograph::Tool` ([examples 52–57](examples/57_grpc_remote_tool.cpp); off by default — needs `grpc++`/`protoc`)
+
+### Observability (built into `neograph::core`)
+
+- **OpenInference tracer** — `openinference_tracer` wraps a run so `graph.run > node.* > llm.complete` lands as a single trace tree (12 OpenInference attributes); verified end-to-end in Phoenix ([example 49](examples/49_openinference.cpp))
+
+### Durable checkpoint stores
+
+- **`neograph::postgres`** — `PostgresCheckpointStore`, survives process restart, async libpq path
+- **`neograph::sqlite`** — `SqliteCheckpointStore`, single-file durable runs, no server ([example 48](examples/48_sqlite_checkpoint.cpp))
+- Both Python-bound; both behind the same `CheckpointStore` interface as `InMemoryCheckpointStore`
+
 ### Utilities (`neograph::util`)
 
 - **RequestQueue** — Lock-free worker pool with backpressure (moodycamel::ConcurrentQueue)
+- **AsyncTool** — coroutine-shaped tool execution adapter ([example 50](examples/50_async_tool.cpp))
 
 ## Examples
 
@@ -525,6 +560,37 @@ target_link_libraries(my_app PRIVATE neograph::core neograph::llm)
 | 28 | `corrective_rag` | Corrective RAG (arXiv:2401.15884) — retrieve → evaluator routes to refine / web / both → generate, all over `/v1/responses` | Required (OpenAI) |
 | 29 | `responses_envelope` | Wire-level dump of `/v1/responses`'s `output[]` envelope — debug/pedagogy aid for understanding tool-calling shape before SchemaProvider flattens it | Required (OpenAI) |
 | 30 | `reasoning_effort` | Same prompt at `reasoning.effort` ∈ {none, low, medium, high} on a reasoning model — compares wall, hidden-CoT tokens, and answer | Required (OpenAI, reasoning model) |
+| 31 | `local_transformer` | Point `OpenAIProvider` at a local OpenAI-compatible server (TransformerCPP / llama.cpp / vLLM) — model weights stay out of the agent's address space | Local server |
+| 32 | `inproc_gemma` | Fully-local: TransformerCPP linked into the process, inline `Provider` adapter (~60 lines), no HTTP | GGUF file |
+| 33 | `openai_responses_ws` | OpenAI Responses API over WebSocket — ~40% lower latency on multi-tool loops | Required (OpenAI) |
+| 34 | `openai_responses_ws_tools` | Tour of every Responses-API built-in tool (web_search, image_generation, file_search, …) at wire level | Required (OpenAI) |
+| 35 | `re_agent` | Reverse-engineering agent — recovers function names from a stripped binary via Ghidra MCP | Required (OpenAI + Ghidra) |
+| 36 | `classifier_fanout` | Five small classifiers fan out via Send and run in parallel — the small-model edge story (inline ONNX swap-in guide) | No |
+| 37 | `a2a_client` | Drive a *remote* Agent-to-Agent agent (run example 38 first) | No |
+| 38 | `a2a_server` | Expose a NeoGraph as an Agent-to-Agent endpoint | No |
+| 39 | `acp_server` | Expose a NeoGraph over the Agent Client Protocol (editor-driven, JSON-RPC over stdio) | No |
+| 40 | `react_async_streaming` | Outer `io_context` + `co_await run_stream_async()` driving a ReAct loop with token streaming | Required (OpenAI) |
+| 41 | `resume_if_exists_chat` | LangGraph-style multi-turn chat via `resume_if_exists` checkpoint reload | No |
+| 42 | `custom_reducer_condition` | Register custom reducers and conditions from C++ | No |
+| 43 | `store_personalization` | Cross-thread `Store` driving per-user node behaviour (`in.ctx.store`) | No |
+| 44 | `request_queue_backpressure` | Fixed-worker pool with backpressure (`RequestQueue`) | No |
+| 46 | `cancel_token` | Cooperative cancellation — `CancelToken::fork()`, cascade to in-flight children | No |
+| 47 | `node_cache` | Per-node result cache keyed on node + input | No |
+| 48 | `sqlite_checkpoint` | `SqliteCheckpointStore` — single-file durable runs, no server | No |
+| 49 | `openinference` | OpenInference observability — Tracer adapter pattern, Phoenix-verified (mock provider) | No |
+| 50 | `async_tool` | `AsyncTool` — coroutine-shaped tool execution adapter | No |
+| 51 | `minimal` | Smallest working program — `result.channel<T>("name")` accessor | No |
+| 52 | `export_schema` | `NodeFactory::export_schema()` → topology JSON Schema dump (codeless-editor source of truth) | No |
+| 52†| `grpc_server` | Expose a `GraphEngine` over gRPC (build with `-DNEOGRAPH_BUILD_GRPC=ON`) | No |
+| 53 | `grpc_client` | Call a NeoGraph gRPC `GraphService` from C++ | No |
+| 54 | `grpc_checkpoint` | Remote `CheckpointStore` over gRPC (state across a network boundary) | No |
+| 55 | `grpc_vs_jsonrpc_toolcall` | Head-to-head: tool-calling over JSON-RPC vs gRPC (honest microbench) | No |
+| 56 | `history_compaction` | Conversation history compaction — bounded window + LLM summary of dropped prefix | No (Optional OpenAI) |
+| 57 | `grpc_remote_tool` | A remote gRPC tool exposed as a local `neograph::Tool` | No |
+
+† Two examples share the upstream number `52` (`52_export_schema.cpp`
+and `52_grpc_server.cpp`); the table lists them by filename to avoid
+ambiguity.
 
 Every API-using example above auto-loads `.env` from the cwd or any
 parent directory via the bundled `cppdotenv`, so the recipe is just
@@ -676,12 +742,21 @@ NeoGraph/
 │   │   └── json_path.h         # JSON dot-path utilities
 │   ├── mcp/
 │   │   └── client.h            # MCP client + tool wrapper
+│   ├── a2a/                    # Agent-to-Agent client + server + caller node
+│   ├── acp/                    # Agent Client Protocol server (types + server)
+│   ├── async/                  # asio::ssl HTTP/HTTPS/WS client + SSE
+│   ├── grpc/                   # GraphService + GrpcCheckpointStore + tool service
+│   ├── observability/          # OpenInference tracer (compiled into core)
 │   └── util/
-│       └── request_queue.h     # Lock-free worker pool
+│       └── request_queue.h     # Lock-free worker pool + AsyncTool
 ├── src/
-│   ├── core/                   # 13 source files (engine + compiler/scheduler/executor/coordinator split)
-│   ├── llm/                    # 3 source files
-│   └── mcp/                    # 1 source file
+│   ├── core/                   # 21 source files (engine + compiler/scheduler/executor/coordinator split, history, observability)
+│   ├── llm/                    # 4 source files
+│   ├── mcp/                    # 1 source file
+│   ├── a2a/                    # 4 source files
+│   ├── acp/                    # 2 source files
+│   ├── async/                  # 10 source files
+│   └── grpc/                   # 3 source files (opt-in)
 ├── schemas/                    # Built-in LLM provider schemas
 │   ├── openai.json
 │   ├── claude.json
@@ -695,7 +770,7 @@ NeoGraph/
 │   ├── clay.h                  # Clay UI layout
 │   └── clay_renderer_raylib.c  # Clay + raylib renderer glue (example 11)
 ├── benchmarks/                 # NeoGraph vs LangGraph engine-overhead bench
-├── examples/                   # 30+ runnable C++ examples + cookbooks (multi-file scenarios)
+├── examples/                   # 55+ runnable C++ examples + 5 cookbooks (multi-file scenarios)
 └── scripts/
     └── embed_schemas.py        # Build-time schema embedding
 ```
@@ -709,17 +784,25 @@ NeoGraph/
 | `neograph::llm` | LLM providers + Agent | core + OpenSSL (httplib PRIVATE) |
 | `neograph::mcp` | MCP client | core + OpenSSL (httplib PRIVATE) |
 | `neograph::a2a` | Agent-to-Agent client + server + caller node | core + async + OpenSSL (httplib PRIVATE) |
+| `neograph::acp` | Agent Client Protocol server (editor-driven, JSON-RPC over stdio) | core (httplib PRIVATE) |
+| `neograph::grpc` | gRPC GraphService + GrpcCheckpointStore + remote tool (opt-in) | core + grpc++ / protoc |
 | `neograph::postgres` | PostgresCheckpointStore | core + libpq |
 | `neograph::sqlite` | SqliteCheckpointStore | core + libsqlite3 |
-| `neograph::util` | RequestQueue | core + concurrentqueue |
+| `neograph::util` | RequestQueue + AsyncTool | core + concurrentqueue |
+
+OpenInference observability (`openinference_tracer`) is compiled into
+`neograph::core` — no separate link target.
 
 ## Build Options
 
 | Option | Default | Description |
 |--------|---------|-------------|
 | `NEOGRAPH_BUILD_LLM` | ON | Build LLM provider module |
+| `NEOGRAPH_BUILD_ASYNC` | ON | Build async HTTP/HTTPS/WS client (`neograph::async`) |
 | `NEOGRAPH_BUILD_MCP` | ON | Build MCP client module |
 | `NEOGRAPH_BUILD_A2A` | ON | Build Agent-to-Agent module (client + server + caller node) |
+| `NEOGRAPH_BUILD_ACP` | ON | Build Agent Client Protocol server (`neograph::acp`) |
+| `NEOGRAPH_BUILD_GRPC` | OFF | Build gRPC GraphService / checkpoint / remote tool (needs grpc++/protoc) |
 | `NEOGRAPH_BUILD_UTIL` | ON | Build utility module |
 | `NEOGRAPH_BUILD_POSTGRES` | ON | Build PostgresCheckpointStore (libpq) |
 | `NEOGRAPH_BUILD_SQLITE` | ON | Build SqliteCheckpointStore (libsqlite3) |

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # C++ API examples
 
-Thirty-six runnable C++ programs covering the NeoGraph engine surface.
+Fifty-six runnable C++ programs covering the NeoGraph engine surface.
 Each is a single file in this directory (with one Docker-Compose
 exception, [`26_postgres_react_hitl/`](26_postgres_react_hitl/)) — copy
 one into your own project, link against `neograph::core` +
@@ -40,6 +40,7 @@ If this is your first time:
 
 | First | What you learn |
 |---|---|
+| [`51_minimal.cpp`](51_minimal.cpp) | The smallest working program — compile, run, read `result.channel<T>("name")`. No API key. |
 | [`02_custom_graph.cpp`](02_custom_graph.cpp) | Compile a JSON graph definition, run it. No API key. |
 | [`05_parallel_fanout.cpp`](05_parallel_fanout.cpp) | Async fan-out with `make_parallel_group`. No API key. |
 | [`10_send_command.cpp`](10_send_command.cpp) | `Send` (dynamic fan-out) + `Command` (routing override). No API key. |
@@ -62,6 +63,11 @@ demonstrate, not by file number.
 | 08 | [`08_state_management.cpp`](08_state_management.cpp) | offline | `get_state` / `update_state` / `fork` — LangGraph's Checkpointer API mapped to C++. |
 | 09 | [`09_all_features.cpp`](09_all_features.cpp) | offline | Six features in one demo — `NodeInterrupt`, `RetryPolicy`, `StreamMode`, `Send`, `Command`, `Store`. |
 | 10 | [`10_send_command.cpp`](10_send_command.cpp) | offline | Planner→Send→researcher→Command(loop|finish) — the canonical Send+Command pattern. |
+| 42 | [`42_custom_reducer_condition.cpp`](42_custom_reducer_condition.cpp) | offline | Register custom channel reducers and edge conditions from C++ — extend the JSON vocabulary without touching the engine. |
+| 43 | [`43_store_personalization.cpp`](43_store_personalization.cpp) | offline | Cross-thread `Store` reached from inside a node via `in.ctx.store` — per-user node behaviour from shared namespaced memory. |
+| 51 | [`51_minimal.cpp`](51_minimal.cpp) | offline | The shortest working program — compile, run, `result.channel<T>("name")`. The fresh-user template. |
+| 52 | [`52_export_schema.cpp`](52_export_schema.cpp) | offline | `NodeFactory::export_schema()` → topology JSON Schema dump. The version-locked source of truth a codeless visual editor builds its palette from. |
+| 56 | [`56_history_compaction.cpp`](56_history_compaction.cpp) | offline (optional OpenAI) | Bounded message window — when history exceeds the budget the dropped prefix is replaced by an LLM-written summary. Mock provider by default. |
 
 ### Real LLM — providers, tools, ReAct
 
@@ -92,6 +98,8 @@ demonstrate, not by file number.
 | 04 | [`04_checkpoint_hitl.cpp`](04_checkpoint_hitl.cpp) | offline | `interrupt_before` a payment node, persist checkpoint, resume after operator approval. Mock provider. |
 | 14 | [`14_plan_executor.cpp`](14_plan_executor.cpp) | offline | Plan-and-Executor with simulated mid-fan-out failure — checkpoint replay only re-runs the failed sibling. Pending-writes machinery in action. |
 | 26 | [`26_postgres_react_hitl/`](26_postgres_react_hitl/) | OpenAI WS + Postgres + Crawl4AI | Process-discontinuous deep-research HITL — PG-backed checkpoints survive `exit` between report and resume. Docker-Compose driven. |
+| 41 | [`41_resume_if_exists_chat.cpp`](41_resume_if_exists_chat.cpp) | offline | LangGraph-style multi-turn chat — `resume_if_exists` reloads the prior checkpoint and appends the new turn. Mock provider. |
+| 48 | [`48_sqlite_checkpoint.cpp`](48_sqlite_checkpoint.cpp) | offline | `SqliteCheckpointStore` — single-file durable runs, no server. Same `CheckpointStore` interface as InMemory/Postgres. |
 
 ### MCP (Model Context Protocol)
 
@@ -110,6 +118,36 @@ demonstrate, not by file number.
 |---|------|-------|---------------|
 | 27 | [`27_async_concurrent_runs.cpp`](27_async_concurrent_runs.cpp) | offline | Three agent runs interleave on one `io_context` thread via `engine->run_async()` — wall ≈ 50 ms instead of 3×50 ms. Stage-4 async-end-to-end. |
 | 40 | [`40_react_async_streaming.cpp`](40_react_async_streaming.cpp) | OpenAI | Outer `asio::io_context` + `co_spawn` + `co_await engine->run_stream_async(...)` driving a ReAct loop, with the LLM node's tokens streaming to stdout via `co_await provider->complete_stream_async(...)` against `SchemaProvider("openai_responses")`. **Exact shape that segfaulted pre-PR-#10** — runs cleanly post-fix; tool round-trip + final answer in ~4s. |
+| 44 | [`44_request_queue_backpressure.cpp`](44_request_queue_backpressure.cpp) | offline | Fixed-worker pool with backpressure (`neograph::util::RequestQueue`) — bounded in-flight work, no unbounded growth under load. |
+| 46 | [`46_cancel_token.cpp`](46_cancel_token.cpp) | offline | Cooperative cancellation — `CancelToken::fork()` per child, parent `cancel()` cascades to all in-flight children. |
+| 47 | [`47_node_cache.cpp`](47_node_cache.cpp) | offline | Per-node result cache keyed on node + input — skip recompute on identical inputs across runs. |
+| 50 | [`50_async_tool.cpp`](50_async_tool.cpp) | offline | `AsyncTool` — coroutine-shaped tool execution adapter, so a tool can `co_await` without blocking the io_context. |
+
+### Agent interop — A2A & ACP
+
+| # | File | Setup | What it shows |
+|---|------|-------|---------------|
+| 38 | [`38_a2a_server.cpp`](38_a2a_server.cpp) | offline | Expose a compiled NeoGraph as an Agent-to-Agent endpoint (HTTP, streaming SSE). Run this first. |
+| 37 | [`37_a2a_client.cpp`](37_a2a_client.cpp) | offline (needs example 38 running) | Drive a *remote* A2A agent — `A2ACallerNode` makes a remote agent look like a local node. |
+| 39 | [`39_acp_server.cpp`](39_acp_server.cpp) | offline | Expose a NeoGraph over the Agent Client Protocol — bidirectional JSON-RPC over stdio, the shape an editor (Zed-style) drives. |
+
+### Distributed — gRPC service & remote checkpoint/tool
+
+Built only with `-DNEOGRAPH_BUILD_GRPC=ON` (needs `grpc++` / `protoc`).
+
+| # | File | Setup | What it shows |
+|---|------|-------|---------------|
+| 52 | [`52_grpc_server.cpp`](52_grpc_server.cpp) | offline (grpc++) | Expose a `GraphEngine` over gRPC — per-distinct-graph engines compiled lazily and cached. |
+| 53 | [`53_grpc_client.cpp`](53_grpc_client.cpp) | offline (grpc++) | Call a NeoGraph gRPC `GraphService` from a C++ client. |
+| 54 | [`54_grpc_checkpoint.cpp`](54_grpc_checkpoint.cpp) | offline (grpc++) | `GrpcCheckpointStore` — a remote `CheckpointStore` across a network boundary, with an honest latency measurement. |
+| 55 | [`55_grpc_vs_jsonrpc_toolcall.cpp`](55_grpc_vs_jsonrpc_toolcall.cpp) | offline (grpc++) | Head-to-head: tool-calling over JSON-RPC vs gRPC — the microbench behind "70× was a Nagle artifact". |
+| 57 | [`57_grpc_remote_tool.cpp`](57_grpc_remote_tool.cpp) | offline (grpc++) | A tool living in another process exposed as a local `neograph::Tool`. |
+
+### Observability
+
+| # | File | Setup | What it shows |
+|---|------|-------|---------------|
+| 49 | [`49_openinference.cpp`](49_openinference.cpp) | offline | OpenInference tracer adapter — `graph.run > node.* > llm.complete` lands as one trace tree (12 attributes). Phoenix-verified. Mock provider. |
 
 ### Deep research / RAG variants
 
@@ -157,15 +195,18 @@ show how the same definition round-trips through `json.dumps` and back.
 
 | Provider | Examples |
 |---|---|
-| `OPENAI_API_KEY` | 01, 03, 12, 13, 20, 22, 23, 24, 28, 29, 30, 33, 34, 35 |
+| `OPENAI_API_KEY` | 01, 03, 12, 13, 20, 22, 23, 24, 28, 29, 30, 33, 34, 35, 40 |
 | `ANTHROPIC_API_KEY` | 15, 16, 17, 18, 19, 25 |
 | local server (no key) | 31, 32 |
-| **none** | 02, 04, 05, 06, 07, 08, 09, 10, 14, 21, 27, 36 |
+| **none** | 02, 04, 05, 06, 07, 08, 09, 10, 14, 21, 27, 36, 37, 38, 39, 41, 42, 43, 44, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57 |
 
-Twelve examples run with no API key — that is the "kick the tyres"
+Thirty-one examples run with no API key — that is the "kick the tyres"
 floor. Examples 21 (MCP fanout, deterministic planner) and 27 (async
 concurrency, `steady_timer` stand-in for LLM latency) in particular
-demonstrate engine plumbing without spending a token.
+demonstrate engine plumbing without spending a token. The gRPC suite
+(52–55, 57) is also key-free but needs `-DNEOGRAPH_BUILD_GRPC=ON`
+(`grpc++` / `protoc`); 56 (`history_compaction`) defaults to a mock
+provider and only touches OpenAI if a key is present.
 
 ## Re-running after CMake config
 


### PR DESCRIPTION
## 왜

README 가 4축 마케팅(성능·자가진화·임베디드·경량)은 강한데, 정작 **실제 기능 폭을 절반도 못 보여주던** 문제. `grep` 으로 확인 시 README 전체에 `neograph::acp` / `neograph::grpc` / `neograph::observability` 문자열이 **0건** — 사용자가 README 만 보면 이 모듈들이 존재하는지조차 모름.

## 무엇 (전부 additive — 기존 문장 안 깨고 더하기만)

### README.md
- **Features**: 누락된 6개 모듈 서브섹션 신설 — `async` / `a2a` / `acp` / `grpc` / `observability` / durable-checkpoint. Core Engine 에 취소 전파·대화 압축·NodeCache·스키마 export·async 엔진 5항목 추가
- **Examples 표**: 30 → 57행 확장, "30+" 과소표기 정정, 52번 중복(`export_schema` vs `grpc_server`) 각주
- **CMake Targets 표**: `neograph::acp` / `neograph::grpc` 행 + observability 가 core 에 컴파일됨 명시
- **Build Options 표**: `NEOGRAPH_BUILD_{ASYNC,ACP,GRPC}` 추가
- **Project Structure 트리**: 누락 모듈 디렉터리 + 정확한 파일 수

### examples/README.md
- 헤더 수 36 → 56, "Start here" 에 `51_minimal` 추가
- 기존 카테고리에 누락분 채움 + 신규 카테고리 3개(A2A&ACP / gRPC / Observability)
- API key economy 표 갱신 (none 12 → 31)

## 정확성 메모

- `observability`·대화 압축은 별도 라이브러리가 아니라 `neograph::core` 안에 컴파일됨 (CMakeLists 확인) — 틀린 타깃 행 안 만듦
- 예제 API 키 컬럼은 각 `.cpp` 의 provider 종류를 직접 확인 (추측 안 함)
- 코드 변경 0 — 문서만

🤖 Generated with [Claude Code](https://claude.com/claude-code)