### PR TITLE
docs: 샌드박스 실측으로 드러난 README 배지 과장·모순 정정

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed (docs)
+
+- **샌드박스 실측으로 드러난 README 요약 배지의 조건 누락·내부 모순 정정.**
+  "The four axes" 요약 표의 배지들이 본문/deep-dive 에 있는 측정 조건을
+  떼어내 과장처럼 읽히던 것을 본문 수치에 맞춰 정정 (측정 데이터 표 자체는
+  불변):
+  - **`p99 17 µs flat` → `p99 7 µs @ 10 K (1 CPU sandbox)`** — 배지의
+    17 µs 는 본문(`At N=10,000 concurrent ... 7 µs p99`)과 모순이었고
+    `flat` 은 µs 측정이 아니라 GPU-bound 부하 테스트의 run-latency
+    (648 ms) 에 해당하는 표현이었다. 배지를 본문의 측정 숫자·조건에 정렬.
+  - **`1.2 MB stripped binary` → `... (MinSizeRel static)`** — `libc.so.6`
+    only 와 1.2 MB 는 MinSizeRel + 정적 libstdc++ 빌드에서만 성립
+    (기본 Release 는 libstdc++/libgcc_s/libm/libc 동적 링크). deep-dive
+    §size 에 이미 명시돼 있던 조건을 배지에도 복원.
+  - **`2 wheel deps` → `2 direct wheel deps (... ; 7 with transitive)`**
+    — 직접 의존은 `certifi` + `pydantic` 둘이 맞으나 실제 설치 트리는
+    pydantic 의 transitive (pydantic-core, typing-extensions,
+    annotated-types, typing-inspection) 포함 7 패키지.
+- **deep-dive MinSizeRel 재현 명령에 `-DNEOGRAPH_BUILD_POSTGRES=OFF` 추가.**
+  POSTGRES 기본 ON 이라 libpq 없는 호스트에서 그대로 실행 시 configure
+  실패하던 것을 수정.
+
 ## [0.10.0] — 2026-05-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,10 +47,10 @@
 
 |   | Axis | Measured value | Reproduce |
 |---|---|---|---|
-| ⚡ | **Performance** | 5 µs engine overhead · 10 K concurrent in 5.5 MB · p99 17 µs flat | [Engine overhead](#engine-overhead-vs-leading-frameworks) · [L3 cache fit](docs/performance-deep-dive.md#the-agent-runtime-that-fits-in-l3-cache) |
+| ⚡ | **Performance** | 5 µs engine overhead · 10 K concurrent in-flight in 5.5 MB · p99 7 µs @ 10 K (1 CPU sandbox) | [Engine overhead](#engine-overhead-vs-leading-frameworks) · [L3 cache fit](docs/performance-deep-dive.md#the-agent-runtime-that-fits-in-l3-cache) |
 | 🧬 | **Self-evolution** | LLM judge → graph_def hot-swap · 5 customer → 3 emergent topology cluster | [self_evolving_chatbot cookbook](examples/cookbook/self_evolving_chatbot/) |
-| 🔌 | **Embedded-ready** | 1.2 MB stripped binary · `libc.so.6` only · runs on RPi Zero 2W · MCU-class possible | [Embedded / robotics](docs/performance-deep-dive.md#what-the-numbers-mean-for-embedded--robotics) |
-| 🪶 | **Lightweight** | 2 wheel deps (`certifi` + `pydantic`) · multi-tenant 1 K customer → 29 MB · t2.micro 1 K concurrent OK | [multi_tenant_chatbot cookbook](examples/cookbook/multi_tenant_chatbot/) |
+| 🔌 | **Embedded-ready** | 1.2 MB stripped binary (MinSizeRel static) · `libc.so.6` only · runs on RPi Zero 2W · MCU-class possible | [Embedded / robotics](docs/performance-deep-dive.md#what-the-numbers-mean-for-embedded--robotics) |
+| 🪶 | **Lightweight** | 2 direct wheel deps (`certifi` + `pydantic`; 7 with transitive) · multi-tenant 1 K customer → 29 MB · t2.micro 1 K concurrent OK | [multi_tenant_chatbot cookbook](examples/cookbook/multi_tenant_chatbot/) |
 
 Each row is a single command away — no setup, no API key needed except
 the live-LLM cookbook variants.

--- a/docs/performance-deep-dive.md
+++ b/docs/performance-deep-dive.md
@@ -314,7 +314,7 @@ time roughly in half on a 2-core host). Steady-state RSS is unaffected.
 ```bash
 cmake -B build-minsize -S . \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
-    -DNEOGRAPH_BUILD_MCP=OFF -DNEOGRAPH_BUILD_TESTS=OFF \
+    -DNEOGRAPH_BUILD_MCP=OFF -DNEOGRAPH_BUILD_TESTS=OFF -DNEOGRAPH_BUILD_POSTGRES=OFF \
     -DCMAKE_CXX_FLAGS="-ffunction-sections -fdata-sections" \
     -DCMAKE_EXE_LINKER_FLAGS="-Wl,--gc-sections -static-libstdc++ -static-libgcc"
 cmake --build build-minsize --target example_plan_executor -j$(nproc)


### PR DESCRIPTION
## 배경
5개 워커가 Docker 샌드박스(`neograph-sandbox`, NeoGraph Release 빌드 + 실제 PyPI 휠) 안에서 README 의 핵심 주장들을 **실제 실행으로 검증**했다. 대부분은 버텼고(엔진 5µs ✅, ctest 478/478 ✅, 멀티테넌트 1만 고객 22MB ✅ — 오히려 보수적, MCP/A2A/ACP 종단 왕복 ✅), 과장은 거의 전부 **"four axes" 요약 표의 배지가 측정 조건을 떼어낸 것**에 몰려 있었다. 이 PR 은 **측정 데이터 표는 그대로 두고**, 배지의 빠진 조건만 본문 수치에 맞춰 복원한다.

## 변경
| 위치 | before | after | 근거 |
|---|---|---|---|
| README four-axes ⚡ | `p99 17 µs flat` | `p99 7 µs @ 10 K (1 CPU sandbox)` | 본문 `At N=10,000 ... 7 µs p99` 과 모순. `flat` 은 µs 가 아니라 GPU-bound 부하테스트 run-latency(648 ms) 표현이었음 |
| README four-axes 🔌 | `1.2 MB stripped binary` | `1.2 MB stripped binary (MinSizeRel static)` | 1.2 MB·libc-only 는 MinSizeRel+정적 빌드에서만 성립. deep-dive §size 에 이미 있던 조건을 배지에도 복원 |
| README four-axes 🪶 | `2 wheel deps` | `2 direct wheel deps (...; 7 with transitive)` | `pip freeze` 실측: 직접 2개(certifi+pydantic), 실제 설치 7개 |
| deep-dive 재현 명령 | (POSTGRES 누락) | `-DNEOGRAPH_BUILD_POSTGRES=OFF` 추가 | POSTGRES 기본 ON → libpq 없는 호스트에서 configure 실패 |

## 검토 포인트 (머지 전 판단 부탁)
- **p99**: 배지를 본문의 측정값 `7 µs`(1 CPU/512 MB 격리 샌드박스)에 정렬했다. 참고로 호스트가 다른 컨테이너로 시끄러울 때(샌드박스 5개 동시 실행) p99 는 ~22 µs 까지 올랐다 — 격리 조건 밖이라 배지엔 안 넣었지만, 원하면 "~7 µs 격리 / 부하 시 low-tens" 형태로 더 보수적으로 갈 수도 있음.
- 측정 데이터 표(RSS 표, 벤치 표)는 의도적으로 **하나도 안 건드렸다**.

자세한 워커별 실측 보고서는 별도 평가 저장소(`neograph-eval`)에 있음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)