### PR TITLE
fix(mcp): HTTP 404 더는 terminate 안 함 + /mcp 이중부착 제거 (#65, #66)

### DIFF
--- a/examples/21_mcp_fanout.cpp
+++ b/examples/21_mcp_fanout.cpp
@@ -128,9 +128,16 @@ public:
 int main(int argc, char** argv) {
     const std::string mcp_url = (argc >= 2) ? argv[1] : "http://localhost:8000";
 
+    try {
     // One shared MCPClient — all fan-out branches reuse it. HTTP client is
     // session-per-rpc under the hood; for stdio the shared session would be
     // reused across tasks too (see example 22).
+    //
+    // initialize() makes a live HTTP round-trip and throws (e.g. on a 404
+    // from a wrong URL or a server that's down). It used to sit outside any
+    // try/catch, so a one-character URL typo escaped main and aborted the
+    // process with std::terminate (issue #65). Wrapping the whole body keeps
+    // that a friendly error + non-zero exit instead.
     auto client = std::make_shared<neograph::mcp::MCPClient>(mcp_url);
     client->initialize();
 
@@ -203,4 +210,10 @@ int main(int argc, char** argv) {
     std::cout << summary_v << "\n";
     std::cout << "Wall clock: " << wall << " ms (all 3 MCP calls concurrent)\n";
     return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "\nError: " << e.what() << "\n";
+        std::cerr << "Is the MCP server running at " << mcp_url
+                  << "? Start it with: python examples/demo_mcp_server.py\n";
+        return 1;
+    }
 }

--- a/src/mcp/client.cpp
+++ b/src/mcp/client.cpp
@@ -906,6 +906,25 @@ MCPClient::rpc_call_async(const std::string& method, const json& params) {
 
     auto endpoint = async::split_async_endpoint(server_url_);
 
+    // Build the request path idempotently. `split_async_endpoint` puts the
+    // URL's path into `prefix`, so a user who configures the full MCP
+    // endpoint (`http://host:8000/mcp`) already has prefix == "/mcp". If we
+    // blindly appended "/mcp" we'd request "/mcp/mcp" and get a 404 even
+    // though the user gave a correct URL (issue #66). Only append the
+    // suffix when it isn't already there.
+    std::string path;
+    auto ends_with_mcp = [](const std::string& s) {
+        return s == "/mcp" ||
+               (s.size() > 4 && s.compare(s.size() - 4, 4, "/mcp") == 0);
+    };
+    if (endpoint.prefix.empty() || endpoint.prefix == "/") {
+        path = "/mcp";
+    } else if (ends_with_mcp(endpoint.prefix)) {
+        path = endpoint.prefix;
+    } else {
+        path = endpoint.prefix + "/mcp";
+    }
+
     async::RequestOptions opts;
     opts.timeout = std::chrono::seconds(30);
 
@@ -916,7 +935,7 @@ MCPClient::rpc_call_async(const std::string& method, const json& params) {
             ex,
             endpoint.host,
             endpoint.port,
-            endpoint.prefix + "/mcp",
+            path,
             body_str,
             std::move(headers),
             endpoint.tls,
@@ -935,8 +954,19 @@ MCPClient::rpc_call_async(const std::string& method, const json& params) {
     }
 
     if (res.status != 200) {
+        std::string scheme = endpoint.tls ? "https://" : "http://";
+        std::string full_url =
+            scheme + endpoint.host + ":" + endpoint.port + path;
+        std::string hint;
+        if (res.status == 404) {
+            hint = " — the server has no MCP endpoint at this path. Check the "
+                   "configured URL (a trailing '/mcp' is added automatically, "
+                   "so pass the server base like 'http://host:8000' or the "
+                   "full 'http://host:8000/mcp').";
+        }
         throw std::runtime_error(
-            "MCP error (HTTP " + std::to_string(res.status) + "): " + res.body);
+            "MCP error (HTTP " + std::to_string(res.status) + ") for " +
+            full_url + ": " + res.body + hint);
     }
 
     // Parse response — may be plain JSON or SSE. Streamable HTTP can

--- a/tests/test_mcp_client_async.cpp
+++ b/tests/test_mcp_client_async.cpp
@@ -168,6 +168,79 @@ TEST(MCPClientAsync, NonOkHttpStatusSurfacesAsRuntimeError) {
     EXPECT_THROW(client.call_tool("x", json::object()), std::runtime_error);
 }
 
+TEST(MCPClientAsync, NotFoundDoesNotTerminateAndThrowsRuntimeError) {
+    // Regression for issue #65: a 404 from the MCP HTTP path used to escape
+    // the sync call as an exception that callers could (and an example
+    // didn't) catch. Here we assert the library surfaces a *catchable*
+    // std::runtime_error rather than aborting the process — and that the
+    // message carries the request URL so a misconfigured path is obvious
+    // (issue #66 friendly-error half).
+    httplib::Server svr;
+    // Register nothing on the MCP path → httplib answers 404 for any POST.
+    int port = svr.bind_to_any_port("127.0.0.1");
+    std::thread t([&] { svr.listen_after_bind(); });
+    for (int i = 0; i < 200 && !svr.is_running(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_TRUE(svr.is_running());
+
+    mcp::MCPClient client("http://127.0.0.1:" + std::to_string(port));
+
+    bool threw_runtime_error = false;
+    try {
+        client.call_tool("x", json::object());
+    } catch (const std::runtime_error& e) {
+        threw_runtime_error = true;
+        std::string what = e.what();
+        // HTTP status and the request URL must both appear.
+        EXPECT_NE(what.find("404"), std::string::npos);
+        EXPECT_NE(what.find("127.0.0.1"), std::string::npos);
+    }
+    EXPECT_TRUE(threw_runtime_error);
+
+    svr.stop();
+    if (t.joinable()) t.join();
+}
+
+TEST(MCPClientAsync, UrlWithMcpSuffixIsNotDoubled) {
+    // Regression for issue #66: a user-supplied URL that already ends in
+    // `/mcp` must resolve to `/mcp`, not `/mcp/mcp`. We register a handler
+    // ONLY at `/mcp`; if the client doubled the suffix it would request
+    // `/mcp/mcp` and httplib would 404 (which call_tool turns into a throw).
+    std::atomic<int> hits_mcp{0};
+    httplib::Server svr;
+    svr.Post("/mcp", [&](const httplib::Request& req, httplib::Response& res) {
+        hits_mcp.fetch_add(1, std::memory_order_relaxed);
+        int id = 0;
+        try {
+            auto parsed = json::parse(req.body);
+            if (parsed.is_object()) id = parsed.value("id", 0);
+        } catch (...) { }
+        res.set_content(
+            R"({"jsonrpc":"2.0","id":)" + std::to_string(id) +
+                R"(,"result":{"ok":true}})",
+            "application/json");
+    });
+    int port = svr.bind_to_any_port("127.0.0.1");
+    std::thread t([&] { svr.listen_after_bind(); });
+    for (int i = 0; i < 200 && !svr.is_running(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_TRUE(svr.is_running());
+
+    // URL already carries the `/mcp` path the spec endpoint uses.
+    mcp::MCPClient client(
+        "http://127.0.0.1:" + std::to_string(port) + "/mcp");
+    auto result = client.call_tool("ping", json::object());
+
+    EXPECT_TRUE(result.is_object());
+    EXPECT_EQ(result.value("ok", false), true);
+    EXPECT_EQ(hits_mcp.load(), 1);  // reached /mcp exactly once, no /mcp/mcp
+
+    svr.stop();
+    if (t.joinable()) t.join();
+}
+
 TEST(MCPClientAsync, SessionIdHeaderRoundTrips) {
     // Regression for the Mcp-Session-Id tracking that was lost in the
     // Sem 2.6 httplib → async_post migration and restored in the


### PR DESCRIPTION
## 무엇
MCP HTTP 클라이언트의 연관된 두 결함을 한 경로에서 수정.

| 이슈 | 원인 | 수정 |
|---|---|---|
| **#66** | `rpc_call_async` 가 `endpoint.prefix + "/mcp"` → 사용자가 `http://host:8000/mcp` 주면 `/mcp/mcp` → 404 | prefix 가 비었거나 `/` 면 `/mcp` 부착, 이미 `/mcp` 로 끝나면 그대로(멱등) |
| **#65** | 그 404 가 `runtime_error` 로 던져지고 `run_sync` 가 정상 rethrow 하는데, `example_mcp_fanout` 이 `initialize()` 를 try/catch 밖에서 호출 → 예외가 main 탈출 → `terminate()`/SIGABRT(core dump) | 예제 초기화/호출을 try/catch 로 감쌈 + 라이브러리 에러 메시지에 URL·`/mcp 자동부착` 힌트 추가 |

라이브러리는 원래 잡을 수 있는 예외를 정상적으로 rethrow 하고 있었음 — 과도하게 손대지 않고, 근본 원인(#66)과 예제 robustness(#65)만 고침. 다른 HTTP-MCP 예제(03/20/22)는 이미 try 로 감싸여 있어 무영향.

## 검증
- 회귀 테스트 2건 추가(`tests/test_mcp_client_async.cpp`): 404→terminate 없이 catch 가능한 `runtime_error` / `/mcp` URL 이 `/mcp/mcp` 로 이중화되지 않음.
- `neograph_tests` MCP 스위트 **12/12 green**.
- 실제 재현: 404 서버에 잘못된 URL 로 `example_mcp_fanout` 실행 → 코어덤프 대신 친절 에러 + 정상 종료 확인.

Closes #65.
Closes #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)