### PR TITLE
fix(example): A2A 서버 예제에 장수 serve 모드 추가 (#67)

### DIFF
--- a/examples/38_a2a_server.cpp
+++ b/examples/38_a2a_server.cpp
@@ -9,17 +9,32 @@
 // calls into A2AServer; the agent is reachable from any A2A client
 // (a2a-js, a2a-python, our own A2AClient, etc.) at the bound URL.
 //
+// Two modes:
+//   * Default (no "serve" arg) — self-verifies by round-tripping with
+//     its own client, then stops the server and exits 0. Good for CI.
+//   * Serve mode ("serve" / "--serve" arg) — runs the self-verification,
+//     then KEEPS listening until a signal (Ctrl-C / SIGTERM) arrives, so
+//     a separate process (e.g. example_a2a_client) can connect across
+//     process boundaries. On signal it stops the server cleanly and exits.
+//
 // Usage:
-//   ./build-pybind/example_a2a_server [port]    (default 8087, 0=auto)
+//   ./build-pybind/example_a2a_server [port]          (default 8087, 0=auto)
+//   ./build-pybind/example_a2a_server [port] serve    (stay up until Ctrl-C)
 
 #include <neograph/neograph.h>
 #include <neograph/a2a/server.h>
 #include <neograph/a2a/client.h>
 
 #include <chrono>
+#include <csignal>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
+
+#if !defined(_WIN32)
+#include <signal.h>
+#endif
 
 using namespace neograph;
 using neograph::graph::ChannelWrite;
@@ -77,10 +92,50 @@ std::shared_ptr<GraphEngine> build_demo_engine() {
     return std::shared_ptr<GraphEngine>(std::move(engine));
 }
 
+// Set by SIGINT/SIGTERM so the serve loop can wake up and shut down.
+// volatile sig_atomic_t is the only type the C++ standard guarantees is
+// safe to touch from an async signal handler.
+volatile std::sig_atomic_t g_stop_requested = 0;
+
+extern "C" void handle_signal(int) { g_stop_requested = 1; }
+
+// Install a portable, persistent handler for SIGINT/SIGTERM. Uses
+// sigaction where available (handler stays installed, no SA_RESETHAND)
+// so the signal reliably reaches our flag instead of the default
+// terminate action — even with asio worker threads in the process.
+void install_signal_handlers() {
+#if defined(_WIN32)
+    std::signal(SIGINT, handle_signal);
+    std::signal(SIGTERM, handle_signal);
+#else
+    struct sigaction sa{};
+    sa.sa_handler = handle_signal;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;  // no SA_RESTART, no SA_RESETHAND
+    sigaction(SIGINT, &sa, nullptr);
+    sigaction(SIGTERM, &sa, nullptr);
+#endif
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
-    int port = (argc > 1) ? std::atoi(argv[1]) : 8087;
+    // Parse args: an optional numeric port, plus an optional "serve" /
+    // "--serve" flag (in any order after the program name).
+    int port = 8087;
+    bool serve = false;
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (a == "serve" || a == "--serve") {
+            serve = true;
+        } else {
+            port = std::atoi(a.c_str());
+        }
+    }
+
+    // In serve mode, claim SIGINT/SIGTERM up front — before any asio
+    // worker threads exist — so the signal reliably reaches our flag.
+    if (serve) install_signal_handlers();
 
     auto engine = build_demo_engine();
 
@@ -137,9 +192,25 @@ int main(int argc, char** argv) {
     std::cout << "    streamed task state: "
               << task_state_to_string(streamed.status.state) << "\n";
 
-    // Server keeps running until we tear it down — for an actual
-    // deployment, replace this with a wait-for-signal loop.
+    if (serve) {
+        // Long-running deployment mode: stay up until a signal arrives so
+        // a separate process can connect across the process boundary.
+        // Re-assert the handlers here: the engine's asio worker threads
+        // (spun up during start_async + self-verification) can reset the
+        // SIGINT/SIGTERM disposition, so installing once at startup isn't
+        // enough — without this, the signal hits the default terminate
+        // action instead of our flag.
+        install_signal_handlers();
+        std::cout << "\n[*] serve mode — staying up at " << url
+                  << " (Ctrl-C or SIGTERM to stop)\n";
+        std::cout.flush();
+        while (g_stop_requested == 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+        std::cout << "\n[*] signal received — stopping server\n";
+    }
+
     server.stop();
-    std::cout << "\n[*] server stopped, exiting cleanly\n";
+    std::cout << "[*] server stopped, exiting cleanly\n";
     return 0;
 }

--- a/tests/test_a2a_server.cpp
+++ b/tests/test_a2a_server.cpp
@@ -179,6 +179,27 @@ TEST(A2AServer, SendsStatusUpdatesOverSSE) {
     EXPECT_EQ(states.back(),  TaskState::Completed);
 }
 
+// Serve-mode contract: a server is expected to stay up and accept many
+// independent client connections over its lifetime, not stop after the
+// first round-trip. This mirrors example_a2a_server's "serve" mode where
+// a separate process connects across the process boundary. Here we use
+// fresh A2AClient objects (independent connections) against one server.
+TEST(A2AServer, StaysUpAcrossIndependentClients) {
+    LiveServer srv;
+    for (int i = 0; i < 5; ++i) {
+        A2AClient client(srv.url());  // fresh connection each iteration
+        auto task = client.send_message_sync("ping " + std::to_string(i));
+        ASSERT_EQ(task.status.state, TaskState::Completed);
+        ASSERT_FALSE(task.history.empty());
+        EXPECT_EQ(task.history.back().parts[0].text,
+                  "echo:ping " + std::to_string(i));
+        EXPECT_TRUE(srv.server->is_running());
+    }
+    // Server still healthy after all those round-trips — only an explicit
+    // stop() (or a signal in the example) tears it down.
+    EXPECT_TRUE(srv.server->is_running());
+}
+
 TEST(A2AServer, MethodNotFoundReturnsCorrectCode) {
     LiveServer srv;
     A2AClient client(srv.url());


### PR DESCRIPTION
## 무엇
`examples/38_a2a_server.cpp` 가 자가검증 후 설계상 `stop()` 으로 즉시 종료해, 별도 프로세스 클라이언트가 붙을 **독립 장수(long-running) 서버 모드가 없던** 문제(#67)를 해결.

- `./example_a2a_server [port]` — **기존 동작 그대로**(자가검증 왕복 후 종료, rc 0) — 회귀 0
- `./example_a2a_server [port] serve` — 자가검증 후 **SIGINT/SIGTERM 올 때까지 계속 listen**, 시그널에 깔끔히 stop 후 종료

## 함정 (커밋 메시지에도 기록)
시그널 핸들러를 시작 시점에만 깔면, 엔진 asio 워커 스레드가 `start_async`/자가검증 중 SIGINT/SIGTERM 처분을 되돌려놓아 기본 terminate(exit 143)로 죽음. **wait 루프 직전에 핸들러 재설치**로 해결(POSIX `sigaction`, Windows `std::signal` 분기, 플래그는 `volatile sig_atomic_t`).

## 검증 (전부 실제 실행)
- 기본 모드 회귀: 자가검증 왕복(discovery/send/SSE 3프레임) → `exiting cleanly`, **rc 0** (변경 전과 동일).
- serve 모드: 별도 프로세스 `example_a2a_client` 가 직접 send + 그래프 노드 위임 둘 다 왕복 성공, 클라이언트 종료 후 서버 생존 확인 → SIGTERM/SIGINT 둘 다 깔끔 종료 rc 0.
- 새 단위 테스트 `A2AServer.StaysUpAcrossIndependentClients`(독립 클라이언트 5회 연속 왕복). `ctest -R A2A` **24/24 green**.

Closes #67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)