### PR TITLE
feat(tool): concurrent tool dispatch via canonical execute_async

### DIFF
--- a/include/neograph/mcp/client.h
+++ b/include/neograph/mcp/client.h
@@ -39,7 +39,7 @@ class StdioSession;
  * through the owning transport (HTTP or stdio). Created automatically
  * by MCPClient::get_tools().
  */
-class NEOGRAPH_API MCPTool : public Tool {
+class NEOGRAPH_API MCPTool : public AsyncTool {
   public:
     /// HTTP-mode constructor. Each execute() opens an ephemeral
     /// MCPClient against @p server_url.
@@ -63,7 +63,11 @@ class NEOGRAPH_API MCPTool : public Tool {
      * @param arguments JSON object containing the tool's input parameters.
      * @return Result string (text content joined by newlines) or JSON dump.
      */
-    std::string execute(const json& arguments) override;
+    /// Native async execution — overlaps with sibling tool calls when a
+    /// node dispatches several at once. stdio rides the session's
+    /// awaitable lock; HTTP runs an ephemeral handshake+call coroutine
+    /// (no run_sync, so no per-call io_context blocks a worker thread).
+    asio::awaitable<std::string> execute_async(const json& arguments) override;
 
     std::string get_name() const override { return name_; }
 
@@ -120,6 +124,11 @@ class NEOGRAPH_API MCPClient {
      */
     bool initialize(const std::string& client_name = "neograph");
 
+    /// Async variant of initialize() — runs the handshake + initialized
+    /// notification through rpc_call_async, so a coroutine can set up an
+    /// HTTP client without blocking a worker thread in run_sync.
+    asio::awaitable<bool> initialize_async(const std::string& client_name = "neograph");
+
     /**
      * @brief Discover tools from the MCP server.
      * @return Vector of Tool unique_ptrs (MCPTool instances).
@@ -133,6 +142,11 @@ class NEOGRAPH_API MCPClient {
      * @return JSON response from the server.
      */
     json call_tool(const std::string& name, const json& arguments);
+
+    /// Async variant of call_tool() — awaits the tools/call RPC without
+    /// blocking. Used by MCPTool::execute_async for concurrent dispatch.
+    asio::awaitable<json> call_tool_async(const std::string& name,
+                                          const json& arguments);
 
     /**
      * @brief Async variant of rpc_call for the HTTP transport.

--- a/include/neograph/tool.h
+++ b/include/neograph/tool.h
@@ -52,6 +52,19 @@ class NEOGRAPH_API Tool {
      * @return Tool name string (must match the name in get_definition()).
      */
     virtual std::string get_name() const = 0;
+
+    /**
+     * @brief Canonical async entry point for tool execution.
+     *
+     * The default bridges to the sync execute() so every existing Tool
+     * keeps working unchanged. I/O-bound tools (HTTP fetch, MCP RPC)
+     * override this with a real coroutine so that a node dispatching
+     * several tool calls at once can overlap their in-flight I/O
+     * instead of running them one-by-one through the blocking
+     * execute() facade. ToolDispatchNode awaits all calls of one
+     * assistant turn through a parallel group on this method.
+     */
+    virtual asio::awaitable<std::string> execute_async(const json& arguments);
 };
 
 /**
@@ -87,12 +100,11 @@ class NEOGRAPH_API Tool {
  */
 class NEOGRAPH_API AsyncTool : public Tool {
   public:
-    /// Async work — override this. Default would infinitely recurse
-    /// against execute(), so an override is mandatory; left non-pure
-    /// only because Tool's contract requires execute() to be present
-    /// and providing both pure-virtual would force every Tool subclass
-    /// to acknowledge AsyncTool, which we don't want.
-    virtual asio::awaitable<std::string> execute_async(const json& arguments) = 0;
+    /// Async work — override this. Kept pure so AsyncTool subclasses
+    /// must supply a real coroutine: relying on Tool's default (which
+    /// bridges to execute()) would recurse here, since AsyncTool's
+    /// execute() drives execute_async() in turn.
+    asio::awaitable<std::string> execute_async(const json& arguments) override = 0;
 
     /// Sync facade — drives execute_async on a private io_context.
     /// Implemented out-of-line in src/core/tool.cpp so the run_sync

--- a/src/core/graph_node.cpp
+++ b/src/core/graph_node.cpp
@@ -1,8 +1,14 @@
 #include <neograph/graph/node.h>
 #include <neograph/graph/engine.h>   // RunContext (forward-declared in node.h)
 #include <neograph/async/run_sync.h>
+#include <asio/co_spawn.hpp>
+#include <asio/deferred.hpp>
+#include <asio/experimental/parallel_group.hpp>
+#include <asio/this_coro.hpp>
+#include <asio/use_awaitable.hpp>
 #include <algorithm>
 #include <stdexcept>
+#include <vector>
 
 namespace neograph::graph {
 
@@ -118,32 +124,87 @@ asio::awaitable<NodeOutput> ToolDispatchNode::run(NodeInput in) {
     }
     if (!assistant_msg) co_return NodeOutput{};
 
-    // Execute each tool call (mirrors agent.cpp:80-104)
-    json results = json::array();
+    const auto& calls = assistant_msg->tool_calls;
 
-    for (const auto& tc : assistant_msg->tool_calls) {
-        auto it = std::find_if(tools_.begin(), tools_.end(),
-            [&](Tool* t) { return t->get_name() == tc.name; });
-
+    // One worker coroutine per tool call. Each resolves the matching
+    // tool and awaits its execute_async; errors (tool-not-found, parse
+    // failure, tool exception) are captured into the result message so
+    // a worker never throws. The workers are launched together so their
+    // I/O-bound work overlaps — e.g. several MCP round-trips stay in
+    // flight at once instead of running one-by-one through the blocking
+    // execute() facade. Results are applied in call order, independent
+    // of which worker finished first.
+    auto worker = [this](ToolCall tc) -> asio::awaitable<ChatMessage> {
         ChatMessage tool_msg;
         tool_msg.role         = "tool";
         tool_msg.tool_call_id = tc.id;
         tool_msg.tool_name    = tc.name;
 
+        auto it = std::find_if(tools_.begin(), tools_.end(),
+            [&](Tool* t) { return t->get_name() == tc.name; });
         if (it == tools_.end()) {
             tool_msg.content = R"({"error": "Tool not found: )" + tc.name + "\"}";
-        } else {
-            try {
-                auto args = json::parse(tc.arguments);
-                tool_msg.content = (*it)->execute(args);
-            } catch (const std::exception& e) {
-                tool_msg.content = std::string(R"({"error": ")") + e.what() + "\"}";
-            }
+            co_return tool_msg;
         }
+        try {
+            auto args = json::parse(tc.arguments);
+            tool_msg.content = co_await (*it)->execute_async(args);
+        } catch (const std::exception& e) {
+            tool_msg.content = std::string(R"({"error": ")") + e.what() + "\"}";
+        }
+        co_return tool_msg;
+    };
 
-        json msg_json;
-        to_json(msg_json, tool_msg);
-        results.push_back(msg_json);
+    json results = json::array();
+
+    // Single call: run inline, skip the parallel-group machinery.
+    if (calls.size() == 1) {
+        ChatMessage m = co_await worker(calls.front());
+        json mj;
+        to_json(mj, m);
+        results.push_back(mj);
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"messages", results});
+        co_return out;
+    }
+
+    // Multiple calls: fan them out via the same parallel-group idiom the
+    // engine uses for independent nodes within a super-step.
+    auto ex = co_await asio::this_coro::executor;
+    using DeferredOp = decltype(asio::co_spawn(
+        ex, worker(std::declval<ToolCall>()), asio::deferred));
+    std::vector<DeferredOp> ops;
+    ops.reserve(calls.size());
+    for (const auto& tc : calls) {
+        ops.push_back(asio::co_spawn(ex, worker(tc), asio::deferred));
+    }
+
+    auto [order, excs, values] = co_await asio::experimental::make_parallel_group(
+        std::move(ops))
+        .async_wait(asio::experimental::wait_for_all(), asio::use_awaitable);
+    (void)order;  // results are applied in call order, not completion order
+
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        ChatMessage m;
+        if (excs[i]) {
+            // Workers catch their own exceptions, so this is a defensive
+            // fallback (e.g. bad_alloc) keyed to the originating call.
+            m.role         = "tool";
+            m.tool_call_id = calls[i].id;
+            m.tool_name    = calls[i].name;
+            try {
+                std::rethrow_exception(excs[i]);
+            } catch (const std::exception& e) {
+                m.content = std::string(R"({"error": ")") + e.what() + "\"}";
+            } catch (...) {
+                m.content = R"({"error": "unknown tool failure"})";
+            }
+        } else {
+            m = std::move(values[i]);
+        }
+        json mj;
+        to_json(mj, m);
+        results.push_back(mj);
     }
 
     NodeOutput out;

--- a/src/core/tool.cpp
+++ b/src/core/tool.cpp
@@ -10,6 +10,14 @@
 
 namespace neograph {
 
+// Default async entry: bridge to the sync execute(). Tools whose work
+// is naturally blocking get a valid awaitable for free; the call runs
+// to completion before the first suspension, so `arguments` stays
+// valid. I/O-bound tools override execute_async() for real overlap.
+asio::awaitable<std::string> Tool::execute_async(const json& arguments) {
+    co_return execute(arguments);
+}
+
 std::string AsyncTool::execute(const json& arguments) {
     return neograph::async::run_sync(execute_async(arguments));
 }

--- a/src/mcp/client.cpp
+++ b/src/mcp/client.cpp
@@ -810,18 +810,30 @@ ChatTool MCPTool::get_definition() const {
     return { name_, description_, input_schema_ };
 }
 
-std::string MCPTool::execute(const json& arguments) {
+asio::awaitable<std::string> MCPTool::execute_async(const json& arguments) {
     if (stdio_session_) {
-        json result = stdio_session_->rpc_call(
-            "tools/call",
-            json{{"name", name_}, {"arguments", arguments}});
-        return format_tool_result(result);
+        json params{{"name", name_}, {"arguments", arguments}};
+        json result = co_await stdio_session_->rpc_call_async("tools/call", params);
+        std::string text = format_tool_result(result);
+        co_return text;
     }
 
-    // HTTP path (legacy) — one ephemeral client per call.
-    MCPClient client(server_url_);
-    client.initialize();
-    return format_tool_result(client.call_tool(name_, arguments));
+    // HTTP — one ephemeral client per call, driven fully async. Unlike
+    // the old sync path (which spun a private io_context via run_sync
+    // per call and parked a worker thread), this awaits on the caller's
+    // executor, so several sibling tool calls dispatched from one node
+    // keep their HTTP round-trips in flight at the same time.
+    //
+    // Heap-allocate the client: MCPClient holds a std::mutex (non-move,
+    // non-copy), and keeping such an object directly in the coroutine
+    // frame across a co_await trips a GCC 13 codegen ICE
+    // (build_special_member_call). A unique_ptr in the frame sidesteps
+    // it — the object lives on the heap, the frame only owns a pointer.
+    auto client = std::make_unique<MCPClient>(server_url_);
+    co_await client->initialize_async();
+    json result = co_await client->call_tool_async(name_, arguments);
+    std::string text = format_tool_result(result);
+    co_return text;
 }
 
 // ===========================================================================
@@ -1127,6 +1139,68 @@ bool MCPClient::initialize(const std::string& client_name) {
     return true;
 }
 
+asio::awaitable<bool> MCPClient::initialize_async(const std::string& client_name) {
+    json params;
+    params["protocolVersion"] = "2025-11-25";
+    params["capabilities"]    = json::object();
+    params["clientInfo"]      = {{"name", client_name}, {"version", "0.1.0"}};
+
+    auto init_result = co_await rpc_call_async("initialize", params);
+    {
+        std::lock_guard lk(http_state_mu_);
+        if (init_result.contains("protocolVersion")
+            && init_result["protocolVersion"].is_string()) {
+            negotiated_protocol_version_ =
+                init_result["protocolVersion"].get<std::string>();
+        } else {
+            negotiated_protocol_version_ = "2025-11-25";
+        }
+    }
+
+    if (stdio_session_) {
+        stdio_session_->notify("notifications/initialized", json::object());
+        co_return true;
+    }
+
+    // HTTP initialized notification — same envelope/headers as the sync
+    // initialize(), but awaited directly instead of through run_sync.
+    json notify;
+    notify["jsonrpc"] = "2.0";
+    notify["method"]  = "notifications/initialized";
+    notify["params"]  = json::object();
+
+    auto endpoint = async::split_async_endpoint(server_url_);
+    std::vector<std::pair<std::string, std::string>> headers;
+    {
+        std::lock_guard lk(http_state_mu_);
+        headers = {
+            {"Content-Type", "application/json"},
+            {"Accept",       "application/json, text/event-stream"},
+            {"Host",         "localhost"},
+        };
+        if (!session_id_.empty()) {
+            headers.emplace_back("Mcp-Session-Id", session_id_);
+        }
+        if (!negotiated_protocol_version_.empty()) {
+            headers.emplace_back("MCP-Protocol-Version",
+                                 negotiated_protocol_version_);
+        }
+    }
+
+    auto notify_body = notify.dump();
+    auto ex  = co_await asio::this_coro::executor;
+    auto res = co_await async::async_post(
+        ex, endpoint.host, endpoint.port, endpoint.prefix + "/mcp",
+        notify_body, headers, endpoint.tls);
+
+    if (res.status != 200 && res.status != 202 && res.status != 204) {
+        throw std::runtime_error(
+            "MCP initialize notification returned HTTP "
+            + std::to_string(res.status) + ": " + res.body);
+    }
+    co_return true;
+}
+
 std::vector<std::unique_ptr<Tool>> MCPClient::get_tools() {
     initialize();
 
@@ -1157,6 +1231,14 @@ json MCPClient::call_tool(const std::string& name, const json& arguments) {
     params["name"]      = name;
     params["arguments"] = arguments;
     return rpc_call("tools/call", params);
+}
+
+asio::awaitable<json>
+MCPClient::call_tool_async(const std::string& name, const json& arguments) {
+    json params;
+    params["name"]      = name;
+    params["arguments"] = arguments;
+    co_return co_await rpc_call_async("tools/call", params);
 }
 
 } // namespace neograph::mcp


### PR DESCRIPTION
## What

`ToolDispatchNode` ran each `tool_call` sequentially through the blocking sync `execute()`. For MCP that meant one `run_sync` io_context per call, so several tool calls in one assistant turn never overlapped their I/O. (Surfaced by an external C++ fork doing parallel MCP calls.)

## Approach (ours — unify on one async entry, not a parallel method)

- `Tool` gains a virtual `execute_async()` whose **default bridges to the sync `execute()`**, so every existing tool keeps working unchanged.
- `MCPTool` now derives `AsyncTool` and implements `execute_async` natively (stdio rides `rpc_call_async`; HTTP runs an async ephemeral handshake via new `MCPClient::initialize_async`/`call_tool_async` — no `run_sync`).
- `ToolDispatchNode::run` fans the calls out with the **same `make_parallel_group` idiom the engine uses for nodes**; single call runs inline; results applied in call order.
- GCC 13 coroutine ICE (`build_special_member_call`) dodged by binding the `co_return` value to a named local.

## Verification

- **478/478** ctest pass; MCP examples (fanout/stdio/agent/multi) build.
- **Valgrind**: 0 errors, no definite/indirect leaks on the changed paths (ToolDispatch + MCP async tests).
- **Ghidra** (headless decompile of `libneograph_mcp.so`): one coroutine-frame `operator new` per fn, freed on all exit paths; no algorithmic loops over input.
- Sync `execute()` facade preserved (back-compat).

## Note (non-blocking)

HTTP MCP tool still re-handshakes per call (pre-existing; ephemeral client). Candidate for a persistent-client follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)