### PR TITLE
ci(windows): pin build-windows to windows-2022 (VS2022 generator)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,13 @@ jobs:
           if-no-files-found: ignore
 
   build-windows:
-    runs-on: windows-latest
+    # Pinned to windows-2022: the windows-latest image rolled to
+    # windows-2025, where CMake's "Visual Studio 17 2022" generator can
+    # no longer locate a VS instance ("could not find any instance of
+    # Visual Studio") at the project() configure step. windows-2022
+    # still ships VS 2022. Revisit when the workflow moves to a
+    # Ninja + msvc-dev-cmd setup that is image-agnostic.
+    runs-on: windows-2022
     # Windows tier is **alpha** for 2.0.0 — CI gates the Windows-
     # specific code paths (MCP stdio named-pipe + PG async socket
     # wrap) compile-wise, not full integration. Scope is deliberately


### PR DESCRIPTION
`windows-latest` migrated to **windows-2025**, where CMake's `-G "Visual Studio 17 2022"` generator fails at `project()` with *"could not find any instance of Visual Studio."* The `build-windows` job has been red on every commit since (unrelated to any source change). The cibuildwheel-based **Wheels** workflow still builds Windows wheels fine — this only affects the generator-based C++ CI job.

Fix: pin `build-windows` to `windows-2022` (ships VS 2022). One-line, restores the gate.
