### PR TITLE
feat(mcp): overlap concurrent stdio calls via correlation-id demux

### DIFF
--- a/src/mcp/client.cpp
+++ b/src/mcp/client.cpp
@@ -4,6 +4,8 @@
 #include <neograph/async/http_client.h>
 #include <neograph/async/run_sync.h>
 
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
 #include <asio/experimental/channel.hpp>
 #include <asio/read_until.hpp>
 #include <asio/streambuf.hpp>
@@ -32,6 +34,8 @@
 #include <chrono>
 #include <cstring>
 #include <istream>
+#include <map>
+#include <memory>
 #include <mutex>
 #include <sstream>
 #include <stdexcept>
@@ -72,23 +76,24 @@ public:
     json rpc_call(const std::string& method, const json& params);
 
     /// Async variant — wraps the subprocess pipes in
-    /// asio::posix::stream_descriptor for non-blocking I/O. The
-    /// awaitable serialises concurrent rpc_call_async() invocations
-    /// on the same session via an asio::experimental::channel-backed
-    /// lock (capacity 1, token-passing). A second coroutine's
-    /// acquire suspends at its own `co_await async_receive` — no OS
-    /// thread is held, so other coroutines on the io_context keep
-    /// progressing and the first call's I/O completions fire normally.
+    /// asio::posix::stream_descriptor for non-blocking I/O. Concurrent
+    /// rpc_call_async() calls on the same session OVERLAP their in-flight
+    /// I/O via a correlation-id demultiplexer: each caller serialises
+    /// only its frame write (a capacity-1 channel held for microseconds),
+    /// registers a response sink keyed by its JSON-RPC id, then awaits
+    /// that sink. A single reader coroutine owns the read side, routing
+    /// each response line to the matching sink. Wall time for N siblings
+    /// is therefore max(latency), not sum — provided the MCP server
+    /// itself processes concurrently (a serial server is the Amdahl floor
+    /// and gains nothing here).
     ///
-    /// The lock is lazy-initialised on first call using the caller's
-    /// executor. Subsequent calls on executors that can't interoperate
-    /// with that executor would break the serialisation — in practice
-    /// all callers of one session go through one engine and thus one
-    /// io_context, so this isn't a concern.
+    /// All callers of one session are assumed to share one io_context
+    /// (in practice the engine's), so the reader and the writers run on
+    /// the same executor.
     ///
     /// Sync rpc_call() continues to use the std::mutex mtx_ and must
     /// NOT be mixed with rpc_call_async on the same session (the two
-    /// locks don't know about each other).
+    /// paths don't know about each other).
     asio::awaitable<json> rpc_call_async(
         const std::string& method, const json& params);
 
@@ -103,6 +108,12 @@ private:
 
     asio::awaitable<std::string> async_read_line_locked(AsyncHandle& out);
     asio::awaitable<void> async_write_frame_locked(AsyncHandle& in, const json& j);
+
+    /// Demux reader loop. Owns async_out_, reads every response line and
+    /// routes it to the waiter keyed by its JSON-RPC id. Lazily spawned
+    /// while ≥1 call is in flight; exits once no waiters remain so a
+    /// private run_sync io_context can drain and return.
+    asio::awaitable<void> run_reader();
 
 #ifdef _WIN32
     HANDLE process_ = nullptr;   ///< child process handle (CloseHandle on dtor)
@@ -154,6 +165,19 @@ private:
     std::unique_ptr<AsyncHandle> async_in_;
     std::unique_ptr<AsyncHandle> async_out_;
     std::mutex async_handles_init_mtx_;
+
+    // ── Demux multiplexer ───────────────────────────────────────────
+    // `async_lock_` above is repurposed as a WRITE-ONLY lock (held only
+    // around the frame write). One reader coroutine owns async_out_ and
+    // fans each response to the waiter registered under its JSON-RPC id,
+    // so N in-flight calls overlap their reads instead of serialising
+    // behind one round-trip lock.
+    using RespChan =
+        asio::experimental::channel<void(asio::error_code,
+                                         std::shared_ptr<json>)>;
+    std::mutex demux_mu_;                                ///< guards the two fields below
+    std::map<int, std::shared_ptr<RespChan>> waiters_;  ///< id → response sink
+    bool reader_running_ = false;                       ///< a run_reader() coroutine is live
 };
 
 #ifdef _WIN32
@@ -619,6 +643,67 @@ StdioSession::async_read_line_locked(AsyncHandle& out) {
     co_return line;
 }
 
+asio::awaitable<void> StdioSession::run_reader() {
+    std::exception_ptr fail;
+    try {
+        for (;;) {
+            std::string line = co_await async_read_line_locked(*async_out_);
+            if (!line.empty()) {
+                json resp;
+                bool parsed = true;
+                try { resp = json::parse(line); }
+                catch (const std::exception&) { parsed = false; }
+                if (parsed && resp.contains("id")
+                        && resp["id"].is_number_integer()) {
+                    const int rid = resp["id"].get<int>();
+                    std::shared_ptr<RespChan> chan;
+                    {
+                        std::lock_guard<std::mutex> lk(demux_mu_);
+                        auto it = waiters_.find(rid);
+                        if (it != waiters_.end()) {
+                            chan = it->second;
+                            waiters_.erase(it);
+                        }
+                    }
+                    // Unknown / late ids are dropped. Capacity-1 sink is
+                    // empty, so this send always lands for the matched id.
+                    if (chan) {
+                        auto p = std::make_shared<json>(std::move(resp));
+                        chan->try_send(asio::error_code{}, p);
+                    }
+                }
+            }
+            // Stop once nothing is outstanding so a private run_sync
+            // io_context can drain and return; a later call lazily
+            // restarts the reader.
+            bool stop = false;
+            {
+                std::lock_guard<std::mutex> lk(demux_mu_);
+                if (waiters_.empty()) {
+                    reader_running_ = false;
+                    stop = true;
+                }
+            }
+            if (stop) break;
+        }
+    } catch (const std::exception&) {
+        // Pipe EOF / read error (e.g. child died): fail every waiter so
+        // awaiting callers throw instead of hanging on a dead server.
+        fail = std::current_exception();
+    }
+
+    if (fail) {
+        std::map<int, std::shared_ptr<RespChan>> remaining;
+        {
+            std::lock_guard<std::mutex> lk(demux_mu_);
+            remaining.swap(waiters_);
+            reader_running_ = false;
+        }
+        for (auto& kv : remaining) kv.second->close();
+    }
+    co_return;
+}
+
 asio::awaitable<json>
 StdioSession::rpc_call_async(const std::string& method, const json& params) {
     const int id = ++next_id_;
@@ -632,41 +717,19 @@ StdioSession::rpc_call_async(const std::string& method, const json& params) {
 
     auto ex = co_await asio::this_coro::executor;
 
-    // Lazy-init the awaitable lock on first call. Bound to this
-    // caller's executor; subsequent calls assume a compatible executor
-    // (in practice: the engine's single io_context — no cross-executor
-    // mix for one session). std::mutex guards only the one-time
-    // init, not the lock itself.
+    // Lazy-init the WRITE lock on first call (capacity-1 channel = binary
+    // semaphore). Unlike the pre-demux design it is NOT held across the
+    // round trip — only around the frame write below — so concurrent
+    // calls overlap their reads. std::mutex guards only the one-time init.
     {
         std::lock_guard<std::mutex> g(async_lock_init_mtx_);
         if (!async_lock_) {
             async_lock_ = std::make_unique<AsyncLock>(ex, 1);
-            // Seed with the initial token — the first acquirer can
-            // take it without blocking. try_send returns false if
-            // the channel is already full, which we never hit here
-            // because we just created it with capacity 1 and empty.
+            // Seed with the initial token so the first writer takes it
+            // without blocking.
             async_lock_->try_send(asio::error_code{});
         }
     }
-
-    // Acquire the awaitable lock. Second coroutine on the same
-    // session suspends here until the holder releases via try_send
-    // below — cooperative, no OS-thread block.
-    co_await async_lock_->async_receive(asio::use_awaitable);
-
-    // RAII release: put the token back on every exit path, including
-    // exception / cancellation. Destructor runs on coroutine frame
-    // unwind so no co_await inside — safe under GCC 13's catch/await
-    // ICE rules.
-    struct LockReleaser {
-        AsyncLock* ch;
-        ~LockReleaser() {
-            // try_send is noexcept-ish (no throw on a healthy
-            // channel). We're on the hot unwind path; swallow any
-            // residual error rather than abort the program.
-            try { ch->try_send(asio::error_code{}); } catch (...) {}
-        }
-    } lock_rel{async_lock_.get()};
 
     // Cached AsyncHandle wrappers. See member-field comments for why
     // we bind once per session instead of per call. Lazy-init under a
@@ -730,31 +793,62 @@ StdioSession::rpc_call_async(const std::string& method, const json& params) {
         }
     }
 
-    co_await async_write_frame_locked(*async_in_, req);
-
-    for (int guard = 0; guard < 1024; ++guard) {
-        std::string line = co_await async_read_line_locked(*async_out_);
-        if (line.empty()) continue;
-
-        json resp;
-        try {
-            resp = json::parse(line);
-        } catch (const std::exception&) {
-            continue;
+    // Register this call's response sink and make sure the single demux
+    // reader is running. Registration happens AFTER the handles are
+    // bound above, so the reader never dereferences a null async_out_.
+    auto chan = std::make_shared<RespChan>(ex, 1);
+    bool start_reader = false;
+    {
+        std::lock_guard<std::mutex> lk(demux_mu_);
+        waiters_[id] = chan;
+        if (!reader_running_) {
+            reader_running_ = true;
+            start_reader = true;
         }
-
-        if (!resp.contains("id")) continue;
-        if (resp["id"] != id)     continue;
-
-        if (resp.contains("error")) {
-            auto err = resp["error"];
-            throw std::runtime_error(
-                "MCP stdio RPC error: " + err.value("message", "unknown"));
-        }
-        co_return resp.value("result", json::object());
     }
-    throw std::runtime_error(
-        "StdioSession::rpc_call_async: giving up after 1024 lines");
+    if (start_reader) {
+        asio::co_spawn(ex, run_reader(), asio::detached);
+    }
+
+    // Drop our waiter on every exit path (delivered, threw, cancelled).
+    // Erasing an already-served id is a harmless no-op.
+    struct WaiterGuard {
+        StdioSession* self;
+        int           id;
+        ~WaiterGuard() {
+            std::lock_guard<std::mutex> lk(self->demux_mu_);
+            self->waiters_.erase(id);
+        }
+    } wguard{this, id};
+
+    // Serialise ONLY the frame write (held microseconds), releasing the
+    // write lock before we await the response.
+    co_await async_lock_->async_receive(asio::use_awaitable);
+    {
+        struct WriteReleaser {
+            AsyncLock* ch;
+            ~WriteReleaser() {
+                try { ch->try_send(asio::error_code{}); } catch (...) {}
+            }
+        } wrel{async_lock_.get()};
+        co_await async_write_frame_locked(*async_in_, req);
+    }
+
+    // Await our response. use_awaitable turns a closed sink (session torn
+    // down / server gone) into a thrown system_error.
+    std::shared_ptr<json> respptr =
+        co_await chan->async_receive(asio::use_awaitable);
+
+    json& resp = *respptr;
+    if (resp.contains("error")) {
+        auto err = resp["error"];
+        throw std::runtime_error(
+            "MCP stdio RPC error: " + err.value("message", "unknown"));
+    }
+    // Bind to a named local before co_return — dodges the GCC 13
+    // build_special_member_call ICE on co_return of a brace/temp.
+    json result = resp.value("result", json::object());
+    co_return result;
 }
 
 } // namespace detail

--- a/tests/fixtures/mcp_stdio_slow.py
+++ b/tests/fixtures/mcp_stdio_slow.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Concurrent stdio JSON-RPC server for MCP overlap tests.
+
+Like mcp_stdio_echo.py but each `tools/call` is handled on its own
+thread that sleeps `arguments.delay_ms` before replying. This models an
+I/O-bound MCP server that CAN process several requests at once — so a
+client that multiplexes the single pipe sees wall ≈ max(delay), while a
+client that serialises the round trip sees wall ≈ sum(delay).
+
+Pure stdlib so it runs anywhere Python 3 is installed.
+"""
+import json
+import sys
+import threading
+import time
+
+_write_lock = threading.Lock()
+
+
+def reply(obj):
+    line = json.dumps(obj) + "\n"
+    with _write_lock:                 # frame each response atomically
+        sys.stdout.write(line)
+        sys.stdout.flush()
+
+
+def handle_call(rid, params):
+    delay_ms = 0
+    args = params.get("arguments", {}) or {}
+    try:
+        delay_ms = int(args.get("delay_ms", 0))
+    except (TypeError, ValueError):
+        delay_ms = 0
+    if delay_ms > 0:
+        time.sleep(delay_ms / 1000.0)
+    reply({
+        "jsonrpc": "2.0",
+        "id": rid,
+        "result": {
+            "content": [{
+                "type": "text",
+                "text": json.dumps({
+                    "tool": params.get("name", ""),
+                    "args": args,
+                }),
+            }],
+        },
+    })
+
+
+def handle(req):
+    if "id" not in req:
+        return  # notification
+    rid = req["id"]
+    method = req.get("method", "")
+    params = req.get("params", {}) or {}
+
+    if method == "initialize":
+        reply({
+            "jsonrpc": "2.0",
+            "id": rid,
+            "result": {
+                "protocolVersion": "2025-03-26",
+                "serverInfo": {"name": "stdio-slow", "version": "0.1.0"},
+                "capabilities": {},
+            },
+        })
+        return
+
+    if method == "tools/call":
+        # Off-thread so sibling calls overlap their sleeps.
+        threading.Thread(target=handle_call, args=(rid, params),
+                         daemon=True).start()
+        return
+
+    reply({
+        "jsonrpc": "2.0",
+        "id": rid,
+        "error": {"code": -32601, "message": f"method not found: {method}"},
+    })
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            req = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        handle(req)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mcp_stdio_async.cpp
+++ b/tests/test_mcp_stdio_async.cpp
@@ -20,9 +20,13 @@
 #include <asio/co_spawn.hpp>
 #include <asio/detached.hpp>
 #include <asio/io_context.hpp>
+#include <asio/steady_timer.hpp>
+#include <asio/this_coro.hpp>
+#include <asio/use_awaitable.hpp>
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <cstdlib>
 #include <filesystem>
 #include <string>
@@ -195,4 +199,99 @@ TEST(MCPStdioAsync, SyncFacadeStillWorksAlongsideAsync) {
     auto out = client.call_tool("echo", json{{"msg", "hello"}});
     EXPECT_TRUE(out.is_object());
     ASSERT_TRUE(out.contains("content"));
+}
+
+TEST(MCPStdioAsync, ConcurrentStdioCallsOverlapIO) {
+    // Demux-multiplexer proof: N tool calls on ONE stdio session, each
+    // an I/O-bound 100 ms server-side wait, fanned out concurrently.
+    // With the correlation-id demux the writes are pipelined and the
+    // reads overlap, so wall ≈ one delay; the pre-demux round-trip lock
+    // would serialise to ≈ N delays. The slow fixture handles each call
+    // on its own thread so the server itself is NOT the bottleneck.
+    if (!python3_available()) {
+        GTEST_SKIP() << "python3 not available";
+    }
+    std::filesystem::path here(__FILE__);
+    auto fixture = here.parent_path() / "fixtures" / "mcp_stdio_slow.py";
+    ASSERT_TRUE(std::filesystem::exists(fixture))
+        << "fixture missing: " << fixture;
+
+    constexpr int kN = 5;
+    constexpr int kDelayMs = 100;
+
+    asio::io_context io;
+    mcp::MCPClient client({python_cmd(), fixture.string()});
+
+    json init_params;
+    init_params["protocolVersion"] = "2025-03-26";
+    init_params["capabilities"] = json::object();
+    init_params["clientInfo"] = json::object();
+    init_params["clientInfo"]["name"] = "test";
+    init_params["clientInfo"]["version"] = "0";
+
+    // Pre-build each call's params OUTSIDE the coroutine (GCC 13 nested
+    // brace-init-in-coroutine ICE). Each carries a distinct marker so we
+    // can prove the demux routed each response to the RIGHT caller.
+    std::array<json, kN> call_params;
+    for (int i = 0; i < kN; ++i) {
+        json args;
+        args["delay_ms"] = kDelayMs;
+        args["marker"] = i;
+        json p;
+        p["name"] = "echo";
+        p["arguments"] = args;
+        call_params[i] = p;
+    }
+
+    std::array<json, kN> results;
+    std::atomic<int> done{0};
+    long wall_ms = 0;
+
+    asio::co_spawn(
+        io,
+        [&]() -> asio::awaitable<void> {
+            co_await client.rpc_call_async("initialize", init_params);
+            auto t0 = std::chrono::steady_clock::now();
+            for (int i = 0; i < kN; ++i) {
+                asio::co_spawn(
+                    io,
+                    [&, i]() -> asio::awaitable<void> {
+                        results[i] = co_await client.rpc_call_async(
+                            "tools/call", call_params[i]);
+                        done.fetch_add(1, std::memory_order_relaxed);
+                    },
+                    asio::detached);
+            }
+            // Spin the same io_context cooperatively until all siblings
+            // report in, then stamp the wall time.
+            while (done.load(std::memory_order_relaxed) < kN) {
+                asio::steady_timer t(co_await asio::this_coro::executor);
+                t.expires_after(std::chrono::milliseconds(1));
+                co_await t.async_wait(asio::use_awaitable);
+            }
+            wall_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - t0).count();
+        },
+        asio::detached);
+    io.run();
+
+    ASSERT_EQ(done.load(), kN);
+
+    // Correctness: every response was routed to its own caller by id.
+    for (int i = 0; i < kN; ++i) {
+        ASSERT_TRUE(results[i].is_object()) << "call " << i << " no result";
+        ASSERT_TRUE(results[i].contains("content"));
+        const auto& content = results[i]["content"];
+        ASSERT_TRUE(content.is_array() && !content.empty());
+        auto text = content[0].value("text", std::string{});
+        auto echoed = json::parse(text);
+        EXPECT_EQ(echoed["args"].value("marker", -1), i)
+            << "demux mis-routed: call " << i << " got " << text;
+    }
+
+    // Overlap: serial would be ≈ kN*kDelayMs (500 ms); demux ≈ kDelayMs
+    // (100 ms). Assert well under the serial floor with generous slack.
+    EXPECT_LT(wall_ms, kN * kDelayMs * 3 / 5)
+        << "calls did not overlap: wall=" << wall_ms
+        << "ms, serial floor=" << (kN * kDelayMs) << "ms";
 }


### PR DESCRIPTION
## What

`StdioSession::rpc_call_async` held a capacity-1 channel lock for the **whole** request→response round trip, so N tool calls fanned out from one assistant turn queued one-behind-another on a single stdio session — wall ≈ sum(latency). The single pipe is NOT the reason: JSON-RPC ids exist precisely to pipeline one connection.

Replace the round-trip lock with a **correlation-id demultiplexer**:

- The capacity-1 channel becomes a **write-only lock**, held only around the frame write (microseconds) so writers never interleave bytes — reads are no longer serialised.
- One reader coroutine (`run_reader`) owns `async_out_`, reads every response line and routes it to the per-call sink registered under its JSON-RPC id. N in-flight calls now overlap their reads: wall ≈ max(latency), **provided the server itself processes concurrently** (a serial server is the Amdahl floor and gains nothing — by design).

## Lifetime safety

The reader is lazily spawned while ≥1 call is in flight and exits once no waiters remain, so a private `run_sync` io_context still drains and returns (the sync `execute()`/`rpc_call` paths pass no cancel token and never strand a blocked reader). A waiter exists only while a caller awaits — and that caller holds the session alive via `MCPTool`'s `shared_ptr` — so the reader can never touch a destroyed session; no dtor-join needed. On pipe EOF / read error the reader closes every outstanding sink so awaiting callers throw instead of hanging.

## Tests

- New `mcp_stdio_slow.py` fixture (threaded, honours `arguments.delay_ms`).
- `ConcurrentStdioCallsOverlapIO`: 5×100 ms calls land in **~130 ms** (serial floor 500 ms), and each response is asserted to route back to its own caller by id (demux correctness).

## Verification

- 479 gtests pass (3 skipped = live network); existing concurrency + sync-facade tests green (0 regression).
- Clean under **ASan + UBSan ×3** (async teardown safe).
- MCP examples build.
- **No engine perf regression**: interleaved A/B `bench_neograph` master vs branch — seq/par median Δ 0%, min within ±2.3% noise. (`bench_neograph` links `neograph::core` only; the change lives in `neograph_mcp`, so engine hot-path is unaffected by construction and by measurement.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)