### PR TITLE
feat(compiler): M1 회귀 봉쇄 — 소비 회계 + translation validation (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **토폴로지 컴파일 정합성 게이트 — 소비 회계 + translation validation** (#75 M1).
+  "조용한 의미 소실" 클래스(v0.1.0–v0.1.7 `conditional_edges` 무언 드롭과
+  동형의 사고)를 구조적으로 봉쇄하는 2중 장치:
+  - **소비 회계(consumed-key accounting)**: `"schema_version": 1` 을 선언한
+    문서는 strict 컴파일로 전환 — 파서가 소비하지 않은 키(오타
+    `conditionnal_edges`, 미지원 필드, 빈 `wait_for` 로 무언 드롭될
+    barrier, inline conditional 의 무시되는 `to`)가 전부 컴파일 에러로
+    모아서 보고된다. 마킹은 파싱 블록 **안**에서 이뤄지므로 파싱 단계를
+    지우면 마크도 함께 사라져, 해당 기능을 쓰는 strict 문서가 즉시
+    실패한다 — 드롭 회귀가 조용할 수 없는 구조. `_`/`x-` 접두 키
+    (`_comment`, `x-studio-*`)는 주석 네임스페이스로 항상 허용.
+    `schema_version` 없는 기존 문서는 관용 동작 그대로 (바이트 단위 보존).
+  - **translation validation**: `CompiledGraph::to_json()` 역방출 +
+    `GraphCompiler::canon()` 정규형으로 매 컴파일마다
+    `canon(입력) == canon(재방출)` 을 검사한다. 불일치(= 컴파일러가
+    뭔가를 떨어뜨렸거나 오배선)는 strict 문서에서 throw, 관용 문서에서
+    stderr 경고. 등가 판정은 구조 비교 — 라우트 키 뒤바뀜 같은 오배선도
+    잡는다 (존재-여부 비교가 놓치는 클래스).
+  - `NodeFactory::config_schema(type)` 조회 추가, `export_schema()` 에
+    `schema_version` 필드 문서화. 신규 테스트 27개
+    (`tests/test_compiler_strict.cpp`) — v0.1.x 드롭 mutant 시뮬레이션
+    (conditional_edges/barrier/interrupt 드롭 + 라우트 오배선) 포함.
+
 ## [0.11.1] - 2026-06-25
 
 ### Changed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -773,6 +773,45 @@ before `compile()`. (Background: issue #56.)
 
 ---
 
+## Strict topology validation
+
+### Symptom
+
+`compile()` throws `strict topology validation failed (schema_version 1)`
+listing keys like `$: unknown or unconsumed key 'conditionnal_edges'`,
+`nodes.X.barrier: 'wait_for' is missing or empty`, or
+`translation validation failed: compiled graph does not round-trip`.
+
+### Why this happens
+
+Your topology declares `"schema_version": 1`, which opts it into strict
+compilation: every key of every object the compiler owns must be
+*consumed* by the parser. A key nobody consumed is almost always a typo
+(`conditionnal_edges`, `max_retry`, `promt`) or a construct the engine
+would otherwise **silently drop** — the failure mode behind the
+v0.1.0–v0.1.7 `conditional_edges` regression. The round-trip
+(translation-validation) error means the compiled graph re-emitted as
+JSON no longer matches your input: the compiler lost or rewired
+something, and the message lists exactly what.
+
+### Fix
+
+- Fix the listed keys — each error carries its JSON path.
+- Comments and editor metadata belong in the annotation namespace:
+  keys starting with `_` or `x-` (e.g. `_comment`, `x-studio-pos`) are
+  always allowed and never validated.
+- A barrier needs a non-empty `wait_for` array; an inline conditional
+  edge routes through `routes`, so a `to` on it is dead — move the
+  target into `routes` or drop it.
+- Custom node types registered *with* a declared config schema
+  (3-arg `register_type`) are checked closed-world; add
+  `"additionalProperties": true` to the schema to opt a type out.
+- To fall back to the historical lenient parsing, remove
+  `schema_version` — unknown keys are then ignored again and round-trip
+  mismatches only warn on stderr. New documents should stay strict.
+
+---
+
 ## Reporting a bug
 
 If your symptom isn't above:

--- a/include/neograph/graph/compiler.h
+++ b/include/neograph/graph/compiler.h
@@ -41,6 +41,11 @@ struct ChannelDef {
     ReducerType  type = ReducerType::OVERWRITE;
     std::string  reducer_name = "overwrite";
     json         initial_value;
+    /// True iff the JSON channel definition carried an explicit
+    /// "initial" key. Distinguishes `"initial": null` from an absent
+    /// key so CompiledGraph::to_json() can re-emit exactly what was
+    /// declared (round-trip fidelity).
+    bool         has_initial = false;
 };
 
 /**
@@ -67,6 +72,37 @@ struct CompiledGraph {
     /// Present iff the JSON defined a top-level "retry_policy" object.
     /// When absent, GraphEngine keeps its RetryPolicy default-constructed.
     std::optional<RetryPolicy> retry_policy;
+
+    /// Declared "schema_version" from the topology JSON, or 0 when the
+    /// document did not carry one. Version >= 1 opts the document into
+    /// strict compilation (unknown/unconsumed keys are hard errors —
+    /// see GraphCompiler docs). 0 preserves the historical lenient
+    /// behavior for existing files.
+    int schema_version = 0;
+
+    /// Verbatim copy of each node's JSON definition (config + "type"),
+    /// minus the "barrier" key (barriers are re-emitted from
+    /// barrier_specs, so translation validation compares the compiled
+    /// barrier state — not an input echo). Backs to_json().
+    std::map<std::string, json> node_defs;
+
+    /**
+     * @brief Re-emit this compiled graph as topology JSON.
+     *
+     * Every field is reconstructed from compiled (L2) state where such
+     * state exists — channels from channel_defs, edges from
+     * edges/conditional_edges, barriers from barrier_specs, interrupts
+     * from the sets, retry_policy from the parsed struct. Node configs
+     * are the one pass-through: the compiler hands them verbatim to
+     * NodeFactory, so they are re-emitted from node_defs.
+     *
+     * Contract (translation validation):
+     *   canon(definition) == canon(compile(definition).to_json())
+     * must hold for every accepted document. A mismatch means the
+     * compiler dropped or rewired something silently — exactly the
+     * v0.1.0–v0.1.7 conditional_edges regression class.
+     */
+    json to_json() const;
 };
 
 /**
@@ -81,8 +117,9 @@ public:
     /**
      * @brief Parse a JSON graph definition into a CompiledGraph.
      *
-     * @param definition Top-level graph JSON ({name, channels, nodes,
-     *                   edges, interrupt_before, interrupt_after,
+     * @param definition Top-level graph JSON ({schema_version, name,
+     *                   channels, nodes, edges, conditional_edges,
+     *                   interrupt_before, interrupt_after,
      *                   retry_policy}).
      * @param default_context Shared NodeContext forwarded to every
      *                        NodeFactory-created node.
@@ -90,9 +127,73 @@ public:
      *         GraphEngine internals.
      * @throws std::runtime_error If a required field is malformed or a
      *                            referenced node type is unknown.
+     *
+     * ## Strict mode (consumed-key accounting)
+     *
+     * A document declaring `"schema_version": 1` opts into strict
+     * compilation: every key of every object the compiler owns
+     * (top level, channel defs, node defs, barrier, edges,
+     * conditional_edges items, retry_policy) must be *consumed* by the
+     * parser. A key nobody consumed — a typo like `conditionnal_edges`,
+     * a field the engine doesn't support, a barrier whose wait_for is
+     * missing/empty — is a hard compile error listing every offender.
+     * This makes the v0.1.0–v0.1.7 "silently dropped block" regression
+     * class structurally impossible: deleting a parsing step deletes
+     * its consumption mark, and any document using that feature fails
+     * loudly instead of degrading silently.
+     *
+     * Annotation namespace: keys starting with `_` or `x-` (e.g.
+     * `_comment`, `x-studio-pos`) are never consumed, never errors,
+     * and are ignored by canon() — they belong to humans and tooling,
+     * not to the engine.
+     *
+     * Documents without `schema_version` (or 0) keep the historical
+     * lenient behavior byte-for-byte. `schema_version` above the
+     * engine's supported version (currently 1) is always an error.
      */
     static CompiledGraph compile(const json& definition,
                                  const NodeContext& default_context);
+
+    /**
+     * @brief Canonicalize a topology JSON document for equivalence
+     *        comparison. Pure function; no registries touched.
+     *
+     * Two topology documents describe the same graph iff their canon()
+     * forms are equal (nlohmann object comparison is key-order
+     * insensitive; canon sorts all owned arrays). Used as the
+     * translation-validation oracle:
+     *   canon(definition) == canon(compile(definition).to_json())
+     *
+     * Normalizations applied (the *whitelist* — anything the compiler
+     * rewrites on purpose must be mirrored here, and nothing else;
+     * every whitelist addition needs review):
+     *   - defaults made explicit: name, channel reducer, retry_policy
+     *     fields, schema_version dropped when 0/absent
+     *   - inline conditional edges (legacy `edges` items carrying
+     *     `condition` / type:"conditional") are moved into
+     *     `conditional_edges`
+     *   - owned arrays sorted: edges, conditional_edges,
+     *     interrupt_before/after (deduped), barrier wait_for (deduped)
+     *   - empty owned containers dropped (routes:{}, interrupt:[])
+     *   - `_`/`x-` annotation keys stripped at every owned level
+     *     (node config *contents* are not descended into)
+     *
+     * Unknown keys are deliberately PRESERVED, not stripped — that is
+     * how the TV compare flags a key the compiler ignored.
+     */
+    static json canon(const json& definition);
+
+    /**
+     * @brief Translation validation: assert compile() lost nothing.
+     *
+     * Compares canon(definition) against canon(cg.to_json()). On
+     * mismatch: throws std::runtime_error carrying the JSON-Patch diff
+     * when the document is strict (schema_version >= 1); writes a
+     * one-shot warning to stderr when lenient (legacy documents keep
+     * compiling, but silent drops become visible).
+     */
+    static void verify_roundtrip(const json& definition,
+                                 const CompiledGraph& cg);
 };
 
 } // namespace neograph::graph

--- a/include/neograph/graph/loader.h
+++ b/include/neograph/graph/loader.h
@@ -216,6 +216,18 @@ public:
     std::vector<std::string> registered_types() const;
 
     /**
+     * @brief Declared config schema for a node type.
+     *
+     * Returns the schema passed to the 3-arg register_type overload,
+     * or the permissive `{"type":"object"}` default for types
+     * registered without one (never throws on unknown types — returns
+     * the permissive default; create() is where unknown types fail).
+     * Backs strict-mode consumed-key accounting in GraphCompiler and
+     * per-type introspection for external tooling.
+     */
+    json config_schema(const std::string& type) const;
+
+    /**
      * @brief Export a machine-readable description of the topology
      *        JSON format this engine accepts.
      *

--- a/src/core/graph_compiler.cpp
+++ b/src/core/graph_compiler.cpp
@@ -1,20 +1,182 @@
 #include <neograph/graph/compiler.h>
 #include <neograph/graph/node.h>
+#include <algorithm>
+#include <cstdio>
+#include <vector>
 
 namespace neograph::graph {
+
+namespace {
+
+// Highest schema_version this compiler understands. Documents declaring
+// a higher version were written for a newer engine — refusing them is
+// the whole point of carrying the field (silent reinterpretation of a
+// newer document is worse than an error).
+constexpr int kSupportedSchemaVersion = 1;
+
+// Keys starting with '_' or 'x-' are annotations: for humans
+// (`_comment`, used across the cookbook corpus) and external tooling
+// (`x-studio-pos`). The engine never consumes them, strict mode never
+// flags them, and canon() strips them before equivalence comparison.
+bool is_annotation_key(const std::string& k) {
+    return (!k.empty() && k[0] == '_') || k.rfind("x-", 0) == 0;
+}
+
+// Consumed-key accounting: every object the compiler owns gets a
+// consumed-set populated AT THE READ SITE (inside the same block that
+// parses the key — never a detached allowlist). If a parsing step is
+// deleted, its mark disappears with it, and any strict document using
+// that feature fails here instead of silently degrading. This is the
+// structural fix for the v0.1.0–v0.1.7 conditional_edges drop class.
+void enforce_consumed(const json& obj,
+                      const std::set<std::string>& consumed,
+                      const std::string& path,
+                      std::vector<std::string>& errors) {
+    if (!obj.is_object()) return;
+    for (const auto& [k, v] : obj.items()) {
+        (void)v;
+        if (is_annotation_key(k)) continue;
+        if (!consumed.count(k)) {
+            errors.push_back(path + ": unknown or unconsumed key '" + k + "'");
+        }
+    }
+}
+
+// retry_policy carries a float member; canon() must push input numbers
+// through the same float truncation the parser applies, or TV would
+// flag e.g. 0.1 (double) != 0.1f (parsed) as a phantom mismatch.
+json canon_backoff(const json& v) {
+    return json(static_cast<float>(v.get<double>()));
+}
+
+// neograph::json is yyjson-backed: objects preserve insertion order and
+// operator== compares serializations, so canonical forms must rebuild
+// every object with sorted keys (recursively) or two semantically equal
+// documents would compare unequal.
+json sort_keys(const json& v) {
+    if (v.is_object()) {
+        std::vector<std::string> keys;
+        for (const auto& [k, val] : v.items()) { (void)val; keys.push_back(k); }
+        std::sort(keys.begin(), keys.end());
+        json out = json::object();
+        for (const auto& k : keys) out[k] = sort_keys(v[k]);
+        return out;
+    }
+    if (v.is_array()) {
+        json out = json::array();
+        for (const auto& e : v) out.push_back(sort_keys(e));
+        return out;
+    }
+    return v;
+}
+
+// Human-readable structural mismatch report for translation-validation
+// failures (the wrapper has no json::diff). Phrased from the compiler's
+// point of view: input-only = lost, reemit-only = fabricated.
+void collect_mismatches(const json& declared, const json& compiled,
+                        const std::string& path,
+                        std::vector<std::string>& out) {
+    constexpr size_t kMax = 8;
+    if (out.size() >= kMax || declared == compiled) return;
+    if (declared.is_object() && compiled.is_object()) {
+        for (const auto& [k, v] : declared.items()) {
+            if (out.size() >= kMax) return;
+            if (!compiled.contains(k)) {
+                out.push_back(path + "/" + k + ": lost in compilation");
+            } else {
+                collect_mismatches(v, compiled[k], path + "/" + k, out);
+            }
+        }
+        for (const auto& [k, v] : compiled.items()) {
+            (void)v;
+            if (out.size() >= kMax) return;
+            if (!declared.contains(k)) {
+                out.push_back(path + "/" + k + ": fabricated by compilation");
+            }
+        }
+        return;
+    }
+    if (declared.is_array() && compiled.is_array()) {
+        if (declared.size() != compiled.size()) {
+            out.push_back(path + ": " + std::to_string(declared.size())
+                          + " element(s) declared, "
+                          + std::to_string(compiled.size()) + " compiled");
+            return;
+        }
+        for (size_t i = 0; i < declared.size(); ++i) {
+            if (out.size() >= kMax) return;
+            collect_mismatches(declared[i], compiled[i],
+                               path + "[" + std::to_string(i) + "]", out);
+        }
+        return;
+    }
+    out.push_back(path + ": declared " + declared.dump()
+                  + ", compiled " + compiled.dump());
+}
+
+// Normalize one conditional edge (either the legacy inline `edges`
+// form or a top-level `conditional_edges` item) for canon(). Unknown
+// keys are preserved so TV flags anything the compiler ignored;
+// annotations are stripped; empty routes are dropped.
+json canon_conditional(const json& e) {
+    json out = json::object();
+    for (const auto& [k, v] : e.items()) {
+        if (is_annotation_key(k)) continue;
+        if (k == "type") continue;              // form marker, not meaning
+        if (k == "routes") {
+            if (v.is_object() && !v.empty()) out["routes"] = v;
+            continue;
+        }
+        out[k] = v;
+    }
+    return out;
+}
+
+} // namespace
 
 CompiledGraph GraphCompiler::compile(const json& definition,
                                      const NodeContext& default_context) {
     CompiledGraph cg;
+    std::vector<std::string> errors;
+    std::set<std::string> top_consumed;
+
+    // --- schema_version (strict-mode gate) ---
+    if (definition.contains("schema_version")) {
+        top_consumed.insert("schema_version");
+        const auto& sv = definition["schema_version"];
+        if (!sv.is_number_integer() || sv.get<int>() < 0) {
+            throw std::runtime_error(
+                "topology 'schema_version' must be a non-negative integer, got: "
+                + sv.dump());
+        }
+        cg.schema_version = sv.get<int>();
+        if (cg.schema_version > kSupportedSchemaVersion) {
+            throw std::runtime_error(
+                "topology schema_version " + std::to_string(cg.schema_version)
+                + " is newer than this engine supports (max "
+                + std::to_string(kSupportedSchemaVersion)
+                + "). Upgrade NeoGraph or re-export the topology.");
+        }
+    }
+    const bool strict = cg.schema_version >= 1;
+
     cg.name = definition.value("name", "unnamed_graph");
+    top_consumed.insert("name");
 
     // --- Channels ---
     if (definition.contains("channels")) {
+        top_consumed.insert("channels");
         for (const auto& [name, ch_def] : definition["channels"].items()) {
             ChannelDef cd;
-            cd.name          = name;
-            cd.reducer_name  = ch_def.value("reducer", "overwrite");
-            cd.initial_value = ch_def.contains("initial") ? ch_def["initial"] : json();
+            std::set<std::string> ch_consumed;
+
+            cd.name         = name;
+            cd.reducer_name = ch_def.value("reducer", "overwrite");
+            ch_consumed.insert("reducer");
+
+            cd.has_initial   = ch_def.contains("initial");
+            cd.initial_value = cd.has_initial ? ch_def["initial"] : json();
+            ch_consumed.insert("initial");
 
             if (cd.reducer_name == "append")
                 cd.type = ReducerType::APPEND;
@@ -23,32 +185,89 @@ CompiledGraph GraphCompiler::compile(const json& definition,
             else
                 cd.type = ReducerType::CUSTOM;
 
+            if (strict) {
+                enforce_consumed(ch_def, ch_consumed,
+                                 "channels." + name, errors);
+            }
             cg.channel_defs.push_back(std::move(cd));
         }
     }
 
     // --- Nodes + optional per-node barrier specs ---
     if (definition.contains("nodes")) {
+        top_consumed.insert("nodes");
         for (const auto& [name, node_def] : definition["nodes"].items()) {
             auto type = node_def.value("type", "");
             auto node = NodeFactory::instance().create(type, name, node_def, default_context);
             cg.nodes[name] = std::move(node);
 
+            std::set<std::string> node_consumed = {"type"};
+
             // {"barrier": {"wait_for": [...]}} opts this node into
             // AND-join semantics: it fires only after every listed
             // upstream has signaled (accumulated across super-steps).
             if (node_def.contains("barrier")) {
+                node_consumed.insert("barrier");
                 const auto& b = node_def["barrier"];
                 std::set<std::string> wait_for;
+                std::set<std::string> barrier_consumed;
                 if (b.contains("wait_for")) {
+                    barrier_consumed.insert("wait_for");
                     for (const auto& up : b["wait_for"]) {
                         wait_for.insert(up.get<std::string>());
                     }
                 }
                 if (!wait_for.empty()) {
                     cg.barrier_specs[name] = std::move(wait_for);
+                } else if (strict) {
+                    // Historically an empty/missing wait_for was
+                    // silently dropped — the node quietly lost its
+                    // AND-join. Strict mode refuses instead.
+                    errors.push_back(
+                        "nodes." + name + ".barrier: 'wait_for' is missing or "
+                        "empty — the barrier would be silently dropped. "
+                        "List the upstream nodes to wait for, or remove "
+                        "the 'barrier' block.");
+                }
+                if (strict) {
+                    enforce_consumed(b, barrier_consumed,
+                                     "nodes." + name + ".barrier", errors);
                 }
             }
+
+            // Strict mode checks the node's config keys against the
+            // type's declared schema. Enforcement is closed-world only
+            // when the registration declared "properties" and did not
+            // opt out via "additionalProperties": true — types
+            // registered without a schema stay permissive (the
+            // cookbook's custom nodes carry free-form config).
+            if (strict) {
+                const json schema = NodeFactory::instance().config_schema(type);
+                bool open = !schema.contains("properties");
+                if (schema.contains("additionalProperties")) {
+                    const auto& ap = schema["additionalProperties"];
+                    if (!ap.is_boolean() || ap.get<bool>()) open = true;
+                }
+                if (!open) {
+                    for (const auto& [pk, pv] : schema["properties"].items()) {
+                        (void)pv;
+                        node_consumed.insert(pk);
+                    }
+                    enforce_consumed(node_def, node_consumed,
+                                     "nodes." + name, errors);
+                }
+            }
+
+            // Verbatim node definition minus "barrier" — barriers are
+            // re-emitted from barrier_specs so translation validation
+            // compares compiled state, not an input echo. (Copy-skip:
+            // the yyjson wrapper has no erase().)
+            json stored = json::object();
+            for (const auto& [k, v] : node_def.items()) {
+                if (k == "barrier") continue;
+                stored[k] = v;
+            }
+            cg.node_defs[name] = std::move(stored);
         }
     }
 
@@ -59,8 +278,11 @@ CompiledGraph GraphCompiler::compile(const json& definition,
     //      our README + Python examples). The compiler used to silently
     //      drop form 2, which made the documented Python ReAct example
     //      degenerate to a single LLM call with no tool dispatch.
-    auto parse_conditional = [&](const json& edge_def) {
+    auto parse_conditional = [&](const json& edge_def, const std::string& path,
+                                 bool inline_form) {
         ConditionalEdge ce;
+        std::set<std::string> e_consumed = {"from", "condition", "routes"};
+        if (inline_form) e_consumed.insert("type");
         ce.from      = edge_def.at("from").get<std::string>();
         ce.condition = edge_def.at("condition").get<std::string>();
         if (edge_def.contains("routes")) {
@@ -68,37 +290,51 @@ CompiledGraph GraphCompiler::compile(const json& definition,
                 ce.routes[key] = target.get<std::string>();
             }
         }
+        if (strict) enforce_consumed(edge_def, e_consumed, path, errors);
         cg.conditional_edges.push_back(std::move(ce));
     };
 
     if (definition.contains("edges")) {
+        top_consumed.insert("edges");
+        size_t i = 0;
         for (const auto& edge_def : definition["edges"]) {
+            const std::string path = "edges[" + std::to_string(i++) + "]";
             bool is_conditional = edge_def.contains("condition")
                                || edge_def.value("type", "") == "conditional";
 
             if (is_conditional) {
-                parse_conditional(edge_def);
+                // NOTE: a 'to' on an inline conditional is NOT consumed
+                // — routing goes through 'routes', so 'to' would be
+                // silently ignored. Strict mode surfaces it.
+                parse_conditional(edge_def, path, /*inline_form=*/true);
             } else {
                 Edge e;
                 e.from = edge_def.at("from").get<std::string>();
                 e.to   = edge_def.at("to").get<std::string>();
+                if (strict) enforce_consumed(edge_def, {"from", "to"}, path, errors);
                 cg.edges.push_back(std::move(e));
             }
         }
     }
     if (definition.contains("conditional_edges")) {
+        top_consumed.insert("conditional_edges");
+        size_t i = 0;
         for (const auto& edge_def : definition["conditional_edges"]) {
-            parse_conditional(edge_def);
+            parse_conditional(edge_def,
+                              "conditional_edges[" + std::to_string(i++) + "]",
+                              /*inline_form=*/false);
         }
     }
 
     // --- Interrupt sets ---
     if (definition.contains("interrupt_before")) {
+        top_consumed.insert("interrupt_before");
         for (const auto& n : definition["interrupt_before"]) {
             cg.interrupt_before.insert(n.get<std::string>());
         }
     }
     if (definition.contains("interrupt_after")) {
+        top_consumed.insert("interrupt_after");
         for (const auto& n : definition["interrupt_after"]) {
             cg.interrupt_after.insert(n.get<std::string>());
         }
@@ -106,16 +342,294 @@ CompiledGraph GraphCompiler::compile(const json& definition,
 
     // --- Retry policy (optional; engine uses its own default otherwise) ---
     if (definition.contains("retry_policy")) {
+        top_consumed.insert("retry_policy");
         auto rp = definition["retry_policy"];
         RetryPolicy policy;
+        std::set<std::string> rp_consumed;
         policy.max_retries        = rp.value("max_retries", 0);
+        rp_consumed.insert("max_retries");
         policy.initial_delay_ms   = rp.value("initial_delay_ms", 100);
+        rp_consumed.insert("initial_delay_ms");
         policy.backoff_multiplier = rp.value("backoff_multiplier", 2.0f);
+        rp_consumed.insert("backoff_multiplier");
         policy.max_delay_ms       = rp.value("max_delay_ms", 5000);
+        rp_consumed.insert("max_delay_ms");
+        if (strict) enforce_consumed(rp, rp_consumed, "retry_policy", errors);
         cg.retry_policy = policy;
     }
 
+    if (strict) {
+        enforce_consumed(definition, top_consumed, "$", errors);
+        if (!errors.empty()) {
+            std::string msg =
+                "strict topology validation failed (schema_version "
+                + std::to_string(cg.schema_version) + "), "
+                + std::to_string(errors.size()) + " error(s):";
+            for (const auto& e : errors) msg += "\n  - " + e;
+            msg += "\nAnnotation keys ('_'/'x-' prefixes) are always allowed. "
+                   "Remove 'schema_version' to fall back to lenient parsing. "
+                   "See docs/troubleshooting.md \"Strict topology validation\".";
+            throw std::runtime_error(msg);
+        }
+    }
+
     return cg;
+}
+
+// =========================================================================
+// Re-emission + canonicalization + translation validation
+// =========================================================================
+
+json CompiledGraph::to_json() const {
+    json j = json::object();
+    if (schema_version > 0) j["schema_version"] = schema_version;
+    j["name"] = name;
+
+    if (!channel_defs.empty()) {
+        json channels = json::object();
+        for (const auto& cd : channel_defs) {
+            json c = json::object();
+            c["reducer"] = cd.reducer_name;
+            if (cd.has_initial) c["initial"] = cd.initial_value;
+            channels[cd.name] = std::move(c);
+        }
+        j["channels"] = std::move(channels);
+    }
+
+    if (!node_defs.empty()) {
+        json nodes = json::object();
+        for (const auto& [nname, ndef] : node_defs) {
+            json n = ndef;
+            auto bit = barrier_specs.find(nname);
+            if (bit != barrier_specs.end()) {
+                json wait_for = json::array();
+                for (const auto& up : bit->second) wait_for.push_back(up);
+                n["barrier"] = json{{"wait_for", std::move(wait_for)}};
+            }
+            nodes[nname] = std::move(n);
+        }
+        j["nodes"] = std::move(nodes);
+    }
+
+    if (!edges.empty()) {
+        json arr = json::array();
+        for (const auto& e : edges) {
+            arr.push_back(json{{"from", e.from}, {"to", e.to}});
+        }
+        j["edges"] = std::move(arr);
+    }
+
+    if (!conditional_edges.empty()) {
+        json arr = json::array();
+        for (const auto& ce : conditional_edges) {
+            json e = json::object();
+            e["from"]      = ce.from;
+            e["condition"] = ce.condition;
+            if (!ce.routes.empty()) {
+                json routes = json::object();
+                for (const auto& [k, v] : ce.routes) routes[k] = v;
+                e["routes"] = std::move(routes);
+            }
+            arr.push_back(std::move(e));
+        }
+        j["conditional_edges"] = std::move(arr);
+    }
+
+    auto emit_set = [&](const char* key, const std::set<std::string>& s) {
+        if (s.empty()) return;
+        json arr = json::array();
+        for (const auto& n : s) arr.push_back(n);
+        j[key] = std::move(arr);
+    };
+    emit_set("interrupt_before", interrupt_before);
+    emit_set("interrupt_after", interrupt_after);
+
+    if (retry_policy) {
+        j["retry_policy"] = json{
+            {"max_retries",        retry_policy->max_retries},
+            {"initial_delay_ms",   retry_policy->initial_delay_ms},
+            {"backoff_multiplier", retry_policy->backoff_multiplier},
+            {"max_delay_ms",       retry_policy->max_delay_ms},
+        };
+    }
+
+    return j;
+}
+
+json GraphCompiler::canon(const json& definition) {
+    json out = json::object();
+
+    // Unknown top-level keys are preserved (minus annotations) — the
+    // TV compare is precisely how a key the compiler ignored becomes
+    // visible. Owned keys are rebuilt in normalized form below.
+    static const std::set<std::string> owned = {
+        "schema_version", "name", "channels", "nodes", "edges",
+        "conditional_edges", "interrupt_before", "interrupt_after",
+        "retry_policy",
+    };
+    for (const auto& [k, v] : definition.items()) {
+        if (is_annotation_key(k) || owned.count(k)) continue;
+        out[k] = v;
+    }
+
+    if (definition.contains("schema_version")
+        && definition["schema_version"].is_number_integer()
+        && definition["schema_version"].get<int>() > 0) {
+        out["schema_version"] = definition["schema_version"];
+    }
+    out["name"] = definition.value("name", "unnamed_graph");
+
+    if (definition.contains("channels") && definition["channels"].is_object()
+        && !definition["channels"].empty()) {
+        json channels = json::object();
+        for (const auto& [name, ch] : definition["channels"].items()) {
+            json c = json::object();
+            if (ch.is_object()) {
+                for (const auto& [k, v] : ch.items()) {
+                    if (is_annotation_key(k)) continue;
+                    c[k] = v;
+                }
+            }
+            if (!c.contains("reducer")) c["reducer"] = "overwrite";
+            channels[name] = std::move(c);
+        }
+        out["channels"] = std::move(channels);
+    }
+
+    if (definition.contains("nodes") && definition["nodes"].is_object()
+        && !definition["nodes"].empty()) {
+        json nodes = json::object();
+        for (const auto& [name, nd] : definition["nodes"].items()) {
+            json n = json::object();
+            for (const auto& [k, v] : nd.items()) {
+                if (is_annotation_key(k)) continue;
+                if (k == "barrier") {
+                    // Normalize to {"wait_for": sorted-deduped array}.
+                    // An empty/missing wait_for is deliberately KEPT
+                    // (as an empty array): the parser drops such a
+                    // barrier, so lenient TV flags the drop and strict
+                    // mode has already refused it.
+                    std::set<std::string> wait_for;
+                    if (v.is_object() && v.contains("wait_for")) {
+                        for (const auto& up : v["wait_for"]) {
+                            wait_for.insert(up.get<std::string>());
+                        }
+                    }
+                    json arr = json::array();
+                    for (const auto& up : wait_for) arr.push_back(up);
+                    json b = json::object();
+                    if (v.is_object()) {
+                        for (const auto& [bk, bv] : v.items()) {
+                            if (is_annotation_key(bk) || bk == "wait_for") continue;
+                            b[bk] = bv;   // unknown barrier keys preserved
+                        }
+                    }
+                    b["wait_for"] = std::move(arr);
+                    n["barrier"] = std::move(b);
+                    continue;
+                }
+                n[k] = v;
+            }
+            nodes[name] = std::move(n);
+        }
+        out["nodes"] = std::move(nodes);
+    }
+
+    // Edges: split legacy inline conditionals out of `edges` into
+    // `conditional_edges` (the one intentional rewrite the compiler
+    // performs), then sort both arrays for order-insensitive compare.
+    std::vector<json> plain, conditional;
+    if (definition.contains("edges") && definition["edges"].is_array()) {
+        for (const auto& e : definition["edges"]) {
+            bool is_conditional = e.contains("condition")
+                               || e.value("type", "") == "conditional";
+            if (is_conditional) {
+                // sort_keys BEFORE the dump-based array sort: the
+                // comparator must see identical serializations for
+                // identical meaning regardless of input key order.
+                conditional.push_back(sort_keys(canon_conditional(e)));
+            } else {
+                json p = json::object();
+                for (const auto& [k, v] : e.items()) {
+                    if (is_annotation_key(k)) continue;
+                    p[k] = v;
+                }
+                plain.push_back(sort_keys(p));
+            }
+        }
+    }
+    if (definition.contains("conditional_edges")
+        && definition["conditional_edges"].is_array()) {
+        for (const auto& e : definition["conditional_edges"]) {
+            conditional.push_back(sort_keys(canon_conditional(e)));
+        }
+    }
+    auto by_dump = [](const json& a, const json& b) { return a.dump() < b.dump(); };
+    std::sort(plain.begin(), plain.end(), by_dump);
+    std::sort(conditional.begin(), conditional.end(), by_dump);
+    auto to_array = [](const std::vector<json>& v) {
+        json arr = json::array();
+        for (const auto& e : v) arr.push_back(e);
+        return arr;
+    };
+    if (!plain.empty())       out["edges"] = to_array(plain);
+    if (!conditional.empty()) out["conditional_edges"] = to_array(conditional);
+
+    auto canon_set = [&](const char* key) {
+        if (!definition.contains(key) || !definition[key].is_array()) return;
+        std::set<std::string> s;
+        for (const auto& n : definition[key]) s.insert(n.get<std::string>());
+        if (s.empty()) return;
+        json arr = json::array();
+        for (const auto& n : s) arr.push_back(n);
+        out[key] = std::move(arr);
+    };
+    canon_set("interrupt_before");
+    canon_set("interrupt_after");
+
+    if (definition.contains("retry_policy") && definition["retry_policy"].is_object()) {
+        const auto& rp = definition["retry_policy"];
+        json p = json::object();
+        for (const auto& [k, v] : rp.items()) {
+            if (is_annotation_key(k)) continue;
+            p[k] = v;    // unknown keys preserved
+        }
+        if (!p.contains("max_retries"))        p["max_retries"] = 0;
+        if (!p.contains("initial_delay_ms"))   p["initial_delay_ms"] = 100;
+        if (!p.contains("max_delay_ms"))       p["max_delay_ms"] = 5000;
+        p["backoff_multiplier"] = p.contains("backoff_multiplier")
+            ? canon_backoff(p["backoff_multiplier"])
+            : json(2.0f);
+        out["retry_policy"] = std::move(p);
+    }
+
+    // Recursive key sort — see sort_keys(): equality is serialization-
+    // based, so canonical form must fix object key order everywhere
+    // (including inside pass-through node configs).
+    return sort_keys(out);
+}
+
+void GraphCompiler::verify_roundtrip(const json& definition,
+                                     const CompiledGraph& cg) {
+    const json a = canon(definition);
+    const json b = canon(cg.to_json());
+    if (a == b) return;
+
+    // Structural mismatch report: what compilation lost or rewired.
+    std::vector<std::string> mismatches;
+    collect_mismatches(a, b, "$", mismatches);
+    std::string msg =
+        "translation validation failed: compiled graph does not round-trip "
+        "to its definition — the compiler dropped or rewired something:";
+    for (const auto& m : mismatches) msg += "\n  - " + m;
+
+    if (cg.schema_version >= 1) {
+        throw std::runtime_error(msg);
+    }
+    // Lenient documents keep compiling (historical behavior), but the
+    // silent drop is no longer silent. FILE* stderr, not std::cerr —
+    // see graph_executor.cpp for the Windows capfd rationale.
+    std::fprintf(stderr, "[neograph] warning: %s\n", msg.c_str());
 }
 
 } // namespace neograph::graph

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -40,6 +40,12 @@ std::unique_ptr<GraphEngine> GraphEngine::compile(
 
     auto cg = GraphCompiler::compile(definition, default_context);
 
+    // Translation validation: assert nothing was silently dropped or
+    // rewired between the JSON definition and the compiled graph.
+    // Strict documents (schema_version >= 1) fail hard; legacy
+    // documents get a stderr warning. Must run before the moves below.
+    GraphCompiler::verify_roundtrip(definition, cg);
+
     auto engine = std::unique_ptr<GraphEngine>(new GraphEngine());
     engine->name_              = std::move(cg.name);
     engine->channel_defs_      = std::move(cg.channel_defs);

--- a/src/core/graph_loader.cpp
+++ b/src/core/graph_loader.cpp
@@ -303,6 +303,12 @@ std::vector<std::string> NodeFactory::registered_types() const {
     return registry_names(registry_);
 }
 
+json NodeFactory::config_schema(const std::string& type) const {
+    auto it = schemas_.find(type);
+    if (it != schemas_.end()) return it->second;
+    return json::parse(R"JSON({"type":"object","description":"No declared config schema; any object accepted."})JSON");
+}
+
 json NodeFactory::export_schema() const {
     // Fixed top-level envelope. This mirrors exactly what
     // GraphCompiler::compile reads (src/core/graph_compiler.cpp);
@@ -311,6 +317,7 @@ json NodeFactory::export_schema() const {
         "type": "object",
         "description": "NeoGraph topology definition consumed by GraphEngine::compile / the JSON loader.",
         "properties": {
+            "schema_version": { "type": "integer", "description": "Topology schema version. 1 opts this document into strict compilation: every key must be consumed by the parser (unknown keys, typos, and silently-droppable constructs are hard errors), and translation validation failures throw instead of warning. Absent or 0 = legacy lenient parsing. Keys prefixed '_' or 'x-' are annotations and always allowed." },
             "name": { "type": "string", "description": "Optional graph name." },
             "channels": {
                 "type": "object",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(neograph_tests
     test_scheduler.cpp
     test_node_execution.cpp
     test_compiler.cpp
+    test_compiler_strict.cpp
     test_barrier_persistence.cpp
     test_coordinator.cpp
     test_sends_interrupt_order.cpp

--- a/tests/test_compiler_strict.cpp
+++ b/tests/test_compiler_strict.cpp
@@ -1,0 +1,353 @@
+// M1 "regression seal" tests (issue #75): consumed-key accounting
+// (strict mode via schema_version), CompiledGraph::to_json() re-emission,
+// canon() normalization, and translation validation (verify_roundtrip).
+//
+// The contract under test:
+//   canon(definition) == canon(compile(definition).to_json())
+// for every accepted document — a mismatch is a silent drop/rewire, the
+// v0.1.0–v0.1.7 conditional_edges regression class. Strict documents
+// must refuse unknown/unconsumed keys instead of ignoring them.
+
+#include <gtest/gtest.h>
+#include <neograph/neograph.h>
+#include <neograph/graph/compiler.h>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+class StrictNoopNode : public GraphNode {
+public:
+    explicit StrictNoopNode(std::string n) : name_(std::move(n)) {}
+    asio::awaitable<NodeOutput> run(NodeInput) override { co_return NodeOutput{}; }
+    std::string get_name() const override { return name_; }
+private:
+    std::string name_;
+};
+
+void ensure_types_registered() {
+    // "snoop": registered WITHOUT a declared schema — permissive, any
+    // config accepted even in strict mode (models the cookbook's
+    // custom nodes with free-form config).
+    NodeFactory::instance().register_type(
+        "snoop",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<StrictNoopNode>(name);
+        });
+    // "snoop_closed": registered WITH a declared schema — strict mode
+    // enforces closed-world config keys.
+    NodeFactory::instance().register_type(
+        "snoop_closed",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<StrictNoopNode>(name);
+        },
+        json::parse(R"({"type":"object","properties":{"knob":{"type":"string"}}})"));
+}
+
+// The yyjson wrapper has no erase() — rebuild minus one key.
+json without_key(const json& obj, const std::string& key) {
+    json out = json::object();
+    for (const auto& [k, v] : obj.items()) {
+        if (k != key) out[k] = v;
+    }
+    return out;
+}
+
+json minimal_strict() {
+    return json{
+        {"schema_version", 1},
+        {"nodes", {{"a", {{"type", "snoop"}}}}},
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "a"}},
+                                {{"from", "a"}, {"to", "__end__"}} })},
+    };
+}
+
+// Expect compile() to throw and the message to contain every fragment.
+void expect_strict_error(const json& def, std::initializer_list<const char*> fragments) {
+    ensure_types_registered();
+    try {
+        GraphCompiler::compile(def, NodeContext{});
+        FAIL() << "expected strict validation to reject the document";
+    } catch (const std::runtime_error& e) {
+        const std::string msg = e.what();
+        for (const char* f : fragments) {
+            EXPECT_NE(msg.find(f), std::string::npos)
+                << "error message missing '" << f << "'\nfull message: " << msg;
+        }
+    }
+}
+
+} // namespace
+
+// =========================================================================
+// Strict mode: consumed-key accounting
+// =========================================================================
+
+TEST(StrictCompiler, TypoConditionalEdgesIsError) {
+    auto def = minimal_strict();
+    def["conditionnal_edges"] = json::array();   // the historical nightmare
+    expect_strict_error(def, {"conditionnal_edges", "unknown or unconsumed"});
+}
+
+TEST(StrictCompiler, UnknownChannelKeyIsError) {
+    auto def = minimal_strict();
+    def["channels"] = {{"c", {{"reducer", "append"}, {"initail", 5}}}};
+    expect_strict_error(def, {"channels.c", "initail"});
+}
+
+TEST(StrictCompiler, DeclaredSchemaNodeConfigTypoIsError) {
+    auto def = minimal_strict();
+    def["nodes"]["b"] = {{"type", "snoop_closed"}, {"knbo", "x"}};
+    expect_strict_error(def, {"nodes.b", "knbo"});
+}
+
+TEST(StrictCompiler, BuiltinIntentClassifierConfigTypoIsError) {
+    auto def = minimal_strict();
+    def["nodes"]["ic"] = {{"type", "intent_classifier"},
+                          {"routes", json::array({"x"})},
+                          {"promt", "classify"}};   // typo of "prompt"
+    expect_strict_error(def, {"nodes.ic", "promt"});
+}
+
+TEST(StrictCompiler, PermissiveCustomTypeConfigAllowed) {
+    ensure_types_registered();
+    auto def = minimal_strict();
+    def["nodes"]["a"] = {{"type", "snoop"},
+                         {"model_path", "assets/foo.bin"},
+                         {"vad_threshold", 0.5}};
+    EXPECT_NO_THROW(GraphCompiler::compile(def, NodeContext{}));
+}
+
+TEST(StrictCompiler, RetryPolicyTypoIsError) {
+    auto def = minimal_strict();
+    def["retry_policy"] = {{"max_retry", 3}};   // typo of "max_retries"
+    expect_strict_error(def, {"retry_policy", "max_retry"});
+}
+
+TEST(StrictCompiler, EmptyBarrierWaitForIsError) {
+    auto def = minimal_strict();
+    def["nodes"]["a"]["barrier"] = {{"wait_for", json::array()}};
+    expect_strict_error(def, {"nodes.a.barrier", "silently dropped"});
+}
+
+TEST(StrictCompiler, BarrierMissingWaitForIsError) {
+    auto def = minimal_strict();
+    def["nodes"]["a"]["barrier"] = json::object();
+    expect_strict_error(def, {"nodes.a.barrier", "silently dropped"});
+}
+
+TEST(StrictCompiler, UnknownBarrierKeyIsError) {
+    auto def = minimal_strict();
+    def["nodes"]["a"]["barrier"] = {{"wait_for", json::array({"b"})},
+                                    {"wiat_for", json::array({"c"})}};
+    expect_strict_error(def, {"nodes.a.barrier", "wiat_for"});
+}
+
+TEST(StrictCompiler, InlineConditionalToIsError) {
+    // 'to' on an inline conditional edge is silently ignored by the
+    // parser (routing goes through 'routes') — strict mode surfaces it.
+    auto def = minimal_strict();
+    def["edges"].push_back({{"from", "a"}, {"to", "__end__"},
+                            {"condition", "has_tool_calls"},
+                            {"routes", {{"true", "a"}}}});
+    expect_strict_error(def, {"edges[2]", "'to'"});
+}
+
+TEST(StrictCompiler, UnknownPlainEdgeKeyIsError) {
+    auto def = minimal_strict();
+    def["edges"].push_back({{"from", "a"}, {"to", "__end__"}, {"weight", 3}});
+    expect_strict_error(def, {"edges[2]", "weight"});
+}
+
+TEST(StrictCompiler, AnnotationsAlwaysAllowed) {
+    ensure_types_registered();
+    auto def = minimal_strict();
+    def["_comment"] = "top-level note";
+    def["x-studio"] = {{"zoom", 1.5}};
+    def["channels"] = {{"c", {{"reducer", "append"}, {"_comment", "log"}}}};
+    def["nodes"]["a"]["_comment"] = "node note";
+    def["nodes"]["a"]["x-pos"] = {{"x", 10}, {"y", 20}};
+    EXPECT_NO_THROW(GraphCompiler::compile(def, NodeContext{}));
+}
+
+TEST(StrictCompiler, AggregatesAllErrors) {
+    auto def = minimal_strict();
+    def["conditionnal_edges"] = json::array();
+    def["retry_policy"] = {{"max_retry", 3}};
+    expect_strict_error(def, {"2 error(s)", "conditionnal_edges", "max_retry"});
+}
+
+TEST(StrictCompiler, SchemaVersionTooNewIsError) {
+    auto def = minimal_strict();
+    def["schema_version"] = 2;
+    expect_strict_error(def, {"newer than this engine"});
+}
+
+TEST(StrictCompiler, SchemaVersionMustBeInteger) {
+    auto def = minimal_strict();
+    def["schema_version"] = "1";
+    expect_strict_error(def, {"schema_version", "integer"});
+}
+
+// =========================================================================
+// Lenient mode: historical behavior preserved byte-for-byte
+// =========================================================================
+
+TEST(LenientCompiler, UnknownTopLevelKeyStillIgnored) {
+    ensure_types_registered();
+    json def = {{"nodes", {{"a", {{"type", "snoop"}}}}},
+                {"conditionnal_edges", json::array()}};
+    auto cg = GraphCompiler::compile(def, NodeContext{});
+    EXPECT_TRUE(cg.conditional_edges.empty());
+    EXPECT_EQ(cg.schema_version, 0);
+}
+
+TEST(LenientCompiler, EmptyBarrierStillDropped) {
+    ensure_types_registered();
+    json def = {{"nodes", {{"a", {{"type", "snoop"},
+                                  {"barrier", {{"wait_for", json::array()}}}}}}}};
+    auto cg = GraphCompiler::compile(def, NodeContext{});
+    EXPECT_TRUE(cg.barrier_specs.empty());
+}
+
+// =========================================================================
+// canon() + to_json(): translation-validation round-trip
+// =========================================================================
+
+namespace {
+
+json full_feature_def() {
+    return json{
+        {"schema_version", 1},
+        {"name", "full"},
+        {"channels", {
+            {"messages", {{"reducer", "append"}}},
+            {"counter",  {{"reducer", "overwrite"}, {"initial", 42}}},
+            {"maybe",    {{"reducer", "overwrite"}, {"initial", nullptr}}},
+        }},
+        {"nodes", {
+            {"a", {{"type", "snoop"}, {"free_form", {{"nested", true}}}}},
+            {"b", {{"type", "snoop_closed"}, {"knob", "v"}}},
+            {"j", {{"type", "snoop"},
+                   {"barrier", {{"wait_for", json::array({"b", "a"})}}}}},
+        }},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "a"}},
+            {{"from", "__start__"}, {"to", "b"}},
+            {{"from", "a"}, {"to", "j"}},
+            {{"from", "b"}, {"to", "j"}},
+            // legacy inline conditional form:
+            {{"from", "j"}, {"condition", "has_tool_calls"},
+             {"routes", {{"true", "a"}, {"false", "__end__"}}}},
+        })},
+        {"conditional_edges", json::array({
+            {{"from", "a"}, {"condition", "route_channel"},
+             {"routes", {{"x", "b"}, {"default", "__end__"}}}},
+        })},
+        {"interrupt_before", json::array({"j"})},
+        {"interrupt_after", json::array({"a", "b"})},
+        {"retry_policy", {{"max_retries", 3}, {"backoff_multiplier", 1.5}}},
+    };
+}
+
+} // namespace
+
+TEST(RoundTrip, FullFeatureCanonEquality) {
+    ensure_types_registered();
+    auto def = full_feature_def();
+    auto cg  = GraphCompiler::compile(def, NodeContext{});
+    EXPECT_EQ(GraphCompiler::canon(def), GraphCompiler::canon(cg.to_json()))
+        << "input:    " << GraphCompiler::canon(def).dump(2)
+        << "\nreemit: " << GraphCompiler::canon(cg.to_json()).dump(2);
+    EXPECT_NO_THROW(GraphCompiler::verify_roundtrip(def, cg));
+}
+
+TEST(RoundTrip, ExplicitNullInitialSurvives) {
+    ensure_types_registered();
+    auto def = full_feature_def();
+    auto cg  = GraphCompiler::compile(def, NodeContext{});
+    auto reemitted = cg.to_json();
+    ASSERT_TRUE(reemitted["channels"]["maybe"].contains("initial"));
+    EXPECT_TRUE(reemitted["channels"]["maybe"]["initial"].is_null());
+    EXPECT_FALSE(reemitted["channels"]["messages"].contains("initial"));
+}
+
+TEST(RoundTrip, InlineAndTopLevelConditionalCanonToSameForm) {
+    json inline_form = {{"nodes", {{"a", {{"type", "snoop"}}}}},
+                        {"edges", json::array({
+                            {{"from", "a"}, {"condition", "route_channel"},
+                             {"routes", {{"x", "__end__"}}}} })}};
+    json top_form    = {{"nodes", {{"a", {{"type", "snoop"}}}}},
+                        {"conditional_edges", json::array({
+                            {{"from", "a"}, {"condition", "route_channel"},
+                             {"routes", {{"x", "__end__"}}}} })}};
+    EXPECT_EQ(GraphCompiler::canon(inline_form), GraphCompiler::canon(top_form));
+}
+
+TEST(RoundTrip, CanonIsIdempotent) {
+    auto def = full_feature_def();
+    auto once = GraphCompiler::canon(def);
+    EXPECT_EQ(once, GraphCompiler::canon(once));
+}
+
+TEST(RoundTrip, CanonStripsAnnotationsAndSortsInterrupts) {
+    json def = {{"_comment", "note"},
+                {"nodes", {{"a", {{"type", "snoop"}, {"x-pos", 1}}}}},
+                {"interrupt_before", json::array({"b", "a", "b"})}};
+    auto c = GraphCompiler::canon(def);
+    EXPECT_FALSE(c.contains("_comment"));
+    EXPECT_FALSE(c["nodes"]["a"].contains("x-pos"));
+    EXPECT_EQ(c["interrupt_before"], json::array({"a", "b"}));
+}
+
+// =========================================================================
+// Translation validation catches the v0.1.x mutant class
+// =========================================================================
+
+TEST(TranslationValidation, DetectsConditionalEdgesDrop) {
+    // Simulate reverting the v0.1.8 fix: compile correctly, then drop
+    // the compiled conditional edges — exactly what v0.1.0–v0.1.7 did.
+    ensure_types_registered();
+    auto def = full_feature_def();
+    auto cg  = GraphCompiler::compile(def, NodeContext{});
+    cg.conditional_edges.clear();
+    EXPECT_THROW(GraphCompiler::verify_roundtrip(def, cg), std::runtime_error);
+}
+
+TEST(TranslationValidation, DetectsRouteRewiring) {
+    // An edge that survives but routes to the wrong target must fail —
+    // presence-only comparison would miss this.
+    ensure_types_registered();
+    auto def = full_feature_def();
+    auto cg  = GraphCompiler::compile(def, NodeContext{});
+    ASSERT_FALSE(cg.conditional_edges.empty());
+    for (auto& ce : cg.conditional_edges) {
+        for (auto& [key, target] : ce.routes) target = "j";   // rewire all
+    }
+    EXPECT_THROW(GraphCompiler::verify_roundtrip(def, cg), std::runtime_error);
+}
+
+TEST(TranslationValidation, DetectsBarrierDrop) {
+    ensure_types_registered();
+    auto def = full_feature_def();
+    auto cg  = GraphCompiler::compile(def, NodeContext{});
+    cg.barrier_specs.clear();
+    EXPECT_THROW(GraphCompiler::verify_roundtrip(def, cg), std::runtime_error);
+}
+
+TEST(TranslationValidation, DetectsInterruptDrop) {
+    ensure_types_registered();
+    auto def = full_feature_def();
+    auto cg  = GraphCompiler::compile(def, NodeContext{});
+    cg.interrupt_before.clear();
+    EXPECT_THROW(GraphCompiler::verify_roundtrip(def, cg), std::runtime_error);
+}
+
+TEST(TranslationValidation, LenientDocumentWarnsButDoesNotThrow) {
+    ensure_types_registered();
+    auto def = without_key(full_feature_def(), "schema_version");   // legacy
+    auto cg = GraphCompiler::compile(def, NodeContext{});
+    cg.conditional_edges.clear();
+    EXPECT_NO_THROW(GraphCompiler::verify_roundtrip(def, cg));
+}


### PR DESCRIPTION
## M1 — 회귀 봉쇄 (silent drop 클래스 소멸), #75 1/4

설계 근거: [dsl-compiler-research.md](https://github.com/weasel1245/NeoGraph-Studio/blob/main/docs/dsl-compiler-research.md) §4.2 방어선 1·2

### 무엇

1. **소비 회계** — `"schema_version": 1` 선언 문서는 strict 컴파일: 파서가 소비하지 않은 키 = 하드 에러(전부 모아 보고). 마킹이 파싱 블록 안에 있으므로 파싱 단계 삭제 = 마크 삭제 = strict 문서 즉사. v0.1.0–v0.1.7 `conditional_edges` 무언 드롭 클래스가 구조적으로 불가능해짐.
2. **translation validation** — `CompiledGraph::to_json()` + `GraphCompiler::canon()`, 매 컴파일 `canon(input)==canon(reemit)`. strict=throw / 관용=stderr 경고. 구조 비교라 라우트 오배선도 잡음.
3. 주석 네임스페이스 `_`/`x-` 접두 항상 허용 (jarvis 코퍼스 `_comment` 관용구 보존).

### 완료 조건 검증

- [x] `conditionnal_edges` 오타·미지 키·빈 `wait_for`·inline conditional의 `to`·config 오타(`promt`) 전부 컴파일 에러 (테스트 15종)
- [x] canon round-trip: 전 기능 봉투(채널 initial null 포함·양형식 conditional·barrier·interrupt·retry) 통과 (테스트 5종)
- [x] v0.1.7 드롭 mutant 즉사 시연: conditional_edges/barrier/interrupt 드롭 + 전 라우트 오배선 → TV throw (테스트 5종)
- [x] 기존 동작 무회귀: 535/536 (실패 1건 `pybind_smoke`는 master에서도 3/3 재현되는 기존 환경성 결함 — stash 기준선으로 확인)
- [x] 실전 코퍼스 무해: jarvis/python 예제 topology에 미지 톱레벨 키·빈 barrier 없음 → lenient 경고 0

### 파일

- `src/core/graph_compiler.cpp` — 소비 회계·canon·to_json·verify_roundtrip
- `src/core/graph_engine.cpp` — compile 경로에 TV 삽입
- `include/neograph/graph/{compiler,loader}.h`, `src/core/graph_loader.cpp` — config_schema() + schema_version 스키마 문서화
- `tests/test_compiler_strict.cpp` — 신규 27 테스트
- `docs/troubleshooting.md` "Strict topology validation", CHANGELOG

다음: M2 (스코프 해석·effect·route 완전성·WF-net 구조 검사) — 이 브랜치 위에 스택.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
