### PR TITLE
feat(validator): M2 정적 의미 검사 — E3~E11 + 채널 effect (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **GraphValidator — 토폴로지 정적 의미 검사 (E3~E11 + effect)** (#75 M2).
+  파싱(M1)과 실행 사이의 패스 계층. strict 문서(schema_version>=1)에서
+  에러는 컴파일 실패, 경고는 stderr lint; 관용 문서는 에러급만 stderr
+  경고로 표면화(기존 그래프 무소음). 판정 철학 = 체커 건전성 우선:
+  엔진 의미론상 절대 옳을 수 없는 것만 에러(dangling 참조 E3, 신호
+  경로 없는 barrier E8 — goto 는 barrier 회계를 우회하므로 구제 불가,
+  빈 routes E10 — 디스패치가 rend() 역참조 UB, 미선언 채널 write E4 —
+  런타임 확정 throw), Command.goto/Send 가 정당화할 수 있는 것은 경고
+  (도달성 E7, 탈출 없는 사이클 E11, barrier 없는 plain fan-in E9,
+  overwrite 경쟁 E5, dead channel E6). 모든 진단은 기계가 읽을 수 있는
+  witness(반례) JSON 동반 — Studio 캔버스 하이라이트용(M3).
+  - **route 완전성(E10)**: `ConditionSpec` 라벨 계약 도입.
+    `register_condition` 3-인자 오버로드로 조건의 출력 라벨 집합을
+    선언하면, closed 조건의 라우트는 라벨과 정확히 일치해야 한다 —
+    미커버 라벨은 스케줄러의 "사전순 마지막 라우트" 폴백(순서 의존
+    임의 타깃)으로 떨어지므로 에러. 빌트인 `has_tool_calls` =
+    closed {false,true}, `route_channel` = open + known {default}.
+  - **채널 effect 계약**: `register_type` 4-인자 오버로드로 노드
+    타입의 reads/writes 채널을 선언. 그래프의 **모든** 노드 타입이
+    선언한 경우에만 E4/E5/E6 분석 가동(미지 타입 하나면 전체 스킵 —
+    커버리지보다 건전성). 빌트인 3종(llm_call/tool_dispatch/
+    intent_classifier) 선언 완료.
+  - `export_schema()` 에 `node_effects`·`condition_specs` 추가
+    (기존 `conditions` 배열은 하위호환 유지). 신규 테스트 22개.
+
 - **토폴로지 컴파일 정합성 게이트 — 소비 회계 + translation validation** (#75 M1).
   "조용한 의미 소실" 클래스(v0.1.0–v0.1.7 `conditional_edges` 무언 드롭과
   동형의 사고)를 구조적으로 봉쇄하는 2중 장치:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,7 @@ add_library(neograph_core
     src/core/tool.cpp
     src/core/graph_engine.cpp
     src/core/graph_compiler.cpp
+    src/core/graph_validator.cpp
     src/core/graph_coordinator.cpp
     src/core/graph_executor.cpp
     src/core/node_cache.cpp

--- a/include/neograph/graph/loader.h
+++ b/include/neograph/graph/loader.h
@@ -15,6 +15,7 @@
 #include <neograph/graph/types.h>
 #include <unordered_map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -101,6 +102,26 @@ private:
  *     });
  * @endcode
  */
+/**
+ * @brief Declared output-label contract of a condition function.
+ *
+ * Backs static route-completeness checking (GraphValidator E10): a
+ * conditional edge over a *closed* condition must map exactly the
+ * declared labels — an unmapped label would fall into the scheduler's
+ * lexicographically-last-route fallback (an arbitrary target), and a
+ * route key outside the label set is dead. Conditions registered
+ * without a spec are skipped by the validator.
+ */
+struct ConditionSpec {
+    /// Labels the condition is known to return ("known" for open specs,
+    /// "exactly these" for closed specs).
+    std::vector<std::string> labels;
+    /// True when the condition can return values outside `labels`
+    /// (e.g. route_channel returns arbitrary channel content) — the
+    /// validator then only warns about uncovered *known* labels.
+    bool open = false;
+};
+
 class NEOGRAPH_API ConditionRegistry {
 public:
     /// @brief Get the singleton instance.
@@ -115,11 +136,26 @@ public:
     void register_condition(const std::string& name, ConditionFn fn);
 
     /**
+     * @brief Register a named condition function with a declared
+     *        output-label contract (enables E10 route-completeness
+     *        checking on conditional edges using this condition).
+     */
+    void register_condition(const std::string& name, ConditionFn fn,
+                            ConditionSpec spec);
+
+    /**
      * @brief Look up a condition by name.
      * @param name Condition name.
      * @return The ConditionFn, or throws if not found.
      */
     ConditionFn get(const std::string& name) const;
+
+    /**
+     * @brief Declared label contract for a condition, if any.
+     * @return The ConditionSpec, or std::nullopt for conditions
+     *         registered without one (validator skips those).
+     */
+    std::optional<ConditionSpec> condition_spec(const std::string& name) const;
 
     /**
      * @brief List all registered condition names, sorted.
@@ -134,6 +170,7 @@ public:
 private:
     ConditionRegistry();
     std::unordered_map<std::string, ConditionFn> registry_;
+    std::unordered_map<std::string, ConditionSpec> specs_;
 };
 
 /**
@@ -195,6 +232,27 @@ public:
      */
     void register_type(const std::string& type, NodeFactoryFn fn,
                        json config_schema);
+
+    /**
+     * @brief Register a custom node type with a declared config schema
+     *        AND a declared channel-effect contract.
+     * @param effects `{"reads": ["ch", ...], "writes": ["ch", ...]}` —
+     *        the channels instances of this type touch at runtime.
+     *        Enables static effect checking (GraphValidator E4/E5/E6:
+     *        writes to undeclared channels, overwrite races, dead
+     *        channels). Effect analysis only runs on graphs where
+     *        EVERY node's type declared effects — one unknown type
+     *        disables it (soundness of the checker over coverage).
+     */
+    void register_type(const std::string& type, NodeFactoryFn fn,
+                       json config_schema, json effects);
+
+    /**
+     * @brief Declared channel effects for a node type.
+     * @return `{"reads":[...],"writes":[...]}`, or null json for types
+     *         registered without an effect contract.
+     */
+    json node_effects(const std::string& type) const;
 
     /**
      * @brief Create a node by type name.
@@ -261,6 +319,7 @@ private:
     NodeFactory();
     std::unordered_map<std::string, NodeFactoryFn> registry_;
     std::unordered_map<std::string, json> schemas_;
+    std::unordered_map<std::string, json> effects_;
 };
 
 } // namespace neograph::graph

--- a/include/neograph/graph/validator.h
+++ b/include/neograph/graph/validator.h
@@ -1,0 +1,97 @@
+/**
+ * @file graph/validator.h
+ * @brief Static semantic analysis over a CompiledGraph (issue #75 M2).
+ *
+ * GraphValidator is the pass layer between parsing (GraphCompiler, M1:
+ * every key consumed) and execution (GraphEngine): it checks what the
+ * *graph* means, not what the JSON says — dangling references,
+ * unreachable nodes, barriers that can never fire, conditional routes
+ * that fall into the scheduler's arbitrary lexicographically-last
+ * fallback, channel effect violations.
+ *
+ * Severity philosophy (checker soundness over coverage): a diagnostic
+ * is an ERROR only when the construct can never be right under the
+ * engine's semantics (dangling name, barrier waiting on a node that
+ * has no path to signal it, empty route map = UB at dispatch, write to
+ * an undeclared channel = guaranteed runtime throw). Anything a
+ * dynamic mechanism could legitimize — Command.goto / Send can reach
+ * statically-unreachable nodes — is a WARNING, so a correct graph is
+ * never rejected (no false errors), while Studio/tooling can still
+ * render every warning as lint.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/graph/compiler.h>
+#include <string>
+#include <vector>
+
+namespace neograph::graph {
+
+/// One static-analysis finding, with a machine-readable witness
+/// (counterexample) for tooling to highlight.
+struct Diagnostic {
+    std::string code;       ///< "E3".."E11" (docs/dsl §5 catalog)
+    std::string severity;   ///< "error" | "warning"
+    std::string path;       ///< JSON-ish path of the offending construct
+    std::string message;    ///< human-readable, self-contained
+    json        witness;    ///< machine-readable counterexample
+};
+
+struct NEOGRAPH_API ValidationReport {
+    std::vector<Diagnostic> diagnostics;
+
+    bool has_errors() const;
+    std::vector<const Diagnostic*> errors() const;
+    std::vector<const Diagnostic*> warnings() const;
+    /// Aggregated multi-line text of all diagnostics (throw/log body).
+    std::string summary() const;
+};
+
+class NEOGRAPH_API GraphValidator {
+public:
+    /**
+     * @brief Run all static checks against a compiled graph.
+     *
+     * Checks (catalog codes from the DSL research doc §5):
+     *  - E3  dangling references: edge endpoints, conditional-edge
+     *        sources and route targets, interrupt names, barrier
+     *        wait_for members must name existing nodes (errors).
+     *  - E7  reachability from __start__ (warning — Command.goto/Send
+     *        can reach nodes the static edge set cannot).
+     *  - E8  barrier liveness: every wait_for member must have a
+     *        static edge/route into the barrier node, else the AND-join
+     *        can never satisfy (error). Self-wait is E3.
+     *  - E9  unsynchronized fan-in: >=2 plain in-edges without a
+     *        barrier — double-activation risk when arrival supersteps
+     *        differ (warning; XOR-merges are legitimate).
+     *  - E10 route completeness against declared ConditionSpecs:
+     *        closed conditions must map exactly their label set (dead
+     *        route keys / uncovered labels are errors — an uncovered
+     *        label falls into the scheduler's lexicographically-last
+     *        fallback, an arbitrary target). Open conditions warn on
+     *        uncovered known labels. An EMPTY route map is always an
+     *        error: dispatch would dereference rend() (UB). Conditions
+     *        without a declared spec are skipped.
+     *  - E11 no path to __end__ (warning), honoring the scheduler's
+     *        implicit rule that a node with no outgoing edges routes
+     *        to __end__ — so this fires only for genuinely trapped
+     *        cycles.
+     *  - E4/E5/E6 channel effects — run ONLY when every node's type
+     *        declared an effect contract (one unknown type disables
+     *        the whole family; soundness over coverage):
+     *        E4 write to undeclared channel (error: the engine throws
+     *        at runtime on every execution), read of undeclared
+     *        channel (warning: silently yields null);
+     *        E5 overwrite-reducer channel written by two direct
+     *        fan-out siblings (warning: racy last-writer-wins);
+     *        E6 dead channel — declared but never read nor written,
+     *        read-only without initial value (warnings).
+     *
+     * Pure function of the CompiledGraph + registries; does not
+     * execute anything.
+     */
+    static ValidationReport validate(const CompiledGraph& cg);
+};
+
+} // namespace neograph::graph

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -1,5 +1,6 @@
 #include <neograph/graph/engine.h>
 #include <neograph/graph/loader.h>
+#include <neograph/graph/validator.h>
 #include <neograph/graph/coordinator.h>
 
 #include <neograph/async/run_sync.h>
@@ -45,6 +46,31 @@ std::unique_ptr<GraphEngine> GraphEngine::compile(
     // Strict documents (schema_version >= 1) fail hard; legacy
     // documents get a stderr warning. Must run before the moves below.
     GraphCompiler::verify_roundtrip(definition, cg);
+
+    // Static semantic analysis (issue #75 M2). Strict documents:
+    // errors throw, warnings go to stderr. Legacy documents: only
+    // errors are surfaced (as stderr warnings — they were silent
+    // breakage before, e.g. a dangling edge or an empty route map),
+    // heuristic lint is suppressed to keep existing graphs quiet.
+    {
+        auto report = GraphValidator::validate(cg);
+        if (cg.schema_version >= 1) {
+            if (report.has_errors()) {
+                std::string msg = "graph validation failed (schema_version "
+                    + std::to_string(cg.schema_version) + "):\n" + report.summary();
+                throw std::runtime_error(msg);
+            }
+            for (const auto* w : report.warnings()) {
+                std::fprintf(stderr, "[neograph] lint [%s] %s: %s\n",
+                             w->code.c_str(), w->path.c_str(), w->message.c_str());
+            }
+        } else {
+            for (const auto* e : report.errors()) {
+                std::fprintf(stderr, "[neograph] warning: [%s] %s: %s\n",
+                             e->code.c_str(), e->path.c_str(), e->message.c_str());
+            }
+        }
+    }
 
     auto engine = std::unique_ptr<GraphEngine>(new GraphEngine());
     engine->name_              = std::move(cg.name);

--- a/src/core/graph_loader.cpp
+++ b/src/core/graph_loader.cpp
@@ -106,7 +106,7 @@ ConditionRegistry& ConditionRegistry::instance() {
 }
 
 ConditionRegistry::ConditionRegistry() {
-    // Built-in: has_tool_calls
+    // Built-in: has_tool_calls — closed contract: exactly true/false.
     register_condition("has_tool_calls",
         [](const GraphState& state) -> std::string {
             auto messages = state.get_messages();
@@ -116,21 +116,40 @@ ConditionRegistry::ConditionRegistry() {
                 }
             }
             return "false";
-        });
+        },
+        ConditionSpec{{"false", "true"}, /*open=*/false});
 
     // Built-in: route_channel
     // Reads the "__route__" channel and returns its string value.
     // Used with IntentClassifierNode for dynamic intent-based routing.
+    // Open contract: returns arbitrary channel content — but "default"
+    // is a KNOWN label (returned whenever __route__ is missing or not
+    // a string), so the validator can warn when it is unrouted.
     register_condition("route_channel",
         [](const GraphState& state) -> std::string {
             auto route = state.get("__route__");
             if (route.is_string()) return route.get<std::string>();
             return "default";
-        });
+        },
+        ConditionSpec{{"default"}, /*open=*/true});
 }
 
 void ConditionRegistry::register_condition(const std::string& name, ConditionFn fn) {
     registry_[name] = std::move(fn);
+    specs_.erase(name);   // re-registration without a spec clears the old one
+}
+
+void ConditionRegistry::register_condition(const std::string& name, ConditionFn fn,
+                                           ConditionSpec spec) {
+    registry_[name] = std::move(fn);
+    specs_[name]    = std::move(spec);
+}
+
+std::optional<ConditionSpec> ConditionRegistry::condition_spec(
+    const std::string& name) const {
+    auto it = specs_.find(name);
+    if (it == specs_.end()) return std::nullopt;
+    return it->second;
 }
 
 ConditionFn ConditionRegistry::get(const std::string& name) const {
@@ -169,7 +188,8 @@ NodeFactory::NodeFactory() {
             "type": "object",
             "properties": {},
             "description": "LLM call node. Uses the NodeContext provider/model; no type-specific config fields."
-        })JSON"));
+        })JSON"),
+        json::parse(R"JSON({"reads":["messages"],"writes":["messages"]})JSON"));
 
     register_type("tool_dispatch",
         [](const std::string& name, const json& /*config*/,
@@ -180,7 +200,8 @@ NodeFactory::NodeFactory() {
             "type": "object",
             "properties": {},
             "description": "Executes tool calls from the last assistant message using NodeContext tools; no type-specific config fields."
-        })JSON"));
+        })JSON"),
+        json::parse(R"JSON({"reads":["messages"],"writes":["messages"]})JSON"));
 
     // intent_classifier: LLM-based intent routing
     register_type("intent_classifier",
@@ -210,7 +231,8 @@ NodeFactory::NodeFactory() {
                 }
             },
             "required": ["routes"]
-        })JSON"));
+        })JSON"),
+        json::parse(R"JSON({"reads":["messages"],"writes":["__route__"]})JSON"));
 
     // subgraph: recursively compile an inner graph definition as a single node
     // Supports both inline JSON and external file path:
@@ -297,6 +319,20 @@ void NodeFactory::register_type(const std::string& type, NodeFactoryFn fn,
                                 json config_schema) {
     registry_[type] = std::move(fn);
     schemas_[type]  = std::move(config_schema);
+    effects_.erase(type);   // re-registration without effects clears them
+}
+
+void NodeFactory::register_type(const std::string& type, NodeFactoryFn fn,
+                                json config_schema, json effects) {
+    registry_[type] = std::move(fn);
+    schemas_[type]  = std::move(config_schema);
+    effects_[type]  = std::move(effects);
+}
+
+json NodeFactory::node_effects(const std::string& type) const {
+    auto it = effects_.find(type);
+    if (it != effects_.end()) return it->second;
+    return json();   // null: no declared effect contract
 }
 
 std::vector<std::string> NodeFactory::registered_types() const {
@@ -400,13 +436,36 @@ json NodeFactory::export_schema() const {
             : json::parse(R"JSON({"type":"object","description":"No declared config schema; any object accepted."})JSON");
     }
 
+    // Per-type channel-effect contracts (only types that declared one).
+    json node_effects = json::object();
+    for (const auto& kv : registry_) {
+        auto eit = effects_.find(kv.first);
+        if (eit != effects_.end()) node_effects[kv.first] = eit->second;
+    }
+
+    // Per-condition output-label contracts (only conditions that
+    // declared one). `conditions` stays a plain name array for
+    // backward compatibility with existing tooling.
+    json condition_specs = json::object();
+    auto& creg = ConditionRegistry::instance();
+    for (const auto& cname : creg.names()) {
+        if (auto spec = creg.condition_spec(cname)) {
+            json labels = json::array();
+            for (const auto& l : spec->labels) labels.push_back(l);
+            condition_specs[cname] = json{{"labels", std::move(labels)},
+                                          {"open", spec->open}};
+        }
+    }
+
     json doc;
     doc["neograph_version"] = NEOGRAPH_VERSION_STR;
     doc["$schema"]          = "https://json-schema.org/draft/2020-12/schema";
     doc["topology"]         = json::parse(kTopologySchema);
     doc["node_types"]       = std::move(node_types);
+    doc["node_effects"]     = std::move(node_effects);
     doc["reducers"]         = ReducerRegistry::instance().names();
-    doc["conditions"]       = ConditionRegistry::instance().names();
+    doc["conditions"]       = creg.names();
+    doc["condition_specs"]  = std::move(condition_specs);
     return doc;
 }
 

--- a/src/core/graph_validator.cpp
+++ b/src/core/graph_validator.cpp
@@ -1,0 +1,455 @@
+#include <neograph/graph/validator.h>
+#include <neograph/graph/loader.h>
+#include <algorithm>
+#include <map>
+#include <queue>
+#include <set>
+
+namespace neograph::graph {
+
+namespace {
+
+constexpr const char* kStart = "__start__";
+constexpr const char* kEnd   = "__end__";
+
+json string_set_to_array(const std::set<std::string>& s) {
+    json arr = json::array();
+    for (const auto& v : s) arr.push_back(v);
+    return arr;
+}
+
+struct Ctx {
+    const CompiledGraph& cg;
+    std::set<std::string> node_names;
+    // Static successor map: plain edges + every conditional route
+    // target. The scheduler's fallback route is always one of the
+    // declared routes, so this over-approximates nothing.
+    std::map<std::string, std::set<std::string>> succ;
+    std::vector<Diagnostic> out;
+
+    void error(std::string code, std::string path, std::string msg, json witness) {
+        out.push_back({std::move(code), "error", std::move(path),
+                       std::move(msg), std::move(witness)});
+    }
+    void warn(std::string code, std::string path, std::string msg, json witness) {
+        out.push_back({std::move(code), "warning", std::move(path),
+                       std::move(msg), std::move(witness)});
+    }
+
+    bool is_node(const std::string& n) const { return node_names.count(n) > 0; }
+
+    std::string node_type(const std::string& n) const {
+        auto it = cg.node_defs.find(n);
+        if (it == cg.node_defs.end()) return "";
+        return it->second.value("type", "");
+    }
+};
+
+// ---- E3: dangling references --------------------------------------------
+
+void check_references(Ctx& c) {
+    size_t i = 0;
+    for (const auto& e : c.cg.edges) {
+        const std::string path = "edges[" + std::to_string(i++) + "]";
+        if (e.from != kStart && !c.is_node(e.from)) {
+            c.error("E3", path, "edge 'from' references unknown node '" + e.from + "'",
+                    json{{"edge_from", e.from}, {"edge_to", e.to}});
+        }
+        if (e.to != kEnd && !c.is_node(e.to)) {
+            c.error("E3", path, "edge 'to' references unknown node '" + e.to + "'",
+                    json{{"edge_from", e.from}, {"edge_to", e.to}});
+        }
+    }
+    i = 0;
+    for (const auto& ce : c.cg.conditional_edges) {
+        const std::string path = "conditional_edges[" + std::to_string(i++) + "]";
+        if (!c.is_node(ce.from)) {
+            c.error("E3", path, "conditional edge 'from' references unknown node '"
+                    + ce.from + "'", json{{"from", ce.from}});
+        }
+        for (const auto& [key, target] : ce.routes) {
+            if (target != kEnd && !c.is_node(target)) {
+                c.error("E3", path + ".routes." + key,
+                        "route '" + key + "' targets unknown node '" + target + "'",
+                        json{{"from", ce.from}, {"route", key}, {"target", target}});
+            }
+        }
+    }
+    auto check_interrupts = [&](const char* which, const std::set<std::string>& s) {
+        for (const auto& n : s) {
+            if (!c.is_node(n)) {
+                c.error("E3", which, std::string(which)
+                        + " references unknown node '" + n + "'",
+                        json{{"node", n}});
+            }
+        }
+    };
+    check_interrupts("interrupt_before", c.cg.interrupt_before);
+    check_interrupts("interrupt_after", c.cg.interrupt_after);
+
+    for (const auto& [bnode, wait_for] : c.cg.barrier_specs) {
+        for (const auto& u : wait_for) {
+            const std::string path = "nodes." + bnode + ".barrier";
+            if (u == bnode) {
+                c.error("E3", path, "barrier waits for the node itself ('"
+                        + u + "') — it can never receive its own signal before firing",
+                        json{{"barrier", bnode}, {"waits_for", u}});
+            } else if (!c.is_node(u)) {
+                c.error("E3", path, "barrier wait_for references unknown node '"
+                        + u + "'", json{{"barrier", bnode}, {"waits_for", u}});
+            }
+        }
+    }
+}
+
+// ---- successor map (shared by E7/E8/E11) --------------------------------
+
+void build_successors(Ctx& c) {
+    for (const auto& e : c.cg.edges) c.succ[e.from].insert(e.to);
+    for (const auto& ce : c.cg.conditional_edges) {
+        for (const auto& [key, target] : ce.routes) {
+            (void)key;
+            c.succ[ce.from].insert(target);
+        }
+    }
+}
+
+// ---- E7: reachability from __start__ -------------------------------------
+
+std::set<std::string> reachable_from_start(const Ctx& c) {
+    std::set<std::string> seen;
+    std::queue<std::string> q;
+    q.push(kStart);
+    seen.insert(kStart);
+    while (!q.empty()) {
+        auto cur = q.front(); q.pop();
+        auto it = c.succ.find(cur);
+        if (it == c.succ.end()) continue;
+        for (const auto& nxt : it->second) {
+            if (seen.insert(nxt).second) q.push(nxt);
+        }
+    }
+    return seen;
+}
+
+void check_reachability(Ctx& c, const std::set<std::string>& reachable) {
+    std::set<std::string> unreachable;
+    for (const auto& n : c.node_names) {
+        if (!reachable.count(n)) unreachable.insert(n);
+    }
+    if (!unreachable.empty()) {
+        c.warn("E7", "$",
+               "node(s) unreachable from __start__ via static edges/routes: "
+               + string_set_to_array(unreachable).dump()
+               + " (only Command.goto / Send can reach them at runtime — "
+               "if none of your nodes emits those, this is dead topology)",
+               json{{"unreachable", string_set_to_array(unreachable)}});
+    }
+}
+
+// ---- E11: no path to __end__ ---------------------------------------------
+
+void check_termination(Ctx& c, const std::set<std::string>& reachable) {
+    // Forward closure under the scheduler's implicit rule: a node with
+    // no outgoing edges at all routes to __end__ — so only genuinely
+    // trapped cycles fail this.
+    std::set<std::string> can_end;
+    bool grew = true;
+    auto reaches_end_directly = [&](const std::string& n) {
+        auto it = c.succ.find(n);
+        if (it == c.succ.end() || it->second.empty()) return true;  // implicit __end__
+        return it->second.count(kEnd) > 0;
+    };
+    while (grew) {
+        grew = false;
+        for (const auto& n : c.node_names) {
+            if (can_end.count(n)) continue;
+            bool ok = reaches_end_directly(n);
+            if (!ok) {
+                auto it = c.succ.find(n);
+                for (const auto& s : it->second) {
+                    if (can_end.count(s)) { ok = true; break; }
+                }
+            }
+            if (ok) { can_end.insert(n); grew = true; }
+        }
+    }
+    std::set<std::string> trapped;
+    for (const auto& n : c.node_names) {
+        if (reachable.count(n) && !can_end.count(n)) trapped.insert(n);
+    }
+    if (!trapped.empty()) {
+        c.warn("E11", "$",
+               "node(s) with no static path to __end__ (cycle without exit): "
+               + string_set_to_array(trapped).dump()
+               + " (a Command.goto could still exit at runtime; otherwise "
+               "the run only stops at the recursion limit)",
+               json{{"trapped", string_set_to_array(trapped)}});
+    }
+}
+
+// ---- E8: barrier liveness -------------------------------------------------
+
+void check_barriers(Ctx& c) {
+    for (const auto& [bnode, wait_for] : c.cg.barrier_specs) {
+        for (const auto& u : wait_for) {
+            if (u == bnode || !c.is_node(u)) continue;   // reported as E3
+            auto it = c.succ.find(u);
+            const bool signals = it != c.succ.end() && it->second.count(bnode) > 0;
+            if (!signals) {
+                c.error("E8", "nodes." + bnode + ".barrier",
+                        "barrier waits for '" + u + "', but '" + u
+                        + "' has no edge or conditional route into '" + bnode
+                        + "' — the AND-join can never be satisfied "
+                        "(Command.goto bypasses barrier accounting, so no "
+                        "dynamic mechanism can rescue this)",
+                        json{{"barrier", bnode}, {"waits_for", u}});
+            }
+        }
+    }
+}
+
+// ---- E9: unsynchronized plain fan-in --------------------------------------
+
+void check_fan_in(Ctx& c) {
+    std::map<std::string, std::set<std::string>> plain_in;
+    for (const auto& e : c.cg.edges) {
+        if (e.from != kStart && e.to != kEnd) plain_in[e.to].insert(e.from);
+    }
+    for (const auto& [node, sources] : plain_in) {
+        if (sources.size() < 2 || c.cg.barrier_specs.count(node)) continue;
+        c.warn("E9", "nodes." + node,
+               "'" + node + "' has " + std::to_string(sources.size())
+               + " plain in-edges and no barrier — if those sources can be "
+               "concurrently active (AND fan-out upstream), it fires once "
+               "per arrival super-step instead of once; declare "
+               "\"barrier\": {\"wait_for\": [...]} for AND-join, or ignore "
+               "if the sources are mutually exclusive (XOR merge)",
+               json{{"node", node}, {"sources", string_set_to_array(sources)}});
+    }
+}
+
+// ---- E10: route completeness ----------------------------------------------
+
+void check_routes(Ctx& c) {
+    size_t i = 0;
+    for (const auto& ce : c.cg.conditional_edges) {
+        const std::string path = "conditional_edges[" + std::to_string(i++) + "]";
+
+        if (ce.routes.empty()) {
+            c.error("E10", path,
+                    "conditional edge from '" + ce.from + "' has no routes — "
+                    "dispatch would dereference an empty route map (UB)",
+                    json{{"from", ce.from}, {"condition", ce.condition}});
+            continue;
+        }
+
+        auto spec = ConditionRegistry::instance().condition_spec(ce.condition);
+        if (!spec) continue;   // no declared contract — skip
+
+        const std::set<std::string> labels(spec->labels.begin(), spec->labels.end());
+        std::set<std::string> keys;
+        for (const auto& [k, v] : ce.routes) { (void)v; keys.insert(k); }
+
+        std::set<std::string> dead, uncovered;
+        for (const auto& k : keys)   if (!labels.count(k)) dead.insert(k);
+        for (const auto& l : labels) if (!keys.count(l))   uncovered.insert(l);
+
+        if (!spec->open && !dead.empty()) {
+            c.error("E10", path,
+                    "route key(s) " + string_set_to_array(dead).dump()
+                    + " can never be produced by condition '" + ce.condition
+                    + "' (declared labels: " + string_set_to_array(labels).dump()
+                    + ") — dead route",
+                    json{{"from", ce.from}, {"condition", ce.condition},
+                         {"dead_keys", string_set_to_array(dead)}});
+        }
+        if (!uncovered.empty()) {
+            const std::string fallback = ce.routes.rbegin()->first;
+            const std::string msg =
+                "label(s) " + string_set_to_array(uncovered).dump()
+                + " of condition '" + ce.condition + "' have no route — the "
+                "scheduler falls back to the lexicographically-last route ('"
+                + fallback + "' -> '" + ce.routes.rbegin()->second
+                + "'), which is order-dependent, not intent";
+            json witness = json{{"from", ce.from}, {"condition", ce.condition},
+                                {"uncovered", string_set_to_array(uncovered)},
+                                {"fallback_route", fallback}};
+            if (spec->open) {
+                c.warn("E10", path, msg, std::move(witness));
+            } else {
+                c.error("E10", path, msg, std::move(witness));
+            }
+        }
+    }
+}
+
+// ---- E4/E5/E6: channel effects ---------------------------------------------
+
+void check_effects(Ctx& c) {
+    // Gate: every node's type must declare effects, else skip the
+    // whole family (an unknown type could touch anything).
+    std::map<std::string, std::pair<std::set<std::string>, std::set<std::string>>>
+        node_rw;   // node -> (reads, writes)
+    for (const auto& n : c.node_names) {
+        const json eff = NodeFactory::instance().node_effects(c.node_type(n));
+        if (eff.is_null() || !eff.is_object()) return;   // gate: skip family
+        std::set<std::string> reads, writes;
+        if (eff.contains("reads"))
+            for (const auto& ch : eff["reads"]) reads.insert(ch.get<std::string>());
+        if (eff.contains("writes"))
+            for (const auto& ch : eff["writes"]) writes.insert(ch.get<std::string>());
+        node_rw[n] = {std::move(reads), std::move(writes)};
+    }
+
+    std::set<std::string> declared;
+    std::map<std::string, ReducerType> reducer_of;
+    std::set<std::string> has_initial;
+    for (const auto& cd : c.cg.channel_defs) {
+        declared.insert(cd.name);
+        reducer_of[cd.name] = cd.type;
+        if (cd.has_initial) has_initial.insert(cd.name);
+    }
+
+    std::map<std::string, std::set<std::string>> readers, writers;
+    for (const auto& [n, rw] : node_rw) {
+        for (const auto& ch : rw.first) {
+            readers[ch].insert(n);
+            if (!declared.count(ch)) {
+                c.warn("E4", "nodes." + n,
+                       "'" + n + "' (type " + c.node_type(n) + ") reads channel '"
+                       + ch + "' which is not declared — the read silently "
+                       "yields null",
+                       json{{"node", n}, {"channel", ch}});
+            }
+        }
+        for (const auto& ch : rw.second) {
+            writers[ch].insert(n);
+            if (!declared.count(ch)) {
+                c.error("E4", "nodes." + n,
+                        "'" + n + "' (type " + c.node_type(n) + ") writes channel '"
+                        + ch + "' which is not declared — the engine throws "
+                        "\"Write to unknown channel\" on every execution of "
+                        "this node; declare it under \"channels\"",
+                        json{{"node", n}, {"channel", ch}});
+            }
+        }
+    }
+
+    // E6: dead / write-only / initial-less read-only channels.
+    for (const auto& ch : declared) {
+        const bool r = readers.count(ch) && !readers[ch].empty();
+        const bool w = writers.count(ch) && !writers[ch].empty();
+        // Conditions read channels too (route_channel reads __route__)
+        // but have no effect contracts — treat __-prefixed engine
+        // channels as read by the routing layer.
+        const bool engine_channel = ch.rfind("__", 0) == 0;
+        if (!r && !w && !engine_channel) {
+            c.warn("E6", "channels." + ch,
+                   "channel '" + ch + "' is declared but no node reads or "
+                   "writes it (dead channel)",
+                   json{{"channel", ch}});
+        } else if (!r && w && !engine_channel) {
+            c.warn("E6", "channels." + ch,
+                   "channel '" + ch + "' is written but never read",
+                   json{{"channel", ch},
+                        {"writers", string_set_to_array(writers[ch])}});
+        } else if (r && !w && !has_initial.count(ch)) {
+            c.warn("E6", "channels." + ch,
+                   "channel '" + ch + "' is read but never written and has "
+                   "no initial value — every read yields null",
+                   json{{"channel", ch},
+                        {"readers", string_set_to_array(readers[ch])}});
+        }
+    }
+
+    // E5: overwrite race between direct fan-out siblings. Direct plain
+    // fan-out from a common source is the one place static analysis
+    // knows two nodes run in the same super-step; deeper concurrency
+    // is left to the runtime backstop (under-approximation, no false
+    // positives on sequential graphs).
+    std::map<std::string, std::set<std::string>> plain_out;
+    for (const auto& e : c.cg.edges) {
+        if (e.to != kEnd) plain_out[e.from].insert(e.to);
+    }
+    std::set<std::string> reported;
+    for (const auto& [src, targets] : plain_out) {
+        if (targets.size() < 2) continue;
+        std::map<std::string, std::set<std::string>> channel_writers;
+        for (const auto& t : targets) {
+            auto it = node_rw.find(t);
+            if (it == node_rw.end()) continue;
+            for (const auto& ch : it->second.second) {
+                if (reducer_of.count(ch) && reducer_of[ch] == ReducerType::OVERWRITE) {
+                    channel_writers[ch].insert(t);
+                }
+            }
+        }
+        for (const auto& [ch, ws] : channel_writers) {
+            if (ws.size() < 2) continue;
+            const std::string key = src + "/" + ch;
+            if (!reported.insert(key).second) continue;
+            c.warn("E5", "channels." + ch,
+                   "overwrite channel '" + ch + "' is written by "
+                   + std::to_string(ws.size()) + " concurrently-active nodes "
+                   + string_set_to_array(ws).dump() + " (fan-out siblings of '"
+                   + src + "') — last-writer-wins is nondeterministic under "
+                   "parallel dispatch; use an append reducer or serialize "
+                   "the writers",
+                   json{{"channel", ch}, {"fan_out_source", src},
+                        {"writers", string_set_to_array(ws)}});
+        }
+    }
+}
+
+} // namespace
+
+// ---- report helpers ---------------------------------------------------------
+
+bool ValidationReport::has_errors() const {
+    return std::any_of(diagnostics.begin(), diagnostics.end(),
+                       [](const Diagnostic& d) { return d.severity == "error"; });
+}
+
+std::vector<const Diagnostic*> ValidationReport::errors() const {
+    std::vector<const Diagnostic*> v;
+    for (const auto& d : diagnostics) if (d.severity == "error") v.push_back(&d);
+    return v;
+}
+
+std::vector<const Diagnostic*> ValidationReport::warnings() const {
+    std::vector<const Diagnostic*> v;
+    for (const auto& d : diagnostics) if (d.severity == "warning") v.push_back(&d);
+    return v;
+}
+
+std::string ValidationReport::summary() const {
+    std::string s;
+    for (const auto& d : diagnostics) {
+        if (!s.empty()) s += "\n";
+        s += "  [" + d.code + "/" + d.severity + "] " + d.path + ": " + d.message;
+    }
+    return s;
+}
+
+ValidationReport GraphValidator::validate(const CompiledGraph& cg) {
+    Ctx c{cg, {}, {}, {}};
+    for (const auto& [name, node] : cg.nodes) {
+        (void)node;
+        c.node_names.insert(name);
+    }
+
+    check_references(c);
+    build_successors(c);
+    const auto reachable = reachable_from_start(c);
+    check_reachability(c, reachable);
+    check_termination(c, reachable);
+    check_barriers(c);
+    check_fan_in(c);
+    check_routes(c);
+    check_effects(c);
+
+    return ValidationReport{std::move(c.out)};
+}
+
+} // namespace neograph::graph

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(neograph_tests
     test_node_execution.cpp
     test_compiler.cpp
     test_compiler_strict.cpp
+    test_validator.cpp
     test_barrier_persistence.cpp
     test_coordinator.cpp
     test_sends_interrupt_order.cpp

--- a/tests/test_validator.cpp
+++ b/tests/test_validator.cpp
@@ -1,0 +1,368 @@
+// M2 static-semantics tests (issue #75): GraphValidator over
+// CompiledGraph — dangling references (E3), reachability (E7), barrier
+// liveness (E8), unsynchronized fan-in (E9), route completeness (E10),
+// trapped cycles (E11), and channel effects (E4/E5/E6).
+//
+// Fixture style: build the definition JSON, compile leniently (the
+// checks under test are the validator's, not the parser's), validate,
+// then assert on diagnostic codes + witnesses. Engine-integration
+// tests at the bottom assert the strict-mode throw path.
+
+#include <gtest/gtest.h>
+#include <neograph/neograph.h>
+#include <neograph/graph/compiler.h>
+#include <neograph/graph/validator.h>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+class VNoopNode : public GraphNode {
+public:
+    explicit VNoopNode(std::string n) : name_(std::move(n)) {}
+    asio::awaitable<NodeOutput> run(NodeInput) override { co_return NodeOutput{}; }
+    std::string get_name() const override { return name_; }
+private:
+    std::string name_;
+};
+
+void ensure_vtypes_registered() {
+    // vnoop: no declared effects (disables the E4/E5/E6 family).
+    NodeFactory::instance().register_type(
+        "vnoop",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<VNoopNode>(name);
+        });
+    // vfx_*: declared effects, for the effect-analysis tests.
+    NodeFactory::instance().register_type(
+        "vfx_writer",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<VNoopNode>(name);
+        },
+        json::parse(R"({"type":"object"})"),
+        json::parse(R"({"reads":[],"writes":["out"]})"));
+    NodeFactory::instance().register_type(
+        "vfx_reader",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<VNoopNode>(name);
+        },
+        json::parse(R"({"type":"object"})"),
+        json::parse(R"({"reads":["out"],"writes":[]})"));
+    // closed two-label condition for E10 tests.
+    ConditionRegistry::instance().register_condition(
+        "vcond_binary",
+        [](const GraphState&) -> std::string { return "yes"; },
+        ConditionSpec{{"no", "yes"}, /*open=*/false});
+}
+
+ValidationReport validate_def(const json& def) {
+    ensure_vtypes_registered();
+    auto cg = GraphCompiler::compile(def, NodeContext{});
+    return GraphValidator::validate(cg);
+}
+
+// All diagnostics with the given code.
+std::vector<const Diagnostic*> by_code(const ValidationReport& r, const std::string& code) {
+    std::vector<const Diagnostic*> v;
+    for (const auto& d : r.diagnostics) if (d.code == code) v.push_back(&d);
+    return v;
+}
+
+json two_node_base() {
+    return json{
+        {"nodes", {{"a", {{"type", "vnoop"}}}, {"b", {{"type", "vnoop"}}}}},
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "a"}},
+                                {{"from", "a"}, {"to", "b"}},
+                                {{"from", "b"}, {"to", "__end__"}} })},
+    };
+}
+
+} // namespace
+
+// =========================================================================
+// E3: dangling references (errors)
+// =========================================================================
+
+TEST(Validator, CleanGraphHasNoDiagnostics) {
+    auto r = validate_def(two_node_base());
+    EXPECT_TRUE(r.diagnostics.empty()) << r.summary();
+}
+
+TEST(Validator, E3_DanglingEdgeTarget) {
+    auto def = two_node_base();
+    def["edges"].push_back({{"from", "a"}, {"to", "ghost"}});
+    auto r = validate_def(def);
+    auto e3 = by_code(r, "E3");
+    ASSERT_EQ(e3.size(), 1u) << r.summary();
+    EXPECT_EQ(e3[0]->severity, "error");
+    EXPECT_EQ(e3[0]->witness["edge_to"].get<std::string>(), "ghost");
+}
+
+TEST(Validator, E3_DanglingRouteTargetAndInterrupt) {
+    auto def = two_node_base();
+    def["conditional_edges"] = json::array({
+        {{"from", "a"}, {"condition", "route_channel"},
+         {"routes", {{"x", "ghost"}, {"default", "__end__"}}}} });
+    def["interrupt_before"] = json::array({"phantom"});
+    auto r = validate_def(def);
+    auto e3 = by_code(r, "E3");
+    ASSERT_EQ(e3.size(), 2u) << r.summary();
+}
+
+TEST(Validator, E3_BarrierSelfWaitAndUnknownMember) {
+    auto def = two_node_base();
+    def["nodes"]["b"]["barrier"] = {{"wait_for", json::array({"b", "ghost"})}};
+    auto r = validate_def(def);
+    auto e3 = by_code(r, "E3");
+    ASSERT_EQ(e3.size(), 2u) << r.summary();   // self-wait + unknown member
+}
+
+// =========================================================================
+// E7 / E11: reachability (warnings — Command.goto/Send caveat)
+// =========================================================================
+
+TEST(Validator, E7_UnreachableNodeWarns) {
+    auto def = two_node_base();
+    def["nodes"]["island"] = {{"type", "vnoop"}};
+    auto r = validate_def(def);
+    auto e7 = by_code(r, "E7");
+    ASSERT_EQ(e7.size(), 1u) << r.summary();
+    EXPECT_EQ(e7[0]->severity, "warning");
+    EXPECT_EQ(e7[0]->witness["unreachable"][0].get<std::string>(), "island");
+    EXPECT_FALSE(r.has_errors());
+}
+
+TEST(Validator, E11_TrappedCycleWarns) {
+    // a <-> b cycle with no exit; both have outgoing edges, so the
+    // scheduler's implicit-__end__ rule does not apply.
+    json def = {
+        {"nodes", {{"a", {{"type", "vnoop"}}}, {"b", {{"type", "vnoop"}}}}},
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "a"}},
+                                {{"from", "a"}, {"to", "b"}},
+                                {{"from", "b"}, {"to", "a"}} })},
+    };
+    auto r = validate_def(def);
+    auto e11 = by_code(r, "E11");
+    ASSERT_EQ(e11.size(), 1u) << r.summary();
+    EXPECT_EQ(e11[0]->witness["trapped"].size(), 2u);
+}
+
+TEST(Validator, E11_NoOutgoingMeansImplicitEnd) {
+    // Node with zero outgoing edges auto-routes to __end__ — no warning.
+    json def = {
+        {"nodes", {{"a", {{"type", "vnoop"}}}}},
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "a"}} })},
+    };
+    auto r = validate_def(def);
+    EXPECT_TRUE(by_code(r, "E11").empty()) << r.summary();
+}
+
+// =========================================================================
+// E8: barrier liveness (error)
+// =========================================================================
+
+TEST(Validator, E8_BarrierMemberWithoutSignalPath) {
+    auto def = two_node_base();
+    // b waits for a — ok (edge a->b exists). Add c waiting on b, but b
+    // routes to __end__, never to c... build explicitly:
+    def["nodes"]["c"] = {{"type", "vnoop"},
+                         {"barrier", {{"wait_for", json::array({"a", "b"})}}}};
+    def["edges"].push_back({{"from", "a"}, {"to", "c"}});
+    // b -> c edge deliberately missing: b can never signal c.
+    auto r = validate_def(def);
+    auto e8 = by_code(r, "E8");
+    ASSERT_EQ(e8.size(), 1u) << r.summary();
+    EXPECT_EQ(e8[0]->severity, "error");
+    EXPECT_EQ(e8[0]->witness["waits_for"].get<std::string>(), "b");
+}
+
+TEST(Validator, E8_SatisfiedBarrierIsClean) {
+    json def = {
+        {"nodes", {{"a", {{"type", "vnoop"}}}, {"b", {{"type", "vnoop"}}},
+                   {"j", {{"type", "vnoop"},
+                          {"barrier", {{"wait_for", json::array({"a", "b"})}}}}}}},
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "a"}},
+                                {{"from", "__start__"}, {"to", "b"}},
+                                {{"from", "a"}, {"to", "j"}},
+                                {{"from", "b"}, {"to", "j"}},
+                                {{"from", "j"}, {"to", "__end__"}} })},
+    };
+    auto r = validate_def(def);
+    EXPECT_TRUE(by_code(r, "E8").empty()) << r.summary();
+    EXPECT_TRUE(by_code(r, "E9").empty()) << r.summary();   // barrier present
+}
+
+// =========================================================================
+// E9: unsynchronized plain fan-in (warning)
+// =========================================================================
+
+TEST(Validator, E9_FanInWithoutBarrierWarns) {
+    json def = {
+        {"nodes", {{"a", {{"type", "vnoop"}}}, {"b", {{"type", "vnoop"}}},
+                   {"j", {{"type", "vnoop"}}}}},
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "a"}},
+                                {{"from", "__start__"}, {"to", "b"}},
+                                {{"from", "a"}, {"to", "j"}},
+                                {{"from", "b"}, {"to", "j"}},
+                                {{"from", "j"}, {"to", "__end__"}} })},
+    };
+    auto r = validate_def(def);
+    auto e9 = by_code(r, "E9");
+    ASSERT_EQ(e9.size(), 1u) << r.summary();
+    EXPECT_EQ(e9[0]->severity, "warning");
+    EXPECT_EQ(e9[0]->witness["node"].get<std::string>(), "j");
+}
+
+// =========================================================================
+// E10: route completeness
+// =========================================================================
+
+TEST(Validator, E10_EmptyRoutesIsError) {
+    auto def = two_node_base();
+    def["conditional_edges"] = json::array({
+        {{"from", "a"}, {"condition", "route_channel"}} });
+    auto r = validate_def(def);
+    auto e10 = by_code(r, "E10");
+    ASSERT_EQ(e10.size(), 1u) << r.summary();
+    EXPECT_EQ(e10[0]->severity, "error");
+}
+
+TEST(Validator, E10_ClosedConditionDeadRouteIsError) {
+    auto def = two_node_base();
+    def["conditional_edges"] = json::array({
+        {{"from", "a"}, {"condition", "vcond_binary"},
+         {"routes", {{"yes", "b"}, {"no", "__end__"}, {"maybe", "b"}}}} });
+    auto r = validate_def(def);
+    auto e10 = by_code(r, "E10");
+    ASSERT_EQ(e10.size(), 1u) << r.summary();
+    EXPECT_EQ(e10[0]->severity, "error");
+    EXPECT_EQ(e10[0]->witness["dead_keys"][0].get<std::string>(), "maybe");
+}
+
+TEST(Validator, E10_ClosedConditionUncoveredLabelIsError) {
+    auto def = two_node_base();
+    def["conditional_edges"] = json::array({
+        {{"from", "a"}, {"condition", "vcond_binary"},
+         {"routes", {{"yes", "b"}}}} });   // "no" uncovered
+    auto r = validate_def(def);
+    auto e10 = by_code(r, "E10");
+    ASSERT_EQ(e10.size(), 1u) << r.summary();
+    EXPECT_EQ(e10[0]->severity, "error");
+    EXPECT_EQ(e10[0]->witness["uncovered"][0].get<std::string>(), "no");
+}
+
+TEST(Validator, E10_OpenConditionUncoveredKnownLabelWarns) {
+    auto def = two_node_base();
+    def["conditional_edges"] = json::array({
+        {{"from", "a"}, {"condition", "route_channel"},
+         {"routes", {{"x", "b"}, {"y", "__end__"}}}} });   // "default" uncovered
+    auto r = validate_def(def);
+    auto e10 = by_code(r, "E10");
+    ASSERT_EQ(e10.size(), 1u) << r.summary();
+    EXPECT_EQ(e10[0]->severity, "warning");
+    EXPECT_EQ(e10[0]->witness["uncovered"][0].get<std::string>(), "default");
+    EXPECT_FALSE(r.has_errors());
+}
+
+TEST(Validator, E10_ExactCoverageIsClean) {
+    auto def = two_node_base();
+    def["conditional_edges"] = json::array({
+        {{"from", "a"}, {"condition", "vcond_binary"},
+         {"routes", {{"yes", "b"}, {"no", "__end__"}}}} });
+    auto r = validate_def(def);
+    EXPECT_TRUE(by_code(r, "E10").empty()) << r.summary();
+}
+
+// =========================================================================
+// E4/E5/E6: channel effects (gated on full effect coverage)
+// =========================================================================
+
+TEST(Validator, E4_WriteToUndeclaredChannelIsError) {
+    json def = {
+        {"nodes", {{"w", {{"type", "vfx_writer"}}}}},   // writes "out"
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "w"}} })},
+        // no channels block at all
+    };
+    auto r = validate_def(def);
+    auto e4 = by_code(r, "E4");
+    ASSERT_EQ(e4.size(), 1u) << r.summary();
+    EXPECT_EQ(e4[0]->severity, "error");
+    EXPECT_EQ(e4[0]->witness["channel"].get<std::string>(), "out");
+}
+
+TEST(Validator, EffectFamilySkippedWhenAnyTypeUndeclared) {
+    json def = {
+        {"nodes", {{"w", {{"type", "vfx_writer"}}},
+                   {"mystery", {{"type", "vnoop"}}}}},   // no effect contract
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "w"}},
+                                {{"from", "w"}, {"to", "mystery"}} })},
+    };
+    auto r = validate_def(def);
+    EXPECT_TRUE(by_code(r, "E4").empty()) << r.summary();
+    EXPECT_TRUE(by_code(r, "E6").empty()) << r.summary();
+}
+
+TEST(Validator, E6_DeadChannelWarns) {
+    json def = {
+        {"channels", {{"out", {{"reducer", "overwrite"}}},
+                      {"unused", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"w", {{"type", "vfx_writer"}}},
+                   {"rd", {{"type", "vfx_reader"}}}}},
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "w"}},
+                                {{"from", "w"}, {"to", "rd"}} })},
+    };
+    auto r = validate_def(def);
+    auto e6 = by_code(r, "E6");
+    ASSERT_EQ(e6.size(), 1u) << r.summary();
+    EXPECT_EQ(e6[0]->witness["channel"].get<std::string>(), "unused");
+}
+
+TEST(Validator, E5_OverwriteRaceBetweenFanOutSiblingsWarns) {
+    json def = {
+        {"channels", {{"out", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"src", {{"type", "vfx_reader"}}},
+                   {"w1", {{"type", "vfx_writer"}}},
+                   {"w2", {{"type", "vfx_writer"}}}}},
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "src"}},
+                                {{"from", "src"}, {"to", "w1"}},
+                                {{"from", "src"}, {"to", "w2"}} })},
+    };
+    auto r = validate_def(def);
+    auto e5 = by_code(r, "E5");
+    ASSERT_EQ(e5.size(), 1u) << r.summary();
+    EXPECT_EQ(e5[0]->severity, "warning");
+    EXPECT_EQ(e5[0]->witness["writers"].size(), 2u);
+}
+
+// =========================================================================
+// Engine integration: strict throws on validator errors
+// =========================================================================
+
+TEST(ValidatorEngine, StrictCompileThrowsOnDanglingEdge) {
+    ensure_vtypes_registered();
+    auto def = two_node_base();
+    def["schema_version"] = 1;
+    def["edges"].push_back({{"from", "a"}, {"to", "ghost"}});
+    try {
+        GraphEngine::compile(def, NodeContext{});
+        FAIL() << "expected validation error";
+    } catch (const std::runtime_error& e) {
+        EXPECT_NE(std::string(e.what()).find("[E3/error]"), std::string::npos)
+            << e.what();
+    }
+}
+
+TEST(ValidatorEngine, LenientCompileSurvivesDanglingEdge) {
+    ensure_vtypes_registered();
+    auto def = two_node_base();
+    def["edges"].push_back({{"from", "a"}, {"to", "ghost"}});
+    EXPECT_NO_THROW(GraphEngine::compile(def, NodeContext{}));
+}
+
+TEST(ValidatorEngine, StrictCompileCleanGraphPasses) {
+    ensure_vtypes_registered();
+    auto def = two_node_base();
+    def["schema_version"] = 1;
+    EXPECT_NO_THROW(GraphEngine::compile(def, NodeContext{}));
+}


### PR DESCRIPTION
## M2 — 정적 의미 검사 (P2~P4), #75 2/4 (stacked on #76)

설계 근거: [dsl-compiler-research.md](https://github.com/weasel1245/NeoGraph-Studio/blob/main/docs/dsl-compiler-research.md) §3 P2~P4, §5 오류 카탈로그

### 무엇

`GraphValidator` — 파싱(M1)과 실행 사이의 정적 분석 패스. 모든 진단에 기계가 읽을 수 있는 **witness(반례) JSON** 동반 (M3 Studio 캔버스 하이라이트의 입력).

| 코드 | 검사 | 판정 |
|---|---|---|
| E3 | dangling 참조 (엣지·route 타깃·interrupt·wait_for·barrier 자기대기) | 에러 |
| E8 | barrier 신호 경로 부재 (goto는 barrier 회계 우회 → 구제 불가) | 에러 |
| E10 | 빈 routes (디스패치 rend() 역참조 UB) / closed 조건 dead route·미커버 라벨 | 에러 |
| E4 | 미선언 채널 write (런타임 확정 throw의 정적 선취) | 에러 |
| E7/E11 | 도달 불가 / 탈출 없는 사이클 (Command.goto·Send가 정당화 가능) | 경고 |
| E9 | barrier 없는 plain fan-in ≥2 (XOR 머지는 정당) | 경고 |
| E5/E6 | overwrite 형제 경쟁 / dead channel | 경고 |

**에러/경고 분할 원리** (Scalas-Yoshida 과잉 거부 경고 준수): 엔진 의미론상 *절대* 옳을 수 없는 것만 에러. 동적 메커니즘(goto/Send)이 정당화할 수 있는 것은 전부 경고 — 올바른 그래프는 절대 거부되지 않는다(체커 건전성).

**발굴한 실결함 2건**: ① 미커버 라우트 키가 스케줄러의 "사전순 마지막 라우트" 폴백으로 떨어짐 — newcomer식 그래프에서 미분류 인텐트가 조용히 "math" 전문가로 감 (E10이 봉쇄) ② 빈 routes의 `routes.rbegin()->second` = rend() 역참조 UB (E10 에러).

### 계약 인프라

- `ConditionSpec{labels, open}` — `register_condition` 3-인자 오버로드. 빌트인: has_tool_calls=closed{false,true}, route_channel=open+known{default}
- effect 계약 `{"reads":[],"writes":[]}` — `register_type` 4-인자 오버로드. **전 노드 타입 선언 시에만** E4/E5/E6 가동 (미지 타입 1개 = 가족 전체 스킵)
- `export_schema()` += `node_effects`·`condition_specs` (기존 `conditions` 배열 하위호환)

### 완료 조건 검증

- [x] E3~E11 위반 픽스처가 witness와 함께 거부/경고 (테스트 22종, witness 내용 단언 포함)
- [x] 과잉 거부 0: 전체 557/557 통과, 기존 테스트 그래프에서 lenient E-경고 **0건** (grep 확증)
- [x] strict 통합: 엔진 compile 경로에서 에러 throw / lint stderr, 관용 문서는 에러급만 표면화

다음: M3 (PBT 생성기 + 차분 하네스 + Studio witness 시각화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
