### PR TITLE
feat(tests): M3 PBT/차분 하네스 — 생성기+mutation+레퍼런스 모델 (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **PBT/차분 검증 하네스** (#75 M3). 300-시드 결정론적 topology 생성기
+  (스키마 봉투에서 유효 strict 문서 생성, 기능 커버리지 자가 계측 —
+  conditional_edges/barrier/interrupt 등장률 30% 미달 시 테스트 실패:
+  "생성기가 안 건드린 기능"이 소리 없는 구멍이 아니라 실패가 되게).
+  - **mutation 검출**: 드롭 5종(conditional_edges/edge/barrier/
+    interrupt/channel) + 오배선 3종(route 붕괴/edge 재타깃/노드 개명 =
+    드롭+날조 상쇄) 전부에 대해 translation validation 이 매 적용마다
+    검출됨을 300-시드 코퍼스에서 확증. 적용률 하한(시드의 10%)도 단언.
+  - **레퍼런스 인터프리터 차분**: 문서화된 super-step 의미론(goto
+    선점·barrier 누적·사전순 폴백·암묵 __end__)을 코드 비공유로 재구현한
+    독립 모델과 Scheduler 를 12-step × 300-graph 대조 (DESIL 교훈:
+    verifier 만으론 wrong-execution 을 못 잡는다).
+  - **엔진↔Studio 공유 코퍼스**: `tests/fixtures/topology_corpus/` 15종
+    (유효 3 + E3~E11 위반 12)이 NeoGraph-Studio `tests/corpus/` 와
+    byte-동일, 양측이 같은 verdict(code:severity multiset)를 단언 —
+    두 구현이 조용히 갈라질 수 없음.
+
 - **GraphValidator — 토폴로지 정적 의미 검사 (E3~E11 + effect)** (#75 M2).
   파싱(M1)과 실행 사이의 패스 계층. strict 문서(schema_version>=1)에서
   에러는 컴파일 실패, 경고는 stderr lint; 관용 문서는 에러급만 stderr

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,8 @@ add_executable(neograph_tests
     test_compiler.cpp
     test_compiler_strict.cpp
     test_validator.cpp
+    test_pbt_roundtrip.cpp
+    test_corpus.cpp
     test_barrier_persistence.cpp
     test_coordinator.cpp
     test_sends_interrupt_order.cpp

--- a/tests/fixtures/topology_corpus/e10_closed_uncovered.json
+++ b/tests/fixtures/topology_corpus/e10_closed_uncovered.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": 1,
+  "name": "e10_closed_uncovered",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    }
+  },
+  "nodes": {
+    "a": {
+      "type": "llm_call"
+    },
+    "t": {
+      "type": "tool_dispatch"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "a"
+    },
+    {
+      "from": "t",
+      "to": "__end__"
+    }
+  ],
+  "conditional_edges": [
+    {
+      "from": "a",
+      "condition": "has_tool_calls",
+      "routes": {
+        "true": "t"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/e10_empty_routes.json
+++ b/tests/fixtures/topology_corpus/e10_empty_routes.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "name": "e10_empty_routes",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    }
+  },
+  "nodes": {
+    "a": {
+      "type": "llm_call"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "a"
+    },
+    {
+      "from": "a",
+      "to": "__end__"
+    }
+  ],
+  "conditional_edges": [
+    {
+      "from": "a",
+      "condition": "route_channel"
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/e10_open_no_default.json
+++ b/tests/fixtures/topology_corpus/e10_open_no_default.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "name": "e10_open_no_default",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    },
+    "__route__": {
+      "reducer": "overwrite"
+    }
+  },
+  "nodes": {
+    "ic": {
+      "type": "intent_classifier",
+      "prompt": "p",
+      "routes": [
+        "x"
+      ]
+    },
+    "a": {
+      "type": "llm_call"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "ic"
+    },
+    {
+      "from": "a",
+      "to": "__end__"
+    }
+  ],
+  "conditional_edges": [
+    {
+      "from": "ic",
+      "condition": "route_channel",
+      "routes": {
+        "x": "a"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/e11_trapped_cycle.json
+++ b/tests/fixtures/topology_corpus/e11_trapped_cycle.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "name": "e11_trapped_cycle",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    }
+  },
+  "nodes": {
+    "a": {
+      "type": "llm_call"
+    },
+    "b": {
+      "type": "llm_call"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "a"
+    },
+    {
+      "from": "a",
+      "to": "b"
+    },
+    {
+      "from": "b",
+      "to": "a"
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/e3_dangling_edge.json
+++ b/tests/fixtures/topology_corpus/e3_dangling_edge.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "name": "e3_dangling_edge",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    }
+  },
+  "nodes": {
+    "a": {
+      "type": "llm_call"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "a"
+    },
+    {
+      "from": "a",
+      "to": "__end__"
+    },
+    {
+      "from": "a",
+      "to": "ghost"
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/e3_interrupt_unknown.json
+++ b/tests/fixtures/topology_corpus/e3_interrupt_unknown.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "name": "e3_interrupt_unknown",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    }
+  },
+  "nodes": {
+    "a": {
+      "type": "llm_call"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "a"
+    },
+    {
+      "from": "a",
+      "to": "__end__"
+    }
+  ],
+  "interrupt_before": [
+    "phantom"
+  ]
+}

--- a/tests/fixtures/topology_corpus/e4_undeclared_write.json
+++ b/tests/fixtures/topology_corpus/e4_undeclared_write.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "name": "e4_undeclared_write",
+  "channels": {
+    "messages": {
+      "reducer": "append",
+      "initial": []
+    }
+  },
+  "nodes": {
+    "ic": {
+      "type": "intent_classifier",
+      "prompt": "p",
+      "routes": [
+        "x"
+      ]
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "ic"
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/e5_overwrite_race.json
+++ b/tests/fixtures/topology_corpus/e5_overwrite_race.json
@@ -1,0 +1,45 @@
+{
+  "schema_version": 1,
+  "name": "e5_overwrite_race",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    },
+    "__route__": {
+      "reducer": "overwrite"
+    }
+  },
+  "nodes": {
+    "src": {
+      "type": "llm_call"
+    },
+    "ic1": {
+      "type": "intent_classifier",
+      "prompt": "p",
+      "routes": [
+        "x"
+      ]
+    },
+    "ic2": {
+      "type": "intent_classifier",
+      "prompt": "p",
+      "routes": [
+        "x"
+      ]
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "src"
+    },
+    {
+      "from": "src",
+      "to": "ic1"
+    },
+    {
+      "from": "src",
+      "to": "ic2"
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/e6_dead_channel.json
+++ b/tests/fixtures/topology_corpus/e6_dead_channel.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "name": "e6_dead_channel",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    },
+    "unused": {
+      "reducer": "overwrite"
+    }
+  },
+  "nodes": {
+    "a": {
+      "type": "llm_call"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "a"
+    },
+    {
+      "from": "a",
+      "to": "__end__"
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/e7_unreachable.json
+++ b/tests/fixtures/topology_corpus/e7_unreachable.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "name": "e7_unreachable",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    }
+  },
+  "nodes": {
+    "a": {
+      "type": "llm_call"
+    },
+    "island": {
+      "type": "llm_call"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "a"
+    },
+    {
+      "from": "a",
+      "to": "__end__"
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/e8_barrier_unsignaled.json
+++ b/tests/fixtures/topology_corpus/e8_barrier_unsignaled.json
@@ -1,0 +1,48 @@
+{
+  "schema_version": 1,
+  "name": "e8_barrier_unsignaled",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    }
+  },
+  "nodes": {
+    "a": {
+      "type": "llm_call"
+    },
+    "b": {
+      "type": "llm_call"
+    },
+    "j": {
+      "type": "llm_call",
+      "barrier": {
+        "wait_for": [
+          "a",
+          "b"
+        ]
+      }
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "a"
+    },
+    {
+      "from": "__start__",
+      "to": "b"
+    },
+    {
+      "from": "a",
+      "to": "j"
+    },
+    {
+      "from": "b",
+      "to": "__end__"
+    },
+    {
+      "from": "j",
+      "to": "__end__"
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/e9_fanin_no_barrier.json
+++ b/tests/fixtures/topology_corpus/e9_fanin_no_barrier.json
@@ -1,0 +1,42 @@
+{
+  "schema_version": 1,
+  "name": "e9_fanin_no_barrier",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    }
+  },
+  "nodes": {
+    "a": {
+      "type": "llm_call"
+    },
+    "b": {
+      "type": "llm_call"
+    },
+    "j": {
+      "type": "llm_call"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "a"
+    },
+    {
+      "from": "__start__",
+      "to": "b"
+    },
+    {
+      "from": "a",
+      "to": "j"
+    },
+    {
+      "from": "b",
+      "to": "j"
+    },
+    {
+      "from": "j",
+      "to": "__end__"
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/manifest.json
+++ b/tests/fixtures/topology_corpus/manifest.json
@@ -1,0 +1,44 @@
+{
+  "_comment": "Shared engine<->Studio differential corpus. Keep tests/fixtures/topology_corpus (NeoGraph) and tests/corpus (NeoGraph-Studio) byte-identical. Expected = sorted code:severity multiset from GraphValidator / lint.js.",
+  "expected": {
+    "valid_minimal.json": [],
+    "valid_full.json": [],
+    "valid_intent_router.json": [],
+    "e3_dangling_edge.json": [
+      "E3:error"
+    ],
+    "e3_interrupt_unknown.json": [
+      "E3:error"
+    ],
+    "e8_barrier_unsignaled.json": [
+      "E8:error"
+    ],
+    "e9_fanin_no_barrier.json": [
+      "E9:warning"
+    ],
+    "e10_empty_routes.json": [
+      "E10:error"
+    ],
+    "e10_closed_uncovered.json": [
+      "E10:error"
+    ],
+    "e10_open_no_default.json": [
+      "E10:warning"
+    ],
+    "e7_unreachable.json": [
+      "E7:warning"
+    ],
+    "e11_trapped_cycle.json": [
+      "E11:warning"
+    ],
+    "e4_undeclared_write.json": [
+      "E4:error"
+    ],
+    "e6_dead_channel.json": [
+      "E6:warning"
+    ],
+    "e5_overwrite_race.json": [
+      "E5:warning"
+    ]
+  }
+}

--- a/tests/fixtures/topology_corpus/valid_full.json
+++ b/tests/fixtures/topology_corpus/valid_full.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": 1,
+  "name": "valid_full",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    },
+    "__route__": {
+      "reducer": "overwrite"
+    }
+  },
+  "nodes": {
+    "ic": {
+      "type": "intent_classifier",
+      "prompt": "route it",
+      "routes": [
+        "x",
+        "y"
+      ]
+    },
+    "a": {
+      "type": "llm_call"
+    },
+    "b": {
+      "type": "llm_call"
+    },
+    "j": {
+      "type": "tool_dispatch",
+      "barrier": {
+        "wait_for": [
+          "a",
+          "b"
+        ]
+      }
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "ic"
+    },
+    {
+      "from": "a",
+      "to": "j"
+    },
+    {
+      "from": "b",
+      "to": "j"
+    },
+    {
+      "from": "j",
+      "to": "__end__"
+    }
+  ],
+  "conditional_edges": [
+    {
+      "from": "ic",
+      "condition": "route_channel",
+      "routes": {
+        "x": "a",
+        "y": "b",
+        "default": "__end__"
+      }
+    }
+  ],
+  "interrupt_before": [
+    "j"
+  ]
+}

--- a/tests/fixtures/topology_corpus/valid_intent_router.json
+++ b/tests/fixtures/topology_corpus/valid_intent_router.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "name": "valid_intent_router",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    },
+    "__route__": {
+      "reducer": "overwrite"
+    }
+  },
+  "nodes": {
+    "ic": {
+      "type": "intent_classifier",
+      "prompt": "math, code, or general",
+      "routes": [
+        "math",
+        "code",
+        "general"
+      ]
+    },
+    "m": {
+      "type": "llm_call"
+    },
+    "c": {
+      "type": "llm_call"
+    },
+    "g": {
+      "type": "llm_call"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "ic"
+    },
+    {
+      "from": "m",
+      "to": "__end__"
+    },
+    {
+      "from": "c",
+      "to": "__end__"
+    },
+    {
+      "from": "g",
+      "to": "__end__"
+    }
+  ],
+  "conditional_edges": [
+    {
+      "from": "ic",
+      "condition": "route_channel",
+      "routes": {
+        "math": "m",
+        "code": "c",
+        "general": "g",
+        "default": "g"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/topology_corpus/valid_minimal.json
+++ b/tests/fixtures/topology_corpus/valid_minimal.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "name": "valid_minimal",
+  "channels": {
+    "messages": {
+      "reducer": "append"
+    }
+  },
+  "nodes": {
+    "a": {
+      "type": "llm_call"
+    }
+  },
+  "edges": [
+    {
+      "from": "__start__",
+      "to": "a"
+    },
+    {
+      "from": "a",
+      "to": "__end__"
+    }
+  ]
+}

--- a/tests/test_corpus.cpp
+++ b/tests/test_corpus.cpp
@@ -1,0 +1,73 @@
+// Engine side of the engine<->Studio differential corpus (issue #75 M3).
+//
+// tests/fixtures/topology_corpus/*.json is byte-shared with
+// NeoGraph-Studio's tests/corpus/ — the Studio lint (editor/lint.js)
+// runs the same fixtures through its JavaScript reimplementation of
+// GraphValidator and asserts the same verdicts. A rule change on either
+// side that isn't mirrored breaks that side's test, so the two loaders
+// cannot silently diverge (differential-testing oracle).
+//
+// Verdict format: sorted multiset of "CODE:severity" strings.
+
+#include <gtest/gtest.h>
+#include <neograph/neograph.h>
+#include <neograph/graph/compiler.h>
+#include <neograph/graph/validator.h>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+std::filesystem::path corpus_dir() {
+    std::filesystem::path here(__FILE__);
+    return here.parent_path() / "fixtures" / "topology_corpus";
+}
+
+json load_json(const std::filesystem::path& p) {
+    std::ifstream f(p);
+    EXPECT_TRUE(f.is_open()) << "cannot open " << p;
+    std::string content((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+    return json::parse(content);
+}
+
+} // namespace
+
+TEST(Corpus, EngineVerdictsMatchManifest) {
+    const auto manifest = load_json(corpus_dir() / "manifest.json");
+    const auto& expected_map = manifest["expected"];
+    size_t checked = 0;
+
+    for (const auto& [fname, expected] : expected_map.items()) {
+        const json def = load_json(corpus_dir() / fname);
+
+        CompiledGraph cg;
+        ASSERT_NO_THROW(cg = GraphCompiler::compile(def, NodeContext{}))
+            << fname << " must parse cleanly (corpus errors are validator-level)";
+
+        auto report = GraphValidator::validate(cg);
+        std::vector<std::string> actual;
+        for (const auto& d : report.diagnostics) {
+            actual.push_back(d.code + ":" + d.severity);
+        }
+        std::sort(actual.begin(), actual.end());
+
+        std::vector<std::string> want;
+        for (const auto& e : expected) want.push_back(e.get<std::string>());
+        std::sort(want.begin(), want.end());
+
+        EXPECT_EQ(actual, want) << fname << "\n" << report.summary();
+
+        // Corpus documents are strict; they must also round-trip.
+        EXPECT_NO_THROW(GraphCompiler::verify_roundtrip(def, cg)) << fname;
+        ++checked;
+    }
+    EXPECT_GE(checked, 15u);
+}

--- a/tests/test_pbt_roundtrip.cpp
+++ b/tests/test_pbt_roundtrip.cpp
@@ -1,0 +1,483 @@
+// M3 property-based harness (issue #75): schema-typed topology
+// generator + canon round-trip property + seeded-bug mutation detection
+// + scheduler-vs-reference-model differential execution.
+//
+// Why generation and not just fixtures: the v0.1.0–v0.1.7 regression
+// survived seven releases precisely because no hand-written test
+// exercised the dropped feature. The generator measures its own
+// feature coverage (conditional_edges / barrier / interrupt occurrence
+// rates must each clear 30%) so "the generator never touched it" is
+// itself a test failure, not a silent gap.
+//
+// Everything is seeded std::mt19937 — deterministic across runs and
+// platforms (no Date.now()-style flakiness).
+
+#include <gtest/gtest.h>
+#include <neograph/neograph.h>
+#include <neograph/graph/compiler.h>
+#include <neograph/graph/validator.h>
+#include <neograph/graph/scheduler.h>
+#include <neograph/graph/state.h>
+
+#include <algorithm>
+#include <map>
+#include <random>
+#include <set>
+#include <string>
+#include <vector>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+class PbtNoopNode : public GraphNode {
+public:
+    explicit PbtNoopNode(std::string n) : name_(std::move(n)) {}
+    asio::awaitable<NodeOutput> run(NodeInput) override { co_return NodeOutput{}; }
+    std::string get_name() const override { return name_; }
+private:
+    std::string name_;
+};
+
+void ensure_pbt_types() {
+    NodeFactory::instance().register_type(
+        "pnoop",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<PbtNoopNode>(name);
+        });
+}
+
+// ---------------------------------------------------------------------
+// Generator: random *valid strict* topology from the schema envelope.
+// Discipline mirrors the validator's error set — generated graphs must
+// compile strictly (validator errors would throw), while warnings
+// (E7/E9/E11 lint) are acceptable.
+// ---------------------------------------------------------------------
+
+struct GenStats {
+    int total = 0, with_ce = 0, with_barrier = 0, with_interrupt = 0;
+};
+
+struct GenGraph {
+    json def;
+    // Nodes that carry a conditional edge (route preempts plain edges).
+    std::set<std::string> ce_nodes;
+    std::vector<std::string> node_names;
+};
+
+GenGraph generate_topology(std::mt19937& rng, GenStats& stats) {
+    auto chance = [&](int pct) {
+        return std::uniform_int_distribution<int>(0, 99)(rng) < pct;
+    };
+    auto pick = [&](size_t n) {
+        return std::uniform_int_distribution<size_t>(0, n - 1)(rng);
+    };
+
+    GenGraph g;
+    const int n_nodes = 2 + static_cast<int>(pick(6));   // 2..7
+    for (int i = 0; i < n_nodes; ++i) {
+        g.node_names.push_back("n" + std::to_string(i));
+    }
+
+    json nodes = json::object();
+    for (const auto& n : g.node_names) nodes[n] = json{{"type", "pnoop"}};
+
+    // Channels: __route__ always (route_channel reads it) + extras.
+    json channels = json::object();
+    channels["__route__"] = json{{"reducer", "overwrite"}};
+    const int extra_ch = static_cast<int>(pick(3));
+    for (int i = 0; i < extra_ch; ++i) {
+        json ch = json{{"reducer", chance(50) ? "append" : "overwrite"}};
+        if (chance(40)) ch["initial"] = static_cast<int>(pick(100));
+        channels["ch" + std::to_string(i)] = std::move(ch);
+    }
+
+    // Plain-edge spine guarantees reachability: __start__ -> n0 -> ... .
+    std::vector<std::pair<std::string, std::string>> edges;
+    edges.push_back({"__start__", g.node_names[0]});
+    for (int i = 0; i + 1 < n_nodes; ++i) {
+        edges.push_back({g.node_names[i], g.node_names[i + 1]});
+    }
+    edges.push_back({g.node_names.back(), "__end__"});
+
+    // Random extra plain edges (may create cycles — E11 is a warning).
+    const int extra_e = static_cast<int>(pick(3));
+    for (int i = 0; i < extra_e; ++i) {
+        edges.push_back({g.node_names[pick(g.node_names.size())],
+                         g.node_names[pick(g.node_names.size())]});
+    }
+
+    // Conditional edge: route_channel with full known-label coverage
+    // ("default" included — E10-clean). The source keeps its plain
+    // edges in the JSON; the scheduler ignores them (route preempts),
+    // which the reference model must mirror.
+    json conditional_edges = json::array();
+    if (chance(60)) {
+        const auto& src = g.node_names[pick(g.node_names.size())];
+        g.ce_nodes.insert(src);
+        json routes = json::object();
+        routes["default"] = chance(50) ? "__end__"
+                                       : g.node_names[pick(g.node_names.size())];
+        const int n_keys = 1 + static_cast<int>(pick(2));
+        for (int k = 0; k < n_keys; ++k) {
+            routes["k" + std::to_string(k)] =
+                chance(30) ? "__end__" : g.node_names[pick(g.node_names.size())];
+        }
+        conditional_edges.push_back(json{
+            {"from", src}, {"condition", "route_channel"}, {"routes", routes}});
+        stats.with_ce++;
+    }
+
+    // Barrier: force a fan-out + AND-join structure so wait_for members
+    // provably signal the barrier (E8-clean). Members must not be
+    // ce_nodes (their plain edges into the join would be preempted).
+    if (chance(55) && n_nodes >= 3) {
+        std::vector<std::string> cands;
+        for (const auto& n : g.node_names) {
+            if (!g.ce_nodes.count(n)) cands.push_back(n);
+        }
+        if (cands.size() >= 3) {
+            const std::string join = cands[0], u1 = cands[1], u2 = cands[2];
+            if (join != u1 && join != u2 && u1 != u2) {
+                edges.push_back({u1, join});
+                edges.push_back({u2, join});
+                nodes[join] = json{{"type", "pnoop"},
+                                   {"barrier", {{"wait_for", json::array({u1, u2})}}}};
+                stats.with_barrier++;
+            }
+        }
+    }
+
+    json def = json::object();
+    def["schema_version"] = 1;
+    def["name"] = "pbt";
+    def["channels"] = std::move(channels);
+    def["nodes"] = std::move(nodes);
+    json earr = json::array();
+    for (const auto& [f, t] : edges) earr.push_back(json{{"from", f}, {"to", t}});
+    def["edges"] = std::move(earr);
+    if (!conditional_edges.empty()) def["conditional_edges"] = std::move(conditional_edges);
+
+    if (chance(45)) {
+        def["interrupt_before"] =
+            json::array({g.node_names[pick(g.node_names.size())]});
+        stats.with_interrupt++;
+    }
+
+    stats.total++;
+    g.def = std::move(def);
+    return g;
+}
+
+constexpr int kSeeds = 300;
+
+} // namespace
+
+// =========================================================================
+// Property 1: every generated strict topology compiles, validates
+// without errors, and round-trips through canon. Coverage instrumented.
+// =========================================================================
+
+TEST(PbtRoundTrip, GeneratedCorpusCompilesValidatesAndRoundTrips) {
+    ensure_pbt_types();
+    GenStats stats;
+    for (int seed = 0; seed < kSeeds; ++seed) {
+        std::mt19937 rng(seed);
+        auto g = generate_topology(rng, stats);
+
+        CompiledGraph cg;
+        ASSERT_NO_THROW(cg = GraphCompiler::compile(g.def, NodeContext{}))
+            << "seed " << seed << "\n" << g.def.dump(2);
+
+        auto report = GraphValidator::validate(cg);
+        ASSERT_FALSE(report.has_errors())
+            << "seed " << seed << "\n" << report.summary()
+            << "\n" << g.def.dump(2);
+
+        ASSERT_NO_THROW(GraphCompiler::verify_roundtrip(g.def, cg))
+            << "seed " << seed << "\n" << g.def.dump(2);
+    }
+
+    // Feature-coverage gate: "the generator never touched it" must be
+    // a loud failure, not a silent hole (the v0.1.x lesson).
+    const double ce_pct        = 100.0 * stats.with_ce / stats.total;
+    const double barrier_pct   = 100.0 * stats.with_barrier / stats.total;
+    const double interrupt_pct = 100.0 * stats.with_interrupt / stats.total;
+    EXPECT_GE(ce_pct, 30.0)        << "conditional_edges coverage collapsed";
+    EXPECT_GE(barrier_pct, 30.0)   << "barrier coverage collapsed";
+    EXPECT_GE(interrupt_pct, 30.0) << "interrupt coverage collapsed";
+}
+
+// =========================================================================
+// Property 2: seeded-bug mutation detection. Eight mutator classes —
+// five drops, three rewires — applied to the *compiled* graph; the
+// translation validator must catch every single application.
+// =========================================================================
+
+TEST(PbtMutation, AllSeededBugsAreDetected) {
+    ensure_pbt_types();
+    std::map<std::string, int> applied;
+
+    for (int seed = 0; seed < kSeeds; ++seed) {
+        std::mt19937 rng(seed);
+        GenStats ignore;
+        auto g = generate_topology(rng, ignore);
+        const auto compile_fresh = [&]() {
+            return GraphCompiler::compile(g.def, NodeContext{});
+        };
+
+        // drop 1: conditional_edges wholesale (the historical bug).
+        {
+            auto cg = compile_fresh();
+            if (!cg.conditional_edges.empty()) {
+                cg.conditional_edges.clear();
+                EXPECT_THROW(GraphCompiler::verify_roundtrip(g.def, cg),
+                             std::runtime_error) << "seed " << seed;
+                applied["drop_conditional_edges"]++;
+            }
+        }
+        // drop 2: one plain edge.
+        {
+            auto cg = compile_fresh();
+            if (!cg.edges.empty()) {
+                cg.edges.erase(cg.edges.begin()
+                               + static_cast<long>(seed % cg.edges.size()));
+                EXPECT_THROW(GraphCompiler::verify_roundtrip(g.def, cg),
+                             std::runtime_error) << "seed " << seed;
+                applied["drop_edge"]++;
+            }
+        }
+        // drop 3: barrier specs.
+        {
+            auto cg = compile_fresh();
+            if (!cg.barrier_specs.empty()) {
+                cg.barrier_specs.clear();
+                EXPECT_THROW(GraphCompiler::verify_roundtrip(g.def, cg),
+                             std::runtime_error) << "seed " << seed;
+                applied["drop_barrier"]++;
+            }
+        }
+        // drop 4: interrupt sets.
+        {
+            auto cg = compile_fresh();
+            if (!cg.interrupt_before.empty()) {
+                cg.interrupt_before.clear();
+                EXPECT_THROW(GraphCompiler::verify_roundtrip(g.def, cg),
+                             std::runtime_error) << "seed " << seed;
+                applied["drop_interrupt"]++;
+            }
+        }
+        // drop 5: one channel (always applicable — __route__ exists).
+        {
+            auto cg = compile_fresh();
+            if (!cg.channel_defs.empty()) {
+                cg.channel_defs.pop_back();
+                EXPECT_THROW(GraphCompiler::verify_roundtrip(g.def, cg),
+                             std::runtime_error) << "seed " << seed;
+                applied["drop_channel"]++;
+            }
+        }
+        // rewire 6: collapse all routes of a conditional edge onto one
+        // target (edge survives; wiring is wrong — presence-only
+        // comparison would miss this).
+        {
+            auto cg = compile_fresh();
+            for (auto& ce : cg.conditional_edges) {
+                if (ce.routes.size() < 2) continue;
+                std::set<std::string> targets;
+                for (const auto& [k, v] : ce.routes) targets.insert(v);
+                if (targets.size() < 2) continue;
+                const std::string first = ce.routes.begin()->second;
+                for (auto& [k, v] : ce.routes) v = first;
+                EXPECT_THROW(GraphCompiler::verify_roundtrip(g.def, cg),
+                             std::runtime_error) << "seed " << seed;
+                applied["rewire_routes"]++;
+                break;
+            }
+        }
+        // rewire 7: retarget one plain edge to a different node.
+        {
+            auto cg = compile_fresh();
+            if (!cg.edges.empty() && g.node_names.size() >= 2) {
+                auto& e = cg.edges[seed % cg.edges.size()];
+                for (const auto& cand : g.node_names) {
+                    if (cand != e.to) { e.to = cand; break; }
+                }
+                EXPECT_THROW(GraphCompiler::verify_roundtrip(g.def, cg),
+                             std::runtime_error) << "seed " << seed;
+                applied["rewire_edge"]++;
+            }
+        }
+        // rewire 8: rename a node in the re-emission source (one node
+        // dropped + one fabricated — the counting-oracle blind spot;
+        // identity mapping must catch it).
+        {
+            auto cg = compile_fresh();
+            if (!cg.node_defs.empty()) {
+                auto it = cg.node_defs.begin();
+                json def_copy = it->second;
+                std::string old_name = it->first;
+                cg.node_defs.erase(it);
+                cg.node_defs[old_name + "_impostor"] = std::move(def_copy);
+                EXPECT_THROW(GraphCompiler::verify_roundtrip(g.def, cg),
+                             std::runtime_error) << "seed " << seed;
+                applied["rename_node"]++;
+            }
+        }
+    }
+
+    // Every mutator class must have fired on a healthy share of the
+    // corpus — a mutator that never applies is a hole in the harness.
+    for (const auto& [name, count] : applied) {
+        EXPECT_GE(count, kSeeds / 10) << "mutator '" << name
+                                      << "' applied too rarely";
+    }
+    EXPECT_EQ(applied.size(), 8u);
+}
+
+// =========================================================================
+// Property 3: differential execution — Scheduler vs an independent
+// reference model of the documented super-step semantics (DESIL
+// lesson: verifiers alone don't catch wrong-execution bugs).
+// =========================================================================
+
+namespace {
+
+// Independent reimplementation of the documented dispatch contract.
+// Deliberately shares no code with Scheduler.
+struct RefModel {
+    std::vector<Edge> edges;
+    std::vector<ConditionalEdge> ces;
+    BarrierSpecs barriers;
+    BarrierState accum;
+
+    std::vector<std::string> start() const {
+        std::set<std::string> s;
+        for (const auto& e : edges) {
+            if (e.from == "__start__" && e.to != "__end__") s.insert(e.to);
+        }
+        return {s.begin(), s.end()};
+    }
+
+    // route_value: what the route_channel condition would return.
+    std::pair<std::vector<std::string>, bool> step(
+        const std::vector<StepRouting>& routings,
+        const std::string& route_value) {
+
+        bool hit_end = false;
+
+        // Command.goto: last writer wins, preempts everything.
+        std::optional<std::string> goto_target;
+        for (const auto& r : routings) {
+            if (r.command_goto) goto_target = r.command_goto;
+        }
+        if (goto_target) {
+            if (*goto_target == "__end__") return {{}, true};
+            return {{*goto_target}, false};
+        }
+
+        std::map<std::string, std::set<std::string>> signals;
+        for (const auto& r : routings) {
+            std::vector<std::string> succ;
+            const ConditionalEdge* ce = nullptr;
+            for (const auto& c : ces) {
+                if (c.from == r.node_name) { ce = &c; break; }
+            }
+            if (ce) {
+                auto it = ce->routes.find(route_value);
+                succ.push_back(it != ce->routes.end()
+                                   ? it->second
+                                   : ce->routes.rbegin()->second);
+            } else {
+                for (const auto& e : edges) {
+                    if (e.from == r.node_name) succ.push_back(e.to);
+                }
+                if (succ.empty()) succ.push_back("__end__");
+            }
+            for (const auto& s : succ) {
+                if (s == "__end__") hit_end = true;
+                else signals[s].insert(r.node_name);
+            }
+        }
+
+        std::set<std::string> ready;
+        for (const auto& [target, signalers] : signals) {
+            auto bit = barriers.find(target);
+            if (bit == barriers.end()) { ready.insert(target); continue; }
+            auto& acc = accum[target];
+            for (const auto& s : signalers) acc.insert(s);
+            if (std::includes(acc.begin(), acc.end(),
+                              bit->second.begin(), bit->second.end())) {
+                ready.insert(target);
+                acc.clear();
+            }
+        }
+        return {{ready.begin(), ready.end()}, hit_end};
+    }
+};
+
+} // namespace
+
+TEST(PbtDifferential, SchedulerMatchesReferenceModel) {
+    ensure_pbt_types();
+    for (int seed = 0; seed < kSeeds; ++seed) {
+        std::mt19937 rng(seed + 100000);   // distinct stream from gen
+        GenStats ignore;
+        auto g = generate_topology(rng, ignore);
+        auto cg = GraphCompiler::compile(g.def, NodeContext{});
+
+        Scheduler sch(cg.edges, cg.conditional_edges, cg.barrier_specs);
+        RefModel ref{cg.edges, cg.conditional_edges, cg.barrier_specs, {}};
+        BarrierState bstate;
+
+        // Same start set.
+        auto actual_start = sch.plan_start_step();
+        auto ref_start = ref.start();
+        std::sort(actual_start.begin(), actual_start.end());
+        EXPECT_EQ(actual_start, ref_start) << "seed " << seed;
+
+        // Random route values each super-step, junk value included so
+        // the lexicographically-last fallback path is exercised too.
+        std::vector<std::string> route_pool = {"default", "k0", "k1", "zzz_junk"};
+        auto ready = actual_start;
+        for (int step = 0; step < 12 && !ready.empty(); ++step) {
+            const auto& route_value =
+                route_pool[std::uniform_int_distribution<size_t>(
+                    0, route_pool.size() - 1)(rng)];
+
+            GraphState state;
+            state.init_channel("__route__", ReducerType::OVERWRITE, nullptr,
+                               json(route_value));
+
+            std::vector<StepRouting> routings;
+            for (const auto& n : ready) {
+                StepRouting r;
+                r.node_name = n;
+                // Occasional Command.goto to exercise the override path.
+                if (std::uniform_int_distribution<int>(0, 99)(rng) < 8) {
+                    r.command_goto =
+                        (std::uniform_int_distribution<int>(0, 1)(rng) == 0)
+                            ? std::string("__end__")
+                            : g.node_names[std::uniform_int_distribution<size_t>(
+                                  0, g.node_names.size() - 1)(rng)];
+                }
+                routings.push_back(std::move(r));
+            }
+
+            auto plan = sch.plan_next_step(routings, state, bstate);
+            auto [ref_ready, ref_end] = ref.step(routings, route_value);
+
+            auto actual = plan.ready;
+            std::sort(actual.begin(), actual.end());
+            ASSERT_EQ(actual, ref_ready)
+                << "seed " << seed << " step " << step
+                << " route=" << route_value << "\n" << g.def.dump(2);
+            ASSERT_EQ(plan.hit_end, ref_end)
+                << "seed " << seed << " step " << step;
+
+            if (plan.hit_end) break;
+            ready = actual;
+        }
+    }
+}


### PR DESCRIPTION
## M3 — PBT/차분 하네스, #75 3/4 (stacked on #77)

설계 근거: research doc §4.2 방어선 4 (Luck POPL 2017 타입-생성, EMI/DESIL 오라클)

### 무엇

1. **300-시드 결정론적 topology 생성기** — 스키마 봉투에서 유효 strict 문서 생성. **기능 커버리지 자가 계측**: conditional_edges/barrier/interrupt 등장률이 30% 밑으로 무너지면 테스트 실패. v0.1.x가 7개 버전을 산 이유("생성기가 안 건드린 기능")를 소리 없는 구멍이 아니라 실패로 만듦.
2. **seeded-bug mutation 검출** — 드롭 5종(conditional_edges·edge·barrier·interrupt·channel) + 오배선 3종(route 붕괴·edge 재타깃·노드 개명=드롭+날조 상쇄 — 카운팅 오라클의 맹점). 전 코퍼스에서 TV가 매 적용마다 검출 + 각 mutator 적용률 하한 단언.
3. **레퍼런스 인터프리터 차분** — 문서화된 super-step 의미론(goto 선점·barrier 누적·사전순-마지막 폴백·암묵 __end__)의 **코드 비공유** 재구현 vs Scheduler, 12-step × 300-graph 완전 일치. (DESIL: verifier만으론 wrong-execution 못 잡음)
4. **엔진↔Studio 공유 코퍼스** — 15픽스처(유효 3 + E-코드 위반 12) + verdict manifest. Studio `tests/corpus/`와 byte-동일; 양측(`test_corpus.cpp` / `node tests/run.js`)이 같은 code:severity multiset 단언 → 두 로더가 조용히 갈라질 수 없음. Studio측 15/15 일치 확인, lint 최대 0.54ms (<500ms).

### 완료 조건 검증

- [x] 커버리지 계측: 3개 기능 각 ≥30% 게이트 (현행 ~45-60%)
- [x] seeded bug 8종 전부 검출 (드롭 5 + 오배선 3)
- [x] Studio 시각화 500ms 내: lint.js 15픽스처 최대 0.54ms (Studio 커밋 참조)
- [x] 전체 561/561 통과 (신규 5 테스트 포함)

다음: M4 (elaboration 계층 + 소스맵 + 스키마 진화 게이트)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
