### PR TITLE
feat(dsl): M4 elaboration 계층 + 업그레이드 체인 + 스키마 진화 게이트 (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **DSL 표면 (elaboration 계층) + 스키마 진화 게이트** (#75 M4).
+  - **Elaborator**: `vars`(`{"$var":...}`·`${...}` 보간, 비순환 강제) /
+    `templates`+`use`(파라미터 정확 일치 강제, 노드 prefix 리네임 —
+    로컬 참조·barrier·routes까지, 채널은 공유 상태라 전역 병합) /
+    `when` 조건부 포함. **non-Turing-complete·total**: 모든 DSL 문서는
+    유한 시간에 유일한 코어로 정규화되고, 코어 문서에 대해선 항등
+    (멱등). 모든 에러가 DSL 소스 좌표(`use[2].args`, `vars.model`)로
+    보고되고, 소스맵(출력 위치→생성 구문)이 동봉된다. 락파일 워크플로:
+    `./example_elaborate harness.dsl.json > harness.json` (example 53).
+  - **`GraphCompiler::upgrade_to_latest()`**: v0→v1 무손실 기계 변환 —
+    strict 가 거부할 키를 전부 `x-upgraded-<키>` 주석 네임스페이스로
+    격리(데이터 삭제 0), 빈 barrier 는 명시적으로 제거. 코퍼스 전체에
+    대해 "legacy 관용 컴파일 IR == 업그레이드 후 strict 컴파일 IR"
+    (canon 동치, 버전 스탬프 제외)을 테스트로 보증.
+  - **스키마 진화 게이트**: `tests/fixtures/schema_snapshot.json`
+    베이스라인 대비 add-only 부분집합 판정(JSON Subschema 계열의
+    결정가능 서브셋) — 노드타입/프로퍼티/reducer/condition 제거,
+    required 증가, closed 조건 라벨 변경, effect 계약 변경이 전부
+    테스트 실패 = CI 머지 차단. 비호환 변경은 버전 범프 + 업그레이더 +
+    스냅샷 재생성을 같은 리뷰 커밋에서 강제.
+
 - **PBT/차분 검증 하네스** (#75 M3). 300-시드 결정론적 topology 생성기
   (스키마 봉투에서 유효 strict 문서 생성, 기능 커버리지 자가 계측 —
   conditional_edges/barrier/interrupt 등장률 30% 미달 시 테스트 실패:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,7 @@ add_library(neograph_core
     src/core/graph_engine.cpp
     src/core/graph_compiler.cpp
     src/core/graph_validator.cpp
+    src/core/elaborator.cpp
     src/core/graph_coordinator.cpp
     src/core/graph_executor.cpp
     src/core/node_cache.cpp
@@ -1124,6 +1125,11 @@ if(NEOGRAPH_BUILD_EXAMPLES)
         # exact engine version it was built against.
         add_executable(example_export_schema examples/52_export_schema.cpp)
         target_link_libraries(example_export_schema PRIVATE neograph::core)
+
+        # DSL -> core topology expander (issue #75 M4). The lockfile
+        # workflow: `./example_elaborate harness.dsl.json > harness.json`.
+        add_executable(example_elaborate examples/53_elaborate.cpp)
+        target_link_libraries(example_elaborate PRIVATE neograph::core)
 
         # Clay + Raylib chatbot (optional — requires Raylib)
         option(NEOGRAPH_BUILD_CLAY_EXAMPLE "Build Clay chatbot example (fetches Raylib)" OFF)

--- a/examples/53_elaborate.cpp
+++ b/examples/53_elaborate.cpp
@@ -1,0 +1,60 @@
+// NeoGraph Example 53: DSL → core topology elaboration (issue #75 M4)
+//
+// The lockfile workflow: author a harness in the DSL surface (vars /
+// templates / use — see include/neograph/graph/elaborator.h), then
+// expand it to the frozen core grammar the engine consumes:
+//
+//   ./example_elaborate harness.dsl.json > harness.json
+//   ./example_elaborate harness.dsl.json --map harness.map.json
+//
+// The expanded core is the artifact you commit and diff-review (the
+// "lockfile"); the source map ties every generated construct back to
+// the DSL coordinate that produced it. Elaboration is total and
+// deterministic — the same DSL source always yields byte-identical
+// core JSON — and errors are reported against DSL coordinates
+// ("use[2].args: missing arg ..."), never against the expanded output.
+//
+// The output is strict by construction if the source declares
+// "schema_version": 1 — feed it to GraphEngine::compile and the M1/M2
+// gates (consumed-key accounting, translation validation, static
+// semantics) do the rest.
+
+#include <neograph/graph/elaborator.h>
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "usage: " << argv[0]
+                  << " <dsl.json> [--map <sourcemap.json>]\n";
+        return 2;
+    }
+
+    std::ifstream in(argv[1]);
+    if (!in.is_open()) {
+        std::cerr << "cannot open " << argv[1] << "\n";
+        return 2;
+    }
+    std::stringstream buf;
+    buf << in.rdbuf();
+
+    try {
+        const auto doc = neograph::json::parse(buf.str());
+        const auto result = neograph::graph::Elaborator::elaborate(doc);
+        std::cout << result.core.dump(2) << "\n";
+
+        for (int i = 2; i + 1 < argc; ++i) {
+            if (std::string(argv[i]) == "--map") {
+                std::ofstream mf(argv[i + 1]);
+                mf << result.sourcemap.dump(2) << "\n";
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << "\n";
+        return 1;
+    }
+    return 0;
+}

--- a/include/neograph/graph/compiler.h
+++ b/include/neograph/graph/compiler.h
@@ -184,6 +184,29 @@ public:
     static json canon(const json& definition);
 
     /**
+     * @brief Upgrade a legacy (schema_version 0 / absent) topology
+     *        document to the current schema version.
+     *
+     * v0 → v1 is purely mechanical and **lossless**: it stamps
+     * `schema_version: 1`, removes barrier blocks whose wait_for is
+     * missing/empty (making the legacy silent drop explicit), and
+     * renames every key strict mode would refuse to
+     * `x-upgraded-<key>` — the annotation namespace — so no user data
+     * is deleted, it is just moved out of the engine's way exactly as
+     * the lenient parser ignored it.
+     *
+     * Guarantee (tested over the corpus): compiling the legacy
+     * document leniently and compiling the upgraded document strictly
+     * yield IR-equivalent graphs
+     * (canon(to_json()) equal modulo the schema_version stamp).
+     *
+     * Like compile(), node-config upgrading consults NodeFactory —
+     * register custom node types before calling. Documents already at
+     * the current version are returned unchanged.
+     */
+    static json upgrade_to_latest(const json& definition);
+
+    /**
      * @brief Translation validation: assert compile() lost nothing.
      *
      * Compares canon(definition) against canon(cg.to_json()). On

--- a/include/neograph/graph/elaborator.h
+++ b/include/neograph/graph/elaborator.h
@@ -1,0 +1,92 @@
+/**
+ * @file graph/elaborator.h
+ * @brief DSL surface → core topology JSON expansion (issue #75 M4).
+ *
+ * The core topology grammar (what GraphCompiler consumes) is frozen;
+ * every DSL convenience lives here and is *fully expanded away* before
+ * the compiler ever sees the document ("programmable surface → data
+ * core"; Nickel/Dhall architecture). The engine, Studio, validation,
+ * and translation validation all keep operating on the core only.
+ *
+ * The elaboration language is deliberately **non-Turing-complete and
+ * total**: variable substitution (acyclic), template instantiation
+ * (no recursion — a template body cannot `use` templates), and boolean
+ * conditional inclusion. Every DSL document therefore normalizes to a
+ * unique core document in bounded time — the property the compile-time
+ * guarantees (M1 TV, M2 static checks) are conditioned on.
+ *
+ * ## Surface grammar (top-level keys, removed by elaboration)
+ *
+ *   "vars": { "<name>": <any JSON> }
+ *       Named values. A var value may reference other vars; cycles are
+ *       an error. Referenced as:
+ *         {"$var": "<name>"}   — whole-value substitution, anywhere
+ *         "...${name}..."      — string interpolation (scalar vars);
+ *                                a string that is exactly "${name}"
+ *                                substitutes the whole value.
+ *
+ *   "templates": { "<tname>": {
+ *        "params": ["p1", ...],
+ *        "channels"?: {...}, "nodes"?: {...},
+ *        "edges"?: [...], "conditional_edges"?: [...] } }
+ *       Reusable topology fragments. Inside a body, parameters are
+ *       referenced as {"$param": "p1"} / "@{p1}" (same rules as vars).
+ *
+ *   "use": [ { "template": "<tname>", "prefix": "<p>",
+ *              "args": { "p1": <JSON>, ... }, "when"?: <bool|$var> } ]
+ *       Instantiations. Every node the template declares is renamed
+ *       "<p>_<localName>", and local references (edge endpoints, route
+ *       targets, barrier wait_for) are renamed with it; sentinels and
+ *       non-local names pass through. Template channels merge globally
+ *       (same name must be an identical definition — channels are the
+ *       shared-state surface, deliberately NOT prefixed). "when": false
+ *       skips the instantiation entirely.
+ *
+ * Annotation keys ('_'/'x-' prefixes) are passed through verbatim —
+ * no substitution happens inside them, so a "${...}" in a _comment is
+ * not an error.
+ *
+ * ## Source map
+ *
+ * Elaboration returns a source map: JSON-pointer-ish output locations
+ * → the DSL construct that produced them (e.g. "/nodes/math_expert" →
+ * "use[0] template 'expert' prefix 'math'"). Elaboration errors always
+ * carry a source coordinate ("vars.model", "use[2].args", ...), so a
+ * mistake in the DSL is reported against the DSL, not against the
+ * expanded core.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/graph/types.h>
+
+namespace neograph::graph {
+
+struct ElaborationResult {
+    /// Pure core topology (no vars/templates/use keys) — feed to
+    /// GraphCompiler::compile / GraphEngine::compile as-is. This is
+    /// the "lockfile" artifact: commit it next to the DSL source.
+    json core;
+    /// Output-location → source-construct map (array of {target,
+    /// source} objects), for tooling and diff review.
+    json sourcemap;
+};
+
+class NEOGRAPH_API Elaborator {
+public:
+    /**
+     * @brief Expand a DSL document into core topology JSON.
+     *
+     * Total function: either returns the unique normal form or throws
+     * std::runtime_error with a DSL source coordinate (unknown var,
+     * var cycle, unknown template, missing/unexpected template args,
+     * node-name collision, conflicting channel merge, non-boolean
+     * "when", "$param" outside a template body).
+     *
+     * A document with no DSL keys is returned unchanged (elaboration
+     * is the identity on core documents — idempotence).
+     */
+    static ElaborationResult elaborate(const json& dsl_doc);
+};
+
+} // namespace neograph::graph

--- a/src/core/elaborator.cpp
+++ b/src/core/elaborator.cpp
@@ -1,0 +1,398 @@
+#include <neograph/graph/elaborator.h>
+
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace neograph::graph {
+
+namespace {
+
+bool is_annotation_key(const std::string& k) {
+    return (!k.empty() && k[0] == '_') || k.rfind("x-", 0) == 0;
+}
+
+[[noreturn]] void fail(const std::string& source_coord, const std::string& msg) {
+    throw std::runtime_error("elaboration failed at " + source_coord + ": " + msg);
+}
+
+// {"$var": "x"} / {"$param": "x"} detector: single-key object.
+bool is_ref(const json& v, const char* key, std::string& out_name) {
+    if (!v.is_object() || v.size() != 1 || !v.contains(key)) return false;
+    const json name = v[key];
+    if (!name.is_string()) return false;
+    out_name = name.get<std::string>();
+    return true;
+}
+
+// One substitution pass, parameterized so vars ({"$var"}, "${...}")
+// and template params ({"$param"}, "@{...}") share the machinery.
+struct Subst {
+    const std::map<std::string, json>& env;
+    const char* whole_key;     // "$var" | "$param"
+    std::string open;          // "${"   | "@{"
+    // When false, an unknown reference passes through untouched
+    // (used by the var pass so template-param syntax survives until
+    // instantiation; the final validation pass rejects leftovers).
+    bool foreign_ok;
+
+    json interpolate_string(const std::string& s, const std::string& path) const {
+        // Exact "${name}" → whole-value substitution.
+        if (s.size() > open.size() + 1 && s.rfind(open, 0) == 0 && s.back() == '}'
+            && s.find('}') == s.size() - 1) {
+            const std::string name = s.substr(open.size(),
+                                              s.size() - open.size() - 1);
+            auto it = env.find(name);
+            if (it == env.end()) {
+                if (foreign_ok) return json(s);
+                fail(path, "unknown reference '" + name + "'");
+            }
+            return it->second;
+        }
+        // Concatenating interpolation — scalars only.
+        std::string out;
+        size_t pos = 0;
+        while (pos < s.size()) {
+            auto at = s.find(open, pos);
+            if (at == std::string::npos) { out += s.substr(pos); break; }
+            auto close = s.find('}', at + open.size());
+            if (close == std::string::npos) { out += s.substr(pos); break; }
+            const std::string name = s.substr(at + open.size(),
+                                              close - at - open.size());
+            auto it = env.find(name);
+            if (it == env.end()) {
+                if (foreign_ok) { out += s.substr(pos, close + 1 - pos);
+                                  pos = close + 1; continue; }
+                fail(path, "unknown reference '" + name + "' in string interpolation");
+            }
+            const json& val = it->second;
+            std::string piece;
+            if (val.is_string())       piece = val.get<std::string>();
+            else if (val.is_number() || val.is_boolean()) piece = val.dump();
+            else fail(path, "'" + name + "' interpolates into a string but is not a scalar");
+            out += s.substr(pos, at - pos) + piece;
+            pos = close + 1;
+        }
+        return json(out);
+    }
+
+    json apply(const json& v, const std::string& path) const {
+        std::string name;
+        if (is_ref(v, whole_key, name)) {
+            auto it = env.find(name);
+            if (it == env.end()) {
+                if (foreign_ok) return v;
+                fail(path, std::string("unknown ") + whole_key + " '" + name + "'");
+            }
+            return it->second;
+        }
+        if (v.is_string()) return interpolate_string(v.get<std::string>(), path);
+        if (v.is_object()) {
+            json out = json::object();
+            for (const auto& [k, val] : v.items()) {
+                // Annotations pass through verbatim — a "${...}" in a
+                // _comment must not be an error.
+                out[k] = is_annotation_key(k) ? val : apply(val, path + "." + k);
+            }
+            return out;
+        }
+        if (v.is_array()) {
+            json out = json::array();
+            size_t i = 0;
+            for (const auto& e : v) {
+                out.push_back(apply(e, path + "[" + std::to_string(i++) + "]"));
+            }
+            return out;
+        }
+        return v;
+    }
+};
+
+// Resolve "vars" into a fully-substituted environment (DFS, cycle-checked).
+std::map<std::string, json> resolve_vars(const json& vars_def) {
+    std::map<std::string, json> resolved;
+    std::set<std::string> visiting;
+
+    // Recursive resolver via explicit lambda-with-self.
+    struct Resolver {
+        const json& defs;
+        std::map<std::string, json>& done;
+        std::set<std::string>& visiting;
+
+        json resolve(const std::string& name) {
+            auto dit = done.find(name);
+            if (dit != done.end()) return dit->second;
+            if (!defs.contains(name)) fail("vars." + name, "unknown var");
+            if (!visiting.insert(name).second) {
+                fail("vars." + name, "cyclic var reference");
+            }
+            // Substitute using every var this one references (resolved
+            // on demand): walk the value; on each reference, recurse.
+            json value = substitute(defs[name], "vars." + name);
+            visiting.erase(name);
+            done[name] = value;
+            return value;
+        }
+
+        json substitute(const json& v, const std::string& path) {
+            std::string ref;
+            if (is_ref(v, "$var", ref)) return resolve(ref);
+            if (v.is_string()) {
+                // Delegate interpolation to Subst over a lazy env: build
+                // the env of referenced names first.
+                const std::string s = v.get<std::string>();
+                std::map<std::string, json> env;
+                size_t pos = 0;
+                while ((pos = s.find("${", pos)) != std::string::npos) {
+                    auto close = s.find('}', pos + 2);
+                    if (close == std::string::npos) break;
+                    const std::string name = s.substr(pos + 2, close - pos - 2);
+                    env[name] = resolve(name);
+                    pos = close + 1;
+                }
+                return Subst{env, "$var", "${", /*foreign_ok=*/false}
+                    .interpolate_string(s, path);
+            }
+            if (v.is_object()) {
+                json out = json::object();
+                for (const auto& [k, val] : v.items()) {
+                    out[k] = is_annotation_key(k) ? val
+                                                  : substitute(val, path + "." + k);
+                }
+                return out;
+            }
+            if (v.is_array()) {
+                json out = json::array();
+                size_t i = 0;
+                for (const auto& e : v) {
+                    out.push_back(substitute(e, path + "[" + std::to_string(i++) + "]"));
+                }
+                return out;
+            }
+            return v;
+        }
+    };
+
+    Resolver r{vars_def, resolved, visiting};
+    for (const auto& [name, v] : vars_def.items()) {
+        (void)v;
+        r.resolve(name);
+    }
+    return resolved;
+}
+
+// Rename template-local node references under a prefix.
+struct Prefixer {
+    const std::set<std::string>& locals;
+    std::string prefix;
+
+    std::string map_name(const std::string& n) const {
+        return locals.count(n) ? prefix + "_" + n : n;
+    }
+};
+
+} // namespace
+
+ElaborationResult Elaborator::elaborate(const json& dsl_doc) {
+    if (!dsl_doc.is_object()) {
+        throw std::runtime_error("elaboration failed at $: document must be an object");
+    }
+
+    const bool has_dsl = dsl_doc.contains("vars") || dsl_doc.contains("templates")
+                      || dsl_doc.contains("use");
+
+    // ---- vars environment -------------------------------------------------
+    std::map<std::string, json> vars;
+    if (dsl_doc.contains("vars")) {
+        if (!dsl_doc["vars"].is_object()) fail("vars", "must be an object");
+        vars = resolve_vars(dsl_doc["vars"]);
+    }
+    const Subst var_pass{vars, "$var", "${", /*foreign_ok=*/false};
+    // During template-body handling the var syntax may appear too; the
+    // param pass must let it through untouched for the global var pass.
+    json sourcemap = json::array();
+    auto map_entry = [&](const std::string& target, const std::string& source) {
+        sourcemap.push_back(json{{"target", target}, {"source", source}});
+    };
+
+    // ---- start from the main document minus DSL keys ----------------------
+    json core = json::object();
+    for (const auto& [k, v] : dsl_doc.items()) {
+        if (k == "vars" || k == "templates" || k == "use") continue;
+        core[k] = v;
+    }
+
+    // ---- expand "use" ------------------------------------------------------
+    if (dsl_doc.contains("use")) {
+        if (!dsl_doc["use"].is_array()) fail("use", "must be an array");
+        const json templates = dsl_doc.contains("templates")
+                                   ? dsl_doc["templates"] : json::object();
+        size_t i = 0;
+        for (const auto& use : dsl_doc["use"]) {
+            const std::string coord = "use[" + std::to_string(i++) + "]";
+            if (!use.is_object()) fail(coord, "must be an object");
+            const std::string tname = use.value("template", "");
+            if (!templates.contains(tname)) {
+                fail(coord, "unknown template '" + tname + "'");
+            }
+            const std::string prefix = use.value("prefix", "");
+            if (prefix.empty()) fail(coord, "missing 'prefix'");
+
+            // when: var-substituted, must end up boolean.
+            if (use.contains("when")) {
+                const json w = var_pass.apply(use["when"], coord + ".when");
+                if (!w.is_boolean()) fail(coord + ".when", "must resolve to a boolean");
+                if (!w.get<bool>()) continue;
+            }
+
+            const json& tmpl = templates[tname];
+            // Exact param/arg matching — a typo'd arg must not vanish.
+            std::set<std::string> params;
+            if (tmpl.contains("params")) {
+                for (const auto& p : tmpl["params"]) params.insert(p.get<std::string>());
+            }
+            std::map<std::string, json> args;
+            if (use.contains("args")) {
+                for (const auto& [k, v] : use["args"].items()) {
+                    if (!params.count(k)) {
+                        fail(coord + ".args", "unexpected arg '" + k
+                             + "' (template '" + tname + "' declares: "
+                             + (params.empty() ? "none" : "") + ")");
+                    }
+                    args[k] = v;
+                }
+            }
+            for (const auto& p : params) {
+                if (!args.count(p)) {
+                    fail(coord + ".args", "missing arg '" + p
+                         + "' required by template '" + tname + "'");
+                }
+            }
+            const Subst param_pass{args, "$param", "@{", /*foreign_ok=*/true};
+
+            // Local node set decides which references get prefixed.
+            std::set<std::string> locals;
+            if (tmpl.contains("nodes")) {
+                for (const auto& [n, v] : tmpl["nodes"].items()) {
+                    (void)v;
+                    locals.insert(n);
+                }
+            }
+            const Prefixer px{locals, prefix};
+            const std::string src_tag =
+                coord + " template '" + tname + "' prefix '" + prefix + "'";
+
+            // nodes
+            if (tmpl.contains("nodes")) {
+                if (!core.contains("nodes")) core["nodes"] = json::object();
+                json merged = core["nodes"];
+                for (const auto& [n, nd] : tmpl["nodes"].items()) {
+                    const std::string out_name = px.map_name(n);
+                    if (merged.contains(out_name)) {
+                        fail(coord, "node '" + out_name
+                             + "' collides with an existing node");
+                    }
+                    json body = param_pass.apply(nd, coord + ".nodes." + n);
+                    // barrier wait_for refers to node names — prefix locals.
+                    if (body.contains("barrier") && body["barrier"].is_object()
+                        && body["barrier"].contains("wait_for")) {
+                        json wf = json::array();
+                        for (const auto& u : body["barrier"]["wait_for"]) {
+                            wf.push_back(px.map_name(u.get<std::string>()));
+                        }
+                        json b = body["barrier"];
+                        b["wait_for"] = std::move(wf);
+                        body["barrier"] = std::move(b);
+                    }
+                    merged[out_name] = std::move(body);
+                    map_entry("/nodes/" + out_name, src_tag);
+                }
+                core["nodes"] = std::move(merged);
+            }
+            // channels: global shared state — merged, never prefixed.
+            if (tmpl.contains("channels")) {
+                json merged = core.contains("channels") ? core["channels"]
+                                                        : json::object();
+                for (const auto& [cn, cd] : tmpl["channels"].items()) {
+                    json out_cd = param_pass.apply(cd, coord + ".channels." + cn);
+                    if (merged.contains(cn) && merged[cn] != out_cd) {
+                        fail(coord, "channel '" + cn
+                             + "' conflicts with an existing, different definition");
+                    }
+                    if (!merged.contains(cn)) map_entry("/channels/" + cn, src_tag);
+                    merged[cn] = std::move(out_cd);
+                }
+                core["channels"] = std::move(merged);
+            }
+            // edges / conditional_edges: appended with local refs prefixed.
+            auto expand_edges = [&](const char* key) {
+                if (!tmpl.contains(key)) return;
+                json arr = core.contains(key) ? core[key] : json::array();
+                size_t ei = 0;
+                for (const auto& e : tmpl[key]) {
+                    json out = param_pass.apply(
+                        e, coord + "." + key + "[" + std::to_string(ei++) + "]");
+                    if (out.contains("from") && out["from"].is_string()) {
+                        out["from"] = json(px.map_name(out["from"].get<std::string>()));
+                    }
+                    if (out.contains("to") && out["to"].is_string()) {
+                        out["to"] = json(px.map_name(out["to"].get<std::string>()));
+                    }
+                    if (out.contains("routes") && out["routes"].is_object()) {
+                        json routes = json::object();
+                        for (const auto& [rk, rt] : out["routes"].items()) {
+                            routes[rk] = rt.is_string()
+                                ? json(px.map_name(rt.get<std::string>())) : rt;
+                        }
+                        out["routes"] = std::move(routes);
+                    }
+                    map_entry(std::string("/") + key + "/"
+                              + std::to_string(arr.size()), src_tag);
+                    arr.push_back(std::move(out));
+                }
+                core[key] = std::move(arr);
+            };
+            expand_edges("edges");
+            expand_edges("conditional_edges");
+        }
+    }
+
+    // ---- global var pass over the merged document --------------------------
+    core = var_pass.apply(core, "$");
+
+    // ---- leftover-$param guard ---------------------------------------------
+    // A "$param" outside any template body is a user mistake that would
+    // otherwise flow into the compiler as a weird object.
+    {
+        struct Guard {
+            static void check(const json& v, const std::string& path) {
+                std::string name;
+                if (is_ref(v, "$param", name)) {
+                    fail(path, "'$param' reference '" + name
+                         + "' outside a template body");
+                }
+                if (v.is_object()) {
+                    for (const auto& [k, val] : v.items()) {
+                        if (!is_annotation_key(k)) check(val, path + "." + k);
+                    }
+                } else if (v.is_array()) {
+                    size_t i = 0;
+                    for (const auto& e : v) {
+                        check(e, path + "[" + std::to_string(i++) + "]");
+                    }
+                }
+            }
+        };
+        Guard::check(core, "$");
+    }
+
+    ElaborationResult result;
+    result.core = std::move(core);
+    result.sourcemap = std::move(sourcemap);
+    (void)has_dsl;
+    return result;
+}
+
+} // namespace neograph::graph

--- a/src/core/graph_compiler.cpp
+++ b/src/core/graph_compiler.cpp
@@ -609,6 +609,113 @@ json GraphCompiler::canon(const json& definition) {
     return sort_keys(out);
 }
 
+json GraphCompiler::upgrade_to_latest(const json& definition) {
+    if (definition.contains("schema_version")
+        && definition["schema_version"].is_number_integer()
+        && definition["schema_version"].get<int>() >= kSupportedSchemaVersion) {
+        return definition;   // already current
+    }
+
+    // Rebuild an object keeping `consumed` keys, renaming everything
+    // else (except annotations) into the x- namespace — data preserved,
+    // strict mode satisfied, semantics identical to the lenient parser
+    // that ignored those keys.
+    auto quarantine = [](const json& obj, const std::set<std::string>& consumed) {
+        json out = json::object();
+        for (const auto& [k, v] : obj.items()) {
+            if (consumed.count(k) || is_annotation_key(k)) out[k] = v;
+            else out["x-upgraded-" + k] = v;
+        }
+        return out;
+    };
+
+    json up = json::object();
+    up["schema_version"] = kSupportedSchemaVersion;
+
+    static const std::set<std::string> top_keys = {
+        "name", "channels", "nodes", "edges", "conditional_edges",
+        "interrupt_before", "interrupt_after", "retry_policy",
+    };
+    for (const auto& [k, v] : definition.items()) {
+        if (k == "schema_version") continue;   // re-stamped above
+        if (!top_keys.count(k) && !is_annotation_key(k)) {
+            up["x-upgraded-" + k] = v;
+            continue;
+        }
+        if (k == "channels" && v.is_object()) {
+            json channels = json::object();
+            for (const auto& [cn, cd] : v.items()) {
+                channels[cn] = cd.is_object()
+                    ? quarantine(cd, {"reducer", "initial"}) : cd;
+            }
+            up["channels"] = std::move(channels);
+        } else if (k == "nodes" && v.is_object()) {
+            json nodes = json::object();
+            for (const auto& [nn, nd] : v.items()) {
+                if (!nd.is_object()) { nodes[nn] = nd; continue; }
+                // Node config keys are checked against the declared
+                // schema only when it is closed-world (mirrors strict
+                // compile) — permissive types keep their config as-is.
+                const std::string type = nd.value("type", "");
+                const json schema = NodeFactory::instance().config_schema(type);
+                bool open = !schema.contains("properties");
+                if (schema.contains("additionalProperties")) {
+                    const auto& ap = schema["additionalProperties"];
+                    if (!ap.is_boolean() || ap.get<bool>()) open = true;
+                }
+                std::set<std::string> consumed = {"type", "barrier"};
+                if (!open) {
+                    for (const auto& [pk, pv] : schema["properties"].items()) {
+                        (void)pv;
+                        consumed.insert(pk);
+                    }
+                }
+                json node = open ? nd : quarantine(nd, consumed);
+                // Legacy: an empty/missing wait_for silently dropped
+                // the barrier — make that explicit.
+                if (node.contains("barrier")) {
+                    const auto& b = node["barrier"];
+                    const bool empty = !b.is_object() || !b.contains("wait_for")
+                        || !b["wait_for"].is_array() || b["wait_for"].empty();
+                    if (empty) {
+                        json cleaned = json::object();
+                        for (const auto& [nk, nv] : node.items()) {
+                            if (nk != "barrier") cleaned[nk] = nv;
+                        }
+                        node = std::move(cleaned);
+                    }
+                }
+                nodes[nn] = std::move(node);
+            }
+            up["nodes"] = std::move(nodes);
+        } else if (k == "edges" && v.is_array()) {
+            json edges = json::array();
+            for (const auto& e : v) {
+                if (!e.is_object()) { edges.push_back(e); continue; }
+                const bool cond = e.contains("condition")
+                               || e.value("type", "") == "conditional";
+                edges.push_back(cond
+                    ? quarantine(e, {"from", "condition", "routes", "type"})
+                    : quarantine(e, {"from", "to"}));
+            }
+            up["edges"] = std::move(edges);
+        } else if (k == "conditional_edges" && v.is_array()) {
+            json ces = json::array();
+            for (const auto& e : v) {
+                ces.push_back(e.is_object()
+                    ? quarantine(e, {"from", "condition", "routes"}) : e);
+            }
+            up["conditional_edges"] = std::move(ces);
+        } else if (k == "retry_policy" && v.is_object()) {
+            up["retry_policy"] = quarantine(v, {"max_retries", "initial_delay_ms",
+                                                "backoff_multiplier", "max_delay_ms"});
+        } else {
+            up[k] = v;
+        }
+    }
+    return up;
+}
+
 void GraphCompiler::verify_roundtrip(const json& definition,
                                      const CompiledGraph& cg) {
     const json a = canon(definition);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ add_executable(neograph_tests
     test_validator.cpp
     test_pbt_roundtrip.cpp
     test_corpus.cpp
+    test_elaborator.cpp
+    test_schema_evolution.cpp
     test_barrier_persistence.cpp
     test_coordinator.cpp
     test_sends_interrupt_order.cpp

--- a/tests/fixtures/schema_snapshot.json
+++ b/tests/fixtures/schema_snapshot.json
@@ -1,0 +1,259 @@
+{
+    "neograph_version": "0.11.1",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "topology": {
+        "type": "object",
+        "description": "NeoGraph topology definition consumed by GraphEngine::compile / the JSON loader.",
+        "properties": {
+            "schema_version": {
+                "type": "integer",
+                "description": "Topology schema version. 1 opts this document into strict compilation: every key must be consumed by the parser (unknown keys, typos, and silently-droppable constructs are hard errors), and translation validation failures throw instead of warning. Absent or 0 = legacy lenient parsing. Keys prefixed '_' or 'x-' are annotations and always allowed."
+            },
+            "name": {
+                "type": "string",
+                "description": "Optional graph name."
+            },
+            "channels": {
+                "type": "object",
+                "description": "State channels. Key = channel name.",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "reducer": {
+                            "type": "string",
+                            "default": "overwrite",
+                            "description": "Reducer name (see top-level 'reducers')."
+                        },
+                        "initial": {
+                            "description": "Initial value (any JSON)."
+                        }
+                    }
+                }
+            },
+            "nodes": {
+                "type": "object",
+                "description": "Graph nodes. Key = unique node name. 'type' selects a node type from 'node_types'; remaining fields are that type's config.",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "description": "Node type name (key in 'node_types')."
+                        },
+                        "barrier": {
+                            "type": "object",
+                            "description": "Opt into AND-join: fire only after every listed upstream node has signaled.",
+                            "properties": {
+                                "wait_for": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                }
+            },
+            "edges": {
+                "type": "array",
+                "description": "Edges. '__start__' and '__end__' are sentinel endpoints. An edge carrying a 'condition' (or type:'conditional') is a conditional edge (legacy inline form).",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "from": {
+                            "type": "string"
+                        },
+                        "to": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "string",
+                            "enum": [
+                                "conditional"
+                            ]
+                        },
+                        "condition": {
+                            "type": "string",
+                            "description": "Condition name (see 'conditions'); makes this a branch."
+                        },
+                        "routes": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "route key -> target node name."
+                        }
+                    },
+                    "required": [
+                        "from"
+                    ]
+                }
+            },
+            "conditional_edges": {
+                "type": "array",
+                "description": "Top-level conditional (branch) edges; LangGraph add_conditional_edges parity. NOTE: a compiler regression silently dropped this block in v0.1.0-v0.1.7 (fixed v0.1.8) — tooling round-trip tests MUST assert these survive loader->compile.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "from": {
+                            "type": "string"
+                        },
+                        "condition": {
+                            "type": "string",
+                            "description": "Condition name (see 'conditions')."
+                        },
+                        "routes": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            },
+                            "description": "route key -> target node name."
+                        }
+                    },
+                    "required": [
+                        "from",
+                        "condition"
+                    ]
+                }
+            },
+            "interrupt_before": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "description": "Node names to pause before (human-in-the-loop / checkpoint resume point)."
+            },
+            "interrupt_after": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                },
+                "description": "Node names to pause after (human-in-the-loop / checkpoint resume point)."
+            },
+            "retry_policy": {
+                "type": "object",
+                "description": "Optional engine retry-policy override."
+            }
+        },
+        "required": [
+            "nodes"
+        ]
+    },
+    "node_types": {
+        "subgraph": {
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "description": "Inner graph: an inline topology object, or a string path to a .json topology file.",
+                    "oneOf": [
+                        {
+                            "type": "object"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "input_map": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Map outer channel name -> inner channel name for inputs."
+                },
+                "output_map": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "description": "Map inner channel name -> outer channel name for outputs."
+                }
+            },
+            "required": [
+                "definition"
+            ]
+        },
+        "intent_classifier": {
+            "type": "object",
+            "properties": {
+                "prompt": {
+                    "type": "string",
+                    "description": "Classification prompt shown to the LLM."
+                },
+                "routes": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Allowed route keys the classifier may emit. Written to the __route__ channel; pair with the route_channel condition on an outgoing conditional edge."
+                }
+            },
+            "required": [
+                "routes"
+            ]
+        },
+        "tool_dispatch": {
+            "type": "object",
+            "properties": {},
+            "description": "Executes tool calls from the last assistant message using NodeContext tools; no type-specific config fields."
+        },
+        "llm_call": {
+            "type": "object",
+            "properties": {},
+            "description": "LLM call node. Uses the NodeContext provider/model; no type-specific config fields."
+        }
+    },
+    "node_effects": {
+        "intent_classifier": {
+            "reads": [
+                "messages"
+            ],
+            "writes": [
+                "__route__"
+            ]
+        },
+        "tool_dispatch": {
+            "reads": [
+                "messages"
+            ],
+            "writes": [
+                "messages"
+            ]
+        },
+        "llm_call": {
+            "reads": [
+                "messages"
+            ],
+            "writes": [
+                "messages"
+            ]
+        }
+    },
+    "reducers": [
+        "append",
+        "overwrite"
+    ],
+    "conditions": [
+        "has_tool_calls",
+        "route_channel"
+    ],
+    "condition_specs": {
+        "has_tool_calls": {
+            "labels": [
+                "false",
+                "true"
+            ],
+            "open": false
+        },
+        "route_channel": {
+            "labels": [
+                "default"
+            ],
+            "open": true
+        }
+    }
+}

--- a/tests/test_elaborator.cpp
+++ b/tests/test_elaborator.cpp
@@ -1,0 +1,341 @@
+// M4 elaboration-layer tests (issue #75): vars / templates / when /
+// source map / determinism, plus the upgrade chain's IR-equivalence
+// guarantee.
+//
+// The property under test for the DSL surface: every DSL document
+// normalizes to a UNIQUE core document (total, deterministic), errors
+// carry DSL source coordinates, and the expanded core sails through
+// the full strict pipeline (compile + validate + TV).
+
+#include <gtest/gtest.h>
+#include <neograph/neograph.h>
+#include <neograph/graph/compiler.h>
+#include <neograph/graph/elaborator.h>
+#include <neograph/graph/validator.h>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+class ENoopNode : public GraphNode {
+public:
+    explicit ENoopNode(std::string n) : name_(std::move(n)) {}
+    asio::awaitable<NodeOutput> run(NodeInput) override { co_return NodeOutput{}; }
+    std::string get_name() const override { return name_; }
+private:
+    std::string name_;
+};
+
+void ensure_etypes() {
+    NodeFactory::instance().register_type(
+        "enoop",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<ENoopNode>(name);
+        });
+}
+
+void expect_elab_error(const json& doc, std::initializer_list<const char*> fragments) {
+    try {
+        Elaborator::elaborate(doc);
+        FAIL() << "expected elaboration error";
+    } catch (const std::runtime_error& e) {
+        const std::string msg = e.what();
+        for (const char* f : fragments) {
+            EXPECT_NE(msg.find(f), std::string::npos)
+                << "missing '" << f << "' in: " << msg;
+        }
+    }
+}
+
+} // namespace
+
+// =========================================================================
+// vars
+// =========================================================================
+
+TEST(Elaborator, VarWholeValueAndInterpolation) {
+    json doc = {
+        {"vars", {{"target", "__end__"}, {"n", 3}, {"greet", "hello ${n} worlds"}}},
+        {"nodes", {{"a", {{"type", "enoop"}, {"note", {{"$var", "greet"}}}}}}},
+        {"edges", json::array({ {{"from", "__start__"}, {"to", "a"}},
+                                {{"from", "a"}, {"to", "${target}"}} })},
+    };
+    auto r = Elaborator::elaborate(doc);
+    EXPECT_EQ(r.core["nodes"]["a"]["note"].get<std::string>(), "hello 3 worlds");
+    EXPECT_EQ(r.core["edges"][1]["to"].get<std::string>(), "__end__");
+    EXPECT_FALSE(r.core.contains("vars"));
+}
+
+TEST(Elaborator, ExactInterpolationSubstitutesWholeValue) {
+    json doc = {
+        {"vars", {{"routes", json::array({"x", "y"})}}},
+        {"nodes", {{"a", {{"type", "enoop"}, {"routes", "${routes}"}}}}},
+    };
+    auto r = Elaborator::elaborate(doc);
+    EXPECT_TRUE(r.core["nodes"]["a"]["routes"].is_array());
+    EXPECT_EQ(r.core["nodes"]["a"]["routes"].size(), 2u);
+}
+
+TEST(Elaborator, ChainedVarsResolve) {
+    json doc = {
+        {"vars", {{"a", "v"}, {"b", "${a}-suffix"}, {"c", {{"$var", "b"}}}}},
+        {"nodes", {{"n", {{"type", "enoop"}, {"x", "${c}"}}}}},
+    };
+    auto r = Elaborator::elaborate(doc);
+    EXPECT_EQ(r.core["nodes"]["n"]["x"].get<std::string>(), "v-suffix");
+}
+
+TEST(Elaborator, VarCycleIsErrorWithCoordinate) {
+    json doc = {{"vars", {{"a", "${b}"}, {"b", "${a}"}}}, {"nodes", json::object()}};
+    expect_elab_error(doc, {"vars.", "cyclic"});
+}
+
+TEST(Elaborator, UnknownVarIsErrorWithPath) {
+    json doc = {{"nodes", {{"a", {{"type", "enoop"}, {"x", "${nope}"}}}}}};
+    expect_elab_error(doc, {"$.nodes.a.x", "nope"});
+}
+
+TEST(Elaborator, AnnotationsAreNotSubstituted) {
+    json doc = {{"_comment", "docs may say ${anything} freely"},
+                {"nodes", {{"a", {{"type", "enoop"},
+                                  {"_comment", "also ${here}"}}}}}};
+    auto r = Elaborator::elaborate(doc);
+    EXPECT_NE(r.core["_comment"].get<std::string>().find("${anything}"),
+              std::string::npos);
+}
+
+// =========================================================================
+// templates / use
+// =========================================================================
+
+namespace {
+
+json expert_dsl() {
+    return json{
+        {"schema_version", 1},
+        {"vars", {{"final", "__end__"}}},
+        {"templates", {{"expert", {
+            {"params", json::array({"target"})},
+            {"channels", {{"messages", {{"reducer", "append"}}}}},
+            {"nodes", {{"worker", {{"type", "enoop"},
+                                   {"tag", "@{target}"}}}}},
+            {"edges", json::array({
+                {{"from", "worker"}, {"to", {{"$param", "target"}}}} })},
+        }}}},
+        {"use", json::array({
+            {{"template", "expert"}, {"prefix", "math"},
+             {"args", {{"target", "__end__"}}}},
+            {{"template", "expert"}, {"prefix", "code"},
+             {"args", {{"target", {{"$var", "final"}}}}}},
+        })},
+        {"nodes", {{"router", {{"type", "enoop"}}}}},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "router"}},
+            {{"from", "router"}, {"to", "math_worker"}},
+            {{"from", "router"}, {"to", "code_worker"}} })},
+    };
+}
+
+} // namespace
+
+TEST(Elaborator, TemplateInstantiationPrefixesAndSubstitutes) {
+    ensure_etypes();
+    auto r = Elaborator::elaborate(expert_dsl());
+    const json& core = r.core;
+
+    ASSERT_TRUE(core["nodes"].contains("math_worker"));
+    ASSERT_TRUE(core["nodes"].contains("code_worker"));
+    EXPECT_EQ(core["nodes"]["math_worker"]["tag"].get<std::string>(), "__end__");
+    EXPECT_FALSE(core.contains("templates"));
+    EXPECT_FALSE(core.contains("use"));
+    // channels merged once, not duplicated or prefixed
+    EXPECT_TRUE(core["channels"].contains("messages"));
+
+    // Local refs prefixed; the $var arg resolved through the template.
+    bool math_edge = false, code_edge = false;
+    for (const auto& e : core["edges"]) {
+        if (e.value("from", "") == "math_worker")
+            math_edge = (e.value("to", "") == "__end__");
+        if (e.value("from", "") == "code_worker")
+            code_edge = (e.value("to", "") == "__end__");
+    }
+    EXPECT_TRUE(math_edge);
+    EXPECT_TRUE(code_edge);
+}
+
+TEST(Elaborator, ExpandedCoreSurvivesFullStrictPipeline) {
+    ensure_etypes();
+    auto r = Elaborator::elaborate(expert_dsl());
+    CompiledGraph cg;
+    ASSERT_NO_THROW(cg = GraphCompiler::compile(r.core, NodeContext{}))
+        << r.core.dump(2);
+    EXPECT_FALSE(GraphValidator::validate(cg).has_errors());
+    EXPECT_NO_THROW(GraphCompiler::verify_roundtrip(r.core, cg));
+}
+
+TEST(Elaborator, SourceMapPointsAtInstantiations) {
+    auto r = Elaborator::elaborate(expert_dsl());
+    bool found = false;
+    for (const auto& m : r.sourcemap) {
+        if (m["target"].get<std::string>() == "/nodes/math_worker") {
+            found = true;
+            EXPECT_NE(m["source"].get<std::string>().find("use[0]"), std::string::npos);
+            EXPECT_NE(m["source"].get<std::string>().find("'expert'"), std::string::npos);
+        }
+    }
+    EXPECT_TRUE(found) << r.sourcemap.dump(2);
+}
+
+TEST(Elaborator, WhenFalseSkipsInstantiation) {
+    auto doc = expert_dsl();
+    json uses = json::array();
+    uses.push_back({{"template", "expert"}, {"prefix", "math"},
+                    {"args", {{"target", "__end__"}}}, {"when", false}});
+    doc["use"] = uses;
+    doc["edges"] = json::array({ {{"from", "__start__"}, {"to", "router"}} });
+    auto r = Elaborator::elaborate(doc);
+    EXPECT_FALSE(r.core["nodes"].contains("math_worker"));
+    EXPECT_TRUE(r.core["nodes"].contains("router"));
+}
+
+TEST(Elaborator, ArgErrorsCarrySourceCoordinates) {
+    auto doc = expert_dsl();
+    json uses = json::array();
+    uses.push_back({{"template", "expert"}, {"prefix", "m"}, {"args", json::object()}});
+    doc["use"] = uses;
+    expect_elab_error(doc, {"use[0].args", "missing arg 'target'"});
+
+    uses = json::array();
+    uses.push_back({{"template", "expert"}, {"prefix", "m"},
+                    {"args", {{"target", "__end__"}, {"typo", 1}}}});
+    doc["use"] = uses;
+    expect_elab_error(doc, {"use[0].args", "unexpected arg 'typo'"});
+
+    uses = json::array();
+    uses.push_back({{"template", "ghost"}, {"prefix", "m"}, {"args", json::object()}});
+    doc["use"] = uses;
+    expect_elab_error(doc, {"use[0]", "unknown template 'ghost'"});
+}
+
+TEST(Elaborator, NodeCollisionIsError) {
+    auto doc = expert_dsl();
+    doc["nodes"]["math_worker"] = json{{"type", "enoop"}};
+    expect_elab_error(doc, {"use[0]", "math_worker", "collides"});
+}
+
+TEST(Elaborator, LeftoverParamOutsideTemplateIsError) {
+    json doc = {{"nodes", {{"a", {{"type", "enoop"},
+                                  {"cfg", {{"$param", "oops"}}}}}}}};
+    expect_elab_error(doc, {"$.nodes.a.cfg", "$param", "outside"});
+}
+
+// =========================================================================
+// totality / determinism / idempotence
+// =========================================================================
+
+TEST(Elaborator, DeterministicAndIdempotent) {
+    auto r1 = Elaborator::elaborate(expert_dsl());
+    auto r2 = Elaborator::elaborate(expert_dsl());
+    EXPECT_EQ(r1.core, r2.core);
+
+    // Elaboration is the identity on core documents.
+    auto r3 = Elaborator::elaborate(r1.core);
+    EXPECT_EQ(GraphCompiler::canon(r3.core), GraphCompiler::canon(r1.core));
+    EXPECT_TRUE(r3.sourcemap.empty());
+}
+
+// =========================================================================
+// upgrade chain: legacy corpus -> v1, IR-equivalent
+// =========================================================================
+
+namespace {
+
+json strip_version(const json& j) {
+    json out = json::object();
+    for (const auto& [k, v] : j.items()) {
+        if (k != "schema_version") out[k] = v;
+    }
+    return out;
+}
+
+} // namespace
+
+TEST(Upgrade, LegacyDocumentUpgradesToEquivalentIR) {
+    ensure_etypes();
+    // Legacy document exercising every quarantine rule: unknown
+    // top-level key, unknown retry key, empty barrier, inline
+    // conditional with dead 'to', unknown channel key.
+    json legacy = {
+        {"name", "legacy"},
+        {"conditionnal_edges", json::array()},               // the typo
+        {"channels", {{"c", {{"reducer", "append"}, {"initail", 1}}}}},
+        {"nodes", {{"a", {{"type", "enoop"},
+                          {"barrier", {{"wait_for", json::array()}}}}},
+                   {"b", {{"type", "enoop"}}}}},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "a"}},
+            {{"from", "a"}, {"to", "b"}, {"weight", 3}},
+            {{"from", "b"}, {"to", "__end__"},
+             {"condition", "route_channel"},
+             {"routes", {{"default", "__end__"}}}} })},
+        {"retry_policy", {{"max_retries", 2}, {"max_retry", 9}}},
+    };
+
+    // Legacy compiles leniently.
+    auto cg_legacy = GraphCompiler::compile(legacy, NodeContext{});
+
+    // Upgraded compiles STRICTLY (throws on any leftover refusal).
+    json up = GraphCompiler::upgrade_to_latest(legacy);
+    EXPECT_EQ(up["schema_version"].get<int>(), 1);
+    CompiledGraph cg_up;
+    ASSERT_NO_THROW(cg_up = GraphCompiler::compile(up, NodeContext{}))
+        << up.dump(2);
+
+    // Same IR modulo the version stamp (data quarantined into x- keys
+    // is annotation-invisible to canon on both sides).
+    EXPECT_EQ(GraphCompiler::canon(strip_version(cg_legacy.to_json())),
+              GraphCompiler::canon(strip_version(cg_up.to_json())))
+        << "legacy IR: " << cg_legacy.to_json().dump(2)
+        << "\nupgraded IR: " << cg_up.to_json().dump(2);
+
+    // Quarantine preserved the data.
+    EXPECT_TRUE(up.contains("x-upgraded-conditionnal_edges"));
+    EXPECT_TRUE(up["retry_policy"].contains("x-upgraded-max_retry"));
+    EXPECT_TRUE(up["channels"]["c"].contains("x-upgraded-initail"));
+    EXPECT_FALSE(up["nodes"]["a"].contains("barrier"));
+
+    // Already-current documents pass through unchanged.
+    EXPECT_EQ(GraphCompiler::upgrade_to_latest(up), up);
+}
+
+TEST(Upgrade, CorpusUpgradesLosslessly) {
+    // Every corpus fixture stripped to legacy form, upgraded, and both
+    // compiled — IR must match (fixture set from M3, all built-ins).
+    ensure_etypes();
+    std::filesystem::path here(__FILE__);
+    const auto dir = here.parent_path() / "fixtures" / "topology_corpus";
+    size_t checked = 0;
+    for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+        const auto fname = entry.path().filename().string();
+        if (fname == "manifest.json") continue;
+        std::ifstream f(entry.path());
+        std::string content((std::istreambuf_iterator<char>(f)),
+                            std::istreambuf_iterator<char>());
+        const json strict_doc = json::parse(content);
+        const json legacy = strip_version(strict_doc);
+
+        auto cg_legacy = GraphCompiler::compile(legacy, NodeContext{});
+        const json up = GraphCompiler::upgrade_to_latest(legacy);
+        CompiledGraph cg_up;
+        ASSERT_NO_THROW(cg_up = GraphCompiler::compile(up, NodeContext{})) << fname;
+        EXPECT_EQ(GraphCompiler::canon(strip_version(cg_legacy.to_json())),
+                  GraphCompiler::canon(strip_version(cg_up.to_json()))) << fname;
+        ++checked;
+    }
+    EXPECT_GE(checked, 15u);
+}

--- a/tests/test_schema_evolution.cpp
+++ b/tests/test_schema_evolution.cpp
@@ -1,0 +1,129 @@
+// M4 schema-evolution gate (issue #75): backward-compatibility check of
+// export_schema() against the checked-in snapshot
+// (tests/fixtures/schema_snapshot.json).
+//
+// The rule set is the decidable "add-only" subset of subschema checking
+// (JSON Subschema, arXiv:1911.12651; StableHLO/VHLO practice):
+//   - a node type / reducer / condition present in the snapshot must
+//     still exist;
+//   - a declared config property must not disappear, and the
+//     "required" list must not grow (old documents would be rejected);
+//   - a *closed* condition's label set must not change at all (E10
+//     route-completeness of existing documents depends on it);
+//   - declared node effects must not change for snapshot types
+//     (changed effects re-judge existing graphs).
+//
+// If this test fails, the change is version-visible: bump
+// kSupportedSchemaVersion, provide upgrade_vN_to_vN+1(), and
+// regenerate the snapshot (./example_export_schema >
+// tests/fixtures/schema_snapshot.json) in the SAME reviewed commit.
+// CI runs this test, so an incompatible schema change cannot merge
+// silently.
+
+#include <gtest/gtest.h>
+#include <neograph/neograph.h>
+#include <neograph/graph/loader.h>
+
+#include <filesystem>
+#include <fstream>
+#include <set>
+#include <string>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+json load_snapshot() {
+    std::filesystem::path here(__FILE__);
+    std::ifstream f(here.parent_path() / "fixtures" / "schema_snapshot.json");
+    EXPECT_TRUE(f.is_open());
+    std::string content((std::istreambuf_iterator<char>(f)),
+                        std::istreambuf_iterator<char>());
+    return json::parse(content);
+}
+
+std::set<std::string> string_set(const json& arr) {
+    std::set<std::string> s;
+    for (const auto& v : arr) s.insert(v.get<std::string>());
+    return s;
+}
+
+} // namespace
+
+TEST(SchemaEvolution, CurrentSchemaIsBackwardCompatibleWithSnapshot) {
+    const json snap = load_snapshot();
+    const json cur  = NodeFactory::instance().export_schema();
+
+    // Registries are process-global and other tests register extra
+    // types — the check is containment (snapshot ⊆ current), so test
+    // ordering cannot break it.
+
+    // Reducers / conditions: removal is breaking.
+    for (const auto& r : string_set(snap["reducers"])) {
+        EXPECT_TRUE(string_set(cur["reducers"]).count(r))
+            << "reducer '" << r << "' was removed — breaking change";
+    }
+    for (const auto& c : string_set(snap["conditions"])) {
+        EXPECT_TRUE(string_set(cur["conditions"]).count(c))
+            << "condition '" << c << "' was removed — breaking change";
+    }
+
+    // Node types: removal breaking; required must not grow; declared
+    // properties must not disappear.
+    for (const auto& [type, snap_schema] : snap["node_types"].items()) {
+        ASSERT_TRUE(cur["node_types"].contains(type))
+            << "node type '" << type << "' was removed — breaking change";
+        const json cur_schema = cur["node_types"][type];
+
+        std::set<std::string> snap_req, cur_req;
+        if (snap_schema.contains("required")) snap_req = string_set(snap_schema["required"]);
+        if (cur_schema.contains("required"))  cur_req  = string_set(cur_schema["required"]);
+        for (const auto& r : cur_req) {
+            EXPECT_TRUE(snap_req.count(r))
+                << "node type '" << type << "': new required field '" << r
+                << "' — old documents would be rejected (breaking)";
+        }
+        if (snap_schema.contains("properties")) {
+            for (const auto& [pk, pv] : snap_schema["properties"].items()) {
+                (void)pv;
+                EXPECT_TRUE(cur_schema.contains("properties")
+                            && cur_schema["properties"].contains(pk))
+                    << "node type '" << type << "': property '" << pk
+                    << "' was removed — strict mode would now refuse old documents";
+            }
+        }
+    }
+
+    // Closed conditions: label set is a contract E10 enforces on user
+    // routes — it must not change without a version bump.
+    for (const auto& [cname, snap_spec] : snap["condition_specs"].items()) {
+        ASSERT_TRUE(cur["condition_specs"].contains(cname))
+            << "condition spec '" << cname << "' was removed";
+        const json cur_spec = cur["condition_specs"][cname];
+        EXPECT_EQ(snap_spec["open"].get<bool>(), cur_spec["open"].get<bool>())
+            << "condition '" << cname << "': open/closed flipped";
+        if (!snap_spec["open"].get<bool>()) {
+            EXPECT_EQ(string_set(snap_spec["labels"]), string_set(cur_spec["labels"]))
+                << "closed condition '" << cname
+                << "': label set changed — existing routes re-judged (breaking)";
+        }
+    }
+
+    // Effects: a snapshot type's declared effects must be stable.
+    for (const auto& [type, snap_eff] : snap["node_effects"].items()) {
+        ASSERT_TRUE(cur["node_effects"].contains(type))
+            << "node type '" << type << "' lost its effect contract";
+        EXPECT_EQ(string_set(snap_eff["reads"]),
+                  string_set(cur["node_effects"][type]["reads"])) << type;
+        EXPECT_EQ(string_set(snap_eff["writes"]),
+                  string_set(cur["node_effects"][type]["writes"])) << type;
+    }
+
+    // Topology envelope: properties must not disappear.
+    for (const auto& [pk, pv] : snap["topology"]["properties"].items()) {
+        (void)pv;
+        EXPECT_TRUE(cur["topology"]["properties"].contains(pk))
+            << "topology property '" << pk << "' was removed — breaking change";
+    }
+}


### PR DESCRIPTION
## M4 — DSL 표면 (elaboration) + 스키마 진화 게이트, #75 4/4 (stacked on #78)

설계 근거: research doc §2 (코어 동결 + desugar 계층, Nickel/Dhall 구도; non-Turing-complete 상한이 컴파일 타임 보장의 전제)

### 무엇

1. **Elaborator** (`include/neograph/graph/elaborator.h`) — DSL 표면을 코어로 완전 전개:
   - `vars`: `{"$var":"x"}` 전체 치환 + `"${x}"` 문자열 보간 (정확일치 시 전체값). 비순환 강제 (cycle = 소스 좌표 에러)
   - `templates`+`use`: 파라미터 **정확 일치** 강제(누락/오타 args = 에러), 노드 `<prefix>_<이름>` 리네임 — 엣지 끝점·route 타깃·barrier wait_for의 로컬 참조까지 함께. 채널은 공유 상태 표면이라 의도적으로 전역 병합(동명 상이 정의 = 에러)
   - `when`: bool 조건부 포함
   - **total·결정론·멱등**: 유일 정규화 보장, 코어 문서에 항등. 주석 키(`_`/`x-`) 안은 치환 면제 (`_comment`의 `${...}`가 에러가 아님)
   - **소스맵**: 출력 위치 → 생성 구문 (`/nodes/math_worker` ← `use[0] template 'expert' prefix 'math'`)
2. **락파일 워크플로** — `./example_elaborate harness.dsl.json > harness.json` (+`--map`). E2E 스모크: vars 보간→prompt, when:false 스킵, 소스맵 정확 확인
3. **`upgrade_to_latest()`** — v0→v1 무손실: strict가 거부할 모든 키를 `x-upgraded-<키>`로 격리(삭제 0), 빈 barrier 명시 제거
4. **스키마 진화 게이트** — `schema_snapshot.json` 대비 add-only 부분집합 판정(JSON Subschema arXiv:1911.12651의 결정가능 서브셋): 타입/프로퍼티/reducer/condition 제거·required 증가·closed 라벨 변경·effect 변경 = 테스트 실패 = **CI 머지 차단**. 비호환은 버전 범프+업그레이더+스냅샷 재생성을 같은 커밋에서 강제

### 완료 조건 검증

- [x] 유일 정규화 + 소스 좌표 에러: 결정론/멱등 테스트 + 에러 좌표 단언 (`use[0].args: missing arg 'target'` 등)
- [x] 비호환 스키마 변경 머지 차단: SchemaEvolution 테스트가 CI에서 실행
- [x] 구버전 코퍼스 업그레이드 후 IR 동치: 15픽스처 + 전 격리 규칙 발현 픽스처에서 canon(legacy IR)==canon(upgraded IR) (버전 스탬프 제외)
- [x] 전체 578/578 통과 (신규 17 테스트)

이로써 #75 M1~M4 전 마일스톤 완료. 체인: #76 ← #77 ← #78 ← 이 PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
