### PR TITLE
Make the library installable and consumable via find_package(NeoGraph)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,3 +643,35 @@ jobs:
           ./build-fuzz/tests/fuzz/fuzz_graph_compile \
             -max_total_time=60 -timeout=10 -seed=42 \
             tests/fuzz/corpus/graph_compile/
+
+  # Can a downstream project actually consume an installed NeoGraph?
+  #
+  # No other job can answer this. Every test and example in the repo links
+  # against the build tree, where headers, vendored deps and libraries are all
+  # reachable by accident. `cmake --install` shipped headers and nothing to link
+  # against, with no package config at all, for the entire life of the project
+  # (issue #92) — and the whole suite stayed green throughout.
+  #
+  # This job installs into a throwaway prefix and builds a consumer that sees
+  # nothing but that prefix. It is the only thing standing between us and that
+  # gap reopening.
+  install-consumable:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            cmake \
+            build-essential \
+            libpq-dev \
+            libsqlite3-dev \
+            libssl-dev \
+            libcurl4-openssl-dev \
+            pkg-config
+
+      - name: find_package(NeoGraph) from a clean install prefix
+        run: ./scripts/test_find_package.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,8 +215,25 @@ find_package(Threads REQUIRED)
 set(DEPS_DIR ${PROJECT_SOURCE_DIR}/deps)
 
 # yyjson (C, compiled) — used by all modules for JSON parse/write
+# GNUInstallDirs early: the vendored targets below need CMAKE_INSTALL_INCLUDEDIR
+# for their INSTALL_INTERFACE include paths. Including it twice is harmless.
+include(GNUInstallDirs)
+
+# Vendored deps that leak through NeoGraph's PUBLIC headers must be consumable
+# from an install tree, not just from the build tree (issue #92). asio appears in
+# 18 public headers (provider.h returns asio::awaitable), yyjson in json.h, and
+# concurrentqueue in util/request_queue.h — so a downstream project cannot even
+# *compile* against an installed NeoGraph unless these ship with it and the
+# exported targets point at the installed copies.
+#
+# They install under include/neograph/vendor/ rather than the include root, so a
+# consumer's own asio or httplib is not shadowed by ours.
+set(NEOGRAPH_VENDOR_INSTALL_INCLUDEDIR ${CMAKE_INSTALL_INCLUDEDIR}/neograph/vendor)
+
 add_library(yyjson STATIC ${DEPS_DIR}/yyjson/yyjson.c)
-target_include_directories(yyjson PUBLIC ${DEPS_DIR}/yyjson)
+target_include_directories(yyjson PUBLIC
+    $<BUILD_INTERFACE:${DEPS_DIR}/yyjson>
+    $<INSTALL_INTERFACE:${NEOGRAPH_VENDOR_INSTALL_INCLUDEDIR}>)
 set_target_properties(yyjson PROPERTIES POSITION_INDEPENDENT_CODE ON)
 if(NOT MSVC)
     target_compile_options(yyjson PRIVATE -O2)
@@ -224,7 +241,9 @@ endif()
 
 # cpp-httplib (header-only) — used by llm and mcp (PRIVATE)
 add_library(httplib INTERFACE)
-target_include_directories(httplib INTERFACE ${DEPS_DIR})
+target_include_directories(httplib INTERFACE
+    $<BUILD_INTERFACE:${DEPS_DIR}>
+    $<INSTALL_INTERFACE:${NEOGRAPH_VENDOR_INSTALL_INCLUDEDIR}>)
 # Windows: httplib hard-errors unless _WIN32_WINNT >= 0x0A00 (Windows 10).
 # Set it on the INTERFACE so every TU that links httplib picks it up,
 # regardless of whether it also links asio.
@@ -246,18 +265,24 @@ endif()
 
 # moodycamel::ConcurrentQueue (header-only) — used by util (PRIVATE)
 add_library(concurrentqueue INTERFACE)
-target_include_directories(concurrentqueue INTERFACE ${DEPS_DIR})
+target_include_directories(concurrentqueue INTERFACE
+    $<BUILD_INTERFACE:${DEPS_DIR}>
+    $<INSTALL_INTERFACE:${NEOGRAPH_VENDOR_INSTALL_INCLUDEDIR}>)
 
 # cppdotenv (header-only) — used by examples that read .env for API keys
 add_library(cppdotenv INTERFACE)
-target_include_directories(cppdotenv INTERFACE ${DEPS_DIR})
+target_include_directories(cppdotenv INTERFACE
+    $<BUILD_INTERFACE:${DEPS_DIR}>
+    $<INSTALL_INTERFACE:${NEOGRAPH_VENDOR_INSTALL_INCLUDEDIR}>)
 
 # standalone asio (header-only) — used by the async runtime layer.
 # Vendored as `deps/asio/include/` so the public macro ASIO_STANDALONE
 # turns off the Boost.System coupling. Any TU linking this must also
 # link a threads lib (std::thread backend).
 add_library(asio INTERFACE)
-target_include_directories(asio INTERFACE ${DEPS_DIR}/asio/include)
+target_include_directories(asio INTERFACE
+    $<BUILD_INTERFACE:${DEPS_DIR}/asio/include>
+    $<INSTALL_INTERFACE:${NEOGRAPH_VENDOR_INSTALL_INCLUDEDIR}>)
 target_compile_definitions(asio INTERFACE ASIO_STANDALONE ASIO_NO_DEPRECATED)
 # Windows: target Windows 10+ so httplib compiles (it hard-errors on
 # _WIN32_WINNT < 0x0A00) and asio's newer overlapped/pipe paths light up.
@@ -1449,6 +1474,124 @@ if(NEOGRAPH_INSTALL_HEADERS)
 
     install(DIRECTORY schemas/
         DESTINATION ${CMAKE_INSTALL_DATADIR}/neograph/schemas)
+
+    # ── Vendored headers that leak through the public API (issue #92) ──
+    #
+    # Without these an installed NeoGraph does not compile downstream: 18 public
+    # headers include <asio/...>, json.h includes <yyjson.h>, and
+    # util/request_queue.h includes <concurrentqueue.h>. httplib and cppdotenv
+    # ship too — they appear in PRIVATE link interfaces, which still surface as
+    # $<LINK_ONLY:...> entries in the export set, so the export would be
+    # rejected without them.
+    install(DIRECTORY ${DEPS_DIR}/asio/include/asio
+        DESTINATION ${NEOGRAPH_VENDOR_INSTALL_INCLUDEDIR})
+    install(FILES
+            ${DEPS_DIR}/yyjson/yyjson.h
+            ${DEPS_DIR}/httplib.h
+            ${DEPS_DIR}/concurrentqueue.h
+        DESTINATION ${NEOGRAPH_VENDOR_INSTALL_INCLUDEDIR})
+    if(EXISTS ${DEPS_DIR}/cppdotenv)
+        install(DIRECTORY ${DEPS_DIR}/cppdotenv
+            DESTINATION ${NEOGRAPH_VENDOR_INSTALL_INCLUDEDIR})
+    endif()
+endif()
+
+# ── Export set: the libraries themselves, and find_package() support ────────
+#
+# Before this, `cmake --install` laid down headers and nothing to link against,
+# and there was no package config at all — so `find_package(NeoGraph)` failed
+# outright and the only way to consume the engine was to vendor its whole source
+# tree as a subdirectory. For a library whose pitch is "embed this in your app",
+# that was the most embarrassing gap on the list (issue #92).
+#
+# Exported target names match the in-tree ALIAS names (neograph::core, ...), so
+# the same target_link_libraries line works whether a project consumes NeoGraph
+# via add_subdirectory or via find_package.
+# Default OFF for wheel builds. scikit-build-core packages whatever
+# `cmake --install` lays down, so leaving this on would drop lib/*.a and
+# lib/cmake/NeoGraph/ into the wheel alongside the Python extension — the same
+# reason NEOGRAPH_INSTALL_HEADERS is turned off there. The wheel installs the
+# engine shared objects through its own rules further down.
+if(NEOGRAPH_BUILD_PYBIND)
+    set(_neograph_install_export_default OFF)
+else()
+    set(_neograph_install_export_default ON)
+endif()
+
+option(NEOGRAPH_INSTALL_EXPORT
+    "Install libraries + NeoGraphConfig.cmake for find_package (off for wheel builds)"
+    ${_neograph_install_export_default})
+
+if(NEOGRAPH_INSTALL_EXPORT)
+    set(NEOGRAPH_EXPORT_TARGETS neograph_core yyjson asio)
+    set(NEOGRAPH_COMPONENTS_BUILT core)
+
+    # Vendored INTERFACE targets referenced by any exported link interface must
+    # be in the export set, PRIVATE ones included.
+    foreach(_vendor httplib concurrentqueue cppdotenv)
+        if(TARGET ${_vendor})
+            list(APPEND NEOGRAPH_EXPORT_TARGETS ${_vendor})
+        endif()
+    endforeach()
+
+    foreach(_comp async llm mcp a2a acp util postgres sqlite)
+        if(TARGET neograph_${_comp})
+            list(APPEND NEOGRAPH_EXPORT_TARGETS neograph_${_comp})
+            list(APPEND NEOGRAPH_COMPONENTS_BUILT ${_comp})
+        endif()
+    endforeach()
+
+    # neograph_core -> neograph::core, asio -> neograph::asio, and so on.
+    foreach(_t ${NEOGRAPH_EXPORT_TARGETS})
+        string(REGEX REPLACE "^neograph_" "" _export_name ${_t})
+        set_target_properties(${_t} PROPERTIES EXPORT_NAME ${_export_name})
+    endforeach()
+
+    install(TARGETS ${NEOGRAPH_EXPORT_TARGETS}
+        EXPORT  NeoGraphTargets
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+    install(EXPORT NeoGraphTargets
+        FILE        NeoGraphTargets.cmake
+        NAMESPACE   neograph::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/NeoGraph)
+
+    # Re-find, in the consumer's configure, whatever the engine build actually
+    # linked. Writing these out per-build rather than hardcoding them is the
+    # point: an install that was built without libpq must not make its consumers
+    # hunt for PostgreSQL.
+    set(NEOGRAPH_CONFIG_DEPENDENCIES "find_dependency(Threads)")
+    if(TARGET neograph_async OR TARGET neograph_llm)
+        string(APPEND NEOGRAPH_CONFIG_DEPENDENCIES "\nfind_dependency(OpenSSL)")
+    endif()
+    if(TARGET neograph_postgres)
+        string(APPEND NEOGRAPH_CONFIG_DEPENDENCIES "\nfind_dependency(PostgreSQL)")
+    endif()
+    if(TARGET neograph_sqlite)
+        string(APPEND NEOGRAPH_CONFIG_DEPENDENCIES "\nfind_dependency(SQLite3)")
+    endif()
+    if(NEOGRAPH_USE_LIBCURL AND CURL_FOUND)
+        string(APPEND NEOGRAPH_CONFIG_DEPENDENCIES "\nfind_dependency(CURL)")
+    endif()
+
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(
+        ${PROJECT_SOURCE_DIR}/cmake/NeoGraphConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/NeoGraphConfig.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/NeoGraph)
+
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/NeoGraphConfigVersion.cmake
+        VERSION       ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion)
+
+    install(FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/NeoGraphConfig.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/NeoGraphConfigVersion.cmake
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/NeoGraph)
 endif()
 
 # ── Pybind11 wheel install ───────────────────────────────────────────────

--- a/cmake/NeoGraphConfig.cmake.in
+++ b/cmake/NeoGraphConfig.cmake.in
@@ -1,0 +1,24 @@
+@PACKAGE_INIT@
+
+# Package config for a downstream `find_package(NeoGraph CONFIG REQUIRED)`.
+#
+# The engine's optional pieces (llm, mcp, a2a, acp, postgres, sqlite) are built
+# or not depending on which system libraries were present at engine-build time,
+# so the set of exported targets varies per install. The dependency lookups below
+# are written out at configure time to match what was actually built — see
+# NEOGRAPH_CONFIG_DEPENDENCIES in the top-level CMakeLists.
+#
+# Consumers link the same target names they would use as a subdirectory:
+#
+#   find_package(NeoGraph CONFIG REQUIRED)
+#   target_link_libraries(app PRIVATE neograph::core neograph::llm)
+
+include(CMakeFindDependencyMacro)
+
+@NEOGRAPH_CONFIG_DEPENDENCIES@
+
+include("${CMAKE_CURRENT_LIST_DIR}/NeoGraphTargets.cmake")
+
+set(NEOGRAPH_COMPONENTS_BUILT "@NEOGRAPH_COMPONENTS_BUILT@")
+
+check_required_components(NeoGraph)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,6 +141,11 @@ cmake.args = [
     # Skip the include/ + share/ install rules so they don't end up
     # in the wheel layout.
     "-DNEOGRAPH_INSTALL_HEADERS=OFF",
+    # Same reasoning for the C++ find_package export: lib/*.{a,so} plus
+    # lib/cmake/NeoGraph/ have no business in a Python wheel. CMakeLists
+    # already defaults this OFF when NEOGRAPH_BUILD_PYBIND is on; stating it
+    # here keeps the wheel's layout independent of that default.
+    "-DNEOGRAPH_INSTALL_EXPORT=OFF",
 ]
 
 # Headers + schemas would otherwise land in the wheel under

--- a/scripts/test_find_package.sh
+++ b/scripts/test_find_package.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Can a downstream CMake project actually consume an installed NeoGraph?
+#
+# Builds the engine, installs it into a throwaway prefix, then configures,
+# builds and runs tests/integration/find_package — a project that sees nothing
+# but that prefix. This is the only test that can catch a broken install: every
+# unit test in the repo links against the build tree, where the headers, the
+# vendored deps and the libraries are all reachable by accident.
+#
+#   exit 0 — a consumer can find_package(NeoGraph), link neograph::core, and run
+#   exit 1 — it cannot, at whichever of the four stages failed
+#
+# Usage: scripts/test_find_package.sh [--keep]
+set -uo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+work=$(mktemp -d -t ng-findpkg-XXXXXX)
+keep=${1:-}
+
+cleanup() { [[ "$keep" == "--keep" ]] || rm -rf "$work"; }
+trap cleanup EXIT
+
+prefix="$work/prefix"
+echo "── prefix: $prefix"
+
+step() { echo; echo "── $1"; }
+fail() { echo "   FAILED: $1"; exit 1; }
+
+step "1/4 configure engine"
+cmake -S "$repo_root" -B "$work/build" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_INSTALL_PREFIX="$prefix" \
+    -DNEOGRAPH_BUILD_TESTS=OFF \
+    -DNEOGRAPH_BUILD_EXAMPLES=OFF \
+    > "$work/configure.log" 2>&1 || { tail -20 "$work/configure.log"; fail "engine configure"; }
+
+step "2/4 build + install engine"
+cmake --build "$work/build" -j"$(nproc)" --target install \
+    > "$work/install.log" 2>&1 || { tail -20 "$work/install.log"; fail "engine build/install"; }
+
+echo "   installed libraries:"
+find "$prefix" -name 'libneograph_*' -o -name 'neograph_*.lib' 2>/dev/null \
+    | sed 's|^|     |' || true
+echo "   package config:"
+find "$prefix" -name 'NeoGraphConfig.cmake' 2>/dev/null | sed 's|^|     |' || true
+
+step "3/4 configure consumer against the prefix"
+cmake -S "$repo_root/tests/integration/find_package" -B "$work/consumer" \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_PREFIX_PATH="$prefix" \
+    > "$work/consumer-configure.log" 2>&1 \
+    || { tail -20 "$work/consumer-configure.log"; fail "find_package(NeoGraph) — the consumer cannot see the package"; }
+
+step "4/4 build + run consumer"
+cmake --build "$work/consumer" -j"$(nproc)" \
+    > "$work/consumer-build.log" 2>&1 \
+    || { tail -30 "$work/consumer-build.log"; fail "consumer build — headers or link"; }
+
+out=$("$work/consumer/consumer") || fail "consumer run"
+echo "   consumer says: $out"
+
+echo
+echo "── OK: an installed NeoGraph is consumable via find_package"

--- a/tests/integration/find_package/CMakeLists.txt
+++ b/tests/integration/find_package/CMakeLists.txt
@@ -1,0 +1,13 @@
+# A throwaway downstream project. It knows nothing about NeoGraph's source tree
+# — it only sees an install prefix, exactly like a real consumer would.
+#
+# If this configures, builds and runs, then `find_package(NeoGraph)` works. If
+# it does not, the library is not consumable no matter how green the unit tests
+# are (issue #92).
+cmake_minimum_required(VERSION 3.16)
+project(neograph_consumer LANGUAGES CXX)
+
+find_package(NeoGraph CONFIG REQUIRED)
+
+add_executable(consumer main.cpp)
+target_link_libraries(consumer PRIVATE neograph::core)

--- a/tests/integration/find_package/main.cpp
+++ b/tests/integration/find_package/main.cpp
@@ -1,0 +1,33 @@
+// The smallest program that proves an installed NeoGraph is actually usable:
+// include a public header, construct engine types, run a graph, print the result.
+//
+// It deliberately touches a header that pulls in the vendored asio
+// (graph/engine.h ships asio::awaitable through the coroutine surface) and one
+// that pulls in the vendored yyjson (json.h). Those are the dependencies that
+// leak through NeoGraph's public API, so a consumer cannot compile unless the
+// install ships them and the exported targets point at them. Linking alone is
+// not enough — this has to *compile*.
+
+#include <neograph/neograph.h>
+
+#include <cstdlib>
+#include <iostream>
+
+int main() {
+    using namespace neograph;
+    using namespace neograph::graph;
+
+    GraphState state;
+    state.init_channel("greeting", ReducerType::OVERWRITE,
+                       ReducerRegistry::instance().get("overwrite"), json(""));
+    state.write("greeting", json("hello from an installed NeoGraph"));
+
+    const auto value = state.get("greeting").get<std::string>();
+    std::cout << value << "\n";
+
+    if (value != "hello from an installed NeoGraph") {
+        std::cerr << "unexpected channel value\n";
+        return EXIT_FAILURE;
+    }
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
`cmake --install` shipped headers and no libraries. A downstream project could not link NeoGraph at all — `find_package(NeoGraph)` failed at configure time because no `NeoGraphConfig.cmake` was ever generated.

The cause ran deeper than a missing `install(TARGETS)`: the vendored dependencies leak through the public headers (18 public headers include `<asio/...>`, `json.h` includes `<yyjson.h>`, `util/request_queue.h` includes `<concurrentqueue.h>`). Installing headers alone leaves a consumer unable to *compile*, never mind link.

**What this does**

- Installs the vendored headers under `include/neograph/vendor/` — not at the include root, so a consumer's own asio/httplib is not shadowed.
- `install(TARGETS ... EXPORT NeoGraphTargets)` + `install(EXPORT ... NAMESPACE neograph::)`, so the exported target names match the in-tree aliases: `add_subdirectory` and `find_package` link with the same line.
- `NeoGraphConfig.cmake` re-finds only the optional dependencies that were actually present at build time — an install built without libpq must not make its consumer hunt for PostgreSQL.
- `NEOGRAPH_INSTALL_EXPORT` defaults OFF under `NEOGRAPH_BUILD_PYBIND`, or the Python wheels would carry `lib/*.a` and `lib/cmake/`.

**Verification**

New `install-consumable` CI job: install to a temp prefix, then configure + build + run a separate consumer project against it. Before: 0 libraries installed, configure dies. After: 8 libraries + config installed, consumer builds and runs.

Worth stating plainly: **CI was 100% green for the entire time the library was unusable from an install.** Every test and example links against the build tree, where the headers, vendored deps and libraries all happen to be visible. Nothing exercised the installed artifact. That job is what stops this rotting again.

ctest 595/595, examples build clean.

Closes #92.