### PR TITLE
One implementation of "run the assistant's tool_calls" — Agent was serial, ToolNode was parallel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,6 +405,7 @@ add_library(neograph_core
     src/core/scheduler.cpp
     src/core/graph_state.cpp
     src/core/graph_node.cpp
+    src/core/tool_dispatch.cpp
     src/core/graph_loader.cpp
     src/core/graph_checkpoint.cpp
     src/core/react_graph.cpp

--- a/include/neograph/llm/agent.h
+++ b/include/neograph/llm/agent.h
@@ -107,6 +107,10 @@ class NEOGRAPH_API Agent {
 
     void ensure_system_message(std::vector<ChatMessage>& messages);
     std::vector<ChatTool> get_tool_definitions() const;
+
+    /// Non-owning view of `tools_` for `dispatch_tool_calls`, the one place
+    /// tool execution is implemented (shared with graph::ToolDispatchNode).
+    std::vector<Tool*> tool_ptrs() const;
 };
 
 } // namespace neograph::llm

--- a/include/neograph/tool_dispatch.h
+++ b/include/neograph/tool_dispatch.h
@@ -1,0 +1,59 @@
+/**
+ * @file tool_dispatch.h
+ * @brief The single implementation of "execute an assistant message's tool_calls".
+ *
+ * Before this existed the concept lived in two places — ToolDispatchNode (graph
+ * path) and Agent (standalone path) — and they had drifted: the node fanned the
+ * calls out concurrently, the agent ran them one at a time through the blocking
+ * execute() facade. Measured on three 300 ms async tools: 300 ms via the node,
+ * 900 ms via the agent (issue #87).
+ *
+ * The performance gap was the symptom. The defect was the duplication: every
+ * capability added at this boundary — interception, per-call interrupt, token
+ * accounting — would have landed in one path and silently missed the other,
+ * exactly as concurrency did. Both callers now route through the function below
+ * and nowhere else.
+ *
+ * **Concurrency contract.** Calls are launched together, so a tool that really
+ * suspends (one that overrides `execute_async`) overlaps with its siblings and
+ * may be entered concurrently with itself if the model asked for it twice. A
+ * tool that implements only the sync `execute()` never overlaps: the default
+ * `Tool::execute_async` body runs to completion before the coroutine's first
+ * suspension, so the calls serialize even inside the parallel group. That is
+ * why unifying the two paths cannot introduce a data race into an existing sync
+ * tool — see ToolDispatchParity.SyncToolsDoNotOverlapOnToolNode, which pins the
+ * behavior at 900 ms for three 300 ms sync tools.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/types.h>
+#include <neograph/tool.h>
+
+#include <asio/awaitable.hpp>
+
+#include <vector>
+
+namespace neograph {
+
+/**
+ * @brief Execute every tool call in @p calls and return one tool message each.
+ *
+ * Results come back in **call order**, not completion order, so the caller's
+ * message history is deterministic regardless of which tool finished first.
+ *
+ * Never throws on a per-call failure. A call naming an unregistered tool, an
+ * unparseable argument payload, or a tool that throws all yield a tool message
+ * whose content is an `{"error": "..."}` object — the model sees the failure and
+ * can react to it, which is the behavior both callers already had.
+ *
+ * @param calls Tool calls from the assistant message. Taken **by value**: this
+ *        is a coroutine, and a reference parameter would dangle across the first
+ *        suspension.
+ * @param tools Non-owning tool pointers to resolve names against. Also by value,
+ *        for the same reason. The pointees must outlive the returned awaitable.
+ */
+NEOGRAPH_API asio::awaitable<std::vector<ChatMessage>>
+dispatch_tool_calls(std::vector<ToolCall> calls, std::vector<Tool*> tools);
+
+}  // namespace neograph

--- a/src/core/graph_node.cpp
+++ b/src/core/graph_node.cpp
@@ -1,6 +1,7 @@
 #include <neograph/graph/node.h>
 #include <neograph/graph/engine.h>   // RunContext (forward-declared in node.h)
 #include <neograph/async/run_sync.h>
+#include <neograph/tool_dispatch.h>
 #include <asio/co_spawn.hpp>
 #include <asio/deferred.hpp>
 #include <asio/experimental/parallel_group.hpp>
@@ -135,84 +136,15 @@ asio::awaitable<NodeOutput> ToolDispatchNode::run(NodeInput in) {
     }
     if (!assistant_msg) co_return NodeOutput{};
 
-    const auto& calls = assistant_msg->tool_calls;
-
-    // One worker coroutine per tool call. Each resolves the matching
-    // tool and awaits its execute_async; errors (tool-not-found, parse
-    // failure, tool exception) are captured into the result message so
-    // a worker never throws. The workers are launched together so their
-    // I/O-bound work overlaps — e.g. several MCP round-trips stay in
-    // flight at once instead of running one-by-one through the blocking
-    // execute() facade. Results are applied in call order, independent
-    // of which worker finished first.
-    auto worker = [this](ToolCall tc) -> asio::awaitable<ChatMessage> {
-        ChatMessage tool_msg;
-        tool_msg.role         = "tool";
-        tool_msg.tool_call_id = tc.id;
-        tool_msg.tool_name    = tc.name;
-
-        auto it = std::find_if(tools_.begin(), tools_.end(),
-            [&](Tool* t) { return t->get_name() == tc.name; });
-        if (it == tools_.end()) {
-            tool_msg.content = R"({"error": "Tool not found: )" + tc.name + "\"}";
-            co_return tool_msg;
-        }
-        try {
-            auto args = json::parse(tc.arguments);
-            tool_msg.content = co_await (*it)->execute_async(args);
-        } catch (const std::exception& e) {
-            tool_msg.content = std::string(R"({"error": ")") + e.what() + "\"}";
-        }
-        co_return tool_msg;
-    };
+    // Tool execution lives in exactly one place (issue #87): both this node and
+    // llm::Agent route through dispatch_tool_calls(). When the two had separate
+    // copies they drifted — this one fanned the calls out, the agent ran them
+    // one at a time — and every future capability at this boundary would have
+    // drifted the same way.
+    auto tool_msgs = co_await dispatch_tool_calls(assistant_msg->tool_calls, tools_);
 
     json results = json::array();
-
-    // Single call: run inline, skip the parallel-group machinery.
-    if (calls.size() == 1) {
-        ChatMessage m = co_await worker(calls.front());
-        json mj;
-        to_json(mj, m);
-        results.push_back(mj);
-        NodeOutput out;
-        out.writes.push_back(ChannelWrite{"messages", results});
-        co_return out;
-    }
-
-    // Multiple calls: fan them out via the same parallel-group idiom the
-    // engine uses for independent nodes within a super-step.
-    auto ex = co_await asio::this_coro::executor;
-    using DeferredOp = decltype(asio::co_spawn(
-        ex, worker(std::declval<ToolCall>()), asio::deferred));
-    std::vector<DeferredOp> ops;
-    ops.reserve(calls.size());
-    for (const auto& tc : calls) {
-        ops.push_back(asio::co_spawn(ex, worker(tc), asio::deferred));
-    }
-
-    auto [order, excs, values] = co_await asio::experimental::make_parallel_group(
-        std::move(ops))
-        .async_wait(asio::experimental::wait_for_all(), asio::use_awaitable);
-    (void)order;  // results are applied in call order, not completion order
-
-    for (std::size_t i = 0; i < values.size(); ++i) {
-        ChatMessage m;
-        if (excs[i]) {
-            // Workers catch their own exceptions, so this is a defensive
-            // fallback (e.g. bad_alloc) keyed to the originating call.
-            m.role         = "tool";
-            m.tool_call_id = calls[i].id;
-            m.tool_name    = calls[i].name;
-            try {
-                std::rethrow_exception(excs[i]);
-            } catch (const std::exception& e) {
-                m.content = std::string(R"({"error": ")") + e.what() + "\"}";
-            } catch (...) {
-                m.content = R"({"error": "unknown tool failure"})";
-            }
-        } else {
-            m = std::move(values[i]);
-        }
+    for (const auto& m : tool_msgs) {
         json mj;
         to_json(mj, m);
         results.push_back(mj);

--- a/src/core/tool_dispatch.cpp
+++ b/src/core/tool_dispatch.cpp
@@ -1,0 +1,90 @@
+#include <neograph/tool_dispatch.h>
+
+#include <asio/co_spawn.hpp>
+#include <asio/deferred.hpp>
+#include <asio/experimental/parallel_group.hpp>
+#include <asio/this_coro.hpp>
+#include <asio/use_awaitable.hpp>
+
+#include <algorithm>
+#include <utility>
+
+namespace neograph {
+
+asio::awaitable<std::vector<ChatMessage>>
+dispatch_tool_calls(std::vector<ToolCall> calls, std::vector<Tool*> tools) {
+    std::vector<ChatMessage> results;
+    if (calls.empty()) co_return results;
+
+    // One worker per call. Resolves the tool, awaits execute_async, and folds
+    // every failure mode (unknown tool, bad arguments, throwing tool) into the
+    // returned message so a worker never propagates an exception into the
+    // parallel group.
+    auto worker = [tools](ToolCall tc) -> asio::awaitable<ChatMessage> {
+        ChatMessage tool_msg;
+        tool_msg.role         = "tool";
+        tool_msg.tool_call_id = tc.id;
+        tool_msg.tool_name    = tc.name;
+
+        auto it = std::find_if(tools.begin(), tools.end(),
+            [&](Tool* t) { return t->get_name() == tc.name; });
+        if (it == tools.end()) {
+            tool_msg.content = R"({"error": "Tool not found: )" + tc.name + "\"}";
+            co_return tool_msg;
+        }
+        try {
+            auto args = json::parse(tc.arguments);
+            tool_msg.content = co_await (*it)->execute_async(args);
+        } catch (const std::exception& e) {
+            tool_msg.content = std::string(R"({"error": ")") + e.what() + "\"}";
+        }
+        co_return tool_msg;
+    };
+
+    // Single call: run inline, skip the parallel-group machinery.
+    if (calls.size() == 1) {
+        results.push_back(co_await worker(calls.front()));
+        co_return results;
+    }
+
+    // Multiple calls: fan them out via the same parallel-group idiom the engine
+    // uses for independent nodes within a super-step.
+    auto ex = co_await asio::this_coro::executor;
+    using DeferredOp = decltype(asio::co_spawn(
+        ex, worker(std::declval<ToolCall>()), asio::deferred));
+    std::vector<DeferredOp> ops;
+    ops.reserve(calls.size());
+    for (const auto& tc : calls) {
+        ops.push_back(asio::co_spawn(ex, worker(tc), asio::deferred));
+    }
+
+    auto [order, excs, values] = co_await asio::experimental::make_parallel_group(
+        std::move(ops))
+        .async_wait(asio::experimental::wait_for_all(), asio::use_awaitable);
+    (void)order;  // results are applied in call order, not completion order
+
+    results.reserve(values.size());
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        if (excs[i]) {
+            // Workers catch their own exceptions, so this is a defensive
+            // fallback (e.g. bad_alloc) keyed to the originating call.
+            ChatMessage m;
+            m.role         = "tool";
+            m.tool_call_id = calls[i].id;
+            m.tool_name    = calls[i].name;
+            try {
+                std::rethrow_exception(excs[i]);
+            } catch (const std::exception& e) {
+                m.content = std::string(R"({"error": ")") + e.what() + "\"}";
+            } catch (...) {
+                m.content = R"({"error": "unknown tool failure"})";
+            }
+            results.push_back(std::move(m));
+        } else {
+            results.push_back(std::move(values[i]));
+        }
+    }
+    co_return results;
+}
+
+}  // namespace neograph

--- a/src/llm/agent.cpp
+++ b/src/llm/agent.cpp
@@ -1,10 +1,18 @@
 #include <neograph/llm/agent.h>
 #include <neograph/async/run_sync.h>
+#include <neograph/tool_dispatch.h>
 #include <algorithm>
 #include <iostream>
 #include <stdexcept>
 
 namespace neograph::llm {
+
+std::vector<Tool*> Agent::tool_ptrs() const {
+    std::vector<Tool*> ptrs;
+    ptrs.reserve(tools_.size());
+    for (const auto& t : tools_) ptrs.push_back(t.get());
+    return ptrs;
+}
 
 Agent::Agent(std::shared_ptr<Provider> provider,
              std::vector<std::unique_ptr<Tool>> tools,
@@ -90,27 +98,15 @@ Agent::run(std::vector<ChatMessage>& messages, int max_iterations)
             return msg.content;
         }
 
-        // Execute each tool call (O(1) lookup via tools_by_name_).
-        for (const auto& tc : msg.tool_calls) {
-            auto idx_it = tools_by_name_.find(tc.name);
-
-            ChatMessage tool_msg;
-            tool_msg.role = "tool";
-            tool_msg.tool_call_id = tc.id;
-            tool_msg.tool_name = tc.name;
-
-            if (idx_it == tools_by_name_.end()) {
-                tool_msg.content = R"({"error": "Tool not found: )" + tc.name + "\"}";
-            } else {
-                try {
-                    auto args = json::parse(tc.arguments);
-                    tool_msg.content = idx_it->second->execute(args);
-                } catch (const std::exception& e) {
-                    tool_msg.content = std::string(R"({"error": ")") + e.what() + "\"}";
-                }
-            }
-
-            messages.push_back(tool_msg);
+        // Tool execution is not implemented here — it lives in exactly one
+        // place, shared with graph::ToolDispatchNode (issue #87). This loop
+        // used to call the blocking execute() one tool at a time while the
+        // node fanned the same calls out concurrently; three 300 ms async
+        // tools took 900 ms here and 300 ms there.
+        auto tool_msgs = neograph::async::run_sync(
+            dispatch_tool_calls(msg.tool_calls, tool_ptrs()));
+        for (auto& tm : tool_msgs) {
+            messages.push_back(std::move(tm));
         }
     }
 
@@ -160,29 +156,18 @@ Agent::run_stream(std::vector<ChatMessage>& messages,
             }
         }
 
-        auto& msg = messages.back();
+        // Copy the calls out before touching `messages`. The previous code held
+        // `auto& msg = messages.back()` and push_back'ed tool results into the
+        // same vector while iterating msg.tool_calls — a reallocation there
+        // leaves the reference dangling and the next iteration reads freed
+        // memory. It only bites with two or more tool calls, which is why it
+        // survived this long.
+        auto calls = messages.back().tool_calls;
 
-        // Execute tool calls
-        for (const auto& tc : msg.tool_calls) {
-            auto idx_it = tools_by_name_.find(tc.name);
-
-            ChatMessage tool_msg;
-            tool_msg.role = "tool";
-            tool_msg.tool_call_id = tc.id;
-            tool_msg.tool_name = tc.name;
-
-            if (idx_it == tools_by_name_.end()) {
-                tool_msg.content = R"({"error": "Tool not found: )" + tc.name + "\"}";
-            } else {
-                try {
-                    auto args = json::parse(tc.arguments);
-                    tool_msg.content = idx_it->second->execute(args);
-                } catch (const std::exception& e) {
-                    tool_msg.content = std::string(R"({"error": ")") + e.what() + "\"}";
-                }
-            }
-
-            messages.push_back(tool_msg);
+        auto tool_msgs = neograph::async::run_sync(
+            dispatch_tool_calls(std::move(calls), tool_ptrs()));
+        for (auto& tm : tool_msgs) {
+            messages.push_back(std::move(tm));
         }
 
         has_done_tool_calls = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(neograph_tests
     test_live_llm_cancel_fanout_cpp.cpp
     test_scheduler.cpp
     test_node_execution.cpp
+    test_tool_dispatch_parity.cpp
     test_compiler.cpp
     test_compiler_strict.cpp
     test_validator.cpp

--- a/tests/test_tool_dispatch_parity.cpp
+++ b/tests/test_tool_dispatch_parity.cpp
@@ -1,0 +1,242 @@
+// Tool dispatch: what actually runs concurrently, and on which path (issue #87).
+//
+// Two claims are under test here, and the point of the file is to hold them to
+// numbers rather than to reasoning:
+//
+//   1. A *sync* tool — one that implements only execute() — never overlaps,
+//      even on the "parallel" ToolNode path. Tool::execute_async's default body
+//      is `co_return execute(arguments);`, which runs to completion before the
+//      coroutine's first suspension, so co_spawn'ing three of them into a
+//      parallel_group still runs them end to end. This matters far beyond
+//      performance: it means a stateful sync tool cannot race, and unifying the
+//      dispatch paths cannot introduce a data race into one.
+//
+//   2. An *async* tool — one that overrides execute_async and actually suspends
+//      — does overlap on ToolNode, and does NOT on Agent, which is the defect.
+//
+// Timing assertions use generous bounds (a 3x300ms serial run vs a ~300ms
+// concurrent one) so they discriminate the two regimes without being flaky.
+
+#include <gtest/gtest.h>
+#include <neograph/neograph.h>
+#include <neograph/llm/agent.h>
+#include <neograph/async/run_sync.h>
+
+#include <asio/steady_timer.hpp>
+#include <asio/this_coro.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <thread>
+
+using namespace neograph;
+using namespace neograph::graph;
+using namespace std::chrono_literals;
+
+namespace {
+
+constexpr auto kToolDelay = 300ms;
+
+// Sleeps on the calling thread. Implements only execute() — the common shape.
+class SyncSleepTool : public Tool {
+public:
+    explicit SyncSleepTool(std::string name) : name_(std::move(name)) {}
+
+    ChatTool get_definition() const override {
+        return {name_, "sleeps", json{{"type", "object"}, {"properties", json::object()}}};
+    }
+    std::string execute(const json& /*args*/) override {
+        std::this_thread::sleep_for(kToolDelay);
+        return "slept";
+    }
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+};
+
+// Suspends on a timer — genuinely async, the shape an I/O-bound tool has.
+class AsyncSleepTool : public AsyncTool {
+public:
+    explicit AsyncSleepTool(std::string name) : name_(std::move(name)) {}
+
+    ChatTool get_definition() const override {
+        return {name_, "sleeps", json{{"type", "object"}, {"properties", json::object()}}};
+    }
+    asio::awaitable<std::string> execute_async(const json& /*args*/) override {
+        asio::steady_timer t(co_await asio::this_coro::executor);
+        t.expires_after(kToolDelay);
+        co_await t.async_wait(asio::use_awaitable);
+        co_return "slept";
+    }
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+};
+
+// An assistant message asking for all three tools in one turn.
+ChatMessage assistant_calling(const std::vector<std::string>& names) {
+    ChatMessage m;
+    m.role = "assistant";
+    for (std::size_t i = 0; i < names.size(); ++i) {
+        ToolCall tc;
+        tc.id        = "call_" + std::to_string(i);
+        tc.name      = names[i];
+        tc.arguments = "{}";
+        m.tool_calls.push_back(tc);
+    }
+    return m;
+}
+
+void seed(GraphState& state, const std::vector<ChatMessage>& msgs) {
+    state.init_channel("messages", ReducerType::APPEND,
+                       ReducerRegistry::instance().get("append"), json::array());
+    json arr = json::array();
+    for (const auto& m : msgs) {
+        json j;
+        to_json(j, m);
+        arr.push_back(j);
+    }
+    state.write("messages", arr);
+}
+
+template <typename F>
+std::chrono::milliseconds timed(F&& f) {
+    auto t0 = std::chrono::steady_clock::now();
+    f();
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0);
+}
+
+NodeOutput drive(GraphNode& node, const GraphState& state) {
+    RunContext ctx;
+    return neograph::async::run_sync(node.run(NodeInput{state, ctx, nullptr}));
+}
+
+}  // namespace
+
+// Claim 1. Sync tools do NOT overlap on ToolNode, despite the parallel_group.
+// This is the load-bearing compatibility fact: a stateful sync tool is never
+// re-entered, so unifying Agent onto this dispatch cannot race one.
+TEST(ToolDispatchParity, SyncToolsDoNotOverlapOnToolNode) {
+    SyncSleepTool a("a"), b("b"), c("c");
+    NodeContext ctx;
+    ctx.tools = {&a, &b, &c};
+    ToolDispatchNode node("tools", ctx);
+
+    GraphState state;
+    seed(state, {assistant_calling({"a", "b", "c"})});
+
+    auto elapsed = timed([&] { drive(node, state); });
+    EXPECT_GE(elapsed, 3 * kToolDelay - 50ms)
+        << "sync tools appear to overlap — the no-race assumption behind #87 is wrong";
+}
+
+// Claim 2a. Async tools DO overlap on ToolNode. This is the behavior Agent lacks.
+TEST(ToolDispatchParity, AsyncToolsOverlapOnToolNode) {
+    AsyncSleepTool a("a"), b("b"), c("c");
+    NodeContext ctx;
+    ctx.tools = {&a, &b, &c};
+    ToolDispatchNode node("tools", ctx);
+
+    GraphState state;
+    seed(state, {assistant_calling({"a", "b", "c"})});
+
+    auto elapsed = timed([&] { drive(node, state); });
+    EXPECT_LT(elapsed, 2 * kToolDelay)
+        << "ToolNode did not overlap async tools";
+}
+
+// Claim 2b. RED (#87). The same three async tools through Agent run serially,
+// because Agent loops over the calls and invokes the *sync* execute() on each.
+TEST(ToolDispatchParity, AgentOverlapsAsyncTools) {
+    // A provider that asks for all three tools once, then answers.
+    class ThreeCallProvider : public Provider {
+    public:
+        int turns = 0;
+        ChatCompletion complete(const CompletionParams& /*p*/) override {
+            ChatCompletion comp;
+            comp.message = (turns++ == 0) ? assistant_calling({"a", "b", "c"})
+                                          : ChatMessage{"assistant", "done"};
+            return comp;
+        }
+        ChatCompletion complete_stream(const CompletionParams& p,
+                                       const StreamCallback& /*cb*/) override {
+            return complete(p);
+        }
+        std::string get_name() const override { return "three-call"; }
+    };
+
+    std::vector<std::unique_ptr<Tool>> tools;
+    tools.push_back(std::make_unique<AsyncSleepTool>("a"));
+    tools.push_back(std::make_unique<AsyncSleepTool>("b"));
+    tools.push_back(std::make_unique<AsyncSleepTool>("c"));
+
+    neograph::llm::Agent agent(std::make_shared<ThreeCallProvider>(), std::move(tools));
+
+    std::vector<ChatMessage> messages{{"user", "go"}};
+    auto elapsed = timed([&] { agent.run(messages); });
+    EXPECT_LT(elapsed, 2 * kToolDelay)
+        << "Agent ran the tool calls serially; ToolNode overlaps them (#87)";
+}
+
+// How far does the win actually scale? Three tools gave 3x, but that says
+// nothing about twenty — a single-threaded io_context drives these coroutines,
+// so anything that does not genuinely suspend serializes on that one thread no
+// matter how many calls are in flight.
+//
+// The serial reference is measured, not assumed: sync tools still run one at a
+// time (SyncToolsDoNotOverlapOnToolNode), so N sync tools on this same binary
+// and this same machine IS what the old serial Agent cost. Both regimes are
+// timed side by side and the ratio is printed.
+TEST(ToolDispatchParity, ScalingToTwentyTools) {
+    constexpr int kN = 20;
+
+    std::vector<std::string> names;
+    for (int i = 0; i < kN; ++i) names.push_back("t" + std::to_string(i));
+
+    // Serial reference: N sync tools through the same dispatch.
+    std::vector<std::unique_ptr<SyncSleepTool>> sync_owned;
+    std::vector<Tool*> sync_tools;
+    for (const auto& n : names) {
+        sync_owned.push_back(std::make_unique<SyncSleepTool>(n));
+        sync_tools.push_back(sync_owned.back().get());
+    }
+    NodeContext sync_ctx;
+    sync_ctx.tools = sync_tools;
+    ToolDispatchNode sync_node("tools", sync_ctx);
+    GraphState sync_state;
+    seed(sync_state, {assistant_calling(names)});
+    auto serial = timed([&] { drive(sync_node, sync_state); });
+
+    // Concurrent: N async tools through the same dispatch.
+    std::vector<std::unique_ptr<AsyncSleepTool>> async_owned;
+    std::vector<Tool*> async_tools;
+    for (const auto& n : names) {
+        async_owned.push_back(std::make_unique<AsyncSleepTool>(n));
+        async_tools.push_back(async_owned.back().get());
+    }
+    NodeContext async_ctx;
+    async_ctx.tools = async_tools;
+    ToolDispatchNode async_node("tools", async_ctx);
+    GraphState async_state;
+    seed(async_state, {assistant_calling(names)});
+    auto concurrent = timed([&] { drive(async_node, async_state); });
+
+    const double ratio = static_cast<double>(serial.count()) /
+                         static_cast<double>(std::max<long long>(1, concurrent.count()));
+    std::cout << "[ MEASURE  ] N=" << kN << " tools x " << kToolDelay.count() << "ms: "
+              << "serial " << serial.count() << "ms, "
+              << "concurrent " << concurrent.count() << "ms, "
+              << "speedup " << ratio << "x\n";
+
+    // The claim under test is that concurrency holds at N=20 — i.e. the wall
+    // clock stays near one tool's latency instead of growing with N.
+    EXPECT_LT(concurrent, 2 * kToolDelay)
+        << "concurrency collapsed at N=" << kN;
+    EXPECT_GE(serial, kN * kToolDelay - 200ms)
+        << "the serial reference did not actually serialize";
+}


### PR DESCRIPTION
The graph path (`ToolDispatchNode`) ran tool calls concurrently. The `Agent` path ran the same tool calls in a `for` loop, one at a time, calling the **sync** `execute()` — `grep -c execute_async src/llm/agent.cpp` was `0`.

The speed gap is the symptom. The defect is that *"execute the tool_calls on an assistant message"* was implemented **twice**. Parallelism landed on one copy only; so would the tool gate (#89), the per-call interrupt (#90), and token accounting (#88). This is why it goes in before them: it makes one landing site.

**New:** `dispatch_tool_calls(calls, tools)` in `tool_dispatch.h`. `ToolDispatchNode::run` collapses to a single call to it; `Agent` drives the same coroutine through `run_sync`. Single-call fast path (no parallel-group machinery) is kept — it was already right. Results stay in call order, not completion order.

**Measured**

| | before | after | |
|---|---|---|---|
| Agent, 3 async tools × 300ms | 900 ms | 300 ms | **3.0×** |
| Agent, 20 async tools × 300ms | 6003 ms | 300 ms | **20.0×** |
| Agent, 20 **sync** tools × 300ms | 6002 ms | 6002 ms | unchanged — the compatibility proof |

That last row is the point. `Tool::execute_async`'s default body is `co_return execute(arguments);`, which runs to completion before the first suspension — so a sync tool never overlaps, even inside a parallel group. **Existing stateful sync tools cannot suddenly race.** Concurrency is opt-in, by writing an async tool.

The 20× is 20 *suspending* tools, not 20 tools. `run_sync` drives a single-threaded executor: a tool that burns CPU or blocks queues up on that thread. Said plainly in the docs, because otherwise we end up believing our own headline.

**Side fix found on the way:** `Agent::run_stream` held a reference into `messages` across a `push_back` on the same vector — use-after-realloc, live only with 2+ tool calls.

**Perf:** engine overhead +0.0% (ABBA-interleaved, master vs HEAD, 24 samples each, quiet machine, fresh worktree builds).

ctest 602/602, examples + cookbook build clean.

Closes #87.