### PR TITLE
ChannelWrite::Mode — a node can overwrite a reduced channel, not only feed the reducer

### DIFF
--- a/bindings/python/src/bind_state.cpp
+++ b/bindings/python/src/bind_state.cpp
@@ -61,20 +61,37 @@ void init_state(py::module_& m) {
             [](NodeContext& c, py::object v) { c.extra_config = py_to_json(v); });
 
     // ── ChannelWrite ─────────────────────────────────────────────────────
-    py::class_<ChannelWrite>(m, "ChannelWrite",
-        "A write to a named state channel.")
-        .def(py::init([](const std::string& channel, py::object value) {
+    py::class_<ChannelWrite> channel_write(m, "ChannelWrite",
+        "A write to a named state channel.");
+
+    py::enum_<ChannelWrite::Mode>(channel_write, "Mode",
+        "What a write means for the channel's current value.")
+        .value("REDUCE", ChannelWrite::Mode::Reduce,
+               "Feed the value through the channel's reducer. The default.")
+        .value("OVERWRITE", ChannelWrite::Mode::Overwrite,
+               "Replace the channel's value outright, ignoring the reducer — "
+               "the only way to shrink an accumulating channel such as messages.")
+        .export_values();
+
+    channel_write
+        .def(py::init([](const std::string& channel, py::object value,
+                         ChannelWrite::Mode mode) {
             ChannelWrite w;
             w.channel = channel;
             w.value = py_to_json(value);
+            w.mode = mode;
             return w;
-        }), py::arg("channel"), py::arg("value"))
+        }), py::arg("channel"), py::arg("value"),
+            py::arg("mode") = ChannelWrite::Mode::Reduce)
         .def_readwrite("channel", &ChannelWrite::channel)
+        .def_readwrite("mode", &ChannelWrite::mode)
         .def_property("value",
             [](const ChannelWrite& w) { return json_to_py(w.value); },
             [](ChannelWrite& w, py::object v) { w.value = py_to_json(v); })
         .def("__repr__", [](const ChannelWrite& w) {
-            return "<ChannelWrite channel=" + w.channel + ">";
+            return "<ChannelWrite channel=" + w.channel +
+                   (w.mode == ChannelWrite::Mode::Overwrite ? " mode=OVERWRITE" : "") +
+                   ">";
         });
 
     // ── Send (dynamic fan-out) ───────────────────────────────────────────

--- a/bindings/python/tests/test_channel_write_mode.py
+++ b/bindings/python/tests/test_channel_write_mode.py
@@ -1,0 +1,84 @@
+"""ChannelWrite.Mode from Python (issue #91).
+
+The C++ side gained a way to overwrite an accumulating channel instead of only
+ever growing it. Python had no way to ask for that: ChannelWrite's constructor
+took (channel, value) and nothing else, so the feature existed but half the
+users could not reach it — and Python users hit the same wall, since `messages`
+is append-reduced there too.
+"""
+
+import neograph_engine as ng
+
+
+def _definition():
+    return {
+        "name": "py_channel_write_mode",
+        "channels": {"log": {"reducer": "append"}},
+        "nodes": {"seed": {"type": "cwm_seed"}, "trim": {"type": "cwm_trim"}},
+        "edges": [
+            {"from": "__start__", "to": "seed"},
+            {"from": "seed", "to": "trim"},
+            {"from": "trim", "to": "__end__"},
+        ],
+    }
+
+
+class _SeedNode(ng.GraphNode):
+    """Accumulates two entries through the append reducer."""
+
+    def get_name(self):
+        return "seed"
+
+    def run(self, _input):
+        return [ng.ChannelWrite("log", ["a"]), ng.ChannelWrite("log", ["b"])]
+
+
+def test_overwrite_replaces_an_accumulated_channel():
+    class TrimNode(ng.GraphNode):
+        def get_name(self):
+            return "trim"
+
+        def run(self, _input):
+            return [
+                ng.ChannelWrite("log", ["trimmed"], ng.ChannelWrite.Mode.OVERWRITE)
+            ]
+
+    ng.NodeFactory.register_type("cwm_seed", lambda n, c, x: _SeedNode())
+    ng.NodeFactory.register_type("cwm_trim", lambda n, c, x: TrimNode())
+
+    engine = ng.GraphEngine.compile(_definition(), ng.NodeContext())
+    cfg = ng.RunConfig()
+    cfg.thread_id = "py-cwm-overwrite"
+
+    result = engine.run(cfg)
+    assert result.output["channels"]["log"]["value"] == ["trimmed"]
+
+
+def test_default_mode_still_reduces():
+    """Existing Python code passes no mode and must keep appending."""
+
+    class AppendNode(ng.GraphNode):
+        def get_name(self):
+            return "trim"
+
+        def run(self, _input):
+            return [ng.ChannelWrite("log", ["c"])]
+
+    ng.NodeFactory.register_type("cwm_seed", lambda n, c, x: _SeedNode())
+    ng.NodeFactory.register_type("cwm_trim", lambda n, c, x: AppendNode())
+
+    engine = ng.GraphEngine.compile(_definition(), ng.NodeContext())
+    cfg = ng.RunConfig()
+    cfg.thread_id = "py-cwm-default"
+
+    result = engine.run(cfg)
+    assert result.output["channels"]["log"]["value"] == ["a", "b", "c"]
+
+
+def test_mode_enum_is_exposed():
+    w = ng.ChannelWrite("log", [1], ng.ChannelWrite.Mode.OVERWRITE)
+    assert w.mode == ng.ChannelWrite.Mode.OVERWRITE
+    assert "OVERWRITE" in repr(w)
+
+    plain = ng.ChannelWrite("log", [1])
+    assert plain.mode == ng.ChannelWrite.Mode.REDUCE

--- a/include/neograph/graph/checkpoint.h
+++ b/include/neograph/graph/checkpoint.h
@@ -42,7 +42,11 @@ namespace neograph::graph {
 // platform-variable `int` width is wrong for a value persisted to
 // disk and round-tripped through JSON. Old `int` left the door open
 // to a `-1` sentinel value that wasn't documented anywhere.
-constexpr std::uint32_t CHECKPOINT_SCHEMA_VERSION = 2;
+// v3 (#91): pending-write records may carry a "mode" field ("overwrite").
+// Absent means Reduce, so a v2 blob loads unchanged — same tolerant shape as the
+// v1 -> v2 barrier_state addition. Nothing rejects an older version on read; the
+// number records what the writer was capable of.
+constexpr std::uint32_t CHECKPOINT_SCHEMA_VERSION = 3;
 
 /// Phase at which a Checkpoint was produced. Drives resume semantics —
 /// `Before` means "re-enter before the target node runs", `After` /

--- a/include/neograph/graph/types.h
+++ b/include/neograph/graph/types.h
@@ -83,8 +83,20 @@ struct Channel {
  * @brief Output of a node: a write to a named channel.
  */
 struct ChannelWrite {
-    std::string channel;  ///< Target channel name.
-    json        value;    ///< Value to write through the channel's reducer.
+    /// What the write means for the channel's current value (issue #91).
+    enum class Mode {
+        /// Feed the value through the channel's reducer. The default, and what
+        /// every write did before this existed.
+        Reduce,
+        /// Replace the channel's value outright, ignoring the reducer. The only
+        /// way to shrink an accumulating channel — trim a conversation history,
+        /// drop a poisoned message, reset a scratchpad.
+        Overwrite,
+    };
+
+    std::string channel;              ///< Target channel name.
+    json        value;                ///< Value to write.
+    Mode        mode = Mode::Reduce;  ///< Default preserves the pre-#91 behavior.
 };
 
 /**

--- a/src/core/graph_coordinator.cpp
+++ b/src/core/graph_coordinator.cpp
@@ -12,10 +12,22 @@ namespace {
 // NodeResult and the on-store PendingWrite record; moved here because
 // only the coordinator drives both directions now.
 
+// A write's mode has to survive this round trip, or a replayed Overwrite comes
+// back as a Reduce and the resumed run reconstructs a different state than the
+// original — silently (#91).
+//
+// The field is emitted only when it is not the default, so a graph that never
+// overwrites produces byte-identical records to the pre-#91 format, and a
+// checkpoint written before this existed reads back as Reduce. Same shape as the
+// v1 -> v2 barrier_state addition.
 inline json serialize_writes(const std::vector<ChannelWrite>& writes) {
     json arr = json::array();
     for (const auto& w : writes) {
-        arr.push_back({{"channel", w.channel}, {"value", w.value}});
+        json item{{"channel", w.channel}, {"value", w.value}};
+        if (w.mode == ChannelWrite::Mode::Overwrite) {
+            item["mode"] = "overwrite";
+        }
+        arr.push_back(std::move(item));
     }
     return arr;
 }
@@ -24,10 +36,16 @@ inline std::vector<ChannelWrite> deserialize_writes(const json& arr) {
     if (!arr.is_array()) return out;
     out.reserve(arr.size());
     for (const auto& item : arr) {
-        out.push_back(ChannelWrite{
+        ChannelWrite w{
             item.value("channel", std::string{}),
             item.contains("value") ? item["value"] : json()
-        });
+        };
+        // Absent, unknown, or "reduce" -> Reduce. An older engine reading a
+        // record it does not understand must not silently invent an Overwrite.
+        if (item.value("mode", std::string{}) == "overwrite") {
+            w.mode = ChannelWrite::Mode::Overwrite;
+        }
+        out.push_back(std::move(w));
     }
     return out;
 }

--- a/src/core/graph_state.cpp
+++ b/src/core/graph_state.cpp
@@ -84,8 +84,15 @@ void GraphState::apply_writes(const std::vector<ChannelWrite>& writes) {
                 "definition's \"channels\" block before writing. "
                 "See docs/troubleshooting.md \"Write to unknown channel\".");
         }
-        auto& ch  = it->second;
-        ch.value   = ch.reducer(ch.value, w.value);
+        auto& ch = it->second;
+        // The mode is the whole point of ChannelWrite::Mode (#91): Reduce keeps
+        // the reducer as the law, Overwrite is an explicit, *recorded* escape
+        // from it. Because the intent rides on the write, it lands in the write
+        // log, survives checkpointing, and replays identically — which a
+        // side-door GraphState::overwrite() could never do.
+        ch.value = (w.mode == ChannelWrite::Mode::Overwrite)
+                       ? w.value
+                       : ch.reducer(ch.value, w.value);
         ch.version = ++global_version_;
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(neograph_tests
     test_schema_export.cpp
     test_json_path.cpp
     test_pending_writes.cpp
+    test_channel_write_mode.cpp
     test_plan_execute_graph.cpp
     test_signal_dispatch.cpp
     test_multi_node_resume.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -166,12 +166,18 @@ if(NEOGRAPH_BUILD_POSTGRES)
     # SetUp/TearDown — running them in parallel collides on DDL. Mark
     # them with a RESOURCE_LOCK so ctest serializes only this group
     # while the other ~200 tests still run concurrently.
+    # ChannelWriteModeTest.OverwriteSurvivesReplayThroughPostgres joins the
+    # locked group: it talks to the same database, and the Postgres suite's
+    # drop_schema() will wipe its tables mid-run otherwise. Observed exactly
+    # that — green standalone, red under `ctest -j8`.
+    set(NEOGRAPH_PG_LOCKED_TESTS
+        "PostgresCheckpointTest.*:ChannelWriteModeTest.OverwriteSurvivesReplayThroughPostgres")
     gtest_discover_tests(neograph_tests
-        TEST_FILTER "PostgresCheckpointTest.*"
+        TEST_FILTER "${NEOGRAPH_PG_LOCKED_TESTS}"
         PROPERTIES RESOURCE_LOCK postgres_test_db
     )
     gtest_discover_tests(neograph_tests
-        TEST_FILTER "-PostgresCheckpointTest.*"
+        TEST_FILTER "-${NEOGRAPH_PG_LOCKED_TESTS}"
     )
 else()
     gtest_discover_tests(neograph_tests)

--- a/tests/test_barrier_persistence.cpp
+++ b/tests/test_barrier_persistence.cpp
@@ -59,8 +59,8 @@ TEST(BarrierPersistence, FreshCheckpointHasEmptyBarrierState) {
     Checkpoint cp;
     EXPECT_TRUE(cp.barrier_state.empty());
     EXPECT_EQ(cp.schema_version, CHECKPOINT_SCHEMA_VERSION);
-    EXPECT_EQ(CHECKPOINT_SCHEMA_VERSION, 2)
-        << "barrier_state requires schema v2";
+    EXPECT_EQ(CHECKPOINT_SCHEMA_VERSION, 3)
+        << "barrier_state requires schema v2; v3 adds ChannelWrite::Mode (#91)";
 }
 
 // =========================================================================

--- a/tests/test_channel_write_mode.cpp
+++ b/tests/test_channel_write_mode.cpp
@@ -1,0 +1,232 @@
+// ChannelWrite::Mode — writes carry their intent (issue #91).
+//
+// Every mutation of GraphState went through the channel's reducer, with no way
+// past it. For a channel with an accumulating reducer — `messages` being the
+// obvious one — that means a value can only ever grow: no trimming a
+// conversation history, no dropping a poisoned message, no resetting a
+// scratchpad.
+//
+// The tempting fix is a GraphState::overwrite() that reaches in and mutates the
+// value directly. It works, and it quietly breaks the property the engine rests
+// on: *every mutation is expressible as a ChannelWrite*. That is what makes
+// checkpoint + replay deterministic. A node that mutates state through a side
+// door produces a change the write log never sees, so replaying from a
+// checkpoint does not reproduce the run.
+//
+// So the intent rides on the write instead. The reducer stays the law for the
+// default path; Overwrite is a first-class, recorded write.
+//
+// OverwriteSurvivesPendingWriteReplay is the test that earns the design. It is
+// the one a side-door overwrite() cannot pass.
+
+#include <gtest/gtest.h>
+#include <neograph/neograph.h>
+
+#include <atomic>
+#include <memory>
+#include <stdexcept>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+ReducerFn append_fn() { return ReducerRegistry::instance().get("append"); }
+
+// ── Engine-level fixture: crash mid-fan-out, resume, check the replay ──
+
+// Seeds `banner` with one entry, so Overwrite and Reduce produce *different*
+// results downstream. Without pre-existing content the two are indistinguishable
+// and the replay test would pass even with mode dropped on the floor.
+class SetupNode : public GraphNode {
+public:
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"banner", json::array({"setup"})});
+        co_return out;
+    }
+    std::string get_name() const override { return "setup"; }
+};
+
+class PlannerNode : public GraphNode {
+public:
+    explicit PlannerNode(int fanout) : fanout_(fanout) {}
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        for (int i = 0; i < fanout_; ++i) {
+            Send s;
+            s.target_node = "executor";
+            s.input       = {{"task_idx", i}};
+            out.sends.push_back(std::move(s));
+        }
+        co_return out;
+    }
+    std::string get_name() const override { return "planner"; }
+private:
+    int fanout_;
+};
+
+// Worker 0 overwrites `banner`; the rest append to `log`. Worker `fail_on`
+// throws, which is what forces its successful siblings' writes — including
+// worker 0's Overwrite — to be persisted as pending writes and replayed on
+// resume. If the mode is lost in that round trip, the Overwrite comes back as a
+// Reduce and `banner` accumulates instead of being replaced.
+class ExecutorNode : public GraphNode {
+public:
+    ExecutorNode(std::atomic<int>* fail_on, std::atomic<int>* counter)
+        : fail_on_(fail_on), counter_(counter) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        json v   = in.state.get("task_idx");
+        int  idx = v.is_number_integer() ? v.get<int>() : -999;
+        counter_->fetch_add(1, std::memory_order_relaxed);
+
+        if (fail_on_->load(std::memory_order_relaxed) == idx) {
+            throw std::runtime_error("simulated failure at idx=" + std::to_string(idx));
+        }
+
+        NodeOutput out;
+        if (idx == 0) {
+            ChannelWrite w{"banner", json::array({"final"})};
+            w.mode = ChannelWrite::Mode::Overwrite;
+            out.writes.push_back(w);
+        } else {
+            out.writes.push_back(ChannelWrite{"log", json::array({idx})});
+        }
+        co_return out;
+    }
+    std::string get_name() const override { return "executor"; }
+
+private:
+    std::atomic<int>* fail_on_;
+    std::atomic<int>* counter_;
+};
+
+json make_graph(int fanout) {
+    (void)fanout;
+    return {
+        {"name", "channel_write_mode_test"},
+        {"channels", {
+            {"banner",   {{"reducer", "append"}}},
+            {"log",      {{"reducer", "append"}}},
+            {"task_idx", {{"reducer", "overwrite"}}}
+        }},
+        {"nodes", {
+            {"setup",    {{"type", "cwm_setup"}}},
+            {"planner",  {{"type", "cwm_planner"}}},
+            {"executor", {{"type", "cwm_executor"}}}
+        }},
+        {"edges", {
+            {{"from", "__start__"}, {"to", "setup"}},
+            {{"from", "setup"},     {"to", "planner"}},
+            {{"from", "planner"},   {"to", "__end__"}}
+        }}
+    };
+}
+
+class ChannelWriteModeTest : public ::testing::Test {
+protected:
+    std::atomic<int> fail_on{-1};
+    std::atomic<int> exec_counter{0};
+    int fanout = 4;
+
+    void SetUp() override {
+        fail_on = -1;
+        exec_counter = 0;
+        NodeFactory::instance().register_type("cwm_setup",
+            [](const std::string&, const json&, const NodeContext&) {
+                return std::make_unique<SetupNode>();
+            });
+        NodeFactory::instance().register_type("cwm_planner",
+            [this](const std::string&, const json&, const NodeContext&) {
+                return std::make_unique<PlannerNode>(fanout);
+            });
+        NodeFactory::instance().register_type("cwm_executor",
+            [this](const std::string&, const json&, const NodeContext&) {
+                return std::make_unique<ExecutorNode>(&fail_on, &exec_counter);
+            });
+    }
+};
+
+}  // namespace
+
+// ── 1. GraphState: the mode decides whether the reducer runs ──
+
+TEST(ChannelWriteMode, OverwriteBypassesTheReducer) {
+    GraphState state;
+    state.init_channel("messages", ReducerType::APPEND, append_fn(), json::array());
+
+    state.write("messages", json::array({"a"}));
+    state.write("messages", json::array({"b"}));
+    ASSERT_EQ(state.get("messages").size(), 2u) << "append reducer should accumulate";
+
+    std::vector<ChannelWrite> writes;
+    ChannelWrite w{"messages", json::array({"only"})};
+    w.mode = ChannelWrite::Mode::Overwrite;
+    writes.push_back(w);
+    state.apply_writes(writes);
+
+    EXPECT_EQ(state.get("messages"), json::array({"only"}))
+        << "Overwrite must replace the accumulated value, not append to it";
+}
+
+// Existing behavior — must stay green. A write with no mode set still reduces.
+TEST(ChannelWriteMode, ReduceIsTheDefault) {
+    GraphState state;
+    state.init_channel("messages", ReducerType::APPEND, append_fn(), json::array());
+
+    state.write("messages", json::array({"a"}));
+    state.apply_writes({ChannelWrite{"messages", json::array({"b"})}});
+
+    EXPECT_EQ(state.get("messages"), json::array({"a", "b"}));
+}
+
+// ── 2. The write log is the truth: mode survives checkpoint + replay ──
+//
+// This is the test a side-door GraphState::overwrite() cannot pass. A direct
+// mutation never enters the write log, so nothing is persisted, and the replay
+// silently reconstructs a *different* state than the original run.
+
+TEST_F(ChannelWriteModeTest, OverwriteAppliesOnACleanRun) {
+    auto engine = GraphEngine::compile(make_graph(fanout), NodeContext{},
+                                       std::make_shared<InMemoryCheckpointStore>());
+    RunConfig cfg;
+    cfg.thread_id = "clean";
+    auto result = engine->run(cfg);
+
+    EXPECT_EQ(result.channel_raw("banner"), json::array({"final"}))
+        << "worker 0's Overwrite should have replaced the setup banner";
+}
+
+TEST_F(ChannelWriteModeTest, OverwriteSurvivesPendingWriteReplay) {
+    auto store  = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(make_graph(fanout), NodeContext{}, store);
+
+    RunConfig cfg;
+    cfg.thread_id = "crashy";
+
+    // Worker 2 throws. Workers 0, 1, 3 succeed, and their writes — worker 0's
+    // being the Overwrite — are recorded as pending writes against the parent
+    // checkpoint.
+    fail_on = 2;
+    EXPECT_THROW(engine->run(cfg), std::exception);
+    ASSERT_EQ(exec_counter.load(), fanout) << "all four workers should have been dispatched";
+
+    // resume() (not run()) is the path that replays pending writes. Only the
+    // failed worker re-executes; the successful ones are NOT re-run, so the
+    // Overwrite that lands in the final state can only have come back through
+    // serialize -> store -> deserialize. That is what gives this test teeth:
+    // drop the mode from the wire format and banner reduces to
+    // ["setup", "final"] instead of being replaced.
+    fail_on = -1;
+    auto resumed = engine->resume("crashy");
+
+    ASSERT_EQ(exec_counter.load(), fanout + 1)
+        << "exactly one re-execution (the failed worker) — if the successful "
+           "workers re-ran, this test would pass even with the mode dropped";
+
+    EXPECT_EQ(resumed.channel_raw("banner"), json::array({"final"}))
+        << "the replayed write lost its Overwrite mode and reduced instead";
+    EXPECT_EQ(resumed.channel_raw("log").size(), 3u)
+        << "the three appending workers' writes should all have replayed";
+}

--- a/tests/test_channel_write_mode.cpp
+++ b/tests/test_channel_write_mode.cpp
@@ -21,6 +21,9 @@
 
 #include <gtest/gtest.h>
 #include <neograph/neograph.h>
+#include <neograph/graph/sqlite_checkpoint.h>
+#include <neograph/graph/postgres_checkpoint.h>
+#include <cstdlib>
 
 #include <atomic>
 #include <memory>
@@ -229,4 +232,75 @@ TEST_F(ChannelWriteModeTest, OverwriteSurvivesPendingWriteReplay) {
         << "the replayed write lost its Overwrite mode and reduced instead";
     EXPECT_EQ(resumed.channel_raw("log").size(), 3u)
         << "the three appending workers' writes should all have replayed";
+}
+
+// ── 3. The same replay, through a real persistence backend ──
+//
+// The test above uses InMemoryCheckpointStore, which hands the PendingWrite's
+// json straight back — so it proves the coordinator's serialize/deserialize
+// round trip, but says nothing about a store that has to marshal that json
+// through a database. SqliteCheckpointStore writes writes_json as TEXT and
+// parses it back; Postgres uses a JSONB column. If either dropped an unknown
+// field, the mode would survive unit tests and die in production.
+//
+// Reading the code says it round-trips. This runs it.
+TEST_F(ChannelWriteModeTest, OverwriteSurvivesReplayThroughSqlite) {
+    auto store  = std::make_shared<SqliteCheckpointStore>(":memory:");
+    auto engine = GraphEngine::compile(make_graph(fanout), NodeContext{}, store);
+
+    RunConfig cfg;
+    cfg.thread_id = "crashy-sqlite";
+
+    fail_on = 2;
+    EXPECT_THROW(engine->run(cfg), std::exception);
+    ASSERT_EQ(exec_counter.load(), fanout);
+
+    fail_on = -1;
+    auto resumed = engine->resume("crashy-sqlite");
+
+    ASSERT_EQ(exec_counter.load(), fanout + 1)
+        << "successful workers must not re-run, or this proves nothing";
+
+    EXPECT_EQ(resumed.channel_raw("banner"), json::array({"final"}))
+        << "the Overwrite did not survive the SQLite round trip";
+}
+
+// ── 4. And through Postgres, where the column is JSONB ──
+//
+// Gated on NEOGRAPH_TEST_POSTGRES_URL like the rest of the PG suite. JSONB is
+// not a string round trip: Postgres reparses the document, reorders keys and
+// drops duplicates. It preserves "mode", but that is the sort of claim that
+// deserves a test rather than a paragraph.
+TEST_F(ChannelWriteModeTest, OverwriteSurvivesReplayThroughPostgres) {
+    const char* url = std::getenv("NEOGRAPH_TEST_POSTGRES_URL");
+    if (!url) GTEST_SKIP() << "NEOGRAPH_TEST_POSTGRES_URL unset";
+
+    // Start from a clean database. Without this a previous run's checkpoints for
+    // this thread_id are still there, and the "crash" run below resumes them
+    // instead of starting fresh — the test would pass or fail depending on what
+    // was left behind. The constructor runs ensure_schema(), so dropping and
+    // reconstructing gives empty tables.
+    {
+        PostgresCheckpointStore cleaner(url);
+        cleaner.drop_schema();
+    }
+    auto store = std::make_shared<PostgresCheckpointStore>(url);
+
+    auto engine = GraphEngine::compile(make_graph(fanout), NodeContext{}, store);
+
+    RunConfig cfg;
+    cfg.thread_id = "crashy-pg";
+
+    fail_on = 2;
+    EXPECT_THROW(engine->run(cfg), std::exception);
+    ASSERT_EQ(exec_counter.load(), fanout);
+
+    fail_on = -1;
+    auto resumed = engine->resume("crashy-pg");
+
+    ASSERT_EQ(exec_counter.load(), fanout + 1)
+        << "successful workers must not re-run, or this proves nothing";
+
+    EXPECT_EQ(resumed.channel_raw("banner"), json::array({"final"}))
+        << "the Overwrite did not survive the JSONB round trip";
 }


### PR DESCRIPTION
Every write went through the channel's reducer. On an `append`-reduced channel — which `messages` always is — there was no way for a node to say *replace this*, only *add to it*. Trimming a conversation, compacting history, resetting after an error: none of them were expressible. Users worked around it by declaring a second channel and reading from whichever one was "current", which the checkpoint then has to carry.

**New:**

```cpp
struct ChannelWrite {
    enum class Mode { Reduce, Overwrite };
    std::string channel;
    json        value;
    Mode        mode = Mode::Reduce;   // default = exactly today's behaviour
};
```

Two modes, not three. `Delete` was considered and dropped: channels are declared statically and always hold a value, so "delete" would only ever mean "write the initial value" — `Overwrite` already says that, and says it more honestly.

**Checkpoints.** Pending writes are serialized, so a mode that survives in memory but not in a replayed checkpoint is a correctness bug, not a cosmetic one. Schema goes v2 → v3, and `"mode"` is emitted **only when non-default**, so existing checkpoints are byte-identical and an old checkpoint missing the key reads back as `Reduce`.

Verified across all three stores — InMemory, SQLite, and a **real Postgres** — that an `Overwrite` survives a crash-and-replay: the resumed run replays the recorded pending write rather than re-executing the node, and the value that lands is the overwrite, not a re-reduce.

**On the tests having teeth.** The first version of the replay test passed even with mode-serialization deleted, because it drove the resume through `run()`, which re-executes the node — so the node simply produced the same overwrite again and the test could not tell the difference. It now goes through `resume()`, which replays the *recorded* write, and asserts the node ran exactly once. Mutation-verified: delete the serialization and it goes red.

(The Postgres case was also green standalone and red under `ctest -j8` — the PG suite's `drop_schema()` was wiping its tables. It's in the `RESOURCE_LOCK` group now.)

ctest 608/608. Perf: hot path is one enum compare, no regression measured.

Closes #91.