### PR TITLE
SEGV: a Python Provider passed as a temporary died mid-run

### DIFF
--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -454,6 +454,13 @@ void init_graph(py::module_& m) {
             py::arg("definition"),
             py::arg("ctx"),
             py::arg("store") = std::shared_ptr<CheckpointStore>{},
+            // #98: the compiled engine keeps the NodeContext alive, and the
+            // NodeContext keeps the Python provider alive (see bind_state.cpp).
+            // Without this chain, `GraphEngine.compile(d, ng.NodeContext(
+            // provider=MyProvider()))` — every argument a temporary, which is
+            // how anyone writes it — leaves the engine holding a trampoline
+            // whose Python half has been collected.
+            py::keep_alive<0, 2>(),
             "Compile a graph from a JSON-shaped Python dict.\n\n"
             "Args:\n"
             "    definition: JSON graph definition (nodes, edges, "

--- a/bindings/python/src/bind_state.cpp
+++ b/bindings/python/src/bind_state.cpp
@@ -52,7 +52,15 @@ void init_state(py::module_& m) {
             py::arg("tools") = std::vector<std::shared_ptr<neograph::Tool>>{},
             py::arg("model") = "",
             py::arg("instructions") = "",
-            py::arg("extra_config") = py::dict())
+            py::arg("extra_config") = py::dict(),
+            // #98: keep the Python provider alive for as long as this
+            // NodeContext. The C++ side holds a shared_ptr<Provider>, which
+            // keeps the *C++* trampoline object alive — but the Python instance
+            // carrying the overrides is a separate refcount, and when it dies
+            // the trampoline can no longer find `complete`, falls through to
+            // Provider::complete, which bridges to complete_async, which bridges
+            // back to complete: infinite recursion, stack overflow, SIGSEGV.
+            py::keep_alive<1, 2>())
         .def_readwrite("provider", &NodeContext::provider)
         .def_readwrite("model", &NodeContext::model)
         .def_readwrite("instructions", &NodeContext::instructions)

--- a/bindings/python/tests/test_provider_lifetime.py
+++ b/bindings/python/tests/test_provider_lifetime.py
@@ -1,0 +1,95 @@
+"""A Python Provider subclass must survive being passed as a temporary (#98).
+
+    engine = ng.GraphEngine.compile(defn, ng.NodeContext(provider=MyProvider()))
+
+Every argument there is a temporary — which is how anyone writes it. Before the
+keep_alive chain, this segfaulted: the C++ side holds a shared_ptr<Provider>,
+which keeps the *C++* trampoline alive, but the Python instance carrying the
+overrides is a separate refcount. Once it was collected, the trampoline could no
+longer find `complete`, fell through to the base Provider::complete, which
+bridges to complete_async, which bridges back to complete — infinite recursion,
+stack overflow, SIGSEGV.
+
+It went unnoticed because every existing test that subclasses Provider drives the
+graph through run_stream(), and holds the provider in a local variable.
+"""
+
+import neograph_engine as ng
+import pytest
+
+
+class _Provider(ng.Provider):
+    def __init__(self, reply="ok"):
+        super().__init__()
+        self._reply = reply
+
+    def complete(self, params):
+        c = ng.ChatCompletion()
+        c.message = ng.ChatMessage("assistant", self._reply)
+        c.usage.prompt_tokens = 10
+        c.usage.completion_tokens = 5
+        c.usage.total_tokens = 15
+        return c
+
+    def complete_stream(self, params, on_chunk):
+        return self.complete(params)
+
+    def get_name(self):
+        return "test-provider"
+
+
+def _definition():
+    return {
+        "name": "provider_lifetime",
+        "channels": {"messages": {"reducer": "append"}},
+        "nodes": {"llm": {"type": "llm_call"}},
+        "edges": [
+            {"from": "__start__", "to": "llm"},
+            {"from": "llm", "to": "__end__"},
+        ],
+    }
+
+
+def test_provider_passed_as_a_temporary_survives_the_run():
+    import gc
+
+    # Nothing here holds a reference to the provider or the NodeContext.
+    engine = ng.GraphEngine.compile(_definition(), ng.NodeContext(provider=_Provider()))
+    gc.collect()  # and make sure Python really does try to collect them
+
+    cfg = ng.RunConfig()
+    cfg.thread_id = "temp-provider"
+    result = engine.run(cfg)
+
+    assert result.output["channels"]["messages"]["value"][-1]["content"] == "ok"
+
+
+def test_provider_held_in_a_local_still_works():
+    provider = _Provider("held")
+    engine = ng.GraphEngine.compile(_definition(), ng.NodeContext(provider=provider))
+
+    cfg = ng.RunConfig()
+    cfg.thread_id = "held-provider"
+    result = engine.run(cfg)
+
+    assert result.output["channels"]["messages"]["value"][-1]["content"] == "held"
+
+
+@pytest.mark.parametrize("drive", ["run", "run_stream"])
+def test_every_entry_point_reaches_the_python_override(drive):
+    """run() reaches complete(); run_stream() reaches complete_stream().
+
+    Only the second was ever exercised, which is why the first could crash for
+    the entire life of the binding with a green suite.
+    """
+    engine = ng.GraphEngine.compile(_definition(), ng.NodeContext(provider=_Provider()))
+
+    cfg = ng.RunConfig()
+    cfg.thread_id = f"entry-{drive}"
+
+    if drive == "run":
+        result = engine.run(cfg)
+    else:
+        result = engine.run_stream(cfg, lambda _event: None)
+
+    assert result.output["channels"]["messages"]["value"][-1]["content"] == "ok"


### PR DESCRIPTION
This crashes on `master`:

```python
engine = ng.GraphEngine.compile(defn, ng.NodeContext(provider=MyProvider()))
result = engine.run(cfg)     # SIGSEGV
```

Every argument there is a temporary — which is how anyone writes it.

**Cause.** The C++ side holds a `shared_ptr<Provider>`, which keeps the *trampoline* alive. But the Python instance carrying the overrides is a separate refcount, and nothing held it. Once collected, the trampoline could no longer find `complete`, fell through to the base `Provider::complete`, which bridges to `complete_async`, which bridges back to `complete` — infinite recursion, stack overflow, SIGSEGV.

**Fix.** A `keep_alive` chain: `NodeContext` keeps the provider alive, `compile()` keeps the `NodeContext` alive. The Python object now outlives the run that uses it.

**Why no test caught a crash this basic.** Every existing test that subclasses `Provider` holds it in a local *and* drives the graph through `run_stream()`. Two independent accidents, both required. `run()` reaches `complete()`; `run_stream()` reaches `complete_stream()` — only the second was ever exercised. The new tests parametrize over both entry points and pass the provider as a temporary, with an explicit `gc.collect()` in between.

**A dead end worth recording** (it's in #98): my first diagnosis was the GIL. I wrote a `gil_scoped_acquire` patch for the trampoline's fallback path — and the crash survived it, which is what said the diagnosis was wrong. The patch was removed after A/B proving it changed nothing. It would have shipped as a plausible-looking fix that fixed nothing.

pytest 108 passed + 2 skipped.

Closes #98.