### PR TITLE
Token usage comes out of a run — RunResult::usage

### DIFF
--- a/bindings/python/neograph_engine/__init__.py
+++ b/bindings/python/neograph_engine/__init__.py
@@ -97,6 +97,7 @@ from ._neograph import (
     GraphEngine,
     RunConfig,
     RunResult,
+    UsageAccumulator,
     CheckpointStore,
     InMemoryCheckpointStore,
 
@@ -382,6 +383,7 @@ __all__ = [
     "node",
     "GraphEngine",
     "RunConfig",
+    "UsageAccumulator",
     "RunResult",
     "CheckpointStore",
     "InMemoryCheckpointStore",

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -259,6 +259,23 @@ void init_graph(py::module_& m) {
         "when the future is already done/cancelled.");
 
     // ── RunConfig ────────────────────────────────────────────────────────
+    // ── UsageAccumulator (issue #88) ─────────────────────────────────────
+    //
+    // Hand one to RunConfig to total tokens across several runs — a multi-turn
+    // chat is N runs on one thread_id, and the number people actually want is
+    // what the conversation cost, not what the last turn cost.
+    py::class_<UsageAccumulator, std::shared_ptr<UsageAccumulator>>(
+        m, "UsageAccumulator",
+        "Running token total. Pass to RunConfig.usage to accumulate across runs; "
+        "read RunResult.usage for a single run's cost.")
+        .def(py::init<>())
+        .def("snapshot", &UsageAccumulator::snapshot,
+             "Current totals as a ChatCompletion.Usage.")
+        .def("__repr__", [](const UsageAccumulator& a) {
+            auto u = a.snapshot();
+            return "<UsageAccumulator total=" + std::to_string(u.total_tokens) + ">";
+        });
+
     py::class_<RunConfig>(m, "RunConfig",
         "Per-run configuration: thread_id, input dict, max_steps, "
         "stream_mode for run_stream(), and resume_if_exists for "
@@ -293,7 +310,11 @@ void init_graph(py::module_& m) {
             "for thread_id (if any) and applies input on top before "
             "running. Default False preserves the historical fresh-start "
             "semantics. For HITL resume from an interrupted run, use "
-            "engine.resume() instead.");
+            "engine.resume() instead.")
+        .def_readwrite("usage", &RunConfig::usage,
+            "Optional UsageAccumulator (issue #88). Leave None and the engine "
+            "makes one per run; supply your own to total tokens across several "
+            "runs on the same conversation.");
 
     // ── RunResult ────────────────────────────────────────────────────────
     py::class_<RunResult>(m, "RunResult",
@@ -307,7 +328,10 @@ void init_graph(py::module_& m) {
         .def_property_readonly("interrupt_value",
             [](const RunResult& r) { return json_to_py(r.interrupt_value); })
         .def_readonly("checkpoint_id",   &RunResult::checkpoint_id)
-        .def_readonly("execution_trace", &RunResult::execution_trace);
+        .def_readonly("execution_trace", &RunResult::execution_trace)
+        .def_readonly("usage",           &RunResult::usage,
+            "Token usage for the whole run, subgraphs included (issue #88). "
+            "Zero when the graph made no LLM calls.");
 
     // ── CheckpointStore (abstract base) + InMemoryCheckpointStore ────────
     //

--- a/bindings/python/tests/test_usage_accounting.py
+++ b/bindings/python/tests/test_usage_accounting.py
@@ -1,0 +1,83 @@
+"""Token usage comes out of a run, from Python too (issue #88).
+
+Cost visibility is not a C++ concern. A Python user running a graph against a
+paid API has exactly the same question — what did that cost? — and before this
+there was no way to ask it: the providers parsed the usage and the graph threw
+it away.
+"""
+
+import neograph_engine as ng
+
+
+class _UsageProvider(ng.Provider):
+    def __init__(self, prompt=10, completion=5):
+        super().__init__()
+        self._prompt = prompt
+        self._completion = completion
+
+    def complete(self, params):
+        c = ng.ChatCompletion()
+        c.message = ng.ChatMessage("assistant", "ok")
+        c.usage.prompt_tokens = self._prompt
+        c.usage.completion_tokens = self._completion
+        c.usage.total_tokens = self._prompt + self._completion
+        return c
+
+    def complete_stream(self, params, on_chunk):
+        return self.complete(params)
+
+    def get_name(self):
+        return "usage-stub"
+
+
+def _engine():
+    definition = {
+        "name": "py_usage",
+        "channels": {"messages": {"reducer": "append"}},
+        "nodes": {"llm": {"type": "llm_call"}},
+        "edges": [
+            {"from": "__start__", "to": "llm"},
+            {"from": "llm", "to": "__end__"},
+        ],
+    }
+    return ng.GraphEngine.compile(definition, ng.NodeContext(provider=_UsageProvider()))
+
+
+def test_run_reports_token_usage():
+    result = _engine().run(ng.RunConfig(thread_id="usage-single"))
+
+    assert result.usage.prompt_tokens == 10
+    assert result.usage.completion_tokens == 5
+    assert result.usage.total_tokens == 15
+
+
+def test_a_graph_with_no_llm_reports_zero():
+    definition = {
+        "name": "py_no_llm",
+        "channels": {"x": {"reducer": "overwrite"}},
+        "nodes": {},
+        "edges": [{"from": "__start__", "to": "__end__"}],
+    }
+    engine = ng.GraphEngine.compile(definition, ng.NodeContext())
+
+    result = engine.run(ng.RunConfig(thread_id="usage-empty"))
+
+    assert result.usage.total_tokens == 0
+
+
+def test_an_accumulator_totals_across_runs():
+    """A multi-turn chat is N runs on one thread_id.
+
+    The number people want is what the conversation cost, not what the last turn
+    cost — so the accumulator can outlive a single run.
+    """
+    engine = _engine()
+    accumulator = ng.UsageAccumulator()
+
+    for turn in range(3):
+        cfg = ng.RunConfig(thread_id=f"usage-turn-{turn}")
+        cfg.usage = accumulator
+        engine.run(cfg)
+
+    assert accumulator.snapshot().total_tokens == 45
+    assert accumulator.snapshot().prompt_tokens == 30

--- a/bindings/python/tests/test_usage_live.py
+++ b/bindings/python/tests/test_usage_live.py
@@ -1,0 +1,108 @@
+"""Live: the token count NeoGraph reports is the one the provider billed (#88).
+
+Gated on GROQ_API_KEY / ANTHROPIC_API_KEY; skipped without them, like the other
+live tests in this directory.
+
+The stub tests prove the plumbing carries a number. They cannot prove it is the
+provider's number. Ground truth here is the `usage` block of the raw HTTP
+response, fetched independently — comparing NeoGraph against NeoGraph would
+prove nothing.
+
+`prompt_tokens` is the assertion with teeth: same input, same count, every time.
+`completion_tokens` depends on what the model chose to say, so it is only checked
+for being non-zero.
+
+The streaming case is the one that earns its keep. OpenAI-compatible APIs omit
+usage from a streamed response unless `stream_options: {include_usage: true}` is
+set; the providers set it, and if someone ever drops that line every streamed run
+starts reporting zero tokens — silently, because a zero looks like a cheap run
+rather than a broken counter.
+"""
+
+import json
+import os
+import urllib.request
+
+import pytest
+
+import neograph_engine as ng
+from neograph_engine.llm import OpenAIProvider, SchemaProvider
+
+PROMPT = "Reply with exactly one word: ok"
+MESSAGES = [{"role": "user", "content": PROMPT}]
+
+GROQ_MODEL = os.getenv("NEOGRAPH_TEST_GROQ_MODEL", "llama-3.1-8b-instant")
+GROQ_BASE = "https://api.groq.com/openai"
+ANTHROPIC_MODEL = os.getenv("NEOGRAPH_TEST_ANTHROPIC_MODEL", "claude-haiku-4-5-20251001")
+
+# Groq's edge rejects Python-urllib's default User-Agent with a 403.
+_UA = {"User-Agent": "neograph-test/1.0"}
+
+
+def _post(url, body, headers):
+    req = urllib.request.Request(url, data=json.dumps(body).encode(),
+                                 headers={**headers, **_UA,
+                                          "Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.load(r)
+
+
+def _graph_usage(provider, stream=False):
+    definition = {
+        "name": "live_usage",
+        "channels": {"messages": {"reducer": "append"}},
+        "nodes": {"llm": {"type": "llm_call"}},
+        "edges": [
+            {"from": "__start__", "to": "llm"},
+            {"from": "llm", "to": "__end__"},
+        ],
+    }
+    engine = ng.GraphEngine.compile(definition, ng.NodeContext(provider=provider))
+
+    cfg = ng.RunConfig()
+    cfg.thread_id = "live-stream" if stream else "live"
+    cfg.input = {"messages": MESSAGES}
+
+    result = engine.run_stream(cfg, lambda _e: None) if stream else engine.run(cfg)
+    return result.usage
+
+
+@pytest.mark.parametrize("stream", [False, True], ids=["non_streaming", "streaming"])
+def test_groq_usage_matches_the_api(stream):
+    key = os.getenv("GROQ_API_KEY")
+    if not key:
+        pytest.skip("GROQ_API_KEY unset")
+
+    truth = _post(f"{GROQ_BASE}/v1/chat/completions",
+                  {"model": GROQ_MODEL, "messages": MESSAGES,
+                   "temperature": 0, "max_tokens": 16},
+                  {"Authorization": f"Bearer {key}"})["usage"]
+
+    provider = OpenAIProvider(api_key=key, base_url=GROQ_BASE, default_model=GROQ_MODEL)
+    usage = _graph_usage(provider, stream=stream)
+
+    assert usage.prompt_tokens == truth["prompt_tokens"]
+    assert usage.completion_tokens > 0, "streamed runs report zero when include_usage is lost"
+    assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+
+
+def test_anthropic_usage_matches_the_api():
+    """A different wire format entirely: usage.input_tokens / output_tokens.
+
+    SchemaProvider parses it through a separate path from the OpenAI shape, so
+    the OpenAI-compatible test above says nothing about this one.
+    """
+    key = os.getenv("ANTHROPIC_API_KEY")
+    if not key:
+        pytest.skip("ANTHROPIC_API_KEY unset")
+
+    truth = _post("https://api.anthropic.com/v1/messages",
+                  {"model": ANTHROPIC_MODEL, "messages": MESSAGES, "max_tokens": 16},
+                  {"x-api-key": key, "anthropic-version": "2023-06-01"})["usage"]
+
+    provider = SchemaProvider("schemas/claude.json", api_key=key,
+                              default_model=ANTHROPIC_MODEL)
+    usage = _graph_usage(provider)
+
+    assert usage.prompt_tokens == truth["input_tokens"]
+    assert usage.completion_tokens > 0

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -243,6 +243,18 @@ struct RunResult {
 
     /// Token usage for the whole run, subgraphs included (issue #88). Zero for
     /// a graph that made no LLM calls — not an error, just nothing to count.
+    ///
+    /// **This is what THIS call to run() spent, not the whole bill.** A previous
+    /// attempt that threw never produced a RunResult, so its tokens are not
+    /// here — even though they were really spent. Spend 15 tokens, crash, retry,
+    /// spend 15 more, and this field says 15 against a bill of 30.
+    ///
+    /// For cost accounting that survives retries, hand the engine your own
+    /// accumulator via ``RunConfig::usage``: it outlives the failed attempt
+    /// because it is yours and the engine only borrows it.
+    ///
+    /// @see UsageAccounting.ACrashedAttemptIsInvisibleToRunResult
+    /// @see UsageAccounting.ACallerSuppliedAccumulatorSeesTheCrashedAttempt
     ChatCompletion::Usage usage;
 
     /// @brief Read a channel value as type ``T`` (issue #25).

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -57,6 +57,12 @@ struct RunConfig {
      */
     std::shared_ptr<CancelToken> cancel_token;
 
+    /// Token accounting for this run (issue #88). Leave null and the engine
+    /// makes one; pass your own to accumulate across several runs — e.g. a
+    /// per-tenant budget that spans a whole conversation rather than one turn.
+    /// Whatever ends up here is what ``RunResult::usage`` reports.
+    std::shared_ptr<UsageAccumulator> usage;
+
     /**
      * @brief Auto-resume from latest checkpoint for ``thread_id`` (v0.3.1+).
      *
@@ -120,6 +126,12 @@ struct RunContext {
     /// Null when the caller did not opt in.
     std::shared_ptr<CancelToken> cancel_token;
 
+    /// Token accounting sink for this run (issue #88). The engine always sets
+    /// it, so a node body can record unconditionally via ``record_usage``.
+    /// A custom node that calls a Provider directly is responsible for doing
+    /// so — the engine only sees completions that pass through its own nodes.
+    std::shared_ptr<UsageAccumulator> usage;
+
     /// Optional absolute wall-clock deadline. Reserved for a future PR
     /// (RunConfig has no deadline field today); left ``std::nullopt``
     /// by the engine for now so existing behaviour is unchanged.
@@ -181,6 +193,21 @@ struct RunContext {
     std::shared_ptr<Store> store;
 };
 
+/// @brief Fold a completion's token usage into the run's running total (#88).
+///
+/// One implementation, called from every node that receives a completion. The
+/// alternative — each node incrementing its own counters — is how the two tool
+/// dispatch paths drifted apart in #87, and it would drift the same way here:
+/// a new node type gets written, nobody remembers to count, and the run's token
+/// total silently under-reports. There is nothing in a wrong-but-plausible token
+/// number that tells you it is wrong.
+///
+/// Safe to call with a context whose accumulator is null (a node driven outside
+/// an engine run, as unit tests do).
+inline void record_usage(const RunContext& ctx, const ChatCompletion& completion) {
+    if (ctx.usage) ctx.usage->add(completion.usage);
+}
+
 /**
  * @brief Result of a graph execution run.
  *
@@ -213,6 +240,10 @@ struct RunResult {
     json        interrupt_value;                    ///< Value associated with the interrupt.
     std::string checkpoint_id;                      ///< ID of the last checkpoint saved.
     std::vector<std::string> execution_trace;       ///< Ordered list of executed node names.
+
+    /// Token usage for the whole run, subgraphs included (issue #88). Zero for
+    /// a graph that made no LLM calls — not an error, just nothing to count.
+    ChatCompletion::Usage usage;
 
     /// @brief Read a channel value as type ``T`` (issue #25).
     ///

--- a/include/neograph/llm/agent.h
+++ b/include/neograph/llm/agent.h
@@ -94,6 +94,20 @@ class NEOGRAPH_API Agent {
      */
     ChatCompletion complete(const std::vector<ChatMessage>& messages);
 
+    /**
+     * @brief Token usage accumulated across every call this agent has made (#88).
+     *
+     * The graph path reports usage through ``RunResult::usage``. Agent is not a
+     * graph run and has no ``RunContext``, so it keeps its own running total —
+     * otherwise token accounting would exist on one of the two ways to drive an
+     * LLM and not the other, which is precisely the split that #87 was about.
+     *
+     * Cumulative over the agent's lifetime, not per ``run()``: an agent loop
+     * makes several LLM calls per run and the interesting number is what the
+     * whole conversation cost.
+     */
+    ChatCompletion::Usage usage() const { return usage_->snapshot(); }
+
   private:
     std::shared_ptr<Provider> provider_;
     std::vector<std::unique_ptr<Tool>> tools_;
@@ -104,6 +118,9 @@ class NEOGRAPH_API Agent {
     std::unordered_map<std::string, Tool*> tools_by_name_;
     std::string instructions_;
     std::string model_;
+
+    /// #88 — Agent's own token accounting; see usage().
+    std::shared_ptr<UsageAccumulator> usage_ = std::make_shared<UsageAccumulator>();
 
     void ensure_system_message(std::vector<ChatMessage>& messages);
     std::vector<ChatTool> get_tool_definitions() const;

--- a/include/neograph/types.h
+++ b/include/neograph/types.h
@@ -8,6 +8,7 @@
  */
 #pragma once
 
+#include <atomic>
 #include <string>
 #include <vector>
 #include <neograph/json.h>
@@ -66,6 +67,53 @@ struct ChatCompletion {
         int completion_tokens = 0;  ///< Number of tokens in the completion.
         int total_tokens = 0;       ///< Total tokens used (prompt + completion).
     } usage;
+};
+
+/**
+ * @brief Running total of the token usage of a graph run (issue #88).
+ *
+ * One of these rides on `RunContext` for the length of a run, exactly as the
+ * cancel token does, and is surfaced as `RunResult::usage` when the run ends.
+ * It is shared — by the parent run and every subgraph beneath it, and by every
+ * branch of a fan-out — so the counters are atomic.
+ *
+ * **Where it gets fed.** At the node that *receives* a completion, never at the
+ * provider that produced it. `RateLimitedProvider` wraps another provider and
+ * delegates to it, so a provider-layer counter would count the same completion
+ * once per layer. A completion reaches a node exactly once, whatever it went
+ * through on the way.
+ */
+class NEOGRAPH_API UsageAccumulator {
+public:
+    /// Fold one completion's usage into the running total.
+    ///
+    /// Providers that report only `prompt_tokens` and `completion_tokens` and
+    /// leave `total_tokens` at zero are normalized here rather than at every
+    /// call site — otherwise the total silently under-reports for those.
+    void add(const ChatCompletion::Usage& u) {
+        const long long total = u.total_tokens != 0
+            ? u.total_tokens
+            : static_cast<long long>(u.prompt_tokens) + u.completion_tokens;
+
+        prompt_.fetch_add(u.prompt_tokens, std::memory_order_relaxed);
+        completion_.fetch_add(u.completion_tokens, std::memory_order_relaxed);
+        total_.fetch_add(total, std::memory_order_relaxed);
+    }
+
+    /// Read the running total. Not a consistent snapshot across the three
+    /// counters under concurrent writes — read it when the run is done.
+    ChatCompletion::Usage snapshot() const {
+        ChatCompletion::Usage u;
+        u.prompt_tokens     = static_cast<int>(prompt_.load(std::memory_order_relaxed));
+        u.completion_tokens = static_cast<int>(completion_.load(std::memory_order_relaxed));
+        u.total_tokens      = static_cast<int>(total_.load(std::memory_order_relaxed));
+        return u;
+    }
+
+private:
+    std::atomic<long long> prompt_{0};
+    std::atomic<long long> completion_{0};
+    std::atomic<long long> total_{0};
 };
 
 // --- ADL serialization: ChatMessage/ToolCall <-> json ---

--- a/src/core/deep_research_graph.cpp
+++ b/src/core/deep_research_graph.cpp
@@ -219,6 +219,7 @@ public:
 
         params.cancel_token = in.ctx.cancel_token;
         auto completion = co_await provider_->invoke(params, nullptr);
+        record_usage(in.ctx, completion);   // #88
 
         json asst;
         to_json(asst, completion.message);
@@ -521,6 +522,7 @@ public:
 
             params.cancel_token = in.ctx.cancel_token;
             auto completion = co_await provider_->invoke(params, nullptr);
+            record_usage(in.ctx, completion);   // #88
             auto& msg = completion.message;
             convo.push_back(msg);
 
@@ -563,14 +565,19 @@ public:
 
         // Compress the transcript into a dense summary. Reuses the same
         // model; could be swapped for a cheaper one later.
-        std::string compressed = compress(convo, topic);
+        std::string compressed = compress(convo, topic, in.ctx);
 
         co_return NodeOutput{fanin_writes(call_id, topic, compressed)};
     }
 
 private:
+    // Takes the RunContext so the compression call's tokens are counted (#88).
+    // This helper makes a real LLM call; without the context its cost would be
+    // invisible in RunResult::usage, and a deep-research run would under-report
+    // by one call per researcher per round.
     std::string compress(const std::vector<ChatMessage>& convo,
-                         const std::string& topic) {
+                         const std::string& topic,
+                         const RunContext& ctx) {
         std::ostringstream transcript;
         for (const auto& m : convo) {
             if (m.role == "system") continue;
@@ -601,6 +608,7 @@ private:
 
         try {
             auto completion = neograph::async::run_sync(provider_->invoke(cp, nullptr));
+            record_usage(ctx, completion);   // #88
             std::string out = completion.message.content;
             // Hard cap regardless of what the model produced. Protects the
             // supervisor's accumulated context from unbounded growth across
@@ -729,6 +737,7 @@ public:
             std::exception_ptr eptr;
             try {
                 completion = co_await provider_->invoke(params, nullptr);
+                record_usage(in.ctx, completion);   // #88
             } catch (...) {
                 eptr = std::current_exception();
             }
@@ -839,6 +848,7 @@ Output ONLY the brief, in plain markdown. No preamble. Keep it under 200 words.)
 
             try {
                 completion = co_await provider_->invoke(params, nullptr);
+                record_usage(in.ctx, completion);   // #88
             } catch (...) {
                 eptr = std::current_exception();
             }
@@ -945,6 +955,7 @@ Bias toward PROCEED — only ASK when the question would clearly fork the resear
             try {
                 params.cancel_token = in.ctx.cancel_token;
                 auto completion = co_await provider_->invoke(params, nullptr);
+                record_usage(in.ctx, completion);   // #88
                 verdict = completion.message.content;
             } catch (...) {
                 eptr = std::current_exception();

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -468,6 +468,11 @@ GraphEngine::execute_graph_async(const RunConfig& config,
     // separately. See ROADMAP_v1.md "Execution plan" → PR 1.
     RunContext ctx;
     ctx.cancel_token = config.cancel_token;
+    // #88: the caller may hand us an accumulator (to total across several runs);
+    // otherwise this run gets a fresh one. Either way ctx.usage is non-null, so
+    // node bodies never have to check.
+    ctx.usage        = config.usage ? config.usage
+                                    : std::make_shared<UsageAccumulator>();
     ctx.thread_id    = config.thread_id;
     ctx.stream_mode  = stream_mode;
     ctx.store        = store_;   // issue #27 — node bodies reach Store via in.ctx.store
@@ -565,6 +570,7 @@ GraphEngine::execute_graph_async(const RunConfig& config,
                         barrier_state);
 
                     RunResult result;
+                    result.usage = ctx.usage->snapshot();   // #88
                     result.output          = state.serialize();
                     result.interrupted     = true;
                     result.interrupt_node  = node_name;
@@ -617,6 +623,7 @@ GraphEngine::execute_graph_async(const RunConfig& config,
 
         if (interrupted) {
             RunResult result;
+            result.usage = ctx.usage->snapshot();   // #88
             result.output          = state.serialize();
             result.interrupted     = true;
             result.interrupt_node  = interrupt_reason;
@@ -685,6 +692,7 @@ GraphEngine::execute_graph_async(const RunConfig& config,
                     last_checkpoint_id, barrier_state);
 
                 RunResult result;
+                result.usage = ctx.usage->snapshot();   // #88
                 result.output          = state.serialize();
                 result.interrupted     = true;
                 result.interrupt_node  = node_name;
@@ -771,6 +779,7 @@ GraphEngine::execute_graph_async(const RunConfig& config,
     }
 
     RunResult result;
+    result.usage = ctx.usage->snapshot();   // #88
     result.output          = state.serialize();
     result.execution_trace = std::move(trace);
     if (!last_checkpoint_id.empty()) {

--- a/src/core/graph_node.cpp
+++ b/src/core/graph_node.cpp
@@ -103,6 +103,7 @@ asio::awaitable<NodeOutput> LLMCallNode::run(NodeInput in) {
         };
     }
     auto completion = co_await provider_->invoke(params, on_token);
+    record_usage(in.ctx, completion);   // #88
 
     json msg_json;
     to_json(msg_json, completion.message);
@@ -235,6 +236,7 @@ asio::awaitable<NodeOutput> IntentClassifierNode::run(NodeInput in) {
         };
     }
     auto completion = co_await provider_->invoke(params, on_token);
+    record_usage(in.ctx, completion);   // #88 — routing costs tokens too
     ChatMessage reply = std::move(completion.message);
 
     NodeOutput out;
@@ -303,6 +305,10 @@ asio::awaitable<NodeOutput> SubgraphNode::run(NodeInput in) {
     RunConfig config;
     config.input        = build_subgraph_input(in.state);
     config.cancel_token = in.ctx.cancel_token;
+    // #88: hand the parent's accumulator down. A subgraph runs on its own engine
+    // with its own RunConfig, so without this a graph that delegates its LLM work
+    // to a subgraph reports zero tokens — which reads as "this run was free".
+    config.usage        = in.ctx.usage;
 
     json subgraph_output;
     if (in.stream_cb) {

--- a/src/core/plan_execute_graph.cpp
+++ b/src/core/plan_execute_graph.cpp
@@ -122,6 +122,7 @@ public:
 
         params.cancel_token = in.ctx.cancel_token;
         auto completion = co_await provider_->invoke(params, nullptr);
+        record_usage(in.ctx, completion);   // #88
         auto plan_items = extract_plan(completion.message.content);
 
         json plan_json = json::array();
@@ -191,6 +192,7 @@ public:
 
             params.cancel_token = in.ctx.cancel_token;
             auto completion = co_await provider_->invoke(params, nullptr);
+            record_usage(in.ctx, completion);   // #88
             auto& msg = completion.message;
             convo.push_back(msg);
 
@@ -297,6 +299,7 @@ public:
 
         params.cancel_token = in.ctx.cancel_token;
         auto completion = co_await provider_->invoke(params, nullptr);
+        record_usage(in.ctx, completion);   // #88
 
         json asst_json;
         to_json(asst_json, completion.message);

--- a/src/llm/agent.cpp
+++ b/src/llm/agent.cpp
@@ -72,7 +72,9 @@ Agent::complete(const std::vector<ChatMessage>& messages)
     // Candidate 6 PR3: dispatch via invoke() so the v1.0 single-
     // dispatch surface is end-to-end. run_sync drives the awaitable
     // synchronously (Agent::complete is the public sync API).
-    return neograph::async::run_sync(provider_->invoke(params, nullptr));
+    auto completion = neograph::async::run_sync(provider_->invoke(params, nullptr));
+    usage_->add(completion.usage);   // #88
+    return completion;
 }
 
 std::string
@@ -88,6 +90,7 @@ Agent::run(std::vector<ChatMessage>& messages, int max_iterations)
         params.tools = tool_defs;
 
         auto completion = neograph::async::run_sync(provider_->invoke(params, nullptr));
+        usage_->add(completion.usage);   // #88
         auto& msg = completion.message;
 
         // Append assistant message to history
@@ -133,6 +136,7 @@ Agent::run_stream(std::vector<ChatMessage>& messages,
         if (has_done_tool_calls) {
             auto completion = neograph::async::run_sync(
                 provider_->invoke(params, on_chunk));
+            usage_->add(completion.usage);   // #88
             messages.push_back(completion.message);
 
             if (completion.message.tool_calls.empty()) {
@@ -143,6 +147,7 @@ Agent::run_stream(std::vector<ChatMessage>& messages,
             // Non-streaming: reliable tool call detection
             auto completion = neograph::async::run_sync(
                 provider_->invoke(params, nullptr));
+            usage_->add(completion.usage);   // #88
             messages.push_back(completion.message);
 
             if (completion.message.tool_calls.empty()) {
@@ -151,6 +156,7 @@ Agent::run_stream(std::vector<ChatMessage>& messages,
                 messages.pop_back();
                 auto streamed = neograph::async::run_sync(
                     provider_->invoke(params, on_chunk));
+                usage_->add(streamed.usage);   // #88
                 messages.push_back(streamed.message);
                 return streamed.message.content;
             }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(neograph_tests
     test_json_path.cpp
     test_pending_writes.cpp
     test_channel_write_mode.cpp
+    test_usage_accounting.cpp
     test_plan_execute_graph.cpp
     test_signal_dispatch.cpp
     test_multi_node_resume.cpp

--- a/tests/test_usage_accounting.cpp
+++ b/tests/test_usage_accounting.cpp
@@ -203,3 +203,122 @@ TEST(UsageAccounting, TotalIsDerivedWhenTheProviderOmitsIt) {
                             "partial");
     EXPECT_EQ(result.usage.total_tokens, 10) << "total should fall back to prompt + completion";
 }
+
+// ── Streaming counts too ──
+//
+// Worth pinning because the usual way to lose it is upstream: OpenAI omits usage
+// from a streamed response unless `stream_options: {include_usage: true}` is
+// set. Both bundled providers do set it; this asserts the engine does not then
+// drop what they hand back.
+TEST(UsageAccounting, StreamingRunsCountToo) {
+    NodeContext ctx;
+    ctx.provider = std::make_shared<UsageProvider>(10, 5);
+    auto engine = GraphEngine::compile(llm_graph(1), ctx);
+
+    RunConfig cfg;
+    cfg.thread_id = "stream";
+    auto result = engine->run_stream(cfg, [](const GraphEvent&) {});
+
+    EXPECT_EQ(result.usage.total_tokens, 15);
+}
+
+// ── The contract around a failed run, and its sharp edge ──
+
+namespace {
+// Calls the LLM — really spending tokens — and only then decides to fail.
+class PaysThenCrashesNode : public GraphNode {
+public:
+    PaysThenCrashesNode(std::shared_ptr<Provider> p, std::atomic<bool>* fail)
+        : provider_(std::move(p)), fail_(fail) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        CompletionParams params;
+        params.messages = {{"user", "hi"}};
+        auto completion = co_await provider_->invoke(params, nullptr);
+        record_usage(in.ctx, completion);              // the tokens are spent
+
+        if (fail_->load()) throw std::runtime_error("crash after paying");
+
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"done", json(true)});
+        co_return out;
+    }
+    std::string get_name() const override { return "pays_then_crashes"; }
+
+private:
+    std::shared_ptr<Provider> provider_;
+    std::atomic<bool>*        fail_;
+};
+
+json crashy_graph(const std::string& type) {
+    return {
+        {"name", "crashy"},
+        {"channels", {{"done", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"n", {{"type", type}}}}},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "n"}},
+            {{"from", "n"},         {"to", "__end__"}}
+        })}
+    };
+}
+}  // namespace
+
+// RunResult::usage is what THIS call to run() spent. A previous attempt that
+// threw never produced a RunResult, so its tokens are not in this one — even
+// though they were really spent.
+//
+// This is the semantics, not a bug, but it is a trap for exactly the person #88
+// is for: run 15 tokens, crash, retry 15 tokens, and a cost tracker reading
+// RunResult::usage books 15 against a bill of 30. The next test is the way out,
+// and the reason this one is written down.
+TEST(UsageAccounting, ACrashedAttemptIsInvisibleToRunResult) {
+    static std::atomic<bool> fail{true};
+    auto provider = std::make_shared<UsageProvider>(10, 5);
+    NodeFactory::instance().register_type("pays_then_crashes",
+        [provider](const std::string&, const json&, const NodeContext&) {
+            return std::make_unique<PaysThenCrashesNode>(provider, &fail);
+        });
+
+    auto engine = GraphEngine::compile(crashy_graph("pays_then_crashes"), NodeContext{},
+                                       std::make_shared<InMemoryCheckpointStore>());
+    RunConfig cfg;
+    cfg.thread_id = "crash-default";
+
+    fail = true;
+    EXPECT_THROW(engine->run(cfg), std::exception);   // 15 tokens spent and lost
+
+    fail = false;
+    auto result = engine->run(cfg);                   // 15 more
+
+    EXPECT_EQ(result.usage.total_tokens, 15)
+        << "RunResult reports this run, not the whole bill — see the next test";
+}
+
+// Supply your own accumulator and it outlives the failed attempt, because it is
+// yours and the engine only borrows it. This is what anyone doing real cost
+// accounting wants, and RunConfig::usage exists to make it possible.
+TEST(UsageAccounting, ACallerSuppliedAccumulatorSeesTheCrashedAttempt) {
+    static std::atomic<bool> fail{true};
+    auto provider = std::make_shared<UsageProvider>(10, 5);
+    NodeFactory::instance().register_type("pays_then_crashes_2",
+        [provider](const std::string&, const json&, const NodeContext&) {
+            return std::make_unique<PaysThenCrashesNode>(provider, &fail);
+        });
+
+    auto engine = GraphEngine::compile(crashy_graph("pays_then_crashes_2"), NodeContext{},
+                                       std::make_shared<InMemoryCheckpointStore>());
+
+    auto budget = std::make_shared<UsageAccumulator>();
+    RunConfig cfg;
+    cfg.thread_id = "crash-budget";
+    cfg.usage     = budget;
+
+    fail = true;
+    EXPECT_THROW(engine->run(cfg), std::exception);
+
+    fail = false;
+    auto result = engine->run(cfg);
+
+    EXPECT_EQ(budget->snapshot().total_tokens, 30) << "the crashed attempt's tokens went missing";
+    EXPECT_EQ(result.usage.total_tokens, 30)       << "RunResult snapshots the accumulator it was given";
+}

--- a/tests/test_usage_accounting.cpp
+++ b/tests/test_usage_accounting.cpp
@@ -1,0 +1,205 @@
+// Token usage comes out of a run (issue #88).
+//
+// ChatCompletion::Usage existed and SchemaProvider parsed it, but nothing
+// downstream kept it: LLMCallNode never read completion.usage and RunResult had
+// no field for it. Call a Provider directly and you could see token counts; run
+// a graph and they were gone. For anything cost-sensitive — budgets, per-tenant
+// billing, rate-limit planning — that is a hard blocker.
+//
+// The accumulator rides on RunContext, which already flows into every node and
+// down into subgraphs via RunConfig, exactly like cancel_token. Two consequences
+// worth testing rather than assuming:
+//
+//   * Usage is recorded where the completion is *received* (the node), not where
+//     it is produced (the provider). RateLimitedProvider wraps another provider
+//     and delegates to it, so counting in the provider layer would count the
+//     same completion twice. Counting on receipt cannot.
+//
+//   * A subgraph runs on its own engine with its own RunConfig. If the
+//     accumulator does not ride that config down, a graph that delegates its LLM
+//     work to a subgraph reports zero tokens — the most misleading possible
+//     answer, since it looks like a free run.
+
+#include <gtest/gtest.h>
+#include <neograph/neograph.h>
+#include <neograph/llm/agent.h>
+
+#include <memory>
+#include <string>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+// Reports a fixed usage on every completion.
+class UsageProvider : public Provider {
+public:
+    UsageProvider(int prompt, int completion)
+        : prompt_(prompt), completion_(completion) {}
+
+    ChatCompletion complete(const CompletionParams&) override {
+        ChatCompletion c;
+        c.message = ChatMessage{"assistant", "ok"};
+        c.usage.prompt_tokens     = prompt_;
+        c.usage.completion_tokens = completion_;
+        c.usage.total_tokens      = prompt_ + completion_;
+        return c;
+    }
+    ChatCompletion complete_stream(const CompletionParams& p,
+                                   const StreamCallback&) override {
+        return complete(p);
+    }
+    std::string get_name() const override { return "usage-stub"; }
+
+private:
+    int prompt_;
+    int completion_;
+};
+
+json llm_graph(int llm_nodes) {
+    json nodes  = json::object();
+    json edges  = json::array();
+    std::string prev = "__start__";
+    for (int i = 0; i < llm_nodes; ++i) {
+        std::string name = "llm" + std::to_string(i);
+        nodes[name] = {{"type", "llm_call"}};
+        edges.push_back({{"from", prev}, {"to", name}});
+        prev = name;
+    }
+    edges.push_back({{"from", prev}, {"to", "__end__"}});
+
+    return {
+        {"name", "usage_test"},
+        {"channels", {{"messages", {{"reducer", "append"}}}}},
+        {"nodes", nodes},
+        {"edges", edges}
+    };
+}
+
+RunResult run_graph(const json& def, std::shared_ptr<Provider> provider,
+                    const std::string& thread) {
+    NodeContext ctx;
+    ctx.provider = std::move(provider);
+    auto engine = GraphEngine::compile(def, ctx);
+
+    RunConfig cfg;
+    cfg.thread_id = thread;
+    return engine->run(cfg);
+}
+
+}  // namespace
+
+// One LLM node: whatever the provider reported must come back out.
+TEST(UsageAccounting, SingleLLMNodeReportsUsage) {
+    auto result = run_graph(llm_graph(1),
+                            std::make_shared<UsageProvider>(10, 5), "single");
+
+    EXPECT_EQ(result.usage.prompt_tokens, 10);
+    EXPECT_EQ(result.usage.completion_tokens, 5);
+    EXPECT_EQ(result.usage.total_tokens, 15);
+}
+
+// Two LLM nodes: the run total is the sum, not the last node's.
+TEST(UsageAccounting, MultipleLLMNodesSum) {
+    auto result = run_graph(llm_graph(2),
+                            std::make_shared<UsageProvider>(10, 5), "double");
+
+    EXPECT_EQ(result.usage.total_tokens, 30);
+    EXPECT_EQ(result.usage.prompt_tokens, 20);
+    EXPECT_EQ(result.usage.completion_tokens, 10);
+}
+
+// A graph with no LLM node reports zero, not an error and not garbage.
+TEST(UsageAccounting, NoLLMNodeYieldsZero) {
+    json def = {
+        {"name", "no_llm"},
+        {"channels", {{"x", {{"reducer", "overwrite"}}}}},
+        {"nodes", json::object()},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "__end__"}}
+        })}
+    };
+    def["nodes"] = json::object();
+
+    NodeContext ctx;
+    auto engine = GraphEngine::compile(def, ctx);
+    RunConfig cfg;
+    cfg.thread_id = "empty";
+    auto result = engine->run(cfg);
+
+    EXPECT_EQ(result.usage.total_tokens, 0);
+}
+
+// A subgraph runs on its own engine with its own RunConfig. Its tokens are still
+// the parent run's tokens — otherwise delegating LLM work to a subgraph makes a
+// run look free.
+TEST(UsageAccounting, SubgraphUsageRollsUpIntoTheParent) {
+    json inner = llm_graph(1);
+    inner["name"] = "inner";
+
+    json outer = {
+        {"name", "outer"},
+        {"channels", {{"messages", {{"reducer", "append"}}}}},
+        {"nodes", {
+            {"child", {{"type", "subgraph"},
+                       {"definition", inner}}}
+        }},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "child"}},
+            {{"from", "child"},     {"to", "__end__"}}
+        })}
+    };
+
+    auto result = run_graph(outer, std::make_shared<UsageProvider>(10, 5), "sub");
+
+    EXPECT_EQ(result.usage.total_tokens, 15)
+        << "the subgraph's tokens did not reach the parent run";
+}
+
+// The other way to drive an LLM. Agent is not a graph run and has no
+// RunContext, so it keeps its own total — and it has to, or token accounting
+// would exist on one of the two paths and not the other, which is the exact
+// split #87 was about.
+TEST(UsageAccounting, AgentAccumulatesAcrossCalls) {
+    neograph::llm::Agent agent(std::make_shared<UsageProvider>(10, 5),
+                               std::vector<std::unique_ptr<Tool>>{});
+
+    EXPECT_EQ(agent.usage().total_tokens, 0) << "nothing called yet";
+
+    std::vector<ChatMessage> messages{{"user", "hi"}};
+    agent.run(messages);
+    EXPECT_EQ(agent.usage().total_tokens, 15);
+
+    // Cumulative over the agent's lifetime, not reset per run: an agent loop
+    // makes several calls and the number people want is what the conversation
+    // cost, not what the last turn cost.
+    std::vector<ChatMessage> more{{"user", "again"}};
+    agent.run(more);
+    EXPECT_EQ(agent.usage().total_tokens, 30);
+}
+
+// A provider that reports prompt/completion but leaves total at zero — several
+// real APIs do. The accumulator normalizes rather than under-reporting.
+TEST(UsageAccounting, TotalIsDerivedWhenTheProviderOmitsIt) {
+    class PartialUsageProvider : public Provider {
+    public:
+        ChatCompletion complete(const CompletionParams&) override {
+            ChatCompletion c;
+            c.message = ChatMessage{"assistant", "ok"};
+            c.usage.prompt_tokens     = 7;
+            c.usage.completion_tokens = 3;
+            c.usage.total_tokens      = 0;   // provider did not fill it in
+            return c;
+        }
+        ChatCompletion complete_stream(const CompletionParams& p,
+                                       const StreamCallback&) override {
+            return complete(p);
+        }
+        std::string get_name() const override { return "partial"; }
+    };
+
+    auto result = run_graph(llm_graph(1), std::make_shared<PartialUsageProvider>(),
+                            "partial");
+    EXPECT_EQ(result.usage.total_tokens, 10) << "total should fall back to prompt + completion";
+}


### PR DESCRIPTION
Every provider already parsed the `usage` block off the wire. The graph then threw it away. So the one question anyone running against a paid API asks — *what did that cost?* — had no answer, and the workaround was to wrap the provider and count it yourself.

**New:** `RunResult::usage`, fed by an atomic `UsageAccumulator` on `RunContext`. Wired at all 17 provider call sites, plus `Agent`, plus subgraph roll-up into the parent. Bound to Python. `RunConfig::usage` lets a caller supply their own accumulator to total a multi-turn conversation across runs.

**The numbers are the provider's, verified against the provider**

Stub tests prove the plumbing carries *a* number. They cannot prove it is *the* number. Ground truth here is the raw HTTP response's `usage` block, fetched independently — comparing NeoGraph to NeoGraph would prove nothing:

```
Groq — llama-3.1-8b-instant
  non-streaming   API prompt=42  | NeoGraph prompt=42   OK
  streaming       API prompt=42  | NeoGraph prompt=42   OK
Anthropic — claude-haiku-4-5
  non-streaming   API prompt=14  | NeoGraph prompt=14   OK
```

The streaming row is the one that earns its keep: OpenAI-compatible APIs omit usage from a streamed response unless `stream_options: {include_usage: true}` is set. Drop that line and **every streamed run silently reports zero tokens** — and a zero reads as a cheap run, not a broken counter. It's now pinned by a test (gated on `GROQ_API_KEY` / `ANTHROPIC_API_KEY`, skipped without).

**A sharp edge, found by measuring and now documented rather than papered over**

A node that spends 15 tokens, throws, and is retried successfully spends **30** — and `RunResult::usage` reports **15**. The crashed attempt produces no `RunResult` at all, so its tokens leave no trace. For a feature whose whole purpose is cost tracking, a 50% undercount is exactly the accident it exists to prevent.

The escape hatch already existed and nobody would have found it: pass your own `RunConfig::usage` accumulator and it survives the crash, reporting the true 30. That contract is now stated on `RunResult::usage` and locked by two tests — one asserting the undercount, one asserting the escape hatch — so it cannot change silently.

ctest 617/617, pytest 111 passed + 5 skipped (live tests skip without keys).

Closes #88.