### PR TITLE
Fix red master: three CI failures, two causes — and one of them was hiding nine tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,44 +490,28 @@ jobs:
           # Mirror them here. Keep this in sync with pyproject.toml's
           # ``dependencies = [...]`` list.
           python -m pip install --quiet pytest pydantic certifi
-          # libasan must be in LD_PRELOAD so its __cxa_throw interceptor
-          # is registered before _neograph.so is dlopen'd by Python.
-          # Two tests propagate Python exceptions across the pybind
-          # boundary — a known sanitizer limitation
-          # (asan_interceptors.cpp:458 CHECK failure on real___cxa_throw
-          # not being intercepted) — deselect them by name.
-          export LD_PRELOAD=$(gcc -print-file-name=libasan.so)
-          export PYTHONPATH=build-asan:bindings/python
-          # The ASan ``__cxa_throw`` interceptor in
-          # asan_interceptors.cpp:458 trips a CHECK
-          # (``real___cxa_throw == nullptr``) on every C++ exception
-          # that crosses the engine→Python boundary. It's a known
-          # sanitizer/dlopen-init order interaction with libstdc++
-          # (the interceptor's dlsym to ``real___cxa_throw`` happens
-          # before _neograph.so is loaded). Tests that exercise that
-          # pattern have to be deselected here; coverage is preserved
-          # by ctest under TSan and the live LLM tests in non-
-          # sanitizer builds.
+          # libasan must be in LD_PRELOAD so its __cxa_throw interceptor is
+          # registered before _neograph.so is dlopen'd by Python.
           #
-          # Categories:
-          #   - propagate / undocumented_reducer / noopentelemetry —
-          #     pre-v0.3.x tests, original deselect.
-          #   - cancel_does_not_double_resolve_future — v0.3.x
-          #     CancelledException throw across pybind boundary.
-          #   - raises_under_run / raises_with_hint /
-          #     no_hint_when_no_streaming_override — v0.3.2 #10
-          #     streaming-only NotImplementedError throws.
-          #   - raises_type_error / non_channelwrite_item_raises —
-          #     v0.3.2 #5 update_state pybind type_error throws.
-          python -m pytest bindings/python/tests/ -q \
-            -k "not propagate and not undocumented_reducer and not noopentelemetry \
-               and not run_async_cancel_does_not_double_resolve_future \
-               and not run_stream_async_cancel_does_not_double_resolve_future \
-               and not still_raises_under_run \
-               and not run_raises_with_hint \
-               and not no_hint_when_no_streaming_override \
-               and not raises_type_error_not_silent_noop \
-               and not non_channelwrite_item_raises"
+          # libstdc++ must be preloaded WITH it, and that is the whole story
+          # behind the deselect list this step used to carry. ASan's
+          # __cxa_throw interceptor resolves the real __cxa_throw by dlsym at
+          # init; with only libasan preloaded, libstdc++ is not in the link map
+          # yet, the lookup yields null, and the first C++ throw dies on
+          #
+          #     asan_interceptors.cpp:458 CHECK failed:
+          #       ((__interception::real___cxa_throw)) != (0)
+          #
+          # pybind11 turns *every* Python exception raised inside a node into a
+          # C++ throw (error_already_set), so this hit any test where Python
+          # code raised. Nine of them were switched off by name and written up
+          # as "a known sanitizer limitation". It was not a limitation; it was
+          # a preload-order bug in this file. Preloading libstdc++ as well
+          # makes the symbol resolvable, and all nine pass — so the deselect
+          # list is gone and the whole suite runs under ASan/LSan/UBSan again.
+          export LD_PRELOAD="$(gcc -print-file-name=libasan.so):$(gcc -print-file-name=libstdc++.so)"
+          export PYTHONPATH=build-asan:bindings/python
+          python -m pytest bindings/python/tests/ -q
 
   # ThreadSanitizer race-detection gate. Catches data races that ASan
   # can't see — concurrent reads/writes without happens-before. Caught

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,12 +101,20 @@ target_sources(neograph_tests PRIVATE test_async_get.cpp)
 # PostgresCheckpointStore integration tests are gated on NEOGRAPH_BUILD_POSTGRES
 # at the build level (so projects without libpqxx still build the test
 # binary) and on NEOGRAPH_TEST_POSTGRES_URL at runtime (skipped if unset).
+# The repo's habit is to gate a whole test FILE on its backend. That does not
+# fit a file whose backend cases sit next to backend-independent ones (see
+# test_channel_write_mode.cpp), so those get a compile definition to guard on
+# instead. Without it the file references SqliteCheckpointStore /
+# PostgresCheckpointStore unconditionally and the link fails on any build
+# without them — which is what the Windows and TSan jobs are.
 if(NEOGRAPH_BUILD_POSTGRES)
     target_sources(neograph_tests PRIVATE test_postgres_checkpoint.cpp)
+    target_compile_definitions(neograph_tests PRIVATE NEOGRAPH_TESTS_HAVE_POSTGRES)
 endif()
 
 if(NEOGRAPH_BUILD_SQLITE)
     target_sources(neograph_tests PRIVATE test_sqlite_checkpoint.cpp)
+    target_compile_definitions(neograph_tests PRIVATE NEOGRAPH_TESTS_HAVE_SQLITE)
 endif()
 
 target_link_libraries(neograph_tests PRIVATE

--- a/tests/test_channel_write_mode.cpp
+++ b/tests/test_channel_write_mode.cpp
@@ -21,8 +21,15 @@
 
 #include <gtest/gtest.h>
 #include <neograph/neograph.h>
+// The persistence backends are optional at build time (a Windows or TSan
+// build has neither). Guard both the include and the tests that use them —
+// this file also holds backend-independent tests that must keep running.
+#ifdef NEOGRAPH_TESTS_HAVE_SQLITE
 #include <neograph/graph/sqlite_checkpoint.h>
+#endif
+#ifdef NEOGRAPH_TESTS_HAVE_POSTGRES
 #include <neograph/graph/postgres_checkpoint.h>
+#endif
 #include <cstdlib>
 
 #include <atomic>
@@ -244,6 +251,7 @@ TEST_F(ChannelWriteModeTest, OverwriteSurvivesPendingWriteReplay) {
 // field, the mode would survive unit tests and die in production.
 //
 // Reading the code says it round-trips. This runs it.
+#ifdef NEOGRAPH_TESTS_HAVE_SQLITE
 TEST_F(ChannelWriteModeTest, OverwriteSurvivesReplayThroughSqlite) {
     auto store  = std::make_shared<SqliteCheckpointStore>(":memory:");
     auto engine = GraphEngine::compile(make_graph(fanout), NodeContext{}, store);
@@ -265,12 +273,15 @@ TEST_F(ChannelWriteModeTest, OverwriteSurvivesReplayThroughSqlite) {
         << "the Overwrite did not survive the SQLite round trip";
 }
 
+#endif  // NEOGRAPH_TESTS_HAVE_SQLITE
+
 // ── 4. And through Postgres, where the column is JSONB ──
 //
 // Gated on NEOGRAPH_TEST_POSTGRES_URL like the rest of the PG suite. JSONB is
 // not a string round trip: Postgres reparses the document, reorders keys and
 // drops duplicates. It preserves "mode", but that is the sort of claim that
 // deserves a test rather than a paragraph.
+#ifdef NEOGRAPH_TESTS_HAVE_POSTGRES
 TEST_F(ChannelWriteModeTest, OverwriteSurvivesReplayThroughPostgres) {
     const char* url = std::getenv("NEOGRAPH_TEST_POSTGRES_URL");
     if (!url) GTEST_SKIP() << "NEOGRAPH_TEST_POSTGRES_URL unset";
@@ -304,3 +315,4 @@ TEST_F(ChannelWriteModeTest, OverwriteSurvivesReplayThroughPostgres) {
     EXPECT_EQ(resumed.channel_raw("banner"), json::array({"final"}))
         << "the Overwrite did not survive the JSONB round trip";
 }
+#endif  // NEOGRAPH_TESTS_HAVE_POSTGRES


### PR DESCRIPTION
Merging the seven branches turned `master` red on `build-windows`, `tsan-test` and `sanitizer-test`. Local was green on all of it — these are the three jobs a local run cannot reach.

## 1 + 2. Windows and TSan: a test that assumed the optional backends exist

```
build-windows  LNK2019: unresolved external symbol SqliteCheckpointStore::...
tsan-test      undefined reference to PostgresCheckpointStore::...
```

`test_channel_write_mode.cpp` (#91) referenced both optional persistence backends unconditionally. Neither job builds them, so the **whole test binary** failed to link — not just those two cases.

The repo's habit is to gate a whole test *file* on its backend, which does not fit a file whose two backend cases sit beside four backend-independent ones that must keep running everywhere. The backends now also set a compile definition and the file guards on it.

Verified by reproducing the configuration locally (`-DNEOGRAPH_BUILD_POSTGRES=OFF -DNEOGRAPH_BUILD_SQLITE=OFF`) rather than by asking CI again: it links, and the four backend-independent tests still run.

## 3. The sanitizer job — this one is worth reading

pytest printed 24 dots and the process vanished, no message, no summary. Reproduced locally under the same ASan configuration, which produced the stack the log never showed:

```
AddressSanitizer: CHECK failed: asan_interceptors.cpp:458
  "((__interception::real___cxa_throw)) != (0)" (0x0, 0x0)
  #2 __cxa_throw                              asan_interceptors.cpp:458
  #4 pybind11::detail::simple_collector::call cast.h:1655
  #6 run                                      bindings/python/src/bind_node.cpp:267
```

Note what is throwing: **pybind11's `error_already_set`**, at the moment a Python node's `run()` raised. I had two hypotheses before reproducing — that it was the ordinary-exception test, then that it was my own C++ `NodeInterrupt` — and **both were wrong**. A deselect list written from either would have switched off the wrong tests and left the real one to crash again.

**Root cause is ours, not the sanitizer's.** ASan's `__cxa_throw` interceptor resolves the real `__cxa_throw` by `dlsym` at init. With only libasan in `LD_PRELOAD`, libstdc++ is not in the link map yet, the lookup returns null, and the first C++ throw trips the CHECK. Since pybind11 turns *every* Python exception raised inside a node into a C++ throw, this hits any test where Python code raises.

Nine tests had been switched off by name across three separate incidents, each written up in this workflow as *"a known sanitizer limitation … coverage is preserved elsewhere"*. **It was not a limitation. It was a preload-order bug in `ci.yml`** — and it had been quietly eating test coverage the whole time.

```
LD_PRELOAD="$(gcc -print-file-name=libasan.so):$(gcc -print-file-name=libstdc++.so)"
```

Measured, full suite, `detect_leaks=1` + UBSan + the LSan suppressions, **no `-k` filter at all**:

```
120 passed, 5 skipped        (was: 9 deselected — and today, a crash)
```

So the deselect list is **deleted, not extended**. Cancel propagation, the streaming `NotImplementedError` hint, `update_state`'s type errors, and the new dynamic interrupt now run under ASan/LSan/UBSan for the first time.