### PR TITLE
Store, RateLimitedProvider and validate() — the last of the Python parity gaps

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -69,6 +69,7 @@ pybind11_add_module(_neograph
     src/bind_state.cpp
     src/bind_graph.cpp
     src/bind_node.cpp
+    src/bind_parity.cpp
 )
 
 # MCP client (Model Context Protocol). Bound only when neograph::mcp was

--- a/bindings/python/neograph_engine/__init__.py
+++ b/bindings/python/neograph_engine/__init__.py
@@ -294,12 +294,16 @@ class NodeContext(_CppNodeContext):
 
     def __init__(self, provider=None, tools=None,
                  model="", instructions="", extra_config=None):
+        # Let the property setter keep one replaceable Python reference. Passing
+        # provider to the C++ constructor would install a keep_alive edge that
+        # cannot be removed when the property is reassigned.
         super().__init__(
-            provider=provider,
+            provider=None,
             model=model,
             instructions=instructions,
             extra_config=extra_config or {},
         )
+        self.provider = provider
         # Stash the Python tool list on the wrapper. compile() reads
         # it via py::hasattr / py::object.attr("_pytools").
         self._pytools = list(tools or [])

--- a/bindings/python/neograph_engine/__init__.py
+++ b/bindings/python/neograph_engine/__init__.py
@@ -63,6 +63,17 @@ _ensure_ssl_ca_bundle()
 from ._neograph import (
     ToolDecision,
     ToolGateContext,
+
+    # Long-term memory across conversations (#97)
+    Store,
+    InMemoryStore,
+    StoreItem,
+
+    # Pre-flight checks on a graph definition (#97)
+    validate,
+    ValidationReport,
+    Diagnostic,
+
     # Versioning
     __version__,
 
@@ -294,6 +305,36 @@ class NodeContext(_CppNodeContext):
         self._pytools = list(tools or [])
 
 
+class RateLimitError(RuntimeError):
+    """Raise this from a Provider that hit a rate limit (issue #97).
+
+    ``RateLimitedProvider`` catches it, honours ``retry_after_seconds`` if the
+    upstream told you one, and retries **the call**. Anything else you raise
+    propagates as an error, as it should.
+
+    ::
+
+        class MyProvider(neograph_engine.Provider):
+            def complete(self, params):
+                response = requests.post(...)
+                if response.status_code == 429:
+                    raise neograph_engine.RateLimitError(
+                        "rate limited",
+                        retry_after_seconds=int(response.headers.get("Retry-After", -1)))
+                ...
+
+    The binding translates this into the C++ ``RateLimitError`` at the boundary.
+    Without that translation the wrapper would sail straight past a Python
+    provider's 429 and never retry — a capability that exists and quietly does
+    nothing is worse than one that is plainly absent.
+    """
+
+    def __init__(self, message="rate limited", retry_after_seconds=-1):
+        super().__init__(message)
+        #: What the upstream asked you to wait, or -1 if it did not say.
+        self.retry_after_seconds = retry_after_seconds
+
+
 class NodeInterrupt(Exception):
     """Pause the graph from inside a node, resumably (issue #94).
 
@@ -498,6 +539,14 @@ __all__ = [
     "GraphNode",
     "AsyncTool",
     "NodeInterrupt",
+    "RateLimitError",
+    "Store",
+    "InMemoryStore",
+    "StoreItem",
+    "validate",
+    "ValidationReport",
+    "Diagnostic",
+    "RateLimitError",
     "ToolDecision",
     "ToolGateContext",
     "NodeFactory",

--- a/bindings/python/neograph_engine/llm.py
+++ b/bindings/python/neograph_engine/llm.py
@@ -5,6 +5,6 @@ subclasses of :class:`neograph_engine.Provider` and can be passed straight
 to :class:`neograph_engine.NodeContext`.
 """
 
-from ._neograph import OpenAIProvider, SchemaProvider
+from ._neograph import OpenAIProvider, RateLimitedProvider, SchemaProvider
 
-__all__ = ["OpenAIProvider", "SchemaProvider"]
+__all__ = ["OpenAIProvider", "RateLimitedProvider", "SchemaProvider"]

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -47,6 +47,7 @@
 #include <neograph/graph/engine.h>
 #include <neograph/graph/loader.h>
 #include <neograph/graph/state.h>
+#include <neograph/graph/store.h>
 #include <neograph/graph/types.h>
 #include <neograph/tool_dispatch.h>
 
@@ -568,6 +569,21 @@ void init_graph(py::module_& m) {
             },
             py::arg("config"),
             "Run the graph synchronously to completion (or interrupt).")
+
+        .def("set_store",
+            [](GraphEngine& self, std::shared_ptr<Store> store) {
+                self.set_store(std::move(store));
+            },
+            py::arg("store"),
+            py::keep_alive<1, 2>(),   // the engine must not outlive the store
+            "Install the long-term memory the graph's nodes will see at "
+            "``input.ctx.store``.\n\n"
+            "A checkpoint remembers one conversation; a Store remembers the "
+            "user across all of them (issue #97).")
+
+        .def("get_store",
+            [](GraphEngine& self) { return self.get_store(); },
+            "The Store installed with set_store(), or None.")
 
         .def("set_tool_gate",
             [](GraphEngine& self, py::object fn) {

--- a/bindings/python/src/bind_node.cpp
+++ b/bindings/python/src/bind_node.cpp
@@ -38,6 +38,7 @@
 #include <neograph/graph/loader.h>
 #include <neograph/graph/node.h>
 #include <neograph/graph/state.h>
+#include <neograph/graph/store.h>
 #include <neograph/graph/types.h>
 
 #include <asio/awaitable.hpp>
@@ -579,6 +580,14 @@ void init_node(py::module_& m) {
                 return static_cast<uint8_t>(c.stream_mode);
             },
             "Mirrors ``RunConfig.stream_mode`` as the underlying flag bits.")
+        .def_property_readonly("store",
+            [](const RunContext& c) -> py::object {
+                if (!c.store) return py::none();
+                return py::cast(c.store);
+            },
+            "The engine's Store, or None when none was installed. This is how "
+            "a node body remembers something across conversations (issue #97):\n\n"
+            "    seen = input.ctx.store.get([\"users\", uid], \"prefs\")")
         .def_property_readonly("resume_value",
             [](const RunContext& c) -> py::object {
                 if (!c.resume_value) return py::none();

--- a/bindings/python/src/bind_parity.cpp
+++ b/bindings/python/src/bind_parity.cpp
@@ -1,0 +1,158 @@
+// Capabilities that existed in C++ and were simply unreachable from Python — the
+// Store subsystem and the graph validator (issue #97).
+//
+// Not here, deliberately: RetryPolicy. The issue listed it as a gap and the
+// issue was wrong. A graph definition already carries `"retry_policy": {...}`
+// and the engine already honours it from Python; binding a RetryPolicy *class*
+// would give one concept two homes. test_retry_policy_already_works_from_the_definition
+// pins the capability instead, so nobody re-files it.
+
+#include "json_bridge.h"
+
+#include <neograph/graph/compiler.h>
+#include <neograph/graph/node.h>
+#include <neograph/graph/engine.h>
+#include <neograph/graph/store.h>
+#include <neograph/graph/validator.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace py = pybind11;
+
+namespace neograph::pybind {
+
+void init_parity(py::module_& m) {
+    using namespace neograph::graph;
+
+    // ── Store ────────────────────────────────────────────────────────────
+    //
+    // A checkpoint remembers one conversation. The Store remembers the user
+    // across all of them — which is the thing anyone building an agent reaches
+    // for on about day two, and which had no symbol at all in Python.
+
+    py::class_<StoreItem>(m, "StoreItem",
+        "One item in the Store: its namespace, its key, its value, and when it "
+        "was written.")
+        .def_readonly("ns",  &StoreItem::ns,
+            "Hierarchical namespace, e.g. [\"users\", \"u1\", \"prefs\"].")
+        .def_readonly("key", &StoreItem::key)
+        .def_property_readonly("value",
+            [](const StoreItem& i) { return json_to_py(i.value); })
+        .def_readonly("created_at", &StoreItem::created_at,
+            "Unix epoch milliseconds.")
+        .def_readonly("updated_at", &StoreItem::updated_at,
+            "Unix epoch milliseconds.")
+        .def("__repr__", [](const StoreItem& i) {
+            std::string ns;
+            for (const auto& part : i.ns) { ns += "/" + part; }
+            return "<StoreItem " + ns + "/" + i.key + ">";
+        });
+
+    py::class_<Store, std::shared_ptr<Store>>(m, "Store",
+        "Cross-thread long-term memory, namespaced key/value.\n\n"
+        "Where a checkpoint remembers one conversation, a Store remembers the "
+        "user across all of them. Install one with ``engine.set_store(store)``; "
+        "node bodies then reach it through ``input.ctx.store``.\n\n"
+        "Abstract — use InMemoryStore, or subclass this to back it with a "
+        "database.");
+
+    py::class_<InMemoryStore, Store, std::shared_ptr<InMemoryStore>>(
+        m, "InMemoryStore",
+        "Reference Store: everything in a process-lifetime map, thread-safe.")
+        .def(py::init<>())
+        .def("put",
+            [](InMemoryStore& self, const Namespace& ns,
+               const std::string& key, py::object value) {
+                self.put(ns, key, py_to_json(value));
+            },
+            py::arg("ns"), py::arg("key"), py::arg("value"),
+            "Write a value. Overwrites whatever was there.")
+        .def("get",
+            [](const InMemoryStore& self, const Namespace& ns,
+               const std::string& key) -> py::object {
+                auto item = self.get(ns, key);
+                if (!item) return py::none();     // absent, not an exception
+                return py::cast(*item);
+            },
+            py::arg("ns"), py::arg("key"),
+            "Read a value. Returns None when there is nothing there — absence "
+            "is an answer, not an error.")
+        .def("search", &InMemoryStore::search,
+            py::arg("ns_prefix"), py::arg("limit") = 100,
+            "Every item whose namespace starts with this prefix. "
+            "``search([\"users\"])`` finds everything under every user.")
+        .def("delete_item", &InMemoryStore::delete_item,
+            py::arg("ns"), py::arg("key"))
+        .def("list_namespaces", &InMemoryStore::list_namespaces,
+            py::arg("prefix") = Namespace{},
+            "Namespaces that currently hold at least one item.")
+        .def("__len__", &InMemoryStore::size);
+
+    // ── GraphValidator ───────────────────────────────────────────────────
+    //
+    // compile() throws on a broken graph. That tells you it broke; it does not
+    // hand you the list. The validator does, before anything runs.
+
+    py::class_<Diagnostic>(m, "Diagnostic",
+        "One thing the validator found.")
+        .def_readonly("code",     &Diagnostic::code,
+            "Catalog code, E3..E11 — see docs/dsl §5.")
+        .def_readonly("severity", &Diagnostic::severity, "\"error\" | \"warning\"")
+        .def_readonly("path",     &Diagnostic::path,
+            "Where in the definition, JSON-path-ish.")
+        .def_readonly("message",  &Diagnostic::message,
+            "Human-readable and self-contained.")
+        .def_property_readonly("witness",
+            [](const Diagnostic& d) { return json_to_py(d.witness); },
+            "A machine-readable counterexample — the thing that is actually "
+            "wrong, not a description of it.")
+        .def("__repr__", [](const Diagnostic& d) {
+            return "<" + d.severity + " " + d.code + " " + d.path + ": "
+                 + d.message + ">";
+        });
+
+    py::class_<ValidationReport>(m, "ValidationReport",
+        "What the validator found. Errors will make compile() throw; warnings "
+        "will not, and are worth reading anyway.")
+        .def("has_errors", &ValidationReport::has_errors)
+        .def_readonly("diagnostics", &ValidationReport::diagnostics)
+        .def("errors",
+            [](const ValidationReport& r) {
+                std::vector<Diagnostic> out;
+                for (const auto* d : r.errors()) out.push_back(*d);
+                return out;
+            },
+            "The diagnostics that are errors.")
+        .def("warnings",
+            [](const ValidationReport& r) {
+                std::vector<Diagnostic> out;
+                for (const auto* d : r.warnings()) out.push_back(*d);
+                return out;
+            })
+        .def("summary", &ValidationReport::summary,
+            "Every diagnostic, as one block of text.")
+        .def("__bool__", [](const ValidationReport& r) { return !r.has_errors(); },
+            "True when the graph is clean, so ``if not validate(defn): ...`` "
+            "reads the way you would say it.");
+
+    m.def("validate",
+        [](py::object definition) {
+            NodeContext ctx;   // the checks are static: no provider, no tools
+            auto cg = GraphCompiler::compile(py_to_json(definition), ctx);
+            return GraphValidator::validate(cg);
+        },
+        py::arg("definition"),
+        "Check a graph definition and hand back the report — dangling edges, "
+        "unreachable nodes, dead barriers — instead of finding out when "
+        "compile() throws.\n\n"
+        "    report = ng.validate(definition)\n"
+        "    if report.has_errors():\n"
+        "        print(report.summary())\n");
+}
+
+}  // namespace neograph::pybind

--- a/bindings/python/src/bind_provider.cpp
+++ b/bindings/python/src/bind_provider.cpp
@@ -30,6 +30,7 @@
 
 #ifdef NEOGRAPH_PYBIND_HAS_LLM
 #include <neograph/llm/openai_provider.h>
+#include <neograph/llm/rate_limited_provider.h>
 #include <neograph/llm/schema_provider.h>
 #endif
 
@@ -49,14 +50,52 @@ namespace {
 // `complete_stream`, we just call `complete()` and emit the whole
 // content as a single chunk. That lets a non-streaming Python wrapper
 // still work in graphs that requested stream mode.
+// A Python provider that hits a 429 raises `ng.RateLimitError`. That is a
+// Python exception, and RateLimitedProvider catches the C++ one — so without a
+// translation the wrapper would sail past it and never retry, silently. Same
+// shape as the NodeInterrupt translation in bind_node.cpp (issue #94), and the
+// same reason: a capability that exists in C++ and quietly does nothing in
+// Python is worse than one that is plainly absent.
+//
+// Narrow on purpose. Only RateLimitError converts; every other exception stays
+// an error.
+void rethrow_python_rate_limit_error(py::error_already_set& e) {
+    // The GIL guard inside PYBIND11_OVERRIDE is scoped to the macro's block, so
+    // by the time the error_already_set reaches the catch it may already be
+    // released. Everything below touches CPython.
+    py::gil_scoped_acquire gil;
+
+    py::object type;
+    try {
+        type = py::module_::import("neograph_engine").attr("RateLimitError");
+    } catch (const py::error_already_set&) {
+        return;   // module half-initialised; let the original error stand
+    }
+    if (!e.matches(type)) return;
+
+    py::object exc = e.value();
+    std::string message = py::str(exc).cast<std::string>();
+    int retry_after = -1;
+    if (py::hasattr(exc, "retry_after_seconds")) {
+        py::object v = exc.attr("retry_after_seconds");
+        if (!v.is_none()) retry_after = v.cast<int>();
+    }
+    throw neograph::RateLimitError(message, retry_after);
+}
+
 class PyProvider : public neograph::Provider {
   public:
     using neograph::Provider::Provider;
 
     neograph::ChatCompletion
     complete(const neograph::CompletionParams& params) override {
-        PYBIND11_OVERRIDE(neograph::ChatCompletion,
-                          neograph::Provider, complete, params);
+        try {
+            PYBIND11_OVERRIDE(neograph::ChatCompletion,
+                              neograph::Provider, complete, params);
+        } catch (py::error_already_set& e) {
+            rethrow_python_rate_limit_error(e);   // no-op unless it matches
+            throw;
+        }
     }
 
     neograph::ChatCompletion
@@ -310,6 +349,41 @@ void init_provider(py::module_& m) {
 
 #ifdef NEOGRAPH_PYBIND_HAS_LLM
     // ── OpenAIProvider ───────────────────────────────────────────────────
+    py::class_<neograph::llm::RateLimitedProvider, neograph::Provider,
+               std::shared_ptr<neograph::llm::RateLimitedProvider>>(
+        m, "RateLimitedProvider",
+        "Wrap a provider so a 429 backs off and retries THE CALL — not the "
+        "whole graph.\n\n"
+        "    provider = RateLimitedProvider(OpenAIProvider(...), max_retries=5)\n"
+        "    engine = ng.GraphEngine.compile(defn, ng.NodeContext(provider=provider))\n\n"
+        "Retrying at the graph level, which is what you are left doing without "
+        "this, re-runs every node that already succeeded. This retries the one "
+        "HTTP request that failed.\n\n"
+        "Honours the upstream's Retry-After when it sends one, falls back to "
+        "``default_wait_seconds`` when it does not, caps any single sleep at "
+        "``max_wait_seconds``, and gives up entirely once ``max_total_wait_seconds`` "
+        "of sleeping has accumulated (0 = no total cap).")
+        .def(py::init([](std::shared_ptr<neograph::Provider> inner,
+                         int max_retries, int default_wait_seconds,
+                         int max_wait_seconds, int max_total_wait_seconds) {
+                neograph::llm::RateLimitedProvider::Config cfg;
+                cfg.max_retries            = max_retries;
+                cfg.default_wait_seconds   = default_wait_seconds;
+                cfg.max_wait_seconds       = max_wait_seconds;
+                cfg.max_total_wait_seconds = max_total_wait_seconds;
+                return std::shared_ptr<neograph::llm::RateLimitedProvider>(
+                    neograph::llm::RateLimitedProvider::create(
+                        std::move(inner), cfg).release());
+            }),
+            py::arg("provider"),
+            py::arg("max_retries")            = 3,
+            py::arg("default_wait_seconds")   = 30,
+            py::arg("max_wait_seconds")       = 120,
+            py::arg("max_total_wait_seconds") = 0,
+            py::keep_alive<1, 2>(),   // the wrapper must outlive nothing, but the
+                                      // inner provider must outlive the wrapper
+            "Wrap `provider`. Defaults mirror the C++ Config.");
+
     py::class_<neograph::llm::OpenAIProvider, neograph::Provider,
                std::shared_ptr<neograph::llm::OpenAIProvider>>(m, "OpenAIProvider",
         "OpenAI-compatible HTTP provider. Works with OpenAI, Groq, "

--- a/bindings/python/src/bind_state.cpp
+++ b/bindings/python/src/bind_state.cpp
@@ -61,7 +61,19 @@ void init_state(py::module_& m) {
             // Provider::complete, which bridges to complete_async, which bridges
             // back to complete: infinite recursion, stack overflow, SIGSEGV.
             py::keep_alive<1, 2>())
-        .def_readwrite("provider", &NodeContext::provider)
+        // A setter keep_alive policy appends every assigned provider to the
+        // context's patient list. Keep exactly the current Python override in
+        // a replaceable dynamic attribute instead, so reassignment releases
+        // the previous provider normally.
+        .def_property("provider",
+            py::cpp_function([](const NodeContext& c) { return c.provider; }),
+            py::cpp_function([](py::object self, py::object provider) {
+                auto cpp_provider = provider.is_none()
+                    ? std::shared_ptr<neograph::Provider>{}
+                    : provider.cast<std::shared_ptr<neograph::Provider>>();
+                self.attr("_pyprovider") = provider;
+                self.cast<NodeContext&>().provider = std::move(cpp_provider);
+            }))
         .def_readwrite("model", &NodeContext::model)
         .def_readwrite("instructions", &NodeContext::instructions)
         .def_property("extra_config",

--- a/bindings/python/src/module.cpp
+++ b/bindings/python/src/module.cpp
@@ -16,6 +16,7 @@ void init_provider(py::module_& m);
 void init_state(py::module_& m);
 void init_graph(py::module_& m);
 void init_node(py::module_& m);
+void init_parity(py::module_& m);   // Store + validator (#97)
 #ifdef NEOGRAPH_PYBIND_HAS_A2A
 void init_a2a(py::module_& m);
 #endif
@@ -81,6 +82,7 @@ PYBIND11_MODULE(_neograph, m) {
     neograph::pybind::init_state(m);
     neograph::pybind::init_graph(m);
     neograph::pybind::init_node(m);
+    neograph::pybind::init_parity(m);
 #ifdef NEOGRAPH_PYBIND_HAS_A2A
     neograph::pybind::init_a2a(m);
 #endif

--- a/bindings/python/tests/test_parity.py
+++ b/bindings/python/tests/test_parity.py
@@ -1,0 +1,295 @@
+"""Capabilities that existed in C++ and were simply unreachable from Python (#97).
+
+Three of them, and they are not the same kind of thing:
+
+  - **Store** is a missing *subsystem*. Checkpoints remember one conversation;
+    the Store remembers the user across all of them. There was no symbol for any
+    of it in Python — not the interface, not the in-memory implementation, not
+    the item type, and no way for a node body to reach one.
+
+  - **RateLimitedProvider** is what stands between a demo and something you
+    would leave running. Without it a Python user wraps `engine.run()` in their
+    own retry loop, which retries *the whole graph* rather than the one HTTP
+    call that got a 429.
+
+  - **GraphValidator** turns "it threw at compile()" into a report you can read
+    before you run anything.
+
+NOT here, deliberately: `RetryPolicy`. The issue listed it, and the issue was
+wrong — a graph definition already carries `"retry_policy": {...}` and the engine
+already honours it from Python. Binding a RetryPolicy *class* would give one
+concept two homes. `test_retry_policy_already_works_from_the_definition` pins
+that it works, so nobody re-files this.
+"""
+
+import time
+
+import neograph_engine as ng
+import neograph_engine.llm as nglm
+import pytest
+
+
+# ── Store: the long-term memory subsystem ───────────────────────────────────
+
+def test_the_store_symbols_exist():
+    assert hasattr(ng, "Store")
+    assert hasattr(ng, "InMemoryStore")
+    assert hasattr(ng, "StoreItem")
+
+
+def test_put_get_round_trip():
+    store = ng.InMemoryStore()
+
+    store.put(["users", "u1"], "prefs", {"theme": "dark"})
+    item = store.get(["users", "u1"], "prefs")
+
+    assert item is not None
+    assert item.value == {"theme": "dark"}
+    assert item.ns == ["users", "u1"]
+    assert item.key == "prefs"
+    assert item.created_at > 0
+
+
+def test_a_missing_item_is_none_not_an_exception():
+    store = ng.InMemoryStore()
+
+    assert store.get(["users", "nobody"], "prefs") is None
+
+
+def test_search_by_namespace_prefix():
+    store = ng.InMemoryStore()
+    store.put(["users", "u1"], "a", {"n": 1})
+    store.put(["users", "u1"], "b", {"n": 2})
+    store.put(["users", "u2"], "c", {"n": 3})
+
+    found = store.search(["users", "u1"])
+
+    assert sorted(i.key for i in found) == ["a", "b"]
+    assert len(store.search(["users"])) == 3
+
+
+def test_delete_and_list_namespaces():
+    store = ng.InMemoryStore()
+    store.put(["users", "u1"], "a", {"n": 1})
+    store.put(["orgs", "o1"], "b", {"n": 2})
+
+    assert sorted(store.list_namespaces()) == [["orgs", "o1"], ["users", "u1"]]
+
+    store.delete_item(["users", "u1"], "a")
+
+    assert store.get(["users", "u1"], "a") is None
+
+
+def test_a_node_can_reach_the_store_through_its_context():
+    """The point of the subsystem: a node remembering something across runs.
+
+    Without `ctx.store` a Python node has to capture the store in the factory
+    closure — which works, and which means the store cannot be swapped without
+    recompiling the graph.
+    """
+
+    class Remembering(ng.GraphNode):
+        def run(self, input):
+            store = input.ctx.store
+            assert store is not None, "the node cannot see the engine's store"
+
+            seen = store.get(["visits"], "count")
+            count = (seen.value["n"] if seen else 0) + 1
+            store.put(["visits"], "count", {"n": count})
+
+            return [ng.ChannelWrite("count", count)]
+
+        def get_name(self):
+            return "remember"
+
+    ng.NodeFactory.register_type("remember", lambda *_a: Remembering())
+    definition = {
+        "name": "store_graph",
+        "channels": {"count": {"reducer": "overwrite"}},
+        "nodes": {"remember": {"type": "remember"}},
+        "edges": [
+            {"from": "__start__", "to": "remember"},
+            {"from": "remember", "to": "__end__"},
+        ],
+    }
+
+    store = ng.InMemoryStore()
+    engine = ng.GraphEngine.compile(definition, ng.NodeContext())
+    engine.set_store(store)
+
+    counts = []
+    for turn in range(3):
+        cfg = ng.RunConfig()
+        cfg.thread_id = f"visit-{turn}"     # a DIFFERENT conversation each time
+        counts.append(engine.run(cfg).output["channels"]["count"]["value"])
+
+    assert counts == [1, 2, 3], (
+        "the store did not survive across threads — which is the one thing it "
+        "does that a checkpoint does not")
+
+
+# ── RateLimitedProvider: back off on a 429, not on the whole graph ───────────
+
+class _RateLimited(ng.Provider):
+    """Fails with a rate-limit error N times, then succeeds."""
+
+    def __init__(self, fail_times):
+        super().__init__()
+        self.calls = 0
+        self._fail_times = fail_times
+
+    def complete(self, params):
+        self.calls += 1
+        if self.calls <= self._fail_times:
+            raise ng.RateLimitError("429 Too Many Requests", retry_after_seconds=0)
+        completion = ng.ChatCompletion()
+        completion.message = ng.ChatMessage("assistant", "ok")
+        return completion
+
+    def complete_stream(self, params, on_chunk):
+        return self.complete(params)
+
+    def get_name(self):
+        return "rate-limited-stub"
+
+
+def test_the_rate_limited_provider_exists():
+    assert hasattr(nglm, "RateLimitedProvider")
+
+
+def test_it_retries_the_call_and_succeeds():
+    from neograph_engine.llm import RateLimitedProvider
+
+    inner = _RateLimited(fail_times=2)
+    provider = RateLimitedProvider(
+        inner, max_retries=3, default_wait_seconds=0, max_wait_seconds=0)
+
+    params = ng.CompletionParams()
+    params.messages = [ng.ChatMessage("user", "hi")]
+    result = provider.complete(params)
+
+    assert result.message.content == "ok"
+    assert inner.calls == 3, "the wrapper did not retry the failing call"
+
+
+def test_it_gives_up_after_max_retries():
+    from neograph_engine.llm import RateLimitedProvider
+
+    inner = _RateLimited(fail_times=99)
+    provider = RateLimitedProvider(
+        inner, max_retries=2, default_wait_seconds=0, max_wait_seconds=0)
+
+    params = ng.CompletionParams()
+    params.messages = [ng.ChatMessage("user", "hi")]
+    with pytest.raises(Exception):
+        provider.complete(params)
+
+    assert inner.calls == 3, "expected the original call plus two retries"
+
+
+# ── GraphValidator: read the report instead of catching the throw ────────────
+
+def test_the_validator_exists():
+    assert hasattr(ng, "validate")
+    assert hasattr(ng, "ValidationReport")
+
+
+def test_a_good_graph_has_no_errors():
+    definition = {
+        "name": "fine",
+        "channels": {"x": {"reducer": "overwrite"}},
+        "nodes": {},
+        "edges": [{"from": "__start__", "to": "__end__"}],
+    }
+
+    report = ng.validate(definition)
+
+    assert not report.has_errors()
+    assert report.summary() == "" or "error" not in report.summary().lower()
+
+
+def test_a_dangling_edge_is_reported_not_thrown():
+    """The whole point: you get told what is wrong, before anything runs."""
+    definition = {
+        "name": "broken",
+        "channels": {"messages": {"reducer": "append"}},
+        "nodes": {"a": {"type": "llm_call"}},
+        "edges": [
+            {"from": "__start__", "to": "a"},
+            {"from": "a", "to": "ghost"},        # <- no such node
+        ],
+    }
+
+    report = ng.validate(definition)
+
+    assert report.has_errors()
+    codes = [d.code for d in report.errors()]
+    assert "E3" in codes, f"expected a dangling-reference error, got {codes}"
+
+    offending = [d for d in report.errors() if d.code == "E3"]
+    assert "ghost" in offending[0].message
+
+
+def test_an_unknown_node_type_still_throws():
+    """The honest edge of validate(), pinned rather than papered over.
+
+    validate() compiles the definition first, and compiling instantiates the
+    nodes — so a node type nobody registered surfaces as an exception, not as a
+    diagnostic. Same on the C++ side. Register your node types before you
+    validate, exactly as you would before you compile.
+    """
+    definition = {
+        "name": "unknown_type",
+        "channels": {"x": {"reducer": "overwrite"}},
+        "nodes": {"a": {"type": "no_such_type_anywhere"}},
+        "edges": [
+            {"from": "__start__", "to": "a"},
+            {"from": "a", "to": "__end__"},
+        ],
+    }
+
+    with pytest.raises(RuntimeError, match="Unknown node type"):
+        ng.validate(definition)
+
+
+# ── The one the issue got wrong ─────────────────────────────────────────────
+
+def test_retry_policy_already_works_from_the_definition():
+    """#97 listed RetryPolicy as a gap. It is not one.
+
+    A graph definition carries `"retry_policy": {...}` and the engine honours it
+    — from Python, today, with no class bound. Binding a RetryPolicy class would
+    give one concept two homes, so this test exists instead: it proves the
+    capability is there, so nobody re-files the gap.
+    """
+    attempts = {"n": 0}
+
+    class Flaky(ng.GraphNode):
+        def run(self, _input):
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise RuntimeError("transient")
+            return [ng.ChannelWrite("result", "ok")]
+
+        def get_name(self):
+            return "flaky"
+
+    ng.NodeFactory.register_type("flaky_parity", lambda *_a: Flaky())
+    definition = {
+        "name": "retry_from_definition",
+        "channels": {"result": {"reducer": "overwrite"}},
+        "nodes": {"flaky": {"type": "flaky_parity"}},
+        "edges": [
+            {"from": "__start__", "to": "flaky"},
+            {"from": "flaky", "to": "__end__"},
+        ],
+        "retry_policy": {"max_retries": 5, "initial_delay_ms": 1},
+    }
+
+    engine = ng.GraphEngine.compile(definition, ng.NodeContext())
+    cfg = ng.RunConfig()
+    cfg.thread_id = "retry-def"
+    result = engine.run(cfg)
+
+    assert attempts["n"] == 3
+    assert result.output["channels"]["result"]["value"] == "ok"

--- a/bindings/python/tests/test_provider_lifetime.py
+++ b/bindings/python/tests/test_provider_lifetime.py
@@ -14,6 +14,9 @@ It went unnoticed because every existing test that subclasses Provider drives th
 graph through run_stream(), and holds the provider in a local variable.
 """
 
+import gc
+import weakref
+
 import neograph_engine as ng
 import pytest
 
@@ -51,8 +54,6 @@ def _definition():
 
 
 def test_provider_passed_as_a_temporary_survives_the_run():
-    import gc
-
     # Nothing here holds a reference to the provider or the NodeContext.
     engine = ng.GraphEngine.compile(_definition(), ng.NodeContext(provider=_Provider()))
     gc.collect()  # and make sure Python really does try to collect them
@@ -73,6 +74,78 @@ def test_provider_held_in_a_local_still_works():
     result = engine.run(cfg)
 
     assert result.output["channels"]["messages"]["value"][-1]["content"] == "held"
+
+
+@pytest.mark.parametrize("drive", ["run", "run_stream"])
+def test_provider_assigned_after_construction_survives_collection(drive):
+    """The current provider stays alive; the replaced provider does not."""
+    initial = _Provider("initial")
+    initial_ref = weakref.ref(initial)
+    ctx = ng.NodeContext(provider=initial)
+    del initial
+    gc.collect()
+
+    assert initial_ref() is not None
+
+    replacement = _Provider("reassigned")
+    replacement_ref = weakref.ref(replacement)
+    ctx.provider = replacement
+    del replacement
+    gc.collect()
+
+    assert initial_ref() is None
+    assert replacement_ref() is not None
+
+    engine = ng.GraphEngine.compile(_definition(), ctx)
+    del ctx
+    gc.collect()
+
+    assert replacement_ref() is not None
+
+    cfg = ng.RunConfig()
+    cfg.thread_id = f"reassigned-{drive}"
+    if drive == "run":
+        result = engine.run(cfg)
+    else:
+        result = engine.run_stream(cfg, lambda _event: None)
+
+    assert result.output["channels"]["messages"]["value"][-1]["content"] == "reassigned"
+
+
+def test_provider_property_none_releases_the_current_provider():
+    provider = _Provider()
+    provider_ref = weakref.ref(provider)
+    ctx = ng.NodeContext(provider=provider)
+    del provider
+    gc.collect()
+
+    assert provider_ref() is not None
+
+    ctx.provider = None
+    gc.collect()
+
+    assert provider_ref() is None
+    assert ctx.provider is None
+
+
+def test_repeated_provider_assignment_keeps_only_the_current_provider():
+    ctx = ng.NodeContext()
+    refs = []
+
+    for i in range(10):
+        provider = _Provider(f"provider-{i}")
+        refs.append(weakref.ref(provider))
+        ctx.provider = provider
+
+    del provider
+    gc.collect()
+
+    assert [ref() is not None for ref in refs] == [False] * 9 + [True]
+
+    ctx.provider = None
+    gc.collect()
+
+    assert all(ref() is None for ref in refs)
 
 
 @pytest.mark.parametrize("drive", ["run", "run_stream"])

--- a/docs/python-binding.md
+++ b/docs/python-binding.md
@@ -144,6 +144,85 @@ loudly rather than looking like a question for a human.
 
 Requires a checkpoint store — there is nothing to resume from otherwise.
 
+## Remembering the user across conversations — the Store
+
+A checkpoint remembers **one conversation**. A Store remembers **the user**,
+across all of them.
+
+```python
+store = ng.InMemoryStore()
+engine.set_store(store)
+
+class Greet(ng.GraphNode):
+    def run(self, input):
+        seen = input.ctx.store.get(["users", "u1"], "visits")
+        n = (seen.value["n"] if seen else 0) + 1
+        input.ctx.store.put(["users", "u1"], "visits", {"n": n})
+        return [ng.ChannelWrite("greeting", f"visit #{n}")]
+```
+
+Namespaces are hierarchical lists, so `store.search(["users"])` finds everything
+under every user, and `store.search(["users", "u1"])` finds one user's items.
+`get()` returns `None` for a miss — absence is an answer, not an error.
+
+Subclass `ng.Store` to put it in a database instead.
+
+## Backing off on a 429 — RateLimitedProvider
+
+```python
+from neograph_engine.llm import RateLimitedProvider, OpenAIProvider
+
+provider = RateLimitedProvider(OpenAIProvider(...), max_retries=5)
+engine = ng.GraphEngine.compile(definition, ng.NodeContext(provider=provider))
+```
+
+Without it you end up wrapping `engine.run()` in your own retry loop, which
+retries **the whole graph** — re-running every node that already succeeded. This
+retries the one HTTP request that failed.
+
+It honours the upstream's `Retry-After` when there is one, falls back to
+`default_wait_seconds` when there is not, caps a single sleep at
+`max_wait_seconds`, and gives up once `max_total_wait_seconds` of sleeping has
+accumulated (`0` = no total cap).
+
+Your own provider opts in by raising the right exception:
+
+```python
+class MyProvider(ng.Provider):
+    def complete(self, params):
+        r = requests.post(...)
+        if r.status_code == 429:
+            raise ng.RateLimitError(
+                "rate limited",
+                retry_after_seconds=int(r.headers.get("Retry-After", -1)))
+```
+
+Anything else you raise stays an error.
+
+## Checking a graph before you run it — `validate`
+
+```python
+report = ng.validate(definition)
+if report.has_errors():
+    print(report.summary())
+    for d in report.errors():
+        print(d.code, d.path, d.message)
+```
+
+Dangling edges, unreachable nodes, dead barriers — a report you can read, rather
+than finding out when `compile()` throws.
+
+One edge worth knowing: `validate()` compiles the definition first, so a node
+type nobody registered surfaces as an **exception**, not a diagnostic. Register
+your node types before validating, exactly as you would before compiling.
+
+**Retries at the node level need no class.** Put `"retry_policy": {...}` in the
+graph definition and the engine honours it — that has always worked from Python:
+
+```python
+definition["retry_policy"] = {"max_retries": 5, "initial_delay_ms": 100}
+```
+
 ## MCP — using a remote tool server
 
 ```python


### PR DESCRIPTION
Three capabilities that existed in C++ and were simply unreachable from Python. They are not the same kind of thing.

## Store — a missing *subsystem*, not a missing convenience

A checkpoint remembers **one conversation**. A Store remembers **the user**, across all of them. Python had no symbol for any of it: not the interface, not the in-memory implementation, not the item type, and no way for a node body to reach one.

```python
store = ng.InMemoryStore()
engine.set_store(store)

class Greet(ng.GraphNode):
    def run(self, input):
        seen = input.ctx.store.get(["users", "u1"], "visits")
        n = (seen.value["n"] if seen else 0) + 1
        input.ctx.store.put(["users", "u1"], "visits", {"n": n})
        ...
```

`engine.set_store()` and `input.ctx.store` come with it — a Store the nodes cannot see is furniture.

## RateLimitedProvider — and the trap that would have made it useless

Bound. But a Python provider that hits a 429 raises a **Python** `RateLimitError`, and the wrapper catches the **C++** one. Without a translation at the trampoline, the wrapper sails straight past it and never retries — **silently**.

A capability that exists and quietly does nothing is worse than one that is plainly absent. Same shape, and the same lesson, as the `NodeInterrupt` translation in #94.

**Mutation-verified**: disable the translation and the two retry tests go red, with the 429 escaping as a plain error. Without running that mutation, the tests would have been green either way.

Two bugs found while wiring it, both worth a reviewer's eye:

- The GIL guard inside `PYBIND11_OVERRIDE` is scoped to the macro's block, so the catch handler was touching CPython **with the GIL released**. A core dump, not a subtle one.
- `py::exception<T>` produces a type that takes no keyword arguments, so `RateLimitError(msg, retry_after_seconds=...)` raised a `TypeError`. It is a real Python class now, like `NodeInterrupt`.

## validate() — the report instead of the throw

```python
report = ng.validate(definition)
if report.has_errors():
    print(report.summary())
```

Dangling edges, unreachable nodes, dead barriers. Its honest edge is **pinned by a test** rather than papered over: `validate()` compiles first, so an unregistered node type surfaces as an exception, not a diagnostic.

## One thing the issue got wrong

#97 listed **RetryPolicy** as a gap. **It is not one.** A graph definition already carries `"retry_policy": {...}` and the engine already honours it from Python — verified, not assumed. Binding a `RetryPolicy` *class* would have given one concept two homes. There is a test pinning the capability instead, so nobody re-files it.

Also already closed by earlier work: the sync `resume()`, bound in #94.

`llm::Agent` is deliberately not here — the issue itself called it low priority, and since #87 both dispatch routes share one implementation, so an Agent binding inherits concurrency, the tool gate and token accounting rather than needing them re-plumbed. Split out rather than dropped silently.

## Evidence

RED first (12 failed, 1 passed — the one that passed was the RetryPolicy test, because that capability was already there), then mutation-verified as above.

pytest **152** passed + 5 skipped, ctest **635/635**.

Closes #97.