### PR TITLE
fix(docs): correct GraphNode run signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed (docs)
+
+- **`GraphNode::run` 예제 서명 수정 (issue #129).** 공개 헤더 예제가 실제
+  by-value virtual과 달리 `const NodeInput&`를 받아 override에 실패하던 문제를
+  수정하고, 코루틴 인자 수명에 필요한 by-value 계약을 compile-time test로
+  고정했다.
+
 ### Added
 
 - **DSL 표면 (elaboration 계층) + 스키마 진화 게이트** (#75 M4).

--- a/include/neograph/graph/node.h
+++ b/include/neograph/graph/node.h
@@ -158,7 +158,7 @@ public:
      *
      * @code
      * class MyNode : public GraphNode {
-     *     asio::awaitable<NodeOutput> run(const NodeInput& in) override {
+     *     asio::awaitable<NodeOutput> run(NodeInput in) override {
      *         auto messages = in.state.get_messages();
      *         auto reply = co_await provider_->complete_async({...});
      *         NodeOutput out;

--- a/tests/test_node_run_dispatch.cpp
+++ b/tests/test_node_run_dispatch.cpp
@@ -19,11 +19,17 @@
 #include <atomic>
 #include <memory>
 #include <string>
+#include <type_traits>
 
 using namespace neograph;
 using namespace neograph::graph;
 
 namespace {
+
+using RunSignature = asio::awaitable<NodeOutput> (GraphNode::*)(NodeInput);
+static_assert(std::is_same_v<decltype(&GraphNode::run), RunSignature>,
+              "GraphNode::run must take NodeInput by value so its coroutine "
+              "frame owns the parameter");
 
 // Shared observation slot — the factory lambda captures a
 // shared_ptr<RunObs> by value, every node it produces records into the


### PR DESCRIPTION
## Summary
- correct the public `GraphNode::run` example to take `NodeInput` by value
- add a compile-time signature assertion for the coroutine lifetime contract
- document the fix in the changelog

## Verification
- `NodeRunDispatch.*`: 2/2 passed
- configured suite: 518 passed, 3 expected live tests skipped
- independent review: approved
- `git diff --check`: clean

Closes #129