### PR TITLE
fix(docs): mark RunContext deadline as reserved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed (docs)
+
+- **예약된 `RunContext::deadline` 설명 정정 (issue #115).** 현재
+  `RunConfig`로 설정할 수 없고 Python에도 노출되지 않는 `deadline`과
+  `trace_id`를 사용 가능한 per-run metadata처럼 안내하던 문서와 Doxygen
+  주석을 수정했다.
+
 ### Added
 
 - **DSL 표면 (elaboration 계층) + 스키마 진화 게이트** (#75 M4).
@@ -806,17 +813,18 @@ The opening release of the v1.0 sharpening track (ROADMAP_v1.md).
 The 8-virtual `GraphNode` cross-product (`execute` / `execute_async` /
 `execute_full` / … / `execute_full_stream_async`) collapses to a
 single canonical method: `run(NodeInput) -> awaitable<NodeOutput>`.
-Per-run metadata (cancel token, deadline, trace_id) moves from a
-non-channel-set `GraphState` member + a thread-local smuggling
-channel into an explicit `RunContext` argument. `CancelToken` gains
+Per-run cancellation metadata moves from a non-channel-set `GraphState`
+member + a thread-local smuggling channel into an explicit `RunContext`
+argument. `deadline` and `trace_id` were added only as reserved extension
+slots and are not populated by `RunConfig`. `CancelToken` gains
 hierarchical `fork()` so multi-Send fan-out workers each own a
 private signal that the parent's `cancel()` cascades to.
 
 ### Added
 
-- `RunContext` (`include/neograph/graph/engine.h`) — explicit
-  per-run metadata: `cancel_token`, `deadline`, `trace_id`,
-  `thread_id`, `step`, `stream_mode`. Engine threads through every
+- `RunContext` (`include/neograph/graph/engine.h`) — explicit per-run metadata:
+  usable `cancel_token`, `thread_id`, `step`, `stream_mode`, plus reserved
+  `deadline` and `trace_id` slots. Engine threads it through every
   `NodeExecutor::run` call. **PR 1, commit `a473f0e`.**
 - `GraphNode::run(NodeInput) -> awaitable<NodeOutput>` — single
   canonical dispatch entry point. `NodeInput { state, ctx,

--- a/bindings/python/src/bind_node.cpp
+++ b/bindings/python/src/bind_node.cpp
@@ -552,12 +552,12 @@ void init_node(py::module_& m) {
     //
     // Exposed read-only — the engine constructs and owns the RunContext;
     // Python users read it from ``NodeInput.ctx`` inside their ``run()``
-    // override. Currently exposes the four fields a user is most likely
-    // to consume: cancel_token (so they can pass it explicitly to
+    // override. Currently exposes six user-facing fields:
+    // cancel_token (so they can pass it explicitly to
     // provider.complete instead of relying on the smuggling thread-local),
     // step (super-step counter), thread_id (RunConfig.thread_id), and
-    // stream_mode. ``deadline`` and ``trace_id`` are reserved for
-    // future RunConfig fields and stay default-constructed for now.
+    // stream_mode, store, and resume_value. ``deadline`` and ``trace_id`` are
+    // reserved for future RunConfig fields and stay default-constructed for now.
     py::class_<RunContext>(m, "RunContext",
         "Per-run dispatch metadata threaded by the engine. New nodes "
         "read this from ``input.ctx`` inside their ``run(input)`` "

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -184,7 +184,7 @@ class Researcher(ng.GraphNode):
 
     def run(self, input):
         # input.state    — read channels via input.state.get(...)
-        # input.ctx      — RunContext (cancel_token, deadline, trace_id, ...)
+        # input.ctx      — RunContext (cancel_token, thread_id, step, ...)
         # input.stream_cb — non-None when running in streaming mode
         topic = input.state.get("topic")
         result = await_llm(topic, cancel_token=input.ctx.cancel_token)
@@ -194,6 +194,11 @@ class Researcher(ng.GraphNode):
             sends=[],                                    # optional
         )
 ```
+
+Python exposes `cancel_token`, `thread_id`, `step`, `stream_mode`, `store`,
+and `resume_value` on `input.ctx`. The C++ `deadline` and `trace_id` slots are
+reserved for future `RunConfig` fields; the engine does not populate them and
+Python does not expose them yet.
 
 You can also return a bare `list[ChannelWrite]` when you don't need
 `Send` or `Command` — the binding lifts it into a `NodeResult`

--- a/docs/migration-v0.4-to-v1.0.md
+++ b/docs/migration-v0.4-to-v1.0.md
@@ -213,8 +213,10 @@ asio::awaitable<NodeOutput> run(NodeInput in) override {
 }
 ```
 
-`in.ctx` 의 다른 필드: `deadline`, `trace_id`, `thread_id`, `step`,
-`stream_mode` — 노드가 자기 컨텍스트를 알고 행동을 바꿀 때 활용.
+현재 노드가 활용할 수 있는 `in.ctx` 필드는 `cancel_token`, `usage`,
+`thread_id`, `step`, `stream_mode`, `store`, `resume_value`입니다.
+`deadline`과 `trace_id`는 향후 `RunConfig` 확장을 위한 예약 슬롯으로,
+현재 엔진은 값을 채우지 않으며 Python에도 노출하지 않습니다.
 
 ### `_full` virtual 옮기는 사람 — `co_return out;` 한 줄로 끝
 

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -1040,6 +1040,7 @@ struct RunConfig {
     int                         max_steps    = 50;
     StreamMode                  stream_mode  = StreamMode::ALL;
     std::shared_ptr<CancelToken> cancel_token;          // v0.3+
+    std::shared_ptr<UsageAccumulator> usage;             // optional accumulator
     bool                        resume_if_exists = false; // v0.3.1+
 };
 ```
@@ -1051,33 +1052,41 @@ struct RunConfig {
 | `max_steps` | `int` | `50` | Maximum number of super-steps before forced termination (prevents infinite loops) |
 | `stream_mode` | `StreamMode` | `ALL` | Bitfield controlling which event types are emitted during streaming |
 | `cancel_token` | `std::shared_ptr<CancelToken>` | `nullptr` | Cooperative cancel handle. Engine wraps this into a `RunContext` and threads it to every node's `run(NodeInput)` call as `in.ctx.cancel_token` |
+| `usage` | `std::shared_ptr<UsageAccumulator>` | `nullptr` | Optional token accumulator. The engine creates one when omitted and exposes the active accumulator as `in.ctx.usage` |
 | `resume_if_exists` | `bool` | `false` | If `true` and a checkpoint exists for `thread_id`, seed from it before applying `input` (multi-turn chat shape) |
 
 ### RunContext (v0.4 PR 1, exposed to nodes via `NodeInput.ctx`)
 
-Per-run dispatch metadata threaded by the engine. Constructed from
-`RunConfig`; consumed inside a node's `run(NodeInput) -> NodeOutput`
-override via `in.ctx`.
+Per-run dispatch metadata threaded by the engine. Constructed from `RunConfig`
+(with a new usage accumulator when none was supplied), the engine's Store,
+and an optional resume value. Nodes consume it inside a
+`run(NodeInput) -> NodeOutput` override via `in.ctx`.
 
 ```cpp
 struct RunContext {
     std::shared_ptr<CancelToken>  cancel_token;
-    std::optional<Deadline>       deadline;     // reserved
+    std::shared_ptr<UsageAccumulator> usage;
+    std::optional<std::chrono::steady_clock::time_point> deadline; // reserved
     std::string                   trace_id;     // reserved
     std::string                   thread_id;
     int                           step;
     StreamMode                    stream_mode;
+    std::optional<json>           resume_value;
+    std::shared_ptr<Store>        store;
 };
 ```
 
 | Field | Description |
 |-------|-------------|
 | `cancel_token` | The active token. Pass to `provider.complete(params)` so an LLM HTTP socket aborts on cancel, or poll `is_cancelled()` for your own loops |
+| `usage` | Shared token-accounting sink populated by the engine |
 | `deadline` | Reserved (no `RunConfig.deadline` field yet) |
 | `trace_id` | Reserved for OTel integration |
 | `thread_id` | Mirror of `RunConfig.thread_id` |
 | `step` | Current super-step index, updated each iteration |
 | `stream_mode` | Mirror of `RunConfig.stream_mode` |
+| `resume_value` | Value supplied to `GraphEngine::resume()`, or empty on a fresh run |
+| `store` | Store installed on the engine, or `nullptr` when none is configured |
 
 ### CancelToken
 

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -99,8 +99,9 @@ struct RunConfig {
 /**
  * @brief Per-run dispatch metadata threaded through the engine and executor.
  *
- * Built from ``RunConfig`` at the top of ``execute_graph_async`` and
- * carried by reference through every internal dispatch hop
+ * Built from ``RunConfig`` plus engine state (usage accounting and Store) and
+ * resume input at the top of ``execute_graph_async``, then carried by reference
+ * through every internal dispatch hop
  * (``NodeExecutor::run_one_async`` / ``run_parallel_async`` /
  * ``run_sends_async`` / ``execute_node_with_retry_async``). Replaces the
  * v0.3.x-era smuggling channels — ``GraphState::run_cancel_token_`` and
@@ -108,19 +109,14 @@ struct RunConfig {
  * argument that survives every Send-fan-out / serialize-restore /
  * thread-hop.
  *
- * **PR 1 (v0.4.0) is plumbing-only**: the struct exists, the engine
- * builds it, and ``NodeExecutor`` carries it through, but nothing yet
- * consumes it. ``GraphNode::execute_full_async`` still receives only
- * ``state``. The smuggling channels remain authoritative until
- * subsequent PRs flip the consumers (PR 2: new ``run(NodeInput)``
- * virtual; PR 3: hierarchical CancelToken; PR 4: deprecate the
- * smuggling).
+ * ``GraphNode::run(NodeInput)`` consumes it through ``in.ctx``. Cancellation,
+ * usage, thread/step/stream metadata, Store, and resume values are active;
+ * deadline and trace ID remain reserved extension slots.
  *
- * Cheap to copy (one shared_ptr + a couple of strings); workers that
- * need an isolated copy take it by value, the common path takes it by
- * const reference.
+ * Workers that need an isolated context copy take it by value; the common
+ * path takes it by const reference.
  *
- * @see RunConfig (the caller-supplied source) and ROADMAP_v1.md
+ * @see RunConfig (the primary caller-supplied source) and ROADMAP_v1.md
  * (Candidate 2: "Explicit RunContext for per-run metadata").
  */
 struct RunContext {
@@ -134,7 +130,7 @@ struct RunContext {
     /// so — the engine only sees completions that pass through its own nodes.
     std::shared_ptr<UsageAccumulator> usage;
 
-    /// Optional absolute wall-clock deadline. Reserved for a future PR
+    /// Optional absolute monotonic-clock deadline. Reserved for a future PR
     /// (RunConfig has no deadline field today); left ``std::nullopt``
     /// by the engine for now so existing behaviour is unchanged.
     std::optional<std::chrono::steady_clock::time_point> deadline;

--- a/include/neograph/graph/node.h
+++ b/include/neograph/graph/node.h
@@ -20,11 +20,10 @@
  * same plan will mark the legacy virtuals `[[deprecated]]`; v1.0
  * deletes them.
  *
- * The `RunContext` field plumbed through `NodeInput::ctx` is
- * engine-internal for now — PR 1 (v0.4.0) only carries it through
- * the dispatch hops. User-overridable virtuals receive it once PR 2
- * lands. Until then, cancel token / deadline / trace_id propagate
- * via the legacy paths.
+ * The engine threads `RunContext` through `NodeInput::ctx`. Nodes can use
+ * cancellation, usage accounting, thread/step/stream metadata, Store access,
+ * and resume values. The deadline and trace-id fields are reserved extension
+ * slots and are not populated by current `RunConfig` APIs.
  *
  * Example overrides that match the v0.4.x surface:
  *   - `examples/01_react_agent.cpp` — basic ReAct agent
@@ -73,10 +72,9 @@ struct NodeInput {
     /// Snapshot of the channel state visible to this node.
     const GraphState&  state;
 
-    /// Per-run metadata threaded by the engine — cancel token,
-    /// deadline, trace_id, thread_id, current super-step, stream
-    /// mode. PR 1 plumbed this through every dispatch hop; PR 2 is
-    /// the first place a user-overridable virtual receives it.
+    /// Per-run metadata threaded by the engine — cancel token, usage,
+    /// thread_id, current super-step, stream mode, Store, and resume value.
+    /// Deadline and trace-id members are reserved and currently unpopulated.
     const RunContext&  ctx;
 
     /// Streaming sink. ``nullptr`` for non-streaming runs (the engine
@@ -138,8 +136,8 @@ public:
      *        product over (sync/async) × (writes/full) × (stream/non-stream).
      *
      * **New nodes override THIS method.** Read ``in.state`` for channel
-     * inputs, read ``in.ctx`` for per-run metadata (cancel token,
-     * deadline, current step, …), check ``in.stream_cb`` for an
+     * inputs, read ``in.ctx`` for available per-run metadata (cancel token,
+     * thread ID, current step, …), check ``in.stream_cb`` for an
      * optional ``LLM_TOKEN`` sink, and return a ``NodeOutput`` (alias
      * for ``NodeResult``) populated with channel writes plus optional
      * ``Command`` / ``Send`` directives.


### PR DESCRIPTION
## Summary
- distinguish active `RunContext` fields from reserved `deadline` and `trace_id` slots
- align concepts, migration, API reference, Doxygen, binding comments, and historical changelog
- restore the missing `RunConfig.usage` and current Store/resume fields in the API reference

## Verification
- exhaustive deadline-reference audit completed
- independent final review: approved with no findings
- `git diff --check`: clean

Closes #115