### PR TITLE
feat(python): support custom persistence backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Python persistence backends** (#117) — `Store` and `CheckpointStore` are
+  now constructible subclass bases with C++ virtual dispatch into Python.
+  `StoreItem`, `CheckpointPhase`, `Checkpoint`, and `PendingWrite` are exposed
+  with JSON-shaped fields; checkpoint pending-write methods remain optional.
+
 - **DSL 표면 (elaboration 계층) + 스키마 진화 게이트** (#75 M4).
   - **Elaborator**: `vars`(`{"$var":...}`·`${...}` 보간, 비순환 강제) /
     `templates`+`use`(파라미터 정확 일치 강제, 노드 prefix 리네임 —

--- a/bindings/python/neograph_engine/__init__.py
+++ b/bindings/python/neograph_engine/__init__.py
@@ -112,6 +112,9 @@ from ._neograph import (
     RunConfig,
     RunResult,
     UsageAccumulator,
+    CheckpointPhase,
+    Checkpoint,
+    PendingWrite,
     CheckpointStore,
     InMemoryCheckpointStore,
 
@@ -562,6 +565,9 @@ __all__ = [
     "RunConfig",
     "UsageAccumulator",
     "RunResult",
+    "CheckpointPhase",
+    "Checkpoint",
+    "PendingWrite",
     "CheckpointStore",
     "InMemoryCheckpointStore",
     # Postgres/SqliteCheckpointStore appended dynamically below when present.

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -80,6 +80,58 @@ namespace neograph::pybind {
 
 namespace {
 
+class PyCheckpointStore : public neograph::graph::CheckpointStore {
+public:
+    using CheckpointStore::CheckpointStore;
+
+    void save(const neograph::graph::Checkpoint& cp) override {
+        PYBIND11_OVERRIDE_PURE(void, CheckpointStore, save, cp);
+    }
+
+    std::optional<neograph::graph::Checkpoint>
+    load_latest(const std::string& thread_id) override {
+        PYBIND11_OVERRIDE_PURE(std::optional<neograph::graph::Checkpoint>,
+                               CheckpointStore, load_latest, thread_id);
+    }
+
+    std::optional<neograph::graph::Checkpoint>
+    load_by_id(const std::string& id) override {
+        PYBIND11_OVERRIDE_PURE(std::optional<neograph::graph::Checkpoint>,
+                               CheckpointStore, load_by_id, id);
+    }
+
+    std::vector<neograph::graph::Checkpoint>
+    list(const std::string& thread_id, int limit) override {
+        PYBIND11_OVERRIDE_PURE(std::vector<neograph::graph::Checkpoint>,
+                               CheckpointStore, list, thread_id, limit);
+    }
+
+    void delete_thread(const std::string& thread_id) override {
+        PYBIND11_OVERRIDE_PURE(void, CheckpointStore, delete_thread, thread_id);
+    }
+
+    void put_writes(const std::string& thread_id,
+                    const std::string& parent_checkpoint_id,
+                    const neograph::graph::PendingWrite& write) override {
+        PYBIND11_OVERRIDE(void, CheckpointStore, put_writes,
+                          thread_id, parent_checkpoint_id, write);
+    }
+
+    std::vector<neograph::graph::PendingWrite>
+    get_writes(const std::string& thread_id,
+               const std::string& parent_checkpoint_id) override {
+        PYBIND11_OVERRIDE(std::vector<neograph::graph::PendingWrite>,
+                          CheckpointStore, get_writes,
+                          thread_id, parent_checkpoint_id);
+    }
+
+    void clear_writes(const std::string& thread_id,
+                      const std::string& parent_checkpoint_id) override {
+        PYBIND11_OVERRIDE(void, CheckpointStore, clear_writes,
+                          thread_id, parent_checkpoint_id);
+    }
+};
+
 // Singleton asio runtime that drives all `run_async` calls. One
 // io_context, one worker thread, work-guard prevents premature exit
 // even when there are no coroutines in flight.
@@ -399,11 +451,88 @@ void init_graph(py::module_& m) {
     // mutate the checkpoint store, and refuse to run when one isn't
     // configured. The in-memory store is the simplest option; SQLite /
     // Postgres backends are NeoGraph-side targets (binding deferred).
-    py::class_<CheckpointStore, std::shared_ptr<CheckpointStore>>(m,
+    py::enum_<CheckpointPhase>(m, "CheckpointPhase")
+        .value("Before", CheckpointPhase::Before)
+        .value("After", CheckpointPhase::After)
+        .value("Completed", CheckpointPhase::Completed)
+        .value("NodeInterrupt", CheckpointPhase::NodeInterrupt)
+        .value("Updated", CheckpointPhase::Updated);
+
+    py::class_<Checkpoint>(m, "Checkpoint")
+        .def(py::init([]() { return Checkpoint{}; }))
+        .def_readwrite("id", &Checkpoint::id)
+        .def_readwrite("thread_id", &Checkpoint::thread_id)
+        .def_property("channel_values",
+            [](const Checkpoint& cp) { return json_to_py(cp.channel_values); },
+            [](Checkpoint& cp, py::object value) {
+                cp.channel_values = py_to_json(value);
+            })
+        .def_property("channel_versions",
+            [](const Checkpoint& cp) { return json_to_py(cp.channel_versions); },
+            [](Checkpoint& cp, py::object value) {
+                cp.channel_versions = py_to_json(value);
+            })
+        .def_readwrite("parent_id", &Checkpoint::parent_id)
+        .def_readwrite("current_node", &Checkpoint::current_node)
+        .def_readwrite("next_nodes", &Checkpoint::next_nodes)
+        .def_readwrite("interrupt_phase", &Checkpoint::interrupt_phase)
+        .def_readwrite("barrier_state", &Checkpoint::barrier_state)
+        .def_property("metadata",
+            [](const Checkpoint& cp) { return json_to_py(cp.metadata); },
+            [](Checkpoint& cp, py::object value) {
+                cp.metadata = py_to_json(value);
+            })
+        .def_readwrite("step", &Checkpoint::step)
+        .def_readwrite("timestamp", &Checkpoint::timestamp)
+        .def_readwrite("schema_version", &Checkpoint::schema_version)
+        .def_static("generate_id", &Checkpoint::generate_id);
+
+    py::class_<PendingWrite>(m, "PendingWrite")
+        .def(py::init([]() { return PendingWrite{}; }))
+        .def_readwrite("task_id", &PendingWrite::task_id)
+        .def_readwrite("task_path", &PendingWrite::task_path)
+        .def_readwrite("node_name", &PendingWrite::node_name)
+        .def_property("writes",
+            [](const PendingWrite& write) { return json_to_py(write.writes); },
+            [](PendingWrite& write, py::object value) {
+                write.writes = py_to_json(value);
+            })
+        .def_property("command",
+            [](const PendingWrite& write) { return json_to_py(write.command); },
+            [](PendingWrite& write, py::object value) {
+                write.command = py_to_json(value);
+            })
+        .def_property("sends",
+            [](const PendingWrite& write) { return json_to_py(write.sends); },
+            [](PendingWrite& write, py::object value) {
+                write.sends = py_to_json(value);
+            })
+        .def_readwrite("step", &PendingWrite::step)
+        .def_readwrite("timestamp", &PendingWrite::timestamp);
+
+    py::class_<CheckpointStore, PyCheckpointStore,
+               std::shared_ptr<CheckpointStore>>(m,
         "CheckpointStore",
         "Abstract checkpoint persistence interface. Construct a "
         "concrete subclass like InMemoryCheckpointStore and pass it "
-        "to engine.set_checkpoint_store().");
+        "to engine.set_checkpoint_store().")
+        .def(py::init<>())
+        .def("save", &CheckpointStore::save, py::arg("checkpoint"))
+        .def("load_latest", &CheckpointStore::load_latest,
+             py::arg("thread_id"))
+        .def("load_by_id", &CheckpointStore::load_by_id,
+             py::arg("checkpoint_id"))
+        .def("list", &CheckpointStore::list,
+             py::arg("thread_id"), py::arg("limit") = 100)
+        .def("delete_thread", &CheckpointStore::delete_thread,
+             py::arg("thread_id"))
+        .def("put_writes", &CheckpointStore::put_writes,
+             py::arg("thread_id"), py::arg("parent_checkpoint_id"),
+             py::arg("write"))
+        .def("get_writes", &CheckpointStore::get_writes,
+             py::arg("thread_id"), py::arg("parent_checkpoint_id"))
+        .def("clear_writes", &CheckpointStore::clear_writes,
+             py::arg("thread_id"), py::arg("parent_checkpoint_id"));
 
     py::class_<InMemoryCheckpointStore, CheckpointStore,
                std::shared_ptr<InMemoryCheckpointStore>>(m,
@@ -497,13 +626,14 @@ void init_graph(py::module_& m) {
     // simple. compile() returns unique_ptr; we move into shared_ptr at
     // the binding boundary.
     py::class_<GraphEngine, std::shared_ptr<GraphEngine>>(m, "GraphEngine",
+        py::dynamic_attr(),
         "Compiled graph runtime. Construct via GraphEngine.compile(), "
         "then call run() or run_stream(). Single instance is safe to "
         "share across threads with distinct thread_ids.")
         .def_static("compile",
             [](py::object definition,
                py::object ctx_obj,
-               std::shared_ptr<CheckpointStore> store) {
+               py::object store_obj) {
                 // Take the Python wrapper as py::object (rather than
                 // const NodeContext&) so we can read the `_pytools`
                 // dynamic attr carrying user-defined Python Tool
@@ -527,24 +657,24 @@ void init_graph(py::module_& m) {
                     }
                 }
 
+                auto store = store_obj.is_none()
+                    ? std::shared_ptr<CheckpointStore>{}
+                    : store_obj.cast<std::shared_ptr<CheckpointStore>>();
                 auto j = py_to_json(definition);
                 // GIL held: compile is fast (just walks the JSON).
                 auto unique = GraphEngine::compile(j, ctx, std::move(store));
                 if (!owned_tools.empty()) {
                     unique->own_tools(std::move(owned_tools));
                 }
-                return std::shared_ptr<GraphEngine>(unique.release());
+                auto engine = std::shared_ptr<GraphEngine>(unique.release());
+                py::object result = py::cast(engine);
+                result.attr("_pycontext") = ctx_obj;
+                result.attr("_pycheckpointstore") = store_obj;
+                return result;
             },
             py::arg("definition"),
             py::arg("ctx"),
-            py::arg("store") = std::shared_ptr<CheckpointStore>{},
-            // #98: the compiled engine keeps the NodeContext alive, and the
-            // NodeContext keeps the Python provider alive (see bind_state.cpp).
-            // Without this chain, `GraphEngine.compile(d, ng.NodeContext(
-            // provider=MyProvider()))` — every argument a temporary, which is
-            // how anyone writes it — leaves the engine holding a trampoline
-            // whose Python half has been collected.
-            py::keep_alive<0, 2>(),
+             py::arg("store") = py::none(),
             "Compile a graph from a JSON-shaped Python dict.\n\n"
             "Args:\n"
             "    definition: JSON graph definition (nodes, edges, "
@@ -571,11 +701,14 @@ void init_graph(py::module_& m) {
             "Run the graph synchronously to completion (or interrupt).")
 
         .def("set_store",
-            [](GraphEngine& self, std::shared_ptr<Store> store) {
-                self.set_store(std::move(store));
+            [](py::object self, py::object store_obj) {
+                auto store = store_obj.is_none()
+                    ? std::shared_ptr<Store>{}
+                    : store_obj.cast<std::shared_ptr<Store>>();
+                self.cast<GraphEngine&>().set_store(std::move(store));
+                self.attr("_pystore") = store_obj;
             },
             py::arg("store"),
-            py::keep_alive<1, 2>(),   // the engine must not outlive the store
             "Install the long-term memory the graph's nodes will see at "
             "``input.ctx.store``.\n\n"
             "A checkpoint remembers one conversation; a Store remembers the "
@@ -828,7 +961,14 @@ void init_graph(py::module_& m) {
             return d;
         }, "Return a dict with current cache size, hit count, miss count.")
 
-        .def("set_checkpoint_store", &GraphEngine::set_checkpoint_store,
+        .def("set_checkpoint_store",
+            [](py::object self, py::object store_obj) {
+                auto store = store_obj.is_none()
+                    ? std::shared_ptr<CheckpointStore>{}
+                    : store_obj.cast<std::shared_ptr<CheckpointStore>>();
+                self.cast<GraphEngine&>().set_checkpoint_store(std::move(store));
+                self.attr("_pycheckpointstore") = store_obj;
+            },
             py::arg("store"),
             "Wire a CheckpointStore instance into the engine. Required "
             "before update_state() / fork(); without it those methods "
@@ -845,11 +985,10 @@ void init_graph(py::module_& m) {
         // hopped back to the asyncio loop via
         // `loop.call_soon_threadsafe(fut.set_result, …)`.
         //
-        // Receiver type is std::shared_ptr<GraphEngine> rather than
-        // GraphEngine& so we can capture the shared_ptr by value
-        // into the asio completion lambda — keeps the engine alive
-        // for the duration of the in-flight coroutine even if the
-        // Python wrapper goes out of scope.
+        // Keep both the C++ engine and its Python wrapper alive for the
+        // in-flight coroutine. The wrapper owns dynamic attributes that pin
+        // Python-defined Store / CheckpointStore trampoline instances; the
+        // C++ shared_ptr alone is not enough to preserve those overrides.
         //
         // Lifetime contract for coroutine parameters: run_async,
         // run_stream_async, and resume_async all take parameters by
@@ -861,7 +1000,9 @@ void init_graph(py::module_& m) {
         // that the completion lambda also captures, so the storage
         // outlives the coroutine.
         .def("run_async",
-            [](std::shared_ptr<GraphEngine> self, RunConfig cfg) {
+            [](py::object self_obj, RunConfig cfg) {
+                auto self = self_obj.cast<std::shared_ptr<GraphEngine>>();
+                auto self_h = hold_py(std::move(self_obj));
                 py::object asyncio = py::module_::import("asyncio");
                 py::object loop = asyncio.attr("get_running_loop")();
                 py::object future = loop.attr("create_future")();
@@ -912,7 +1053,7 @@ void init_graph(py::module_& m) {
                     self->run_async(*cfg_h),
                     asio::bind_cancellation_slot(
                         cancel_tok->slot(),
-                        [self, cfg_h, fut_h, loop_h, cancel_tok]
+                        [self, self_h, cfg_h, fut_h, loop_h, cancel_tok]
                         (std::exception_ptr e, RunResult result) {
                             resolve_future_async(fut_h, loop_h, e,
                                                  std::move(result));
@@ -938,9 +1079,11 @@ void init_graph(py::module_& m) {
             "burns LLM tokens until the upstream call finishes.")
 
         .def("run_stream_async",
-            [](std::shared_ptr<GraphEngine> self,
+            [](py::object self_obj,
                RunConfig cfg,
                py::function py_cb) {
+                auto self = self_obj.cast<std::shared_ptr<GraphEngine>>();
+                auto self_h = hold_py(std::move(self_obj));
                 py::object asyncio = py::module_::import("asyncio");
                 py::object loop = asyncio.attr("get_running_loop")();
                 py::object future = loop.attr("create_future")();
@@ -1026,7 +1169,8 @@ void init_graph(py::module_& m) {
                     self->run_stream_async(*cfg_h, *engine_cb_h),
                     asio::bind_cancellation_slot(
                         cancel_tok->slot(),
-                        [self, cfg_h, engine_cb_h, fut_h, loop_h, cancel_tok]
+                        [self, self_h, cfg_h, engine_cb_h, fut_h, loop_h,
+                         cancel_tok]
                         (std::exception_ptr e, RunResult result) {
                             resolve_future_async(fut_h, loop_h, e,
                                                  std::move(result));
@@ -1045,9 +1189,11 @@ void init_graph(py::module_& m) {
             "a cancelled stream stops billable token generation.")
 
         .def("resume_async",
-            [](std::shared_ptr<GraphEngine> self,
+            [](py::object self_obj,
                std::string thread_id,
                py::object resume_value) {
+                auto self = self_obj.cast<std::shared_ptr<GraphEngine>>();
+                auto self_h = hold_py(std::move(self_obj));
                 py::object asyncio = py::module_::import("asyncio");
                 py::object loop = asyncio.attr("get_running_loop")();
                 py::object future = loop.attr("create_future")();
@@ -1059,11 +1205,12 @@ void init_graph(py::module_& m) {
                 // dangling-reference concern as run_async.
                 auto tid_h = std::make_shared<std::string>(std::move(thread_id));
                 auto rv_h  = std::make_shared<json>(py_to_json(resume_value));
+                auto engine_cb_h = std::make_shared<GraphStreamCallback>();
 
                 asio::co_spawn(
                     AsyncRuntime::instance().executor(),
-                    self->resume_async(*tid_h, *rv_h, nullptr),
-                    [self, tid_h, rv_h, fut_h, loop_h]
+                    self->resume_async(*tid_h, *rv_h, *engine_cb_h),
+                    [self, self_h, tid_h, rv_h, engine_cb_h, fut_h, loop_h]
                     (std::exception_ptr e, RunResult result) {
                         resolve_future_async(fut_h, loop_h, e,
                                              std::move(result));

--- a/bindings/python/src/bind_parity.cpp
+++ b/bindings/python/src/bind_parity.cpp
@@ -26,6 +26,43 @@ namespace py = pybind11;
 
 namespace neograph::pybind {
 
+namespace {
+
+class PyStore : public neograph::graph::Store {
+public:
+    using Store::Store;
+
+    void put(const neograph::graph::Namespace& ns, const std::string& key,
+             const neograph::json& value) override {
+        PYBIND11_OVERRIDE_PURE(void, Store, put, ns, key, json_to_py(value));
+    }
+
+    std::optional<neograph::graph::StoreItem>
+    get(const neograph::graph::Namespace& ns, const std::string& key) const override {
+        PYBIND11_OVERRIDE_PURE(std::optional<neograph::graph::StoreItem>,
+                               Store, get, ns, key);
+    }
+
+    std::vector<neograph::graph::StoreItem>
+    search(const neograph::graph::Namespace& ns_prefix, int limit) const override {
+        PYBIND11_OVERRIDE_PURE(std::vector<neograph::graph::StoreItem>,
+                               Store, search, ns_prefix, limit);
+    }
+
+    void delete_item(const neograph::graph::Namespace& ns,
+                     const std::string& key) override {
+        PYBIND11_OVERRIDE_PURE(void, Store, delete_item, ns, key);
+    }
+
+    std::vector<neograph::graph::Namespace>
+    list_namespaces(const neograph::graph::Namespace& prefix) const override {
+        PYBIND11_OVERRIDE_PURE(std::vector<neograph::graph::Namespace>,
+                               Store, list_namespaces, prefix);
+    }
+};
+
+}  // namespace
+
 void init_parity(py::module_& m) {
     using namespace neograph::graph;
 
@@ -38,14 +75,16 @@ void init_parity(py::module_& m) {
     py::class_<StoreItem>(m, "StoreItem",
         "One item in the Store: its namespace, its key, its value, and when it "
         "was written.")
-        .def_readonly("ns",  &StoreItem::ns,
+        .def(py::init([]() { return StoreItem{}; }))
+        .def_readwrite("ns",  &StoreItem::ns,
             "Hierarchical namespace, e.g. [\"users\", \"u1\", \"prefs\"].")
-        .def_readonly("key", &StoreItem::key)
-        .def_property_readonly("value",
-            [](const StoreItem& i) { return json_to_py(i.value); })
-        .def_readonly("created_at", &StoreItem::created_at,
+        .def_readwrite("key", &StoreItem::key)
+        .def_property("value",
+            [](const StoreItem& i) { return json_to_py(i.value); },
+            [](StoreItem& i, py::object value) { i.value = py_to_json(value); })
+        .def_readwrite("created_at", &StoreItem::created_at,
             "Unix epoch milliseconds.")
-        .def_readonly("updated_at", &StoreItem::updated_at,
+        .def_readwrite("updated_at", &StoreItem::updated_at,
             "Unix epoch milliseconds.")
         .def("__repr__", [](const StoreItem& i) {
             std::string ns;
@@ -53,13 +92,25 @@ void init_parity(py::module_& m) {
             return "<StoreItem " + ns + "/" + i.key + ">";
         });
 
-    py::class_<Store, std::shared_ptr<Store>>(m, "Store",
+    py::class_<Store, PyStore, std::shared_ptr<Store>>(m, "Store",
         "Cross-thread long-term memory, namespaced key/value.\n\n"
         "Where a checkpoint remembers one conversation, a Store remembers the "
         "user across all of them. Install one with ``engine.set_store(store)``; "
         "node bodies then reach it through ``input.ctx.store``.\n\n"
         "Abstract — use InMemoryStore, or subclass this to back it with a "
-        "database.");
+        "database.")
+        .def(py::init<>())
+        .def("put",
+            [](Store& self, const Namespace& ns, const std::string& key,
+               py::object value) { self.put(ns, key, py_to_json(value)); },
+            py::arg("ns"), py::arg("key"), py::arg("value"))
+        .def("get", &Store::get, py::arg("ns"), py::arg("key"))
+        .def("search", &Store::search,
+            py::arg("ns_prefix"), py::arg("limit") = 100)
+        .def("delete_item", &Store::delete_item,
+            py::arg("ns"), py::arg("key"))
+        .def("list_namespaces", &Store::list_namespaces,
+            py::arg("prefix") = Namespace{});
 
     py::class_<InMemoryStore, Store, std::shared_ptr<InMemoryStore>>(
         m, "InMemoryStore",

--- a/bindings/python/tests/test_python_store_backends.py
+++ b/bindings/python/tests/test_python_store_backends.py
@@ -1,0 +1,365 @@
+"""Python implementations of the C++ Store contracts (#117)."""
+
+import asyncio
+import concurrent.futures
+import gc
+import threading
+import weakref
+
+import neograph_engine as ng
+import pytest
+
+
+class DictStore(ng.Store):
+    def __init__(self):
+        ng.Store.__init__(self)
+        self.items = {}
+
+    def put(self, ns, key, value):
+        item = ng.StoreItem()
+        item.ns = ns
+        item.key = key
+        item.value = value
+        item.created_at = item.updated_at = 1
+        self.items[(tuple(ns), key)] = item
+
+    def get(self, ns, key):
+        return self.items.get((tuple(ns), key))
+
+    def search(self, ns_prefix, limit=100):
+        prefix = tuple(ns_prefix)
+        return [item for (ns, _), item in self.items.items()
+                if ns[:len(prefix)] == prefix][:limit]
+
+    def delete_item(self, ns, key):
+        self.items.pop((tuple(ns), key), None)
+
+    def list_namespaces(self, prefix=None):
+        prefix = tuple(prefix or [])
+        return sorted({ns for ns, _ in self.items if ns[:len(prefix)] == prefix})
+
+
+def _copy_checkpoint(source):
+    cp = ng.Checkpoint()
+    for name in (
+        "id", "thread_id", "channel_values", "channel_versions", "parent_id",
+        "current_node", "next_nodes", "interrupt_phase", "barrier_state",
+        "metadata", "step", "timestamp", "schema_version",
+    ):
+        setattr(cp, name, getattr(source, name))
+    return cp
+
+
+class DictCheckpointStore(ng.CheckpointStore):
+    def __init__(self):
+        ng.CheckpointStore.__init__(self)
+        self._lock = threading.Lock()
+        self.by_thread = {}
+        self.by_id = {}
+        self.callback_threads = set()
+
+    def save(self, checkpoint):
+        cp = _copy_checkpoint(checkpoint)
+        with self._lock:
+            self.callback_threads.add(threading.get_ident())
+            self.by_thread.setdefault(cp.thread_id, []).append(cp)
+            self.by_id[cp.id] = cp
+
+    def load_latest(self, thread_id):
+        with self._lock:
+            values = self.by_thread.get(thread_id, [])
+            return _copy_checkpoint(values[-1]) if values else None
+
+    def load_by_id(self, checkpoint_id):
+        with self._lock:
+            cp = self.by_id.get(checkpoint_id)
+            return _copy_checkpoint(cp) if cp else None
+
+    def list(self, thread_id, limit=100):
+        with self._lock:
+            return [_copy_checkpoint(cp)
+                    for cp in reversed(self.by_thread.get(thread_id, []))][:limit]
+
+    def delete_thread(self, thread_id):
+        with self._lock:
+            for cp in self.by_thread.pop(thread_id, []):
+                self.by_id.pop(cp.id, None)
+
+
+def _empty_definition():
+    return {
+        "name": "python_checkpoint_backend",
+        "channels": {"value": {"reducer": "overwrite"}},
+        "nodes": {},
+        "edges": [{"from": ng.START_NODE, "to": ng.END_NODE}],
+    }
+
+
+class _NoopNode(ng.GraphNode):
+    def __init__(self):
+        ng.GraphNode.__init__(self)
+
+    def run(self, input):
+        return []
+
+    def get_name(self):
+        return "checkpoint_noop"
+
+
+ng.NodeFactory.register_type("py_checkpoint_noop", lambda *_: _NoopNode())
+
+
+def _noop_definition():
+    definition = _empty_definition()
+    definition["nodes"] = {"checkpoint_noop": {"type": "py_checkpoint_noop"}}
+    definition["edges"] = [
+        {"from": ng.START_NODE, "to": "checkpoint_noop"},
+        {"from": "checkpoint_noop", "to": ng.END_NODE},
+    ]
+    return definition
+
+
+def test_store_base_methods_dispatch_to_python_and_convert_json():
+    store = DictStore()
+    ng.Store.put(store, ["users", "u1"], "prefs",
+                 {"theme": "dark", "flags": [1, True]})
+
+    assert ng.Store.get(store, ["users", "u1"], "prefs").value == {
+        "theme": "dark", "flags": [1, True]
+    }
+    assert [item.key for item in ng.Store.search(store, ["users"])] == ["prefs"]
+    assert ng.Store.list_namespaces(store) == [["users", "u1"]]
+    ng.Store.delete_item(store, ["users", "u1"], "prefs")
+    assert ng.Store.get(store, ["users", "u1"], "prefs") is None
+
+
+def test_checkpoint_base_methods_dispatch_and_pending_methods_keep_defaults():
+    store = DictCheckpointStore()
+    cp = ng.Checkpoint()
+    cp.id = "cp-1"
+    cp.thread_id = "thread-1"
+    cp.channel_values = {"answer": 42}
+    cp.channel_versions = {"answer": 1}
+    cp.metadata = {"source": "python"}
+    cp.interrupt_phase = ng.CheckpointPhase.Updated
+    ng.CheckpointStore.save(store, cp)
+
+    loaded = ng.CheckpointStore.load_latest(store, "thread-1")
+    assert loaded.id == "cp-1"
+    assert loaded.channel_values == {"answer": 42}
+    assert loaded.metadata == {"source": "python"}
+    assert (ng.CheckpointStore.load_by_id(store, "cp-1").interrupt_phase
+            == ng.CheckpointPhase.Updated)
+    assert [item.id for item in ng.CheckpointStore.list(store, "thread-1")] == ["cp-1"]
+
+    write = ng.PendingWrite()
+    write.writes = [{"channel": "answer", "value": 43}]
+    ng.CheckpointStore.put_writes(store, "thread-1", "cp-1", write)
+    assert ng.CheckpointStore.get_writes(store, "thread-1", "cp-1") == []
+    ng.CheckpointStore.clear_writes(store, "thread-1", "cp-1")
+
+
+def test_checkpoint_value_types_are_public_package_exports():
+    assert {"CheckpointPhase", "Checkpoint", "PendingWrite"} <= set(ng.__all__)
+
+
+def test_python_checkpoint_backend_drives_save_get_state_and_resume():
+    class InterruptOnce(ng.GraphNode):
+        def __init__(self):
+            ng.GraphNode.__init__(self)
+            self.calls = 0
+
+        def run(self, input):
+            self.calls += 1
+            if input.ctx.resume_value is None:
+                raise ng.NodeInterrupt({"question": "continue?"}, reason="approval")
+            return [ng.ChannelWrite("value", input.ctx.resume_value["value"])]
+
+        def get_name(self):
+            return "interrupt_once"
+
+    node = InterruptOnce()
+    ng.NodeFactory.register_type("py_checkpoint_interrupt", lambda *_: node)
+    definition = _empty_definition()
+    definition["nodes"] = {"interrupt_once": {"type": "py_checkpoint_interrupt"}}
+    definition["edges"] = [
+        {"from": ng.START_NODE, "to": "interrupt_once"},
+        {"from": "interrupt_once", "to": ng.END_NODE},
+    ]
+    store = DictCheckpointStore()
+    engine = ng.GraphEngine.compile(definition, ng.NodeContext(), store)
+
+    assert engine.run(ng.RunConfig(thread_id="resume-me")).interrupted
+    assert engine.get_state("resume-me") is not None
+    result = engine.resume("resume-me", {"value": 7})
+
+    assert not result.interrupted
+    assert result.output["channels"]["value"]["value"] == 7
+    assert len(store.list("resume-me")) >= 2
+
+
+def test_backend_exception_propagates_out_of_engine_run():
+    class Broken(DictCheckpointStore):
+        def save(self, checkpoint):
+            raise RuntimeError("backend save failed")
+
+    engine = ng.GraphEngine.compile(_noop_definition(), ng.NodeContext(), Broken())
+    with pytest.raises(RuntimeError, match="backend save failed"):
+        engine.run(ng.RunConfig(thread_id="broken"))
+
+
+def test_temporary_backends_survive_compile_and_setter_reassignment():
+    first = DictCheckpointStore()
+    first_ref = weakref.ref(first)
+    engine = ng.GraphEngine.compile(_noop_definition(), ng.NodeContext(), first)
+    del first
+    gc.collect()
+    assert first_ref() is not None
+
+    second = DictCheckpointStore()
+    second_ref = weakref.ref(second)
+    engine.set_checkpoint_store(second)
+    del second
+    gc.collect()
+    assert first_ref() is None
+    assert second_ref() is not None
+    engine.run(ng.RunConfig(thread_id="kept-alive"))
+
+    old_memory = DictStore()
+    old_memory_ref = weakref.ref(old_memory)
+    engine.set_store(old_memory)
+    del old_memory
+    gc.collect()
+    assert old_memory_ref() is not None
+
+    new_memory = DictStore()
+    memory_ref = weakref.ref(new_memory)
+    engine.set_store(new_memory)
+    del new_memory
+    gc.collect()
+    assert old_memory_ref() is None
+    assert memory_ref() is not None
+    engine.get_store().put(["lifetime"], "ok", True)
+
+
+def test_async_engine_path_inherits_the_sync_backend_bridge():
+    store = DictCheckpointStore()
+    engine = ng.GraphEngine.compile(_noop_definition(), ng.NodeContext(), store)
+
+    async def run():
+        return await engine.run_async(ng.RunConfig(thread_id="async-backend"))
+
+    result = asyncio.run(run())
+    assert result.checkpoint_id
+    assert store.load_latest("async-backend").id == result.checkpoint_id
+
+
+def test_async_run_keeps_python_engine_and_backends_alive_until_completion():
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingCheckpointStore(DictCheckpointStore):
+        def save(self, checkpoint):
+            entered.set()
+            assert release.wait(timeout=5)
+            super().save(checkpoint)
+
+    async def run():
+        checkpoint_store = BlockingCheckpointStore()
+        memory_store = DictStore()
+        engine = ng.GraphEngine.compile(
+            _noop_definition(), ng.NodeContext(), checkpoint_store)
+        engine.set_store(memory_store)
+        engine_ref = weakref.ref(engine)
+        checkpoint_ref = weakref.ref(checkpoint_store)
+        memory_ref = weakref.ref(memory_store)
+
+        future = engine.run_async(ng.RunConfig(thread_id="async-lifetime"))
+        assert await asyncio.to_thread(entered.wait, 5)
+        del engine, checkpoint_store, memory_store
+        gc.collect()
+
+        assert engine_ref() is not None
+        assert checkpoint_ref() is not None
+        assert memory_ref() is not None
+
+        release.set()
+        result = await future
+        assert result.checkpoint_id
+
+    asyncio.run(run())
+
+
+def test_async_resume_keeps_callback_engine_and_backend_storage_alive():
+    entered = threading.Event()
+    release = threading.Event()
+
+    class BlockingCheckpointStore(DictCheckpointStore):
+        block = False
+
+        def save(self, checkpoint):
+            if self.block:
+                entered.set()
+                assert release.wait(timeout=5)
+            super().save(checkpoint)
+
+    class InterruptOnce(ng.GraphNode):
+        def __init__(self):
+            ng.GraphNode.__init__(self)
+
+        def run(self, input):
+            if input.ctx.resume_value is None:
+                raise ng.NodeInterrupt({"question": "continue?"})
+            return [ng.ChannelWrite("value", input.ctx.resume_value["value"])]
+
+        def get_name(self):
+            return "async_resume_lifetime"
+
+    node = InterruptOnce()
+    ng.NodeFactory.register_type("py_async_resume_lifetime", lambda *_: node)
+    definition = _empty_definition()
+    definition["nodes"] = {
+        "async_resume_lifetime": {"type": "py_async_resume_lifetime"},
+    }
+    definition["edges"] = [
+        {"from": ng.START_NODE, "to": "async_resume_lifetime"},
+        {"from": "async_resume_lifetime", "to": ng.END_NODE},
+    ]
+
+    async def run():
+        store = BlockingCheckpointStore()
+        engine = ng.GraphEngine.compile(definition, ng.NodeContext(), store)
+        assert engine.run(ng.RunConfig(thread_id="async-resume-lifetime")).interrupted
+        store.block = True
+
+        engine_ref = weakref.ref(engine)
+        store_ref = weakref.ref(store)
+        future = engine.resume_async(
+            "async-resume-lifetime", {"value": 11})
+        assert await asyncio.to_thread(entered.wait, 5)
+        del engine, store
+        gc.collect()
+        assert engine_ref() is not None
+        assert store_ref() is not None
+
+        release.set()
+        result = await future
+        assert result.output["channels"]["value"]["value"] == 11
+
+    asyncio.run(run())
+
+
+def test_callbacks_from_parallel_runs_are_isolated_and_gil_safe():
+    store = DictCheckpointStore()
+    engine = ng.GraphEngine.compile(_noop_definition(), ng.NodeContext(), store)
+
+    def run(index):
+        result = engine.run(ng.RunConfig(thread_id=f"parallel-{index}"))
+        return result.checkpoint_id
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+        checkpoint_ids = list(pool.map(run, range(12)))
+
+    assert all(checkpoint_ids)
+    assert len(store.by_thread) == 12
+    assert len(store.callback_threads) >= 2

--- a/docs/python-binding.md
+++ b/docs/python-binding.md
@@ -167,6 +167,13 @@ under every user, and `store.search(["users", "u1"])` finds one user's items.
 
 Subclass `ng.Store` to put it in a database instead.
 
+Custom checkpoint persistence works the same way: subclass
+`ng.CheckpointStore` and implement `save`, `load_latest`, `load_by_id`, `list`,
+and `delete_thread`. The optional `put_writes`, `get_writes`, and
+`clear_writes` methods default to no-op/full-super-step replay behavior. Values
+inside `StoreItem`, `Checkpoint`, and `PendingWrite` are ordinary Python JSON
+shapes (`dict`, `list`, strings, numbers, booleans, and `None`).
+
 ## Backing off on a 429 — RateLimitedProvider
 
 ```python
@@ -397,7 +404,7 @@ where `fn(state) -> str` returns one of the route keys.
 - **Custom Python nodes** — subclass `neograph_engine.GraphNode`, register via `NodeFactory.register_type` or the `@neograph_engine.node` decorator. Engine dispatches under proper GIL handling, including from fan-out worker threads.
 - **Custom Python tools** — subclass `neograph_engine.Tool`, pass into `NodeContext(tools=[...])`. Engine takes ownership at compile time.
 - **Async** — every `*_async` binding returns an `asyncio.Future` bound to the calling thread's running loop. Stream callbacks are hopped to the loop thread via `loop.call_soon_threadsafe` so callbacks run where asyncio expects.
-- **Checkpoints** — `InMemoryCheckpointStore` always; `PostgresCheckpointStore` when the binding is built from source with `-DNEOGRAPH_BUILD_POSTGRES=ON` (libpq bundling for the PyPI wheel is pending).
+- **Checkpoints** — subclass `CheckpointStore` for a Python backend, use `InMemoryCheckpointStore` directly, or use `PostgresCheckpointStore` when the binding is built from source with `-DNEOGRAPH_BUILD_POSTGRES=ON` (libpq bundling for the PyPI wheel is pending).
 - **OpenAI Responses over WebSocket** — `SchemaProvider(schema="openai_responses", use_websocket=True)`.
 
 Wheels: Linux x86_64 (manylinux_2_34), Linux aarch64 (manylinux_2_34),

--- a/include/neograph/graph/checkpoint.h
+++ b/include/neograph/graph/checkpoint.h
@@ -122,7 +122,7 @@ struct Checkpoint {
      * @brief Generate a new UUID v4 string.
      * @return A random UUID v4 string (e.g., "550e8400-e29b-41d4-a716-446655440000").
      */
-    static std::string generate_id();
+    static NEOGRAPH_API std::string generate_id();
 };
 
 /**


### PR DESCRIPTION
## Summary
- make `Store` and `CheckpointStore` constructible Python subclass bases with C++ virtual dispatch
- expose mutable `StoreItem`, `CheckpointPhase`, `Checkpoint`, and `PendingWrite` values with JSON conversion
- preserve Python backend and callback lifetimes across synchronous and asynchronous engine paths
- document custom backend requirements and optional pending-write behavior

## Validation
- `ctest --test-dir build-issue117 --output-on-failure`: 550/550 passed, 3 live-network tests skipped
- `PYTHONPATH=build-issue117 python3 -m pytest bindings/python/tests/ -q`: 159 passed, 6 skipped
- focused backend suite: 10 passed
- independent final review reproduced and verified fixes for `run_async()` backend lifetime and `resume_async()` callback lifetime crashes
- `git diff --check`

## Python binding decision
This is implemented directly because Python libraries can provide storage, but cannot participate in NeoGraph C++ virtual dispatch, checkpoint resume, pending-write fallback, or engine-owned backend lifetimes without this binding surface.

Closes #117