### PR TITLE
feat(python): expose synchronous run cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Python synchronous cancellation** (#119) — Python callers can construct a
+  `CancelToken`, assign it to `RunConfig.cancel_token`, and cooperatively stop
+  `engine.run()` from another thread.
+
 - **DSL 표면 (elaboration 계층) + 스키마 진화 게이트** (#75 M4).
   - **Elaborator**: `vars`(`{"$var":...}`·`${...}` 보간, 비순환 강제) /
     `templates`+`use`(파라미터 정확 일치 강제, 노드 prefix 리네임 —

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -316,7 +316,11 @@ void init_graph(py::module_& m) {
         .def_readwrite("usage", &RunConfig::usage,
             "Optional UsageAccumulator (issue #88). Leave None and the engine "
             "makes one per run; supply your own to total tokens across several "
-            "runs on the same conversation.");
+            "runs on the same conversation.")
+        .def_readwrite("cancel_token", &RunConfig::cancel_token,
+            "Optional cooperative cancellation handle. Construct a "
+            "CancelToken, assign it here, and call token.cancel() from another "
+            "thread to stop engine.run() at the next cancellation point.");
 
     // ── ToolDecision / ToolGateContext (issue #89) ───────────────────────
     //

--- a/bindings/python/src/bind_node.cpp
+++ b/bindings/python/src/bind_node.cpp
@@ -533,16 +533,17 @@ void init_node(py::module_& m) {
     // ── CancelToken (v0.4 PR 7: exposed so Python users can read /
     // cancel through ``input.ctx.cancel_token``) ────────────────────────
     //
-    // Construction from Python is intentionally not exposed — the engine
-    // owns lifecycle. ``RunConfig.cancel_token`` already accepts a
-    // shared_ptr<CancelToken> via the existing wiring; this just makes
-    // the *read* side usable from a node body.
+    // Python callers can construct a token and attach it to
+    // RunConfig.cancel_token to stop a synchronous run from another thread.
+    // Nodes can also read the active token through input.ctx.cancel_token.
     py::class_<CancelToken, std::shared_ptr<CancelToken>>(m, "CancelToken",
-        "Cooperative cancel handle for an in-flight run. Engine "
-        "constructs these; nodes read ``input.ctx.cancel_token`` and "
+        "Cooperative cancel handle for an in-flight run. Callers may attach "
+        "one to ``RunConfig.cancel_token``; nodes read "
+        "``input.ctx.cancel_token`` and "
         "either pass it to ``provider.complete(params)`` (so an LLM "
         "HTTP socket aborts on cancel) or poll ``is_cancelled()`` for "
         "their own loops.")
+        .def(py::init<>())
         .def("is_cancelled", &CancelToken::is_cancelled,
             "Lock-free polling read of the cancel flag.")
         .def("cancel", &CancelToken::cancel,

--- a/bindings/python/tests/test_sync_cancel.py
+++ b/bindings/python/tests/test_sync_cancel.py
@@ -1,0 +1,129 @@
+"""Synchronous Python run cancellation through RunConfig (#119)."""
+
+import concurrent.futures
+import threading
+
+import neograph_engine as ng
+import pytest
+
+
+_uid = 0
+
+
+def _next_type(prefix):
+    global _uid
+    _uid += 1
+    return f"{prefix}_{_uid}"
+
+
+def test_cancel_token_is_constructible_and_assignable_to_run_config():
+    token = ng.CancelToken()
+    config = ng.RunConfig(thread_id="cancel-surface")
+
+    assert not token.is_cancelled()
+    assert config.cancel_token is None
+    config.cancel_token = token
+    assert config.cancel_token is token
+
+    token.cancel()
+    token.cancel()
+    assert token.is_cancelled()
+
+
+def test_pre_cancelled_sync_run_stops_before_node_execution():
+    called = False
+    type_name = _next_type("pre_cancelled")
+
+    class MustNotRun(ng.GraphNode):
+        def __init__(self):
+            super().__init__()
+
+        def run(self, input):
+            nonlocal called
+            called = True
+            return []
+
+        def get_name(self):
+            return "must_not_run"
+
+    ng.NodeFactory.register_type(type_name, lambda *_: MustNotRun())
+    definition = {
+        "name": "pre_cancelled",
+        "channels": {},
+        "nodes": {"must_not_run": {"type": type_name}},
+        "edges": [
+            {"from": ng.START_NODE, "to": "must_not_run"},
+            {"from": "must_not_run", "to": ng.END_NODE},
+        ],
+    }
+    engine = ng.GraphEngine.compile(definition, ng.NodeContext())
+    token = ng.CancelToken()
+    token.cancel()
+    config = ng.RunConfig(thread_id="pre-cancelled")
+    config.cancel_token = token
+
+    with pytest.raises(RuntimeError, match="run cancelled"):
+        engine.run(config)
+    assert not called
+
+
+def test_sync_run_can_be_cancelled_from_another_python_thread():
+    entered = threading.Event()
+    release = threading.Event()
+    second_node_called = False
+    block_type = _next_type("cancel_block")
+    second_type = _next_type("cancel_second")
+
+    class BlockingNode(ng.GraphNode):
+        def __init__(self):
+            super().__init__()
+
+        def run(self, input):
+            entered.set()
+            assert release.wait(timeout=5)
+            return []
+
+        def get_name(self):
+            return "blocking"
+
+    class MustNotRun(ng.GraphNode):
+        def __init__(self):
+            super().__init__()
+
+        def run(self, input):
+            nonlocal second_node_called
+            second_node_called = True
+            return []
+
+        def get_name(self):
+            return "must_not_run"
+
+    ng.NodeFactory.register_type(block_type, lambda *_: BlockingNode())
+    ng.NodeFactory.register_type(second_type, lambda *_: MustNotRun())
+    definition = {
+        "name": "cross_thread_cancel",
+        "channels": {},
+        "nodes": {
+            "blocking": {"type": block_type},
+            "must_not_run": {"type": second_type},
+        },
+        "edges": [
+            {"from": ng.START_NODE, "to": "blocking"},
+            {"from": "blocking", "to": "must_not_run"},
+            {"from": "must_not_run", "to": ng.END_NODE},
+        ],
+    }
+    engine = ng.GraphEngine.compile(definition, ng.NodeContext())
+    token = ng.CancelToken()
+    config = ng.RunConfig(thread_id="cross-thread-cancel")
+    config.cancel_token = token
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(engine.run, config)
+        assert entered.wait(timeout=5)
+        token.cancel()
+        release.set()
+        with pytest.raises(RuntimeError, match="run cancelled"):
+            future.result(timeout=5)
+
+    assert not second_node_called

--- a/docs/python-binding.md
+++ b/docs/python-binding.md
@@ -91,6 +91,17 @@ result = engine.run(ng.RunConfig(thread_id="t1",
 | `max_steps` | 25 | Super-step ceiling; ReAct loops typically need 10+. |
 | `stream_mode` | `StreamMode.OFF` | Bitmask: `EVENTS \| TOKENS \| DEBUG \| VALUES \| UPDATES \| ALL`. Only consulted by `run_stream` / `run_stream_async`. |
 | `resume_if_exists` | `False` | When `True` and a checkpoint store is configured, the run loads the latest checkpoint for `thread_id` (if any) and applies `input` on top via the channel reducers — multi-turn chat without manually threading prior state through `input`. Default keeps fresh-start semantics for back-compat; for HITL resume from an interrupted run, use `engine.resume_async()` instead. |
+| `cancel_token` | `None` | Optional `CancelToken` for cooperative cancellation. Assign one before `engine.run()`, then call `token.cancel()` from another Python thread. The engine stops at the next super-step boundary; nodes doing long work should poll `input.ctx.cancel_token`. |
+
+```python
+token = ng.CancelToken()
+config = ng.RunConfig(thread_id="job-42", input={"query": "..."})
+config.cancel_token = token
+
+# Run engine.run(config) in a worker thread, then request cancellation from
+# the caller thread when the request disconnects or the user presses Stop.
+token.cancel()
+```
 
 ## Pausing for a human, from a Python node
 


### PR DESCRIPTION
## Summary
- make `CancelToken()` constructible from Python
- expose `RunConfig.cancel_token` without changing constructor arguments or defaults
- document cooperative synchronous cancellation and its super-step boundary
- test token ownership, pre-cancellation, and cancellation from another Python thread

## Validation
- `ctest --test-dir build-issue119 --output-on-failure`: 550/550 passed, 3 live-network tests skipped
- `PYTHONPATH=build-issue119 python3 -m pytest bindings/python/tests/ -q`: 152 passed, 6 skipped
- sync + existing async cancellation focus: 10 passed
- independent review approved registration order, shared ownership, GIL behavior, and API compatibility
- `git diff --check`

## Classification
Feature improvement rather than a general cancellation defect: asyncio Future cancellation already worked, while synchronous `engine.run()` lacked an external cooperative cancellation handle.

## Python binding decision
Python threading alone cannot reach NeoGraph cancellation polling or provider cancellation propagation. The direct binding is required to participate in `RunConfig`, `RunContext`, and engine super-step cancellation.

Closes #119