### PR TITLE
feat(python): expose checkpoint state history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `StoreItem`, `CheckpointPhase`, `Checkpoint`, and `PendingWrite` are exposed
   with JSON-shaped fields; checkpoint pending-write methods remain optional.
 
+- **Python checkpoint history** (#118) — `GraphEngine.get_state_history()`
+  exposes newest-first checkpoint records so callers can inspect parent links,
+  metadata, steps, and IDs before forking from a historical state.
+
 - **DSL 표면 (elaboration 계층) + 스키마 진화 게이트** (#75 M4).
   - **Elaborator**: `vars`(`{"$var":...}`·`${...}` 보간, 비순환 강제) /
     `templates`+`use`(파라미터 정확 일치 강제, 노드 prefix 리네임 —

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -833,6 +833,19 @@ void init_graph(py::module_& m) {
             "verbatim. Slated for removal in v1.0 only if the "
             "deprecation is loud enough; otherwise stays available.")
 
+        .def("get_state_history",
+            [](const GraphEngine& self, const std::string& thread_id, int limit) {
+                if (limit < 0) {
+                    throw py::value_error(
+                        "get_state_history: limit must be non-negative");
+                }
+                return self.get_state_history(thread_id, limit);
+            },
+            py::arg("thread_id"),
+            py::arg("limit") = 100,
+            "Checkpoint history for thread_id, newest first. Returns an "
+            "empty list when no checkpoint store or matching thread exists.")
+
         .def("update_state",
             [](GraphEngine& self,
                const std::string& thread_id,

--- a/bindings/python/tests/test_state_history.py
+++ b/bindings/python/tests/test_state_history.py
@@ -1,0 +1,88 @@
+"""Checkpoint history inspection and historical forks (#118)."""
+
+import neograph_engine as ng
+import pytest
+
+
+class _PassthroughNode(ng.GraphNode):
+    def __init__(self):
+        super().__init__()
+
+    def run(self, input):
+        return []
+
+    def get_name(self):
+        return "history_passthrough"
+
+
+ng.NodeFactory.register_type(
+    "py_state_history_passthrough", lambda *_: _PassthroughNode())
+
+
+def _definition():
+    return {
+        "name": "python_state_history",
+        "channels": {"value": {"reducer": "overwrite"}},
+        "nodes": {
+            "history_passthrough": {"type": "py_state_history_passthrough"},
+        },
+        "edges": [
+            {"from": ng.START_NODE, "to": "history_passthrough"},
+            {"from": "history_passthrough", "to": ng.END_NODE},
+        ],
+    }
+
+
+def _value(state):
+    return state["channels"]["value"]["value"]
+
+
+def test_history_discovers_checkpoint_for_divergent_fork():
+    store = ng.InMemoryCheckpointStore()
+    engine = ng.GraphEngine.compile(_definition(), ng.NodeContext(), store)
+    engine.run(ng.RunConfig(thread_id="source", input={"value": 1}))
+    engine.update_state("source", {"value": 2}, as_node="admin")
+
+    history = engine.get_state_history("source")
+    assert len(history) >= 2
+    newest, previous = history[:2]
+    assert newest.parent_id == previous.id
+    assert newest.step == previous.step
+    assert newest.timestamp > previous.timestamp
+    assert newest.interrupt_phase == ng.CheckpointPhase.Updated
+    assert _value(newest.channel_values) == 2
+    assert [cp.id for cp in history] == [cp.id for cp in store.list("source")]
+    assert [cp.id for cp in engine.get_state_history("source", limit=1)] == [
+        newest.id,
+    ]
+
+    fork_id = engine.fork("source", "branch", checkpoint_id=previous.id)
+    assert _value(engine.get_state("branch")) == 1
+    fork_checkpoint = engine.get_state_history("branch")[0]
+    assert fork_checkpoint.id == fork_id
+    assert fork_checkpoint.parent_id == previous.id
+    assert fork_checkpoint.metadata["forked_from"] == {
+        "thread_id": "source",
+        "checkpoint_id": previous.id,
+    }
+
+    engine.update_state("branch", {"value": 9})
+    assert _value(engine.get_state("branch")) == 9
+    assert _value(engine.get_state("source")) == 2
+
+    engine.run(ng.RunConfig(thread_id="other", input={"value": 77}))
+    other_id = engine.get_state_history("other")[0].id
+    with pytest.raises(RuntimeError, match="does not belong"):
+        engine.fork("source", "wrong-source", checkpoint_id=other_id)
+    assert engine.get_state("wrong-source") is None
+
+
+def test_history_without_store_or_matching_thread_is_empty():
+    engine = ng.GraphEngine.compile(_definition(), ng.NodeContext())
+    assert engine.get_state_history("missing") == []
+
+    engine.set_checkpoint_store(ng.InMemoryCheckpointStore())
+    assert engine.get_state_history("missing") == []
+
+    with pytest.raises(ValueError, match="non-negative"):
+        engine.get_state_history("missing", limit=-1)

--- a/docs/python-binding.md
+++ b/docs/python-binding.md
@@ -400,7 +400,7 @@ where `fn(state) -> str` returns one of the route keys.
 
 ## What's covered by the binding
 
-- **Engine surface** — `GraphEngine.compile / run / run_stream / run_async / run_stream_async / resume / resume_async / get_state / update_state / fork`, `RunConfig`, `RunResult`, `set_worker_count`, `set_checkpoint_store`, `set_node_cache_enabled`.
+- **Engine surface** — `GraphEngine.compile / run / run_stream / run_async / run_stream_async / resume / resume_async / get_state / get_state_history / update_state / fork`, `RunConfig`, `RunResult`, `set_worker_count`, `set_checkpoint_store`, `set_node_cache_enabled`.
 - **Custom Python nodes** — subclass `neograph_engine.GraphNode`, register via `NodeFactory.register_type` or the `@neograph_engine.node` decorator. Engine dispatches under proper GIL handling, including from fan-out worker threads.
 - **Custom Python tools** — subclass `neograph_engine.Tool`, pass into `NodeContext(tools=[...])`. Engine takes ownership at compile time.
 - **Async** — every `*_async` binding returns an `asyncio.Future` bound to the calling thread's running loop. Stream callbacks are hopped to the loop thread via `loop.call_soon_threadsafe` so callbacks run where asyncio expects.

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -267,8 +267,11 @@ void GraphEngine::update_state(const std::string& thread_id,
     // super-step saves propagate this for the same reason.
     new_cp.barrier_state   = cp.barrier_state;
     new_cp.step            = cp.step;
-    new_cp.timestamp       = std::chrono::duration_cast<std::chrono::milliseconds>(
+    const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::system_clock::now().time_since_epoch()).count();
+    // update_state preserves the parent's step, so millisecond timestamp ties
+    // would leave durable stores unable to identify the newer checkpoint.
+    new_cp.timestamp       = std::max(now, cp.timestamp + 1);
 
     checkpoint_store_->save(new_cp);
 }
@@ -287,6 +290,11 @@ std::string GraphEngine::fork(const std::string& source_thread_id,
     }
     if (!cp_opt)
         throw std::runtime_error("No checkpoint found for fork source");
+    if (cp_opt->thread_id != source_thread_id) {
+        throw std::runtime_error(
+            "Checkpoint does not belong to fork source thread: " +
+            source_thread_id);
+    }
 
     Checkpoint forked;
     forked.id              = Checkpoint::generate_id();


### PR DESCRIPTION
## Summary
- bind `GraphEngine.get_state_history(thread_id, limit=100)` using #117 checkpoint value types
- verify newest-first history, limit handling, metadata inspection, and divergent historical forks
- reject negative Python limits consistently across backends
- reject checkpoint IDs owned by a different source thread
- keep sequential `update_state()` checkpoints strictly timestamp-ordered

## Stack
This PR is intentionally based on #133 / `feat/117-python-store-backends`, which supplies the `Checkpoint` and `CheckpointPhase` Python types. Retarget to `master` after #133 merges.

## Validation
- `ctest --test-dir build-issue118 --output-on-failure`: 550/550 passed, 3 live-network tests skipped
- `PYTHONPATH=build-issue118 python3 -m pytest bindings/python/tests/ -q`: 161 passed, 6 skipped
- focused history tests: 2 passed
- independent review approved custom backend dispatch, no-store behavior, ordering, limit validation, and fork ownership
- `git diff --check`

## Classification
Feature improvement: #117 already permits retained stores to call `store.list()`, while this PR completes the engine-level C++/Python surface and makes the historical-fork workflow directly discoverable.

## Python binding decision
No Python library can recover NeoGraph checkpoint lineage hidden behind `GraphEngine`; the direct binding is required to connect engine-owned history records to `fork(checkpoint_id=...)`.

Closes #118