### PR TITLE
feat(python): host graphs through official A2A and ACP SDKs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
       - name: Install build dependencies
         run: |
           sudo apt-get update
@@ -80,6 +84,7 @@ jobs:
             -DNEOGRAPH_BUILD_MCP=ON \
             -DNEOGRAPH_BUILD_UTIL=ON \
             -DNEOGRAPH_BUILD_POSTGRES=ON \
+            -DNEOGRAPH_BUILD_PYBIND=ON \
             -DNEOGRAPH_BUILD_TESTS=ON \
             -DNEOGRAPH_BUILD_EXAMPLES=OFF
 
@@ -89,6 +94,9 @@ jobs:
       - name: ccache stats
         run: ccache --show-stats
 
+      - name: Install Python test dependencies
+        run: python -m pip install -U pytest pydantic certifi
+
       - name: Run tests (with Postgres)
         working-directory: build
         env:
@@ -97,6 +105,17 @@ jobs:
           # prior state, so this DB starts clean every run.
           NEOGRAPH_TEST_POSTGRES_URL: postgresql://postgres:test@localhost:5432/neograph_test
         run: ctest --output-on-failure -j$(nproc)
+
+      - name: Run official A2A and ACP SDK integration tests
+        env:
+          PYTHONPATH: build
+        run: |
+          python -m pip install -U "a2a-sdk[http-server]>=1.1,<2" \
+            "agent-client-protocol==0.11.0" uvicorn
+          NEOGRAPH_TEST_POSTGRES_URL=postgresql://postgres:test@localhost:5432/neograph_test \
+            python -m pytest -q bindings/python/tests/test_protocol_sdk_e2e.py
+          python -m pytest -q \
+            bindings/python/tests/test_protocol_sdk_e2e.py::test_acp_streaming_and_durable_session_load
 
       # On failure, surface the raw gtest log so a contributor can debug
       # without re-running locally with PG provisioned.

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -189,6 +189,7 @@ configure_file(neograph_engine/streaming.py     "${_NEOGRAPH_PY_PKG_DIR}/streami
 configure_file(neograph_engine/tracing.py       "${_NEOGRAPH_PY_PKG_DIR}/tracing.py"       COPYONLY)
 configure_file(neograph_engine/state_view.py    "${_NEOGRAPH_PY_PKG_DIR}/state_view.py"    COPYONLY)
 configure_file(neograph_engine/openinference.py "${_NEOGRAPH_PY_PKG_DIR}/openinference.py" COPYONLY)
+configure_file(neograph_engine/protocol.py      "${_NEOGRAPH_PY_PKG_DIR}/protocol.py"      COPYONLY)
 
 # Install rule for the wheel build. Tagged with the same component as
 # the engine .so files in the root CMakeLists, so a single
@@ -212,6 +213,7 @@ install(FILES
     neograph_engine/tracing.py
     neograph_engine/state_view.py
     neograph_engine/openinference.py
+    neograph_engine/protocol.py
     DESTINATION neograph_engine)
 
 # Make smoke tests runnable straight from the build tree:

--- a/bindings/python/examples/27_a2a_server.py
+++ b/bindings/python/examples/27_a2a_server.py
@@ -8,6 +8,8 @@ http://127.0.0.1:9999/. The agent card is served from the SDK's standard
 well-known route.
 """
 
+import os
+
 import uvicorn
 
 from a2a.helpers import (
@@ -33,6 +35,13 @@ from starlette.applications import Starlette
 from _protocol_demo import make_adapter
 
 
+HOST = os.environ.get("NEOGRAPH_A2A_HOST", "127.0.0.1")
+PORT = int(os.environ.get("NEOGRAPH_A2A_PORT", "9999"))
+PUBLIC_URL = os.environ.get(
+    "NEOGRAPH_A2A_PUBLIC_URL", f"http://127.0.0.1:{PORT}/"
+)
+
+
 class NeoGraphAgentExecutor(AgentExecutor):
     def __init__(self):
         self.adapter = make_adapter()
@@ -52,13 +61,37 @@ class NeoGraphAgentExecutor(AgentExecutor):
             state=TaskState.TASK_STATE_WORKING,
             message=new_text_message("NeoGraph is running"),
         )
-        answer = await self.adapter.run(
+        pending_token = None
+        emitted = False
+        final_answer = ""
+        async for event in self.adapter.stream(
             get_message_text(context.message) or "",
             thread_id=task.context_id,
             request_id=task.id,
-        )
+        ):
+            if event.kind == "token":
+                if pending_token is not None:
+                    await updater.add_artifact(
+                        parts=[new_text_part(
+                            text=pending_token, media_type="text/plain"
+                        )],
+                        artifact_id=f"{task.id}-response",
+                        append=emitted,
+                        last_chunk=False,
+                    )
+                    emitted = True
+                pending_token = event.data
+            else:
+                final_answer = event.data
+
         await updater.add_artifact(
-            parts=[new_text_part(text=answer, media_type="text/plain")]
+            parts=[new_text_part(
+                text=pending_token if pending_token is not None else final_answer,
+                media_type="text/plain",
+            )],
+            artifact_id=f"{task.id}-response",
+            append=emitted,
+            last_chunk=True,
         )
         await updater.update_status(state=TaskState.TASK_STATE_COMPLETED)
 
@@ -86,14 +119,14 @@ card = AgentCard(
     name="NeoGraph A2A Agent",
     description="A NeoGraph engine hosted by the official A2A SDK.",
     version="1.0.0",
-    capabilities=AgentCapabilities(streaming=False),
+    capabilities=AgentCapabilities(streaming=True),
     default_input_modes=["text/plain"],
     default_output_modes=["text/plain"],
     supported_interfaces=[
         AgentInterface(
             protocol_binding="JSONRPC",
             protocol_version="1.0",
-            url="http://127.0.0.1:9999/",
+            url=PUBLIC_URL,
         )
     ],
     skills=[skill],
@@ -111,4 +144,4 @@ app = Starlette(routes=routes)
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="127.0.0.1", port=9999)
+    uvicorn.run(app, host=HOST, port=PORT)

--- a/bindings/python/examples/27_a2a_server.py
+++ b/bindings/python/examples/27_a2a_server.py
@@ -1,0 +1,114 @@
+"""Host a NeoGraph agent through the official A2A Python SDK.
+
+Install the optional server dependency first:
+    pip install "neograph-engine[a2a]"
+
+Then run this file and send A2A 1.0 JSON-RPC requests to
+http://127.0.0.1:9999/. The agent card is served from the SDK's standard
+well-known route.
+"""
+
+import uvicorn
+
+from a2a.helpers import (
+    get_message_text,
+    new_task_from_user_message,
+    new_text_message,
+    new_text_part,
+)
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.routes import create_agent_card_routes, create_jsonrpc_routes
+from a2a.server.tasks import InMemoryTaskStore, TaskUpdater
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentInterface,
+    AgentSkill,
+    TaskState,
+)
+from starlette.applications import Starlette
+
+from _protocol_demo import make_adapter
+
+
+class NeoGraphAgentExecutor(AgentExecutor):
+    def __init__(self):
+        self.adapter = make_adapter()
+
+    async def execute(self, context: RequestContext, event_queue: EventQueue):
+        task = context.current_task
+        if task is None:
+            task = new_task_from_user_message(context.message)
+            await event_queue.enqueue_event(task)
+
+        updater = TaskUpdater(
+            event_queue=event_queue,
+            task_id=task.id,
+            context_id=task.context_id,
+        )
+        await updater.update_status(
+            state=TaskState.TASK_STATE_WORKING,
+            message=new_text_message("NeoGraph is running"),
+        )
+        answer = await self.adapter.run(
+            get_message_text(context.message) or "",
+            thread_id=task.context_id,
+            request_id=task.id,
+        )
+        await updater.add_artifact(
+            parts=[new_text_part(text=answer, media_type="text/plain")]
+        )
+        await updater.update_status(state=TaskState.TASK_STATE_COMPLETED)
+
+    async def cancel(self, context: RequestContext, event_queue: EventQueue):
+        task_id = context.task_id or ""
+        self.adapter.cancel(task_id)
+        updater = TaskUpdater(
+            event_queue=event_queue,
+            task_id=task_id,
+            context_id=context.context_id or "",
+        )
+        await updater.cancel()
+
+
+skill = AgentSkill(
+    id="neograph_echo",
+    name="NeoGraph echo",
+    description="Runs a stateful NeoGraph chat graph.",
+    tags=["neograph", "chat"],
+    examples=["hello"],
+    input_modes=["text/plain"],
+    output_modes=["text/plain"],
+)
+card = AgentCard(
+    name="NeoGraph A2A Agent",
+    description="A NeoGraph engine hosted by the official A2A SDK.",
+    version="1.0.0",
+    capabilities=AgentCapabilities(streaming=False),
+    default_input_modes=["text/plain"],
+    default_output_modes=["text/plain"],
+    supported_interfaces=[
+        AgentInterface(
+            protocol_binding="JSONRPC",
+            protocol_version="1.0",
+            url="http://127.0.0.1:9999/",
+        )
+    ],
+    skills=[skill],
+)
+handler = DefaultRequestHandler(
+    agent_executor=NeoGraphAgentExecutor(),
+    task_store=InMemoryTaskStore(),
+    agent_card=card,
+)
+routes = [
+    *create_agent_card_routes(card),
+    *create_jsonrpc_routes(handler, "/"),
+]
+app = Starlette(routes=routes)
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="127.0.0.1", port=9999)

--- a/bindings/python/examples/28_acp_agent.py
+++ b/bindings/python/examples/28_acp_agent.py
@@ -4,10 +4,14 @@ Install the optional protocol dependency first:
     pip install "neograph-engine[acp]"
 
 ACP clients launch this script as a subprocess. Protocol messages use stdout,
-so application diagnostics must go to stderr or a logging handler.
+so application diagnostics must go to stderr or a logging handler. Set
+NEOGRAPH_ACP_POSTGRES_URL for durable session/load support. Source builds with
+SQLite enabled may use NEOGRAPH_ACP_SQLITE_PATH instead.
 """
 
 import asyncio
+import os
+import re
 from typing import Any
 from uuid import uuid4
 
@@ -15,21 +19,79 @@ from acp import (
     PROTOCOL_VERSION,
     Agent,
     InitializeResponse,
+    LoadSessionResponse,
     NewSessionResponse,
     PromptResponse,
+    RequestError,
     run_agent,
     text_block,
     update_agent_message,
+    update_agent_message_text,
+    update_user_message,
+    update_user_message_text,
 )
 from acp.interfaces import Client
-from acp.schema import AgentCapabilities, ClientCapabilities, Implementation
+from acp.schema import (
+    AgentCapabilities,
+    AudioContentBlock,
+    ClientCapabilities,
+    EmbeddedResourceContentBlock,
+    ImageContentBlock,
+    Implementation,
+    ResourceContentBlock,
+    TextContentBlock,
+)
+import neograph_engine as ng
+from pydantic import TypeAdapter
 
 from _protocol_demo import make_adapter
 
 
+CONTENT_BLOCK = TypeAdapter(
+    TextContentBlock
+    | ImageContentBlock
+    | AudioContentBlock
+    | ResourceContentBlock
+    | EmbeddedResourceContentBlock
+)
+SESSION_ID = re.compile(r"[0-9a-f]{32}")
+
+
+def checkpoint_thread_id(session_id: str) -> str:
+    if SESSION_ID.fullmatch(session_id) is None:
+        raise RequestError.resource_not_found(session_id)
+    return f"acp:{session_id}"
+
+
 class NeoGraphACPAgent(Agent):
-    def __init__(self):
-        self.adapter = make_adapter()
+    def __init__(self, database_url=None, sqlite_path=None, checkpoint_store=None):
+        database_url = database_url or os.environ.get(
+            "NEOGRAPH_ACP_POSTGRES_URL"
+        )
+        sqlite_path = sqlite_path or os.environ.get("NEOGRAPH_ACP_SQLITE_PATH")
+        configured = sum(
+            value is not None
+            for value in (database_url, sqlite_path, checkpoint_store)
+        )
+        if configured > 1:
+            raise ValueError(
+                "configure only one ACP checkpoint backend: PostgreSQL, "
+                "SQLite, or checkpoint_store"
+            )
+        if checkpoint_store is None and database_url:
+            checkpoint_store = ng.PostgresCheckpointStore(
+                database_url, pool_size=1
+            )
+        elif checkpoint_store is None and sqlite_path:
+            if not hasattr(ng, "SqliteCheckpointStore"):
+                raise RuntimeError(
+                    "NEOGRAPH_ACP_SQLITE_PATH needs a wheel/source build with "
+                    "NEOGRAPH_BUILD_SQLITE=ON"
+                )
+            checkpoint_store = ng.SqliteCheckpointStore(sqlite_path)
+        self.durable = checkpoint_store is not None
+        checkpoint_store = checkpoint_store or ng.InMemoryCheckpointStore()
+        self.adapter = make_adapter(checkpoint_store=checkpoint_store)
         self.sessions = set()
         self.connection = None
         self.prompts = {}
@@ -46,7 +108,7 @@ class NeoGraphACPAgent(Agent):
     ) -> InitializeResponse:
         return InitializeResponse(
             protocol_version=PROTOCOL_VERSION,
-            agent_capabilities=AgentCapabilities(),
+            agent_capabilities=AgentCapabilities(load_session=self.durable),
             agent_info=Implementation(
                 name="neograph-agent",
                 title="NeoGraph Agent",
@@ -59,27 +121,82 @@ class NeoGraphACPAgent(Agent):
         self.sessions.add(session_id)
         return NewSessionResponse(session_id=session_id, modes=None)
 
+    async def load_session(
+        self, cwd: str, session_id: str, **kwargs: Any
+    ) -> LoadSessionResponse:
+        if self.connection is None:
+            raise RuntimeError("ACP client is not connected")
+        if not self.durable:
+            raise RequestError.method_not_found("session/load")
+        thread_id = checkpoint_thread_id(session_id)
+        if not self.adapter.has_state(thread_id):
+            raise RequestError.resource_not_found(session_id)
+        self.sessions.add(session_id)
+        state = self.adapter.get_state(thread_id)
+        messages = state["channels"]["messages"]["value"]
+        for message in messages:
+            content = message.get("content", "")
+            role = message.get("role")
+            if role not in ("user", "assistant"):
+                continue
+            if isinstance(content, str):
+                update = (
+                    update_user_message_text(content)
+                    if role == "user"
+                    else update_agent_message_text(content)
+                )
+                await self.connection.session_update(session_id, update)
+            elif isinstance(content, list):
+                for raw_block in content:
+                    block = CONTENT_BLOCK.validate_python(raw_block)
+                    update = (
+                        update_user_message(block)
+                        if role == "user"
+                        else update_agent_message(block)
+                    )
+                    await self.connection.session_update(session_id, update)
+        return LoadSessionResponse()
+
     async def prompt(self, session_id: str, prompt: list, **kwargs: Any):
         if self.connection is None:
             raise RuntimeError("ACP client is not connected")
-        self.sessions.add(session_id)
+        if session_id not in self.sessions:
+            raise RequestError.resource_not_found(session_id)
         task = asyncio.current_task()
         if task is None:
             raise RuntimeError("ACP prompt needs an asyncio task")
         self.prompts.setdefault(session_id, set()).add(task)
-        text = "\n".join(
-            block.get("text", "")
+        blocks = [
+            block
             if isinstance(block, dict)
-            else getattr(block, "text", "")
+            else block.model_dump(by_alias=True, exclude_none=True)
             for block in prompt
+        ]
+        text_only = all(block.get("type") == "text" for block in blocks)
+        payload = (
+            "\n".join(block.get("text", "") for block in blocks)
+            if text_only
+            else blocks
         )
         try:
-            answer = await self.adapter.run(
-                text, thread_id=session_id, request_id=session_id
-            )
-            await self.connection.session_update(
-                session_id, update_agent_message(text_block(answer))
-            )
+            saw_token = False
+            final_answer = ""
+            async for event in self.adapter.stream(
+                payload,
+                thread_id=checkpoint_thread_id(session_id),
+                request_id=session_id,
+            ):
+                if event.kind == "token":
+                    saw_token = True
+                    await self.connection.session_update(
+                        session_id, update_agent_message_text(event.data)
+                    )
+                else:
+                    final_answer = event.data
+            if not saw_token:
+                await self.connection.session_update(
+                    session_id, update_agent_message(text_block(final_answer))
+                )
             return PromptResponse(stop_reason="end_turn")
         except asyncio.CancelledError:
             return PromptResponse(stop_reason="cancelled")

--- a/bindings/python/examples/28_acp_agent.py
+++ b/bindings/python/examples/28_acp_agent.py
@@ -1,0 +1,106 @@
+"""Host a NeoGraph agent through the official ACP Python SDK over stdio.
+
+Install the optional protocol dependency first:
+    pip install "neograph-engine[acp]"
+
+ACP clients launch this script as a subprocess. Protocol messages use stdout,
+so application diagnostics must go to stderr or a logging handler.
+"""
+
+import asyncio
+from typing import Any
+from uuid import uuid4
+
+from acp import (
+    PROTOCOL_VERSION,
+    Agent,
+    InitializeResponse,
+    NewSessionResponse,
+    PromptResponse,
+    run_agent,
+    text_block,
+    update_agent_message,
+)
+from acp.interfaces import Client
+from acp.schema import AgentCapabilities, ClientCapabilities, Implementation
+
+from _protocol_demo import make_adapter
+
+
+class NeoGraphACPAgent(Agent):
+    def __init__(self):
+        self.adapter = make_adapter()
+        self.sessions = set()
+        self.connection = None
+        self.prompts = {}
+
+    def on_connect(self, conn: Client):
+        self.connection = conn
+
+    async def initialize(
+        self,
+        protocol_version: int,
+        client_capabilities: ClientCapabilities | None = None,
+        client_info: Implementation | None = None,
+        **kwargs: Any,
+    ) -> InitializeResponse:
+        return InitializeResponse(
+            protocol_version=PROTOCOL_VERSION,
+            agent_capabilities=AgentCapabilities(),
+            agent_info=Implementation(
+                name="neograph-agent",
+                title="NeoGraph Agent",
+                version="1.0.0",
+            ),
+        )
+
+    async def new_session(self, cwd: str, **kwargs: Any) -> NewSessionResponse:
+        session_id = uuid4().hex
+        self.sessions.add(session_id)
+        return NewSessionResponse(session_id=session_id, modes=None)
+
+    async def prompt(self, session_id: str, prompt: list, **kwargs: Any):
+        if self.connection is None:
+            raise RuntimeError("ACP client is not connected")
+        self.sessions.add(session_id)
+        task = asyncio.current_task()
+        if task is None:
+            raise RuntimeError("ACP prompt needs an asyncio task")
+        self.prompts.setdefault(session_id, set()).add(task)
+        text = "\n".join(
+            block.get("text", "")
+            if isinstance(block, dict)
+            else getattr(block, "text", "")
+            for block in prompt
+        )
+        try:
+            answer = await self.adapter.run(
+                text, thread_id=session_id, request_id=session_id
+            )
+            await self.connection.session_update(
+                session_id, update_agent_message(text_block(answer))
+            )
+            return PromptResponse(stop_reason="end_turn")
+        except asyncio.CancelledError:
+            return PromptResponse(stop_reason="cancelled")
+        finally:
+            prompts = self.prompts.get(session_id)
+            if prompts is not None:
+                prompts.discard(task)
+                if not prompts:
+                    self.prompts.pop(session_id, None)
+
+    async def cancel(self, session_id: str, **kwargs: Any):
+        self.adapter.cancel(session_id)
+        current = asyncio.current_task()
+        for task in tuple(self.prompts.get(session_id, ())):
+            if task is not current:
+                task.cancel()
+
+
+async def main():
+    await run_agent(NeoGraphACPAgent())
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/bindings/python/examples/README.md
+++ b/bindings/python/examples/README.md
@@ -43,8 +43,8 @@ the key is missing.
 | 24 | [`24_tool_approval_gate.py`](24_tool_approval_gate.py) | offline | The tool gate (#89): `engine.set_tool_gate(...)` is consulted for every tool call **before any tool runs**, returning Allow / Allow-with-rewritten-args / Deny / Interrupt. Shows the canonical approval prompt — *"the agent wants to run `rm -rf build/`. Allow?"* — and, crucially, that the harmless sibling call has **not** run while the human is deciding, so a refusal really means nothing happened and an approval does not re-run it. |
 | 25 | [`25_async_tools.py`](25_async_tools.py) | offline | Concurrent tools (#96): `ng.AsyncTool` instead of `ng.Tool` and three 300 ms tools take 0.30 s instead of 0.90 s. Also measures the boundary in the same run — three *CPU-bound* tools take 3.2x the time of one, because a Python function holds the GIL while it runs and no number of threads changes that. Concurrency is opt-in so an existing stateful tool cannot suddenly race itself. |
 | 26 | [`26_mcp_tools.py`](26_mcp_tools.py) | offline | MCP (#95): `ng.mcp.MCPClient(url).get_tools()` pulls a remote tool catalogue and hands it straight to `NodeContext`. Starts its own MCP server, so it runs with no network. Measures the thing that matters — three 0.4 s MCP calls in 0.41 s over HTTP — and says out loud where it does *not* hold: stdio has one pipe, so those calls serialize. |
-| 27 | [`27_a2a_server.py`](27_a2a_server.py) | localhost | A2A hosting (#120): the official `a2a-sdk` owns JSON-RPC, task state, the agent card, and cancellation. `ProtocolHostAdapter` maps A2A context/task IDs to NeoGraph checkpoint threads and active async runs. Requires Python 3.10+ and `pip install "neograph-engine[a2a]"`. |
-| 28 | [`28_acp_agent.py`](28_acp_agent.py) | stdio | ACP hosting (#120): the official `agent-client-protocol` runtime owns stdio framing and session methods. `ProtocolHostAdapter` preserves multi-turn state while the demo process is running and turns ACP cancel notifications into real `run_async()` cancellation. Requires Python 3.10+ and `pip install "neograph-engine[acp]"`. |
+| 27 | [`27_a2a_server.py`](27_a2a_server.py) | localhost | A2A hosting (#120): the official `a2a-sdk` owns JSON-RPC, task state, the agent card, and cancellation. `ProtocolHostAdapter.stream()` maps engine token events to chunked A2A artifacts while preserving checkpoint context. Requires Python 3.10+ and `pip install "neograph-engine[a2a]"`. |
+| 28 | [`28_acp_agent.py`](28_acp_agent.py) | stdio | ACP hosting (#120): streams token updates, preserves text/image/audio/resource content blocks for the graph, and supports durable `session/load` when `NEOGRAPH_ACP_POSTGRES_URL` or `NEOGRAPH_ACP_SQLITE_PATH` is set. Requires Python 3.10+ and `pip install "neograph-engine[acp]"`. |
 
 ## Why hosting uses the official SDKs
 
@@ -59,10 +59,24 @@ that those SDKs cannot: a checkpoint-aware call into the C++ graph engine.
 |------|----------|
 | C++ feature that appears missing | `A2AServer`, `ACPServer`, and their lifecycle methods are not mirrored as Python classes. |
 | Python alternative | Official `a2a-sdk` 1.x and `agent-client-protocol` 0.11.x server runtimes. |
-| NeoGraph integration | `ProtocolHostAdapter` maps protocol conversation IDs to `RunConfig.thread_id`, enables `resume_if_exists`, calls `run_async()`, and cancels the active asyncio task. |
+| NeoGraph integration | `ProtocolHostAdapter` maps protocol conversation IDs to `RunConfig.thread_id`, enables `resume_if_exists`, streams `LLM_TOKEN` events, accepts custom JSON-safe input payloads, and cancels the active asyncio task. |
 | Dependency policy | Both SDKs are optional because they require Python 3.10+, while `neograph-engine` supports Python 3.9. Install `neograph-engine[a2a]`, `neograph-engine[acp]`, or `neograph-engine[protocols]`. |
-| Current limit | The examples return one final text artifact/message. Protocol-native streaming, rich media, ACP editor tool callbacks, and durable ACP `session/load` remain application code. The demo uses an in-memory checkpoint store. |
+| Durable ACP sessions | Set `NEOGRAPH_ACP_POSTGRES_URL` for the wheel-supported durable backend. Source builds with `NEOGRAPH_BUILD_SQLITE=ON` may set `NEOGRAPH_ACP_SQLITE_PATH`. The agent advertises `session/load` only when one is configured; a new session becomes loadable after its first completed prompt creates a checkpoint. Session IDs are server-generated capabilities and checkpoints use a private `acp:` thread namespace. Keep one active agent process per session; checkpoint stores do not serialize concurrent writers across processes. |
+| Current limit | ACP editor callbacks (`fs/read_text_file`, terminal calls, permission prompts) cannot yet be invoked safely from a shared NeoGraph Python tool: today's `AsyncTool` runs a synchronous function on a worker thread and does not carry the current protocol session ID. A fake bridge would risk calling the wrong editor session. |
 | Revisit direct bindings when | A user must embed the exact C++ server in Python, or the official SDK path cannot preserve a required NeoGraph cancellation, checkpoint, tracing, or tool-call behavior. |
+
+`ProtocolHostAdapter.run_payload()` passes any JSON-safe value through the
+configured `input_builder`. The default `message_input` keeps rich content
+blocks as the user message's `content`; graphs whose provider expects another
+shape should pass a custom builder. `ProtocolHostAdapter.stream()` yields
+`ProtocolStreamEvent(kind="token", ...)` values followed by exactly one final
+event. Live tokens are disabled unless `stream_node` names the graph node whose
+tokens exactly form the final answer. This prevents planner/tool-node output
+from leaking through a protocol response. The asyncio consumer queue is bounded
+(1,024 chunks by default); overflow cancels the engine run. Native stream events
+are first scheduled onto the asyncio loop, so this queue is backpressure for a
+slow protocol transport, not a hard process-wide memory cap against an
+unbounded native producer.
 
 Run any one with:
 

--- a/bindings/python/examples/README.md
+++ b/bindings/python/examples/README.md
@@ -1,6 +1,6 @@
 # Python API examples
 
-Twenty-three scripts covering the binding surface end-to-end.
+Twenty-eight scripts covering the binding surface end-to-end.
 
 ## Setup
 
@@ -43,6 +43,26 @@ the key is missing.
 | 24 | [`24_tool_approval_gate.py`](24_tool_approval_gate.py) | offline | The tool gate (#89): `engine.set_tool_gate(...)` is consulted for every tool call **before any tool runs**, returning Allow / Allow-with-rewritten-args / Deny / Interrupt. Shows the canonical approval prompt — *"the agent wants to run `rm -rf build/`. Allow?"* — and, crucially, that the harmless sibling call has **not** run while the human is deciding, so a refusal really means nothing happened and an approval does not re-run it. |
 | 25 | [`25_async_tools.py`](25_async_tools.py) | offline | Concurrent tools (#96): `ng.AsyncTool` instead of `ng.Tool` and three 300 ms tools take 0.30 s instead of 0.90 s. Also measures the boundary in the same run — three *CPU-bound* tools take 3.2x the time of one, because a Python function holds the GIL while it runs and no number of threads changes that. Concurrency is opt-in so an existing stateful tool cannot suddenly race itself. |
 | 26 | [`26_mcp_tools.py`](26_mcp_tools.py) | offline | MCP (#95): `ng.mcp.MCPClient(url).get_tools()` pulls a remote tool catalogue and hands it straight to `NodeContext`. Starts its own MCP server, so it runs with no network. Measures the thing that matters — three 0.4 s MCP calls in 0.41 s over HTTP — and says out loud where it does *not* hold: stdio has one pipe, so those calls serialize. |
+| 27 | [`27_a2a_server.py`](27_a2a_server.py) | localhost | A2A hosting (#120): the official `a2a-sdk` owns JSON-RPC, task state, the agent card, and cancellation. `ProtocolHostAdapter` maps A2A context/task IDs to NeoGraph checkpoint threads and active async runs. Requires Python 3.10+ and `pip install "neograph-engine[a2a]"`. |
+| 28 | [`28_acp_agent.py`](28_acp_agent.py) | stdio | ACP hosting (#120): the official `agent-client-protocol` runtime owns stdio framing and session methods. `ProtocolHostAdapter` preserves multi-turn state while the demo process is running and turns ACP cancel notifications into real `run_async()` cancellation. Requires Python 3.10+ and `pip install "neograph-engine[acp]"`. |
+
+## Why hosting uses the official SDKs
+
+The C++ library has its own `A2AServer` and `ACPServer`, but exposing those
+classes directly would give Python users a second protocol implementation with
+weaker integration than Python's official SDKs. In particular, the official
+SDKs already own current wire-format compatibility, server transports, task or
+session lifecycle, and asyncio cancellation. NeoGraph only supplies the part
+that those SDKs cannot: a checkpoint-aware call into the C++ graph engine.
+
+| Item | Decision |
+|------|----------|
+| C++ feature that appears missing | `A2AServer`, `ACPServer`, and their lifecycle methods are not mirrored as Python classes. |
+| Python alternative | Official `a2a-sdk` 1.x and `agent-client-protocol` 0.11.x server runtimes. |
+| NeoGraph integration | `ProtocolHostAdapter` maps protocol conversation IDs to `RunConfig.thread_id`, enables `resume_if_exists`, calls `run_async()`, and cancels the active asyncio task. |
+| Dependency policy | Both SDKs are optional because they require Python 3.10+, while `neograph-engine` supports Python 3.9. Install `neograph-engine[a2a]`, `neograph-engine[acp]`, or `neograph-engine[protocols]`. |
+| Current limit | The examples return one final text artifact/message. Protocol-native streaming, rich media, ACP editor tool callbacks, and durable ACP `session/load` remain application code. The demo uses an in-memory checkpoint store. |
+| Revisit direct bindings when | A user must embed the exact C++ server in Python, or the official SDK path cannot preserve a required NeoGraph cancellation, checkpoint, tracing, or tool-call behavior. |
 
 Run any one with:
 

--- a/bindings/python/examples/_protocol_demo.py
+++ b/bindings/python/examples/_protocol_demo.py
@@ -13,16 +13,33 @@ class EchoNode(ng.GraphNode):
 
     def run(self, input):
         messages = input.state.get("messages") or []
-        text = messages[-1].get("content", "") if messages else ""
+        content = messages[-1].get("content", "") if messages else ""
+        if isinstance(content, list):
+            text = " ".join(
+                block.get("text") or f"[{block.get('type', 'content')}]"
+                for block in content
+                if isinstance(block, dict)
+            )
+        else:
+            text = str(content)
+        turn = sum(message.get("role") == "user" for message in messages)
+        answer = f"NeoGraph received: {text} (turn {turn})"
+        if input.stream_cb:
+            for token in ("NeoGraph ", "received: ", text, f" (turn {turn})"):
+                event = ng.GraphEvent()
+                event.type = ng.GraphEvent.Type.LLM_TOKEN
+                event.node_name = self._name
+                event.data = token
+                input.stream_cb(event)
         return [
             ng.ChannelWrite(
                 "messages",
-                [{"role": "assistant", "content": f"NeoGraph received: {text}"}],
+                [{"role": "assistant", "content": answer}],
             )
         ]
 
 
-def make_adapter():
+def make_adapter(checkpoint_store=None, input_builder=None):
     type_name = "protocol_demo_echo"
     ng.NodeFactory.register_type(
         type_name, lambda name, config, ctx: EchoNode(name)
@@ -37,5 +54,9 @@ def make_adapter():
         ],
     }
     engine = ng.GraphEngine.compile(definition, ng.NodeContext())
-    engine.set_checkpoint_store(ng.InMemoryCheckpointStore())
-    return ng.ProtocolHostAdapter(engine)
+    engine.set_checkpoint_store(
+        checkpoint_store or ng.InMemoryCheckpointStore()
+    )
+    return ng.ProtocolHostAdapter(
+        engine, input_builder=input_builder, stream_node="echo"
+    )

--- a/bindings/python/examples/_protocol_demo.py
+++ b/bindings/python/examples/_protocol_demo.py
@@ -1,0 +1,41 @@
+"""Shared offline graph for the A2A and ACP hosting examples."""
+
+import neograph_engine as ng
+
+
+class EchoNode(ng.GraphNode):
+    def __init__(self, name):
+        super().__init__()
+        self._name = name
+
+    def get_name(self):
+        return self._name
+
+    def run(self, input):
+        messages = input.state.get("messages") or []
+        text = messages[-1].get("content", "") if messages else ""
+        return [
+            ng.ChannelWrite(
+                "messages",
+                [{"role": "assistant", "content": f"NeoGraph received: {text}"}],
+            )
+        ]
+
+
+def make_adapter():
+    type_name = "protocol_demo_echo"
+    ng.NodeFactory.register_type(
+        type_name, lambda name, config, ctx: EchoNode(name)
+    )
+    definition = {
+        "name": "protocol_demo",
+        "channels": {"messages": {"reducer": "append"}},
+        "nodes": {"echo": {"type": type_name}},
+        "edges": [
+            {"from": ng.START_NODE, "to": "echo"},
+            {"from": "echo", "to": ng.END_NODE},
+        ],
+    }
+    engine = ng.GraphEngine.compile(definition, ng.NodeContext())
+    engine.set_checkpoint_store(ng.InMemoryCheckpointStore())
+    return ng.ProtocolHostAdapter(engine)

--- a/bindings/python/neograph_engine/__init__.py
+++ b/bindings/python/neograph_engine/__init__.py
@@ -596,10 +596,16 @@ __all__.append("StateView")
 # cancellation semantics inside those SDK callbacks.
 from .protocol import (  # noqa: E402
     ProtocolHostAdapter,
+    ProtocolStreamEvent,
     last_message_text,
     message_input,
 )
-__all__.extend(["ProtocolHostAdapter", "last_message_text", "message_input"])
+__all__.extend([
+    "ProtocolHostAdapter",
+    "ProtocolStreamEvent",
+    "last_message_text",
+    "message_input",
+])
 
 
 def _engine_get_state_view(self, thread_id, model=None):

--- a/bindings/python/neograph_engine/__init__.py
+++ b/bindings/python/neograph_engine/__init__.py
@@ -591,6 +591,16 @@ __all__.append("message_stream")
 from .state_view import StateView  # noqa: E402
 __all__.append("StateView")
 
+# Protocol hosting bridge. A2A and ACP transports remain owned by their
+# official Python SDKs; this adapter preserves NeoGraph session resume and
+# cancellation semantics inside those SDK callbacks.
+from .protocol import (  # noqa: E402
+    ProtocolHostAdapter,
+    last_message_text,
+    message_input,
+)
+__all__.extend(["ProtocolHostAdapter", "last_message_text", "message_input"])
+
 
 def _engine_get_state_view(self, thread_id, model=None):
     """Flat dot-access wrapper around ``self.get_state(thread_id)``.

--- a/bindings/python/neograph_engine/protocol.py
+++ b/bindings/python/neograph_engine/protocol.py
@@ -8,19 +8,22 @@ SDK callbacks to NeoGraph without duplicating either protocol in pybind11.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import weakref
-from typing import Any, Callable, Mapping, Optional
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Any, AsyncIterator, Callable, Mapping, Optional
 
-from ._neograph import RunConfig
+from ._neograph import GraphEvent, RunConfig, StreamMode
 
 
-InputBuilder = Callable[[str], Mapping[str, Any]]
+InputBuilder = Callable[[Any], Mapping[str, Any]]
 OutputReader = Callable[[Any], str]
 
 
-def message_input(text: str, channel: str = "messages") -> dict[str, Any]:
-    """Build the usual chat-channel input for one user message."""
-    return {channel: [{"role": "user", "content": text}]}
+def message_input(content: Any, channel: str = "messages") -> dict[str, Any]:
+    """Build a chat-channel input from text or JSON-safe content blocks."""
+    return {channel: [{"role": "user", "content": content}]}
 
 
 def last_message_text(result: Any, channel: str = "messages") -> str:
@@ -42,6 +45,14 @@ def last_message_text(result: Any, channel: str = "messages") -> str:
     return text
 
 
+@dataclass(frozen=True)
+class ProtocolStreamEvent:
+    """One protocol-facing token or the final response text."""
+
+    kind: str
+    data: str
+
+
 class ProtocolHostAdapter:
     """Run one NeoGraph engine behind an async agent-protocol server.
 
@@ -61,11 +72,17 @@ class ProtocolHostAdapter:
         input_builder: Optional[InputBuilder] = None,
         output_reader: Optional[OutputReader] = None,
         resume_if_exists: bool = True,
+        stream_queue_size: int = 1024,
+        stream_node: Optional[str] = None,
     ) -> None:
+        if stream_queue_size < 1:
+            raise ValueError("stream_queue_size must be at least 1")
         self._engine = engine
         self._input_builder = input_builder or message_input
         self._output_reader = output_reader or last_message_text
         self._resume_if_exists = resume_if_exists
+        self._stream_queue_size = stream_queue_size
+        self._stream_node = stream_node
         self._active: dict[str, set[asyncio.Task[Any]]] = {}
         self._thread_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
             weakref.WeakValueDictionary()
@@ -84,6 +101,124 @@ class ProtocolHostAdapter:
         ``request_id`` should identify the individual task when the protocol
         provides one; otherwise cancellation applies to all work in the thread.
         """
+        return await self.run_payload(
+            text, thread_id=thread_id, request_id=request_id
+        )
+
+    async def run_payload(
+        self,
+        payload: Any,
+        *,
+        thread_id: str,
+        request_id: Optional[str] = None,
+    ) -> str:
+        """Run a text or rich application payload through ``input_builder``."""
+        return await self._execute(
+            payload, thread_id=thread_id, request_id=request_id
+        )
+
+    async def stream(
+        self,
+        payload: Any,
+        *,
+        thread_id: str,
+        request_id: Optional[str] = None,
+    ) -> AsyncIterator[ProtocolStreamEvent]:
+        """Yield token events followed by one final response event."""
+        queue: asyncio.Queue[str] = asyncio.Queue(
+            maxsize=self._stream_queue_size
+        )
+        done = asyncio.Event()
+        token_digest = hashlib.sha256()
+        token_bytes = 0
+        overflowed = False
+        task = None
+
+        def on_event(event: Any) -> None:
+            nonlocal overflowed, token_bytes
+            if (
+                event.type == GraphEvent.Type.LLM_TOKEN
+                and self._stream_node is not None
+                and event.node_name == self._stream_node
+            ):
+                token = str(event.data)
+                try:
+                    queue.put_nowait(token)
+                    encoded = token.encode("utf-8")
+                    token_digest.update(encoded)
+                    token_bytes += len(encoded)
+                except asyncio.QueueFull:
+                    overflowed = True
+                    if task is not None:
+                        task.cancel()
+
+        async def produce() -> str:
+            try:
+                return await self._execute(
+                    payload,
+                    thread_id=thread_id,
+                    request_id=request_id,
+                    event_handler=on_event,
+                )
+            finally:
+                done.set()
+
+        task = asyncio.create_task(produce())
+        try:
+            while True:
+                if done.is_set() and queue.empty():
+                    break
+                token_ready = asyncio.create_task(queue.get())
+                run_done = asyncio.create_task(done.wait())
+                try:
+                    completed, _ = await asyncio.wait(
+                        (token_ready, run_done),
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    if token_ready in completed:
+                        yield ProtocolStreamEvent(
+                            "token", token_ready.result()
+                        )
+                finally:
+                    for waiter in (token_ready, run_done):
+                        if not waiter.done():
+                            waiter.cancel()
+                            with suppress(asyncio.CancelledError):
+                                await waiter
+            try:
+                final = await task
+            except asyncio.CancelledError:
+                if overflowed:
+                    raise RuntimeError(
+                        "protocol stream queue overflowed; increase "
+                        "stream_queue_size or apply transport backpressure"
+                    ) from None
+                raise
+            final_encoded = final.encode("utf-8")
+            if token_bytes and (
+                token_bytes != len(final_encoded)
+                or token_digest.digest()
+                != hashlib.sha256(final_encoded).digest()
+            ):
+                raise ValueError(
+                    "streamed token text does not match the final response; "
+                    "the configured stream_node must emit only the final answer"
+                )
+            yield ProtocolStreamEvent("final", final)
+        finally:
+            if not task.done():
+                task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await task
+
+    async def _execute(
+        self,
+        payload: Any,
+        *,
+        thread_id: str,
+        request_id: Optional[str],
+        event_handler: Optional[Callable[[Any], None]] = None,
+    ) -> str:
         if not thread_id:
             raise ValueError("thread_id must not be empty")
         key = request_id or thread_id
@@ -105,10 +240,16 @@ class ProtocolHostAdapter:
             async with lock:
                 cfg = RunConfig(
                     thread_id=thread_id,
-                    input=dict(self._input_builder(text)),
+                    input=dict(self._input_builder(payload)),
                     resume_if_exists=self._resume_if_exists,
                 )
-                result = await self._engine.run_async(cfg)
+                if event_handler is None:
+                    result = await self._engine.run_async(cfg)
+                else:
+                    cfg.stream_mode = StreamMode.TOKENS
+                    result = await self._engine.run_stream_async(
+                        cfg, event_handler
+                    )
                 return self._output_reader(result)
         finally:
             tasks = self._active.get(key)
@@ -134,3 +275,11 @@ class ProtocolHostAdapter:
         if request_id is not None:
             return len(self._active.get(request_id, ()))
         return sum(len(tasks) for tasks in self._active.values())
+
+    def has_state(self, thread_id: str) -> bool:
+        """Return whether the configured checkpoint store knows this thread."""
+        return self._engine.get_state(thread_id) is not None
+
+    def get_state(self, thread_id: str) -> Any:
+        """Return the latest checkpoint state for protocol history replay."""
+        return self._engine.get_state(thread_id)

--- a/bindings/python/neograph_engine/protocol.py
+++ b/bindings/python/neograph_engine/protocol.py
@@ -1,0 +1,136 @@
+"""Async bridge for hosting NeoGraph agents through Python protocol SDKs.
+
+The official A2A and ACP Python SDKs already own their transports, wire
+formats, and protocol lifecycle. ``ProtocolHostAdapter`` connects those
+SDK callbacks to NeoGraph without duplicating either protocol in pybind11.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import weakref
+from typing import Any, Callable, Mapping, Optional
+
+from ._neograph import RunConfig
+
+
+InputBuilder = Callable[[str], Mapping[str, Any]]
+OutputReader = Callable[[Any], str]
+
+
+def message_input(text: str, channel: str = "messages") -> dict[str, Any]:
+    """Build the usual chat-channel input for one user message."""
+    return {channel: [{"role": "user", "content": text}]}
+
+
+def last_message_text(result: Any, channel: str = "messages") -> str:
+    """Read the last chat message's text from a ``RunResult``."""
+    try:
+        messages = result.output["channels"][channel]["value"]
+        last = messages[-1]
+        text = last["content"] if isinstance(last, dict) else last
+    except (AttributeError, KeyError, IndexError, TypeError) as exc:
+        raise ValueError(
+            f"run output has no readable final message in channel {channel!r}; "
+            "pass output_reader= for a different graph shape"
+        ) from exc
+    if not isinstance(text, str):
+        raise ValueError(
+            f"final message content in channel {channel!r} is not text; "
+            "pass output_reader= for a different graph shape"
+        )
+    return text
+
+
+class ProtocolHostAdapter:
+    """Run one NeoGraph engine behind an async agent-protocol server.
+
+    Protocol conversation IDs become NeoGraph ``thread_id`` values and
+    checkpoint resume is enabled by default. Active asyncio tasks are tracked
+    by request ID so SDK cancellation callbacks can stop the underlying
+    ``engine.run_async()`` call instead of merely marking a request cancelled.
+
+    By default the adapter reads and writes a ``messages`` chat channel. Pass
+    ``input_builder`` and ``output_reader`` for a different graph state shape.
+    """
+
+    def __init__(
+        self,
+        engine: Any,
+        *,
+        input_builder: Optional[InputBuilder] = None,
+        output_reader: Optional[OutputReader] = None,
+        resume_if_exists: bool = True,
+    ) -> None:
+        self._engine = engine
+        self._input_builder = input_builder or message_input
+        self._output_reader = output_reader or last_message_text
+        self._resume_if_exists = resume_if_exists
+        self._active: dict[str, set[asyncio.Task[Any]]] = {}
+        self._thread_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
+            weakref.WeakValueDictionary()
+        )
+
+    async def run(
+        self,
+        text: str,
+        *,
+        thread_id: str,
+        request_id: Optional[str] = None,
+    ) -> str:
+        """Run one protocol request and return response text.
+
+        ``thread_id`` should be the A2A context ID or ACP session ID.
+        ``request_id`` should identify the individual task when the protocol
+        provides one; otherwise cancellation applies to all work in the thread.
+        """
+        if not thread_id:
+            raise ValueError("thread_id must not be empty")
+        key = request_id or thread_id
+        if not key:
+            raise ValueError("request_id must not be empty")
+
+        task = asyncio.current_task()
+        if task is None:
+            raise RuntimeError("ProtocolHostAdapter.run() needs an asyncio task")
+        self._active.setdefault(key, set()).add(task)
+        lock = self._thread_locks.get(thread_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._thread_locks[thread_id] = lock
+
+        try:
+            # NeoGraph permits concurrent runs on different thread IDs, but
+            # checkpoint updates for one thread must remain ordered.
+            async with lock:
+                cfg = RunConfig(
+                    thread_id=thread_id,
+                    input=dict(self._input_builder(text)),
+                    resume_if_exists=self._resume_if_exists,
+                )
+                result = await self._engine.run_async(cfg)
+                return self._output_reader(result)
+        finally:
+            tasks = self._active.get(key)
+            if tasks is not None:
+                tasks.discard(task)
+                if not tasks:
+                    self._active.pop(key, None)
+
+    def cancel(self, request_id: str) -> int:
+        """Cancel active work for ``request_id`` and return its task count."""
+        tasks = tuple(self._active.get(request_id, ()))
+        try:
+            current = asyncio.current_task()
+        except RuntimeError:
+            current = None
+        for task in tasks:
+            if task is not current:
+                task.cancel()
+        return sum(task is not current for task in tasks)
+
+    def active_count(self, request_id: Optional[str] = None) -> int:
+        """Return active request count, mainly for health checks and tests."""
+        if request_id is not None:
+            return len(self._active.get(request_id, ()))
+        return sum(len(tasks) for tasks in self._active.values())

--- a/bindings/python/tests/test_protocol_hosting.py
+++ b/bindings/python/tests/test_protocol_hosting.py
@@ -1,0 +1,204 @@
+"""Protocol SDK bridge: session continuity, output mapping, and cancellation."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import neograph_engine as ng
+
+
+class RecordingEngine:
+    def __init__(self, output=None):
+        self.configs = []
+        self.output = output or {
+            "channels": {
+                "messages": {
+                    "value": [{"role": "assistant", "content": "hello"}]
+                }
+            }
+        }
+
+    async def run_async(self, cfg):
+        self.configs.append(cfg)
+        return SimpleNamespace(output=self.output)
+
+
+def test_protocol_host_maps_session_and_chat_state():
+    engine = RecordingEngine()
+    adapter = ng.ProtocolHostAdapter(engine)
+
+    answer = asyncio.run(
+        adapter.run("question", thread_id="context-7", request_id="task-2")
+    )
+
+    assert answer == "hello"
+    assert len(engine.configs) == 1
+    cfg = engine.configs[0]
+    assert cfg.thread_id == "context-7"
+    assert cfg.resume_if_exists is True
+    assert cfg.input == {
+        "messages": [{"role": "user", "content": "question"}]
+    }
+    assert adapter.active_count() == 0
+
+
+def test_protocol_host_accepts_custom_graph_shape():
+    engine = RecordingEngine(
+        output={"channels": {"answer": {"value": {"text": "custom"}}}}
+    )
+    adapter = ng.ProtocolHostAdapter(
+        engine,
+        input_builder=lambda text: {"prompt": text},
+        output_reader=lambda result: result.output["channels"]["answer"][
+            "value"
+        ]["text"],
+    )
+
+    answer = asyncio.run(adapter.run("question", thread_id="session-1"))
+
+    assert answer == "custom"
+    assert engine.configs[0].input == {"prompt": "question"}
+
+
+def test_protocol_host_rejects_missing_output_channel():
+    adapter = ng.ProtocolHostAdapter(RecordingEngine(output={"channels": {}}))
+
+    with pytest.raises(ValueError, match="output_reader"):
+        asyncio.run(adapter.run("question", thread_id="session-1"))
+
+
+def test_protocol_cancel_reaches_underlying_async_run():
+    class BlockingEngine:
+        def __init__(self):
+            self.started = asyncio.Event()
+            self.cancelled = False
+
+        async def run_async(self, cfg):
+            self.started.set()
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                self.cancelled = True
+                raise
+
+    async def exercise():
+        engine = BlockingEngine()
+        adapter = ng.ProtocolHostAdapter(engine)
+        call = asyncio.create_task(
+            adapter.run("wait", thread_id="session-1", request_id="request-1")
+        )
+        await engine.started.wait()
+
+        assert adapter.active_count("request-1") == 1
+        assert adapter.cancel("request-1") == 1
+        with pytest.raises(asyncio.CancelledError):
+            await call
+        assert engine.cancelled is True
+        assert adapter.active_count() == 0
+
+    asyncio.run(exercise())
+
+
+def test_protocol_host_requires_thread_id():
+    adapter = ng.ProtocolHostAdapter(RecordingEngine())
+
+    with pytest.raises(ValueError, match="thread_id"):
+        asyncio.run(adapter.run("question", thread_id=""))
+
+
+def test_protocol_host_serializes_runs_for_same_checkpoint_thread():
+    class ConcurrencyEngine:
+        def __init__(self):
+            self.inflight = 0
+            self.max_inflight = 0
+
+        async def run_async(self, cfg):
+            self.inflight += 1
+            self.max_inflight = max(self.max_inflight, self.inflight)
+            await asyncio.sleep(0.01)
+            self.inflight -= 1
+            text = cfg.input["messages"][-1]["content"]
+            return SimpleNamespace(
+                output={
+                    "channels": {
+                        "messages": {
+                            "value": [
+                                {"role": "assistant", "content": text}
+                            ]
+                        }
+                    }
+                }
+            )
+
+    async def exercise():
+        engine = ConcurrencyEngine()
+        adapter = ng.ProtocolHostAdapter(engine)
+        answers = await asyncio.gather(
+            adapter.run("one", thread_id="same", request_id="r1"),
+            adapter.run("two", thread_id="same", request_id="r2"),
+        )
+        same_thread_max = engine.max_inflight
+        engine.max_inflight = 0
+        await asyncio.gather(
+            adapter.run("three", thread_id="left", request_id="r3"),
+            adapter.run("four", thread_id="right", request_id="r4"),
+        )
+        return same_thread_max, engine.max_inflight, answers
+
+    same_thread_max, different_thread_max, answers = asyncio.run(exercise())
+    assert same_thread_max == 1
+    assert different_thread_max == 2
+    assert answers == ["one", "two"]
+
+
+def test_protocol_host_resumes_real_checkpointed_conversation():
+    class EchoNode(ng.GraphNode):
+        def __init__(self, name):
+            super().__init__()
+            self.name = name
+
+        def get_name(self):
+            return self.name
+
+        def run(self, input):
+            messages = input.state.get("messages") or []
+            text = messages[-1]["content"]
+            return [
+                ng.ChannelWrite(
+                    "messages",
+                    [{"role": "assistant", "content": f"reply:{text}"}],
+                )
+            ]
+
+    type_name = "protocol_hosting_test_echo"
+    ng.NodeFactory.register_type(
+        type_name, lambda name, config, ctx: EchoNode(name)
+    )
+    definition = {
+        "name": "protocol_hosting_test",
+        "channels": {"messages": {"reducer": "append"}},
+        "nodes": {"echo": {"type": type_name}},
+        "edges": [
+            {"from": ng.START_NODE, "to": "echo"},
+            {"from": "echo", "to": ng.END_NODE},
+        ],
+    }
+    engine = ng.GraphEngine.compile(definition, ng.NodeContext())
+    engine.set_checkpoint_store(ng.InMemoryCheckpointStore())
+    adapter = ng.ProtocolHostAdapter(engine)
+
+    async def exercise():
+        first = await adapter.run("one", thread_id="session-1")
+        second = await adapter.run("two", thread_id="session-1")
+        return first, second
+
+    assert asyncio.run(exercise()) == ("reply:one", "reply:two")
+    messages = engine.get_state("session-1")["channels"]["messages"]["value"]
+    assert [message["content"] for message in messages] == [
+        "one",
+        "reply:one",
+        "two",
+        "reply:two",
+    ]
+    assert adapter.cancel("not-running") == 0

--- a/bindings/python/tests/test_protocol_hosting.py
+++ b/bindings/python/tests/test_protocol_hosting.py
@@ -55,10 +55,154 @@ def test_protocol_host_accepts_custom_graph_shape():
         ]["text"],
     )
 
-    answer = asyncio.run(adapter.run("question", thread_id="session-1"))
+    payload = [{"type": "image", "url": "https://example.test/cat.png"}]
+    answer = asyncio.run(adapter.run_payload(payload, thread_id="session-1"))
 
     assert answer == "custom"
-    assert engine.configs[0].input == {"prompt": "question"}
+    assert engine.configs[0].input == {"prompt": payload}
+
+
+def test_protocol_stream_yields_tokens_then_final_response():
+    class StreamingEngine(RecordingEngine):
+        async def run_stream_async(self, cfg, callback):
+            self.configs.append(cfg)
+            for token in ("hello", " ", "world"):
+                event = ng.GraphEvent()
+                event.type = ng.GraphEvent.Type.LLM_TOKEN
+                event.node_name = "answer"
+                event.data = token
+                callback(event)
+            return SimpleNamespace(output=self.output)
+
+    async def collect(adapter):
+        return [
+            (event.kind, event.data)
+            async for event in adapter.stream("question", thread_id="session-1")
+        ]
+
+    engine = StreamingEngine()
+    engine.output = {
+        "channels": {
+            "messages": {
+                "value": [{"role": "assistant", "content": "hello world"}]
+            }
+        }
+    }
+    events = asyncio.run(collect(ng.ProtocolHostAdapter(
+        engine, stream_node="answer"
+    )))
+
+    assert events == [
+        ("token", "hello"),
+        ("token", " "),
+        ("token", "world"),
+        ("final", "hello world"),
+    ]
+    assert engine.configs[0].stream_mode == ng.StreamMode.TOKENS
+
+
+def test_protocol_stream_rejects_tokens_that_disagree_with_final_output():
+    class MismatchEngine(RecordingEngine):
+        async def run_stream_async(self, cfg, callback):
+            event = ng.GraphEvent()
+            event.type = ng.GraphEvent.Type.LLM_TOKEN
+            event.node_name = "answer"
+            event.data = "draft"
+            callback(event)
+            return SimpleNamespace(output=self.output)
+
+    async def consume():
+        adapter = ng.ProtocolHostAdapter(
+            MismatchEngine(), stream_node="answer"
+        )
+        return [event async for event in adapter.stream("x", thread_id="s")]
+
+    with pytest.raises(ValueError, match="does not match"):
+        asyncio.run(consume())
+
+
+def test_protocol_stream_bounds_queue_and_cancels_on_overflow():
+    class BurstEngine(RecordingEngine):
+        async def run_stream_async(self, cfg, callback):
+            for token in ("one", "two"):
+                event = ng.GraphEvent()
+                event.type = ng.GraphEvent.Type.LLM_TOKEN
+                event.node_name = "answer"
+                event.data = token
+                callback(event)
+            await asyncio.sleep(0)
+            return SimpleNamespace(output=self.output)
+
+    async def consume():
+        adapter = ng.ProtocolHostAdapter(
+            BurstEngine(), stream_queue_size=1, stream_node="answer"
+        )
+        return [event async for event in adapter.stream("x", thread_id="s")]
+
+    with pytest.raises(RuntimeError, match="queue overflowed"):
+        asyncio.run(asyncio.wait_for(consume(), timeout=1))
+
+    with pytest.raises(ValueError, match="at least 1"):
+        ng.ProtocolHostAdapter(RecordingEngine(), stream_queue_size=0)
+
+
+def test_protocol_stream_without_output_node_yields_only_final():
+    class StreamingEngine(RecordingEngine):
+        async def run_stream_async(self, cfg, callback):
+            event = ng.GraphEvent()
+            event.type = ng.GraphEvent.Type.LLM_TOKEN
+            event.node_name = "planner"
+            event.data = "private draft"
+            callback(event)
+            return SimpleNamespace(output=self.output)
+
+    async def consume():
+        adapter = ng.ProtocolHostAdapter(StreamingEngine())
+        return [event async for event in adapter.stream("x", thread_id="s")]
+
+    events = asyncio.run(consume())
+    assert [(event.kind, event.data) for event in events] == [
+        ("final", "hello")
+    ]
+
+
+def test_protocol_stream_close_cancels_engine_and_cleans_waiters():
+    class BlockingEngine(RecordingEngine):
+        def __init__(self):
+            super().__init__()
+            self.cancelled = False
+
+        async def run_stream_async(self, cfg, callback):
+            event = ng.GraphEvent()
+            event.type = ng.GraphEvent.Type.LLM_TOKEN
+            event.node_name = "answer"
+            event.data = "partial"
+            callback(event)
+            try:
+                await asyncio.Future()
+            except asyncio.CancelledError:
+                self.cancelled = True
+                raise
+
+    async def exercise():
+        engine = BlockingEngine()
+        adapter = ng.ProtocolHostAdapter(engine, stream_node="answer")
+        stream = adapter.stream("x", thread_id="s", request_id="r")
+        first = await stream.__anext__()
+        assert first.data == "partial"
+        await stream.aclose()
+        await asyncio.sleep(0)
+        others = [
+            task
+            for task in asyncio.all_tasks()
+            if task is not asyncio.current_task() and not task.done()
+        ]
+        return engine, adapter, others
+
+    engine, adapter, others = asyncio.run(exercise())
+    assert engine.cancelled is True
+    assert adapter.active_count() == 0
+    assert others == []
 
 
 def test_protocol_host_rejects_missing_output_channel():

--- a/bindings/python/tests/test_protocol_sdk_e2e.py
+++ b/bindings/python/tests/test_protocol_sdk_e2e.py
@@ -1,0 +1,304 @@
+"""Official A2A/ACP SDK integration tests.
+
+The normal test suite skips this module when protocol extras are absent. CI has
+a dedicated Python 3.12 job that installs both SDKs and runs these tests.
+"""
+
+import asyncio
+import contextlib
+import os
+import runpy
+import socket
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+
+pytest.importorskip("a2a")
+pytest.importorskip("acp")
+
+import httpx
+from a2a.client import A2ACardResolver, ClientConfig, create_client
+from a2a.client.errors import AgentCardResolutionError
+from a2a.helpers import new_text_message
+from a2a.types import Role, SendMessageRequest
+from acp import (
+    PROTOCOL_VERSION,
+    RequestError,
+    connect_to_agent,
+    image_block,
+    text_block,
+)
+from acp.schema import ClientCapabilities, Implementation
+
+import neograph_engine as ng
+
+
+ROOT = Path(__file__).resolve().parents[3]
+EXAMPLES = ROOT / "bindings" / "python" / "examples"
+sys.path.insert(0, str(EXAMPLES))
+
+
+def _free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _subprocess_env(**updates):
+    env = os.environ.copy()
+    paths = [str(ROOT / "build"), str(EXAMPLES)]
+    if env.get("PYTHONPATH"):
+        paths.append(env["PYTHONPATH"])
+    env["PYTHONPATH"] = os.pathsep.join(paths)
+    env.update(updates)
+    return env
+
+
+async def _stop_process(process, connection=None):
+    if connection is not None:
+        with contextlib.suppress(Exception):
+            await connection.close()
+    if process.returncode is None:
+        process.terminate()
+        with contextlib.suppress(ProcessLookupError):
+            await process.wait()
+
+
+def test_a2a_streaming_round_trip():
+    async def exercise():
+        port = _free_port()
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            str(EXAMPLES / "27_a2a_server.py"),
+            env=_subprocess_env(NEOGRAPH_A2A_PORT=str(port)),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        assert process.stderr is not None
+        try:
+            base_url = f"http://127.0.0.1:{port}"
+            async with httpx.AsyncClient() as http:
+                resolver = A2ACardResolver(http, base_url)
+                for _ in range(50):
+                    try:
+                        card = await resolver.get_agent_card()
+                        break
+                    except AgentCardResolutionError:
+                        if process.returncode is not None:
+                            stderr = await process.stderr.read()
+                            raise AssertionError(stderr.decode())
+                        await asyncio.sleep(0.1)
+                else:
+                    raise AssertionError("A2A server did not start")
+
+            assert card.capabilities.streaming is True
+            client = await create_client(
+                agent=card, client_config=ClientConfig(streaming=True)
+            )
+            request = SendMessageRequest(
+                message=new_text_message("probe", role=Role.ROLE_USER)
+            )
+            chunks = [chunk async for chunk in client.send_message(request)]
+            await client.close()
+            rendered = repr(chunks)
+            assert "NeoGraph " in rendered
+            assert "received: " in rendered
+            assert "probe" in rendered
+            assert " (turn 1)" in rendered
+            assert len(chunks) >= 4
+        finally:
+            await _stop_process(process)
+
+    asyncio.run(exercise())
+
+
+class _ACPClient:
+    def __init__(self):
+        self.messages = []
+
+    async def session_update(self, session_id, update, **kwargs):
+        self.messages.append(getattr(update.content, "text", ""))
+
+    async def ext_method(self, method, params):
+        raise RuntimeError(method)
+
+    async def ext_notification(self, method, params):
+        raise RuntimeError(method)
+
+
+async def _start_acp(extra_env=None):
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        str(EXAMPLES / "28_acp_agent.py"),
+        env=_subprocess_env(**(extra_env or {})),
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    assert process.stdin is not None and process.stdout is not None
+    client = _ACPClient()
+    connection = connect_to_agent(client, process.stdin, process.stdout)
+    initialized = await connection.initialize(
+        protocol_version=PROTOCOL_VERSION,
+        client_capabilities=ClientCapabilities(),
+        client_info=Implementation(name="test-client", version="1.0"),
+    )
+    return process, client, connection, initialized
+
+
+async def _wait_messages(client, count):
+    for _ in range(100):
+        if len(client.messages) >= count:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        f"expected {count} ACP message chunks, got {client.messages!r}"
+    )
+
+
+def test_acp_streaming_and_durable_session_load(tmp_path):
+    async def exercise():
+        postgres_url = os.environ.get("NEOGRAPH_TEST_POSTGRES_URL")
+        if postgres_url:
+            env = {"NEOGRAPH_ACP_POSTGRES_URL": postgres_url}
+        else:
+            if not hasattr(ng, "SqliteCheckpointStore"):
+                pytest.skip("test build has no durable checkpoint backend")
+            env = {"NEOGRAPH_ACP_SQLITE_PATH": str(tmp_path / "acp.db")}
+        process, client, connection, initialized = await _start_acp(env)
+        try:
+            assert initialized.agent_capabilities.load_session is True
+            session = await connection.new_session(cwd=str(tmp_path), mcp_servers=[])
+            await connection.prompt(
+                session_id=session.session_id,
+                prompt=[text_block("first")],
+            )
+            await _wait_messages(client, 4)
+            assert "".join(client.messages) == (
+                "NeoGraph received: first (turn 1)"
+            )
+            assert len(client.messages) == 4
+        finally:
+            await _stop_process(process, connection)
+
+        process, client, connection, initialized = await _start_acp(env)
+        try:
+            try:
+                await connection.load_session(
+                    cwd=str(tmp_path),
+                    session_id=session.session_id,
+                    mcp_servers=[],
+                )
+            except Exception:
+                process.terminate()
+                await process.wait()
+                assert process.stderr is not None
+                stderr = (await process.stderr.read()).decode()
+                raise AssertionError(stderr) from None
+            await _wait_messages(client, 2)
+            assert client.messages == [
+                "first",
+                "NeoGraph received: first (turn 1)",
+            ]
+            client.messages.clear()
+            await connection.prompt(
+                session_id=session.session_id,
+                prompt=[text_block("second")],
+            )
+            await _wait_messages(client, 4)
+            assert "".join(client.messages) == (
+                "NeoGraph received: second (turn 2)"
+            )
+        finally:
+            await _stop_process(process, connection)
+
+    asyncio.run(exercise())
+
+
+def test_acp_rich_content_reaches_input_builder():
+    namespace = runpy.run_path(str(EXAMPLES / "28_acp_agent.py"))
+
+    class CapturingAdapter:
+        def __init__(self):
+            self.payload = None
+
+        async def stream(self, payload, **kwargs):
+            self.payload = payload
+            self.thread_id = kwargs["thread_id"]
+            yield ng.ProtocolStreamEvent("final", "handled")
+
+        def cancel(self, request_id):
+            return 0
+
+    async def exercise():
+        agent = namespace["NeoGraphACPAgent"]()
+        agent.adapter = CapturingAdapter()
+        agent.connection = _ACPClient()
+        session_id = uuid4().hex
+        agent.sessions.add(session_id)
+        response = await agent.prompt(
+            session_id,
+            [
+                text_block("look"),
+                image_block("aGVsbG8=", "image/png"),
+            ],
+        )
+        assert response.stop_reason == "end_turn"
+        assert agent.adapter.payload == [
+            {"text": "look", "type": "text"},
+            {"data": "aGVsbG8=", "mimeType": "image/png", "type": "image"},
+        ]
+        assert agent.adapter.thread_id == f"acp:{session_id}"
+        assert agent.connection.messages == ["handled"]
+
+    asyncio.run(exercise())
+
+
+def test_acp_cancel_completes_original_prompt_without_final_message():
+    namespace = runpy.run_path(str(EXAMPLES / "28_acp_agent.py"))
+
+    class BlockingAdapter:
+        def __init__(self):
+            self.started = asyncio.Event()
+
+        async def stream(self, payload, **kwargs):
+            self.started.set()
+            await asyncio.Future()
+            if False:
+                yield None
+
+        def cancel(self, request_id):
+            return 0
+
+    async def exercise():
+        agent = namespace["NeoGraphACPAgent"]()
+        agent.adapter = BlockingAdapter()
+        agent.connection = _ACPClient()
+        session_id = uuid4().hex
+        agent.sessions.add(session_id)
+        prompt = asyncio.create_task(
+            agent.prompt(session_id, [text_block("wait")])
+        )
+        await agent.adapter.started.wait()
+        await agent.cancel(session_id)
+        response = await asyncio.wait_for(prompt, timeout=1)
+        assert response.stop_reason == "cancelled"
+        assert agent.connection.messages == []
+
+    asyncio.run(exercise())
+
+
+def test_acp_prompt_rejects_session_not_admitted_by_new_or_load():
+    namespace = runpy.run_path(str(EXAMPLES / "28_acp_agent.py"))
+
+    async def exercise():
+        agent = namespace["NeoGraphACPAgent"]()
+        agent.connection = _ACPClient()
+        with pytest.raises(RequestError) as exc_info:
+            await agent.prompt(uuid4().hex, [text_block("probe")])
+        assert getattr(exc_info.value, "code", None) == -32002
+
+    asyncio.run(exercise())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,24 @@ classifiers = [
 # already has pydantic in the env.
 dependencies = ["certifi", "pydantic>=2.0"]
 
+# Protocol servers are intentionally optional. Their official Python SDKs own
+# fast-moving wire formats and require Python 3.10+, while the NeoGraph wheel
+# itself still supports Python 3.9. The pure-Python ProtocolHostAdapter has no
+# extra dependency and remains available on every supported Python version.
+[project.optional-dependencies]
+a2a = [
+    "a2a-sdk[http-server]>=1.1,<2; python_version >= '3.10'",
+    "uvicorn>=0.35; python_version >= '3.10'",
+]
+acp = [
+    "agent-client-protocol==0.11.0; python_version >= '3.10'",
+]
+protocols = [
+    "a2a-sdk[http-server]>=1.1,<2; python_version >= '3.10'",
+    "uvicorn>=0.35; python_version >= '3.10'",
+    "agent-client-protocol==0.11.0; python_version >= '3.10'",
+]
+
 [project.urls]
 Homepage      = "https://github.com/fox1245/NeoGraph"
 Repository    = "https://github.com/fox1245/NeoGraph"


### PR DESCRIPTION
## Summary
- add `ProtocolHostAdapter` to map protocol conversation IDs to checkpoint threads while serializing same-session runs
- stream NeoGraph token events through chunked A2A artifacts and ACP `session/update` messages
- preserve ACP text, image, audio, and resource content blocks
- support durable ACP `session/load` through PostgreSQL or SQLite, with an isolated `acp:` checkpoint namespace
- propagate protocol cancellation into active NeoGraph async runs
- verify the examples against the official A2A 1.x and ACP 0.11 SDK clients in CI

## Why not direct server bindings
Python already has official A2A and ACP server runtimes that own wire compatibility, transports, and lifecycle. Binding NeoGraph's separate C++ servers would duplicate those implementations and currently provide weaker Python cancellation/session integration. The adapter keeps NeoGraph-specific checkpoint, streaming, and cancellation behavior without taking over either protocol.

## Safety and limits
- live tokens are disabled unless `stream_node` identifies the node whose tokens exactly equal the final answer
- streamed bytes are checked against the final response; queue overflow cancels the run
- ACP prompts require a session admitted by `session/new` or `session/load`
- new durable sessions become loadable after their first completed prompt
- one active process may write a durable session at a time; checkpoint stores do not serialize cross-process writers
- ACP editor callbacks remain deferred until Python tools can safely carry protocol session and event-loop context

## Verification
- C++: 636/636 tests passed
- Python: 168 passed, 6 skipped
- focused protocol adapter tests: 12 passed
- official SDK E2E: 5 passed, including A2A streaming, ACP streaming, durable restart/load, rich content, and cancellation
- `git diff --check` and Python syntax compilation passed
- independent final review: no blocking findings
- normal adapter overhead: +6.9 us median per call (`direct_ns` median 14.3 us, `adapter_ns` median 21.2 us)
- streaming adapter overhead: +67.9 us median per call in the final run

Closes #120