### PR TITLE
perf(core): avoid throwaway json allocations

### DIFF
--- a/benchmarks/bench_neograph.cpp
+++ b/benchmarks/bench_neograph.cpp
@@ -145,6 +145,21 @@ static BenchResult bench(GraphEngine* engine, int iters) {
     return {total_ms, (total_ms * 1000.0) / iters};
 }
 
+static BenchResult bench_stream(GraphEngine* engine, int iters, StreamMode mode) {
+    RunConfig cfg;
+    cfg.stream_mode = mode;
+    const GraphStreamCallback discard = [](const GraphEvent&) {};
+
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < iters; ++i) {
+        (void)engine->run_stream(cfg, discard);
+    }
+    auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+
+    return {total_ms, (total_ms * 1000.0) / iters};
+}
+
 int main(int argc, char** argv) {
     const int seq_iters = (argc > 1) ? std::atoi(argv[1]) : 10000;
     const int par_iters = (argc > 2) ? std::atoi(argv[2]) : 5000;
@@ -166,6 +181,16 @@ int main(int argc, char** argv) {
     auto par = bench(par_engine.get(), par_iters);
     std::cout << "par\t" << par_iters << "\t" << par.total_ms
               << "\t" << par.per_iter_us << "\n";
+
+    // A callback with TOKENS emits nothing for this graph. Comparing it with
+    // EVENTS isolates lifecycle-event construction and callback dispatch.
+    auto seq_stream_idle = bench_stream(seq_engine.get(), seq_iters, StreamMode::TOKENS);
+    std::cout << "seq_stream_idle\t" << seq_iters << "\t" << seq_stream_idle.total_ms
+              << "\t" << seq_stream_idle.per_iter_us << "\n";
+
+    auto seq_events = bench_stream(seq_engine.get(), seq_iters, StreamMode::EVENTS);
+    std::cout << "seq_events\t" << seq_iters << "\t" << seq_events.total_ms
+              << "\t" << seq_events.per_iter_us << "\n";
 
     return 0;
 }

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -715,7 +715,7 @@ private:
         const RunConfig& config,
         const GraphStreamCallback& cb,
         const std::vector<std::string>& resume_from = {},
-        const json& resume_value = json());
+        const json* resume_value = nullptr);
 
     RetryPolicy get_retry_policy(const std::string& node_name) const;
 

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -420,7 +420,7 @@ GraphEngine::resume_async(const std::string& thread_id,
     config.max_steps = 50;
 
     co_return co_await execute_graph_async(
-        config, cb, cp_opt->next_nodes, resume_value);
+        config, cb, cp_opt->next_nodes, &resume_value);
 }
 
 // =========================================================================
@@ -441,7 +441,7 @@ asio::awaitable<RunResult>
 GraphEngine::execute_graph_async(const RunConfig& config,
                                  const GraphStreamCallback& cb,
                                  const std::vector<std::string>& resume_from,
-                                 const json& resume_value) {
+                                 const json* resume_value) {
     const bool is_resume = !resume_from.empty();
 
     // RAII inc/dec on the inflight-run counter — set_worker_count()
@@ -488,7 +488,7 @@ GraphEngine::execute_graph_async(const RunConfig& config,
     // fresh run, which is how a node distinguishes "nobody has answered yet"
     // from "the answer was no". Only engaged on an actual resume, so the
     // common path pays no json allocation.
-    if (!resume_value.is_null()) ctx.resume_value = resume_value;
+    if (resume_value && !resume_value->is_null()) ctx.resume_value = *resume_value;
     ctx.tool_gate    = tool_gate_;   // issue #89 — engine-level, so resume() keeps it
     // ctx.deadline / ctx.trace_id stay default-constructed for now —
     // RunConfig has no source field for either. Future PRs add them.
@@ -516,13 +516,14 @@ GraphEngine::execute_graph_async(const RunConfig& config,
             // dynamic interrupts exist for. Every node now reads the answer
             // from ``ctx.resume_value`` regardless; this write stays for the
             // graphs that were relying on it (issue #94).
-            if (!resume_value.is_null() && state.has_channel("messages")) {
+            if (resume_value && !resume_value->is_null()
+                && state.has_channel("messages")) {
                 // Build the resume message outside the brace-init that
                 // would otherwise nest inside the coroutine body. Same
                 // GCC 13 ICE shape; same workaround.
-                std::string content = resume_value.is_string()
-                    ? resume_value.get<std::string>()
-                    : resume_value.dump();
+                std::string content = resume_value->is_string()
+                    ? resume_value->get<std::string>()
+                    : resume_value->dump();
                 json resume_msg;
                 resume_msg["role"]    = "user";
                 resume_msg["content"] = content;
@@ -606,7 +607,8 @@ GraphEngine::execute_graph_async(const RunConfig& config,
                         json data;
                         data["phase"]         = "before";
                         data["checkpoint_id"] = cp_id;
-                        cb(GraphEvent{GraphEvent::Type::INTERRUPT, node_name, data});
+                        cb(GraphEvent{GraphEvent::Type::INTERRUPT, node_name,
+                                      std::move(data)});
                     }
                     co_return result;
                 }
@@ -739,7 +741,8 @@ GraphEngine::execute_graph_async(const RunConfig& config,
                     json data;
                     data["phase"]         = "after";
                     data["checkpoint_id"] = cp_id;
-                    cb(GraphEvent{GraphEvent::Type::INTERRUPT, node_name, data});
+                    cb(GraphEvent{GraphEvent::Type::INTERRUPT, node_name,
+                                  std::move(data)});
                 }
                 co_return result;
             }
@@ -774,7 +777,8 @@ GraphEngine::execute_graph_async(const RunConfig& config,
             if (plan.winning_command_goto) {
                 json data;
                 data["command_goto"] = *plan.winning_command_goto;
-                cb(GraphEvent{GraphEvent::Type::NODE_START, "__routing__", data});
+                cb(GraphEvent{GraphEvent::Type::NODE_START, "__routing__",
+                              std::move(data)});
             }
             if (!ready.empty()) {
                 json next_nodes_arr = json::array();
@@ -782,7 +786,8 @@ GraphEngine::execute_graph_async(const RunConfig& config,
                 json data;
                 data["next_nodes"] = next_nodes_arr;
                 data["step"]       = step;
-                cb(GraphEvent{GraphEvent::Type::NODE_START, "__routing__", data});
+                cb(GraphEvent{GraphEvent::Type::NODE_START, "__routing__",
+                              std::move(data)});
             }
         }
 

--- a/src/core/graph_executor.cpp
+++ b/src/core/graph_executor.cpp
@@ -204,7 +204,8 @@ asio::awaitable<NodeResult> NodeExecutor::execute_node_with_retry_async(
         if (cb && has_mode(stream_mode, StreamMode::EVENTS)) {
             json data;
             if (attempt > 0) data["retry_attempt"] = attempt;
-            cb(GraphEvent{GraphEvent::Type::NODE_START, node_name, data});
+            cb(GraphEvent{GraphEvent::Type::NODE_START, node_name,
+                          std::move(data)});
         }
 
         // Capture the outcome of one attempt without co_await inside a
@@ -273,7 +274,8 @@ asio::awaitable<NodeResult> NodeExecutor::execute_node_with_retry_async(
                         end_data["command_goto"] = nr.command->goto_node;
                     if (!nr.sends.empty())
                         end_data["sends"] = (int)nr.sends.size();
-                    cb(GraphEvent{GraphEvent::Type::NODE_END, node_name, end_data});
+                    cb(GraphEvent{GraphEvent::Type::NODE_END, node_name,
+                                  std::move(end_data)});
                 }
             }
             if (cache_eligible) {
@@ -659,7 +661,8 @@ asio::awaitable<std::vector<StepRouting>> NodeExecutor::run_sends_async(
         }
         json data;
         data["sends"] = send_info;
-        cb(GraphEvent{GraphEvent::Type::NODE_START, "__send__", data});
+        cb(GraphEvent{GraphEvent::Type::NODE_START, "__send__",
+                      std::move(data)});
     }
 
     // --- Single Send: sequential on shared state, with retry. ---

--- a/src/core/graph_state.cpp
+++ b/src/core/graph_state.cpp
@@ -28,12 +28,8 @@ void GraphState::init_channel(const std::string& name,
                                ReducerFn reducer,
                                const json& initial_value) {
     std::unique_lock lock(mutex_);
-    Channel ch;
-    ch.name         = name;
-    ch.reducer_type = type;
-    ch.reducer      = std::move(reducer);
-    ch.value        = initial_value;
-    channels_[name] = std::move(ch);
+    channels_.insert_or_assign(
+        name, Channel{name, type, std::move(reducer), initial_value, 0});
 }
 
 json GraphState::get(const std::string& channel) const {


### PR DESCRIPTION
## Summary
- remove the private per-run default json resume argument
- construct channels directly instead of allocating and overwriting two null JSON documents
- move lifecycle event payloads into GraphEvent instead of deep-copying them
- add idle-callback and lifecycle-event rows to bench_neograph

## Performance
12-run ABBA comparison against bb9a358, Release build, CPU-pinned:

| Path | Baseline median | Candidate median | Change |
|---|---:|---:|---:|
| Sequential | 5.60 us | 5.46 us | -2.5% |
| Idle stream callback | 5.39 us | 5.18 us | -3.9% |
| EVENTS streaming | 6.19 us | 5.66 us | -8.6% |
| Event-only overhead | 0.80 us | 0.48 us | -40% |

## Verification
- CTest: 635/635 passed, 30 environment-dependent tests skipped
- git diff --check passed
- independent review found no correctness or compatibility regressions

Closes #99