### PR TITLE
fix(engine): expose max-steps exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`max_steps` 종료 상태 노출 (#114).**
+  `RunResult::max_steps_exhausted()`와 Python의 읽기 전용
+  `RunResult.max_steps_exhausted` 속성을 추가했다. 실행할 노드가 남은 상태에서
+  `max_steps`에 도달했을 때만 참이며, 같은 상태를 gRPC 단건 응답과 스트리밍
+  마지막 JSON에서도 제공한다. C++ 구조체 크기는 바꾸지 않았다.
+
 - **`set_worker_count` / `set_worker_count_auto` docstring 정정
   (issue #62, PR #63).** v1.0 prep 사이클에 `compile()` 의 worker pool
   기본값을 `set_worker_count(hardware_concurrency())` 에서

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -383,6 +383,9 @@ void init_graph(py::module_& m) {
         .def(py::init<>())
         .def_property_readonly("output",
             [](const RunResult& r) { return json_to_py(r.output); })
+        .def_property_readonly("max_steps_exhausted",
+            &RunResult::max_steps_exhausted,
+            "True when max_steps stopped execution while runnable work remained.")
         .def_readonly("interrupted",     &RunResult::interrupted)
         .def_readonly("interrupt_node",  &RunResult::interrupt_node)
         .def_property_readonly("interrupt_value",

--- a/bindings/python/tests/test_max_steps_status.py
+++ b/bindings/python/tests/test_max_steps_status.py
@@ -1,0 +1,45 @@
+"""RunResult.max_steps_exhausted reports limit stops without false positives."""
+
+import neograph_engine as ng
+
+
+@ng.node("max_steps_status_noop")
+def noop(_state):
+    return []
+
+
+def make_engine(loop: bool):
+    target = "max_steps_status_noop" if loop else ng.END_NODE
+    definition = {
+        "name": "max_steps_status",
+        "channels": {"value": {"reducer": "overwrite"}},
+        "nodes": {"max_steps_status_noop": {"type": "max_steps_status_noop"}},
+        "edges": [
+            {"from": ng.START_NODE, "to": "max_steps_status_noop"},
+            {"from": "max_steps_status_noop", "to": target},
+        ],
+    }
+    return ng.GraphEngine.compile(definition, ng.NodeContext())
+
+
+def test_self_loop_reports_max_steps_exhausted():
+    result = make_engine(loop=True).run(ng.RunConfig(max_steps=3))
+
+    assert result.execution_trace == ["max_steps_status_noop"] * 3
+    assert result.max_steps_exhausted is True
+    assert result.output["_neograph"]["max_steps_exhausted"] is True
+
+
+def test_exact_boundary_completion_is_not_exhausted():
+    result = make_engine(loop=False).run(ng.RunConfig(max_steps=1))
+
+    assert result.execution_trace == ["max_steps_status_noop"]
+    assert result.max_steps_exhausted is False
+    assert "_neograph" not in result.output
+
+
+def test_zero_max_steps_with_pending_work_is_exhausted():
+    result = make_engine(loop=False).run(ng.RunConfig(max_steps=0))
+
+    assert result.execution_trace == []
+    assert result.max_steps_exhausted is True

--- a/bindings/python/tests/test_readme_quickstart.py
+++ b/bindings/python/tests/test_readme_quickstart.py
@@ -206,6 +206,7 @@ def test_runresult_documented_attributes_exist():
 
     documented_attrs = [
         "output",
+        "max_steps_exhausted",
         "interrupted",
         "interrupt_node",
         "interrupt_value",

--- a/docs/python-binding.md
+++ b/docs/python-binding.md
@@ -76,6 +76,7 @@ result = engine.run(ng.RunConfig(thread_id="t1",
 | Field | Type | Meaning |
 |---|---|---|
 | `output` | `dict` | Final state — `{"channels": {...}, "global_version": int}`. Use `output["channels"][name]["value"]` to read a channel. |
+| `max_steps_exhausted` | `bool` | `True` only when the step ceiling stopped execution while runnable work remained. |
 | `interrupted` | `bool` | `True` if the run paused at an `interrupt_before` / `interrupt_after` / `NodeInterrupt`. |
 | `interrupt_node` | `str` | Name of the node that triggered the interrupt (when `interrupted`). |
 | `interrupt_value` | `dict` | `{"reason": str, "type": "NodeInterrupt", "value": ...}` for a dynamic interrupt (`"value"` present only when the node attached a payload), or `{"message": ...}` for a static `interrupt_before` / `interrupt_after`. |
@@ -88,7 +89,7 @@ result = engine.run(ng.RunConfig(thread_id="t1",
 |---|---|---|
 | `thread_id` | required | Conversation / session identifier — keeps checkpoint streams separate. |
 | `input` | `{}` | Initial channel values — keys must match the graph's `channels` definition. |
-| `max_steps` | 25 | Super-step ceiling; ReAct loops typically need 10+. |
+| `max_steps` | 50 | Super-step ceiling; ReAct loops typically need 10+. |
 | `stream_mode` | `StreamMode.OFF` | Bitmask: `EVENTS \| TOKENS \| DEBUG \| VALUES \| UPDATES \| ALL`. Only consulted by `run_stream` / `run_stream_async`. |
 | `resume_if_exists` | `False` | When `True` and a checkpoint store is configured, the run loads the latest checkpoint for `thread_id` (if any) and applies `input` on top via the channel reducers — multi-turn chat without manually threading prior state through `input`. Default keeps fresh-start semantics for back-compat; for HITL resume from an interrupted run, use `engine.resume_async()` instead. |
 

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -1153,6 +1153,8 @@ struct RunResult {
     json        interrupt_value;                 // Value associated with the interrupt
     std::string checkpoint_id;                   // ID of the last checkpoint saved
     std::vector<std::string> execution_trace;    // Ordered list of executed node names
+
+    bool max_steps_exhausted() const noexcept;    // Limit stopped runnable work
 };
 ```
 
@@ -1164,6 +1166,10 @@ struct RunResult {
 | `interrupt_value` | `json` | Reason or payload from the interrupt |
 | `checkpoint_id` | `std::string` | UUID of the last saved checkpoint |
 | `execution_trace` | `std::vector<std::string>` | Ordered list of node names in execution order |
+
+`max_steps_exhausted()` returns `true` only when the step ceiling stopped the
+run while runnable work remained. A graph that reaches `__end__` exactly on its
+last permitted step returns `false`.
 
 ### GraphEngine
 

--- a/docs/reference-ko.md
+++ b/docs/reference-ko.md
@@ -952,8 +952,14 @@ struct RunResult {
     json        interrupt_value;                 // 인터럽트 사유/값
     std::string checkpoint_id;                   // 마지막 checkpoint ID
     std::vector<std::string> execution_trace;    // 실행된 노드 순서
+
+    bool max_steps_exhausted() const noexcept;    // 실행할 작업을 남기고 한도 도달
 };
 ```
+
+`max_steps_exhausted()`는 실행할 노드가 남아 있는데 단계 한도에 도달한
+경우에만 `true`를 반환한다. 마지막 허용 단계에서 정확히 `__end__`에 도달한
+정상 실행은 `false`다.
 
 ---
 

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -290,6 +290,17 @@ struct RunResult {
     /// @see UsageAccounting.ACallerSuppliedAccumulatorSeesTheCrashedAttempt
     ChatCompletion::Usage usage;
 
+    /// True only when execution stopped at RunConfig::max_steps while work
+    /// remained ready. The status is stored in output rather than as a data
+    /// member so adding this query does not change RunResult's binary layout.
+    inline bool max_steps_exhausted() const noexcept {
+        if (!output.is_object()) return false;
+        auto* metadata = yyjson_mut_obj_get(output.raw_val(), "_neograph");
+        if (!yyjson_mut_is_obj(metadata)) return false;
+        auto* marker = yyjson_mut_obj_get(metadata, "max_steps_exhausted");
+        return yyjson_mut_is_bool(marker) && yyjson_mut_get_bool(marker);
+    }
+
     /// @brief Read a channel value as type ``T`` (issue #25).
     ///
     /// Looks up the value in ``output``. Tries the canonical

--- a/proto/neograph.proto
+++ b/proto/neograph.proto
@@ -48,7 +48,7 @@ message RunGraphRequest {
   // RunConfig::input.
   string input_json = 3;
 
-  // Super-step ceiling. 0 → engine default (25).
+  // Super-step ceiling. 0 → engine default (50).
   uint32 max_steps = 4;
 
   // Stream mode bitmask for RunGraphStream (EVENTS=1, TOKENS=2,
@@ -77,6 +77,10 @@ message RunGraphResponse {
   // Set on engine-side failure instead of a transport error, so the
   // caller distinguishes "graph threw" from "gRPC broke".
   string error = 7;
+
+  // True when max_steps stopped execution while runnable work remained.
+  // Added at a new field number to preserve protobuf wire compatibility.
+  bool max_steps_exhausted = 8;
 }
 
 message GraphEvent {

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -807,6 +807,11 @@ GraphEngine::execute_graph_async(const RunConfig& config,
     result.usage = ctx.usage->snapshot();   // #88
     result.output          = state.serialize();
     result.execution_trace = std::move(trace);
+    if (!ready.empty()) {
+        result.output["_neograph"] = json{
+            {"max_steps_exhausted", true}
+        };
+    }
     if (!last_checkpoint_id.empty()) {
         result.checkpoint_id = last_checkpoint_id;
     }

--- a/src/grpc/graph_service.cpp
+++ b/src/grpc/graph_service.cpp
@@ -48,6 +48,7 @@ public:
             resp->set_interrupt_node(r.interrupt_node);
             resp->set_interrupt_value_json(r.interrupt_value.dump());
             resp->set_checkpoint_id(r.checkpoint_id);
+            resp->set_max_steps_exhausted(r.max_steps_exhausted());
             for (const auto& n : r.execution_trace)
                 resp->add_execution_trace(n);
         } catch (const std::exception& e) {
@@ -91,11 +92,12 @@ public:
             pb::GraphEvent fin;
             fin.set_kind(pb::GraphEvent::FINAL);
             neograph::json f = {
-                {"output",          r.output},
-                {"interrupted",     r.interrupted},
-                {"interrupt_node",  r.interrupt_node},
-                {"checkpoint_id",   r.checkpoint_id},
-                {"execution_trace", r.execution_trace},
+                {"output",              r.output},
+                {"interrupted",         r.interrupted},
+                {"interrupt_node",      r.interrupt_node},
+                {"checkpoint_id",       r.checkpoint_id},
+                {"execution_trace",     r.execution_trace},
+                {"max_steps_exhausted", r.max_steps_exhausted()},
             };
             fin.set_payload_json(f.dump());
             writer->Write(fin);

--- a/tests/test_graph_engine.cpp
+++ b/tests/test_graph_engine.cpp
@@ -182,8 +182,50 @@ TEST_F(GraphEngineTest, MaxStepsLimit) {
     config.max_steps = 5;
     auto result = engine->run(config);
 
-    // Should not run forever — capped by max_steps
-    EXPECT_LE(result.execution_trace.size(), 5u);
+    ASSERT_EQ(result.execution_trace.size(), 5u);
+    EXPECT_TRUE(result.max_steps_exhausted());
+    ASSERT_TRUE(result.output.contains("_neograph"));
+    EXPECT_EQ(result.output["_neograph"]["max_steps_exhausted"], true);
+}
+
+TEST_F(GraphEngineTest, ExactBoundaryCompletionIsNotExhausted) {
+    auto engine = GraphEngine::compile(make_linear_graph(), NodeContext{});
+    RunConfig config;
+    config.max_steps = 1;
+    auto result = engine->run(config);
+
+    ASSERT_EQ(result.execution_trace.size(), 1u);
+    EXPECT_FALSE(result.max_steps_exhausted());
+    EXPECT_FALSE(result.output.contains("_neograph"));
+}
+
+TEST_F(GraphEngineTest, ZeroMaxStepsWithPendingStartWorkIsExhausted) {
+    auto engine = GraphEngine::compile(make_linear_graph(), NodeContext{});
+    RunConfig config;
+    config.max_steps = 0;
+    auto result = engine->run(config);
+
+    EXPECT_TRUE(result.execution_trace.empty());
+    EXPECT_TRUE(result.max_steps_exhausted());
+    ASSERT_TRUE(result.output.contains("_neograph"));
+    EXPECT_EQ(result.output["_neograph"]["max_steps_exhausted"], true);
+}
+
+TEST_F(GraphEngineTest, StartToEndWithZeroMaxStepsIsNotExhausted) {
+    json empty_graph = {
+        {"name", "empty"},
+        {"channels", {{"result", {{"reducer", "overwrite"}}}}},
+        {"nodes", json::object()},
+        {"edges", {{{"from", "__start__"}, {"to", "__end__"}}}}
+    };
+    auto engine = GraphEngine::compile(empty_graph, NodeContext{});
+    RunConfig config;
+    config.max_steps = 0;
+    auto result = engine->run(config);
+
+    EXPECT_TRUE(result.execution_trace.empty());
+    EXPECT_FALSE(result.max_steps_exhausted());
+    EXPECT_FALSE(result.output.contains("_neograph"));
 }
 
 // ── Streaming callback invoked ──

--- a/tests/test_run_result_channel.cpp
+++ b/tests/test_run_result_channel.cpp
@@ -126,3 +126,25 @@ TEST(RunResultChannel, WrappedWithoutValueKeyFallsThroughToFlatLookup) {
     };
     EXPECT_EQ(r.channel<std::string>("weird"), "from-flat");
 }
+
+TEST(RunResultStatus, MaxStepsExhaustedReadsReservedMarker) {
+    RunResult r;
+    r.output = json{{"_neograph", {{"max_steps_exhausted", true}}}};
+    EXPECT_TRUE(r.max_steps_exhausted());
+}
+
+TEST(RunResultStatus, MaxStepsExhaustedRejectsMalformedOrCollidingJson) {
+    RunResult r;
+
+    r.output = json("not an object");
+    EXPECT_FALSE(r.max_steps_exhausted());
+
+    r.output = json{{"_neograph", "user collision"}};
+    EXPECT_FALSE(r.max_steps_exhausted());
+
+    r.output = json{{"_neograph", {{"max_steps_exhausted", "true"}}}};
+    EXPECT_FALSE(r.max_steps_exhausted());
+
+    r.output = json{{"_neograph", {{"max_steps_exhausted", false}}}};
+    EXPECT_FALSE(r.max_steps_exhausted());
+}


### PR DESCRIPTION
## Summary
- distinguish max-step exhaustion from normal graph completion without changing RunResult layout
- expose the status through C++, Python, and gRPC
- cover boundary completion, loops, zero-step runs, and malformed reserved metadata
- update Python and C++ reference documentation

## Verification
- branch originally verified with C++ 523/523 and Python 152/152
- current-master integration reviewed independently; six focused C++ tests passed
- full platform CI will run on this PR

Refs #114