### PR TITLE
fix(cookbook): remove ignored per-node LLM prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed (docs)
+
+- **Provider cookbook의 무시되던 노드별 prompt 제거 (issue #116).** 세 Python
+  예제가 built-in `llm_call`이 읽지 않는 `config.system`으로 여러 역할을
+  수행한다고 설명하던 문제를 수정했다. 각 예제를
+  `NodeContext.instructions`를 쓰는 strict 단일 호출 graph로 바꾸고 관련
+  README를 실제 동작에 맞췄다.
+
 ### Added
 
 - **DSL 표면 (elaboration 계층) + 스키마 진화 게이트** (#75 M4).

--- a/bindings/python/tests/test_llm_call_contract.py
+++ b/bindings/python/tests/test_llm_call_contract.py
@@ -1,0 +1,106 @@
+"""The built-in llm_call takes its prompt from NodeContext (issue #116)."""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+import neograph_engine as ng
+
+
+COOKBOOK_GRAPHS = [
+    "examples/cookbook/byo-openai/hybrid.py",
+    "examples/cookbook/ollama-provider/via_openai_compat.py",
+    "examples/cookbook/ollama-provider/via_native_api.py",
+]
+
+
+class _ResolveGraphConstants(ast.NodeTransformer):
+    def visit_Attribute(self, node):
+        if (isinstance(node.value, ast.Name) and node.value.id == "ng"
+                and node.attr in {"START_NODE", "END_NODE"}):
+            return ast.copy_location(ast.Constant(f"__{node.attr.lower()}__"), node)
+        return self.generic_visit(node)
+
+
+def _cookbook_graph(path):
+    tree = ast.parse(path.read_text(), filename=str(path))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if any(isinstance(target, ast.Name) and target.id == "graph_def"
+               for target in node.targets):
+            value = _ResolveGraphConstants().visit(node.value)
+            return ast.literal_eval(value)
+    raise AssertionError(f"graph_def not found in {path}")
+
+
+class _CapturingProvider(ng.Provider):
+    def __init__(self):
+        super().__init__()
+        self.calls = []
+
+    def complete(self, params):
+        self.calls.append(params)
+        completion = ng.ChatCompletion()
+        completion.message = ng.ChatMessage("assistant", "captured")
+        return completion
+
+    def get_name(self):
+        return "capturing"
+
+
+def _definition(node):
+    return {
+        "name": "llm-call-contract",
+        "schema_version": 1,
+        "channels": {"messages": {"reducer": "append"}},
+        "nodes": {"answer": node},
+        "edges": [
+            {"from": ng.START_NODE, "to": "answer"},
+            {"from": "answer", "to": ng.END_NODE},
+        ],
+    }
+
+
+def test_llm_call_uses_node_context_instructions():
+    provider = _CapturingProvider()
+    context = ng.NodeContext(
+        provider=provider,
+        model="context-model",
+        instructions="Context system prompt",
+    )
+    engine = ng.GraphEngine.compile(
+        _definition({"type": "llm_call"}), context)
+
+    engine.run(ng.RunConfig(
+        thread_id="llm-call-contract",
+        input={"messages": [{"role": "user", "content": "ping"}]},
+    ))
+
+    assert len(provider.calls) == 1
+    params = provider.calls[0]
+    assert params.model == "context-model"
+    assert [(message.role, message.content) for message in params.messages] == [
+        ("system", "Context system prompt"),
+        ("user", "ping"),
+    ]
+
+
+def test_strict_llm_call_rejects_per_node_system_prompt():
+    context = ng.NodeContext(provider=_CapturingProvider())
+
+    with pytest.raises(RuntimeError, match="unknown or unconsumed key 'config'"):
+        ng.GraphEngine.compile(_definition({
+            "type": "llm_call",
+            "config": {"system": "ignored"},
+        }), context)
+
+
+@pytest.mark.parametrize("relative_path", COOKBOOK_GRAPHS)
+def test_provider_cookbook_uses_strict_context_config(relative_path):
+    root = Path(__file__).resolve().parents[3]
+    definition = _cookbook_graph(root / relative_path)
+
+    assert definition["schema_version"] == 1
+    assert definition["nodes"] == {"answer": {"type": "llm_call"}}

--- a/examples/cookbook/byo-openai/README.md
+++ b/examples/cookbook/byo-openai/README.md
@@ -71,13 +71,16 @@ python hybrid.py
 
 Output:
 ```
-[hybrid] using openai SDK 2.33.0 inside NeoGraph 0.2.3 graph
-[hybrid] running 3-node graph: classify → respond → summarise
-[provider] complete() call #1 (system + 1 user) — model=gpt-5.4-mini
-[provider] complete() call #2 (system + 2 user) — model=gpt-5.4-mini
-[provider] complete() call #3 (system + 3 user) — model=gpt-5.4-mini
-[hybrid] final summary: ...
+[hybrid] using openai SDK inside NeoGraph 0.2.3 graph
+[hybrid] running one llm_call through the OpenAI SDK provider
+[provider] complete() call #1 (2 msgs) — model=gpt-5.4-mini
+[... user and assistant messages ...]
+[hybrid] provider.complete() called 1× via openai SDK
 ```
+
+The built-in `llm_call` uses the shared `NodeContext.instructions` as its
+system prompt. Use a custom node type when different graph stages need
+different prompts.
 
 ## What you keep
 

--- a/examples/cookbook/byo-openai/hybrid.py
+++ b/examples/cookbook/byo-openai/hybrid.py
@@ -94,31 +94,22 @@ def main() -> int:
                       "Each turn must fit in 1-2 sentences."),
     )
 
-    # 3-node graph: classify → respond → summarise. Each step is a
-    # built-in `llm_call` node, so each step routes through our
-    # OpenAISdkProvider.
+    # A built-in `llm_call` gets its system prompt from
+    # NodeContext.instructions and routes through our OpenAISdkProvider.
     graph_def = {
         "name": "byo-openai-demo",
+        "schema_version": 1,
         "channels": {"messages": {"reducer": "append"}},
-        "nodes": {
-            "classify": {"type": "llm_call",
-                "config": {"system": "Classify the user's intent in one word."}},
-            "respond": {"type": "llm_call",
-                "config": {"system": "Answer the user given the classification."}},
-            "summarise": {"type": "llm_call",
-                "config": {"system": "Summarise the conversation in one sentence."}},
-        },
+        "nodes": {"answer": {"type": "llm_call"}},
         "edges": [
-            {"from": ng.START_NODE, "to": "classify"},
-            {"from": "classify",     "to": "respond"},
-            {"from": "respond",      "to": "summarise"},
-            {"from": "summarise",    "to": ng.END_NODE},
+            {"from": ng.START_NODE, "to": "answer"},
+            {"from": "answer",     "to": ng.END_NODE},
         ],
     }
-    print(f"[hybrid] running 3-node graph: classify → respond → summarise")
+    print("[hybrid] running one llm_call through the OpenAI SDK provider")
 
     engine = ng.GraphEngine.compile(graph_def, ctx)
-    user_q = "How do I make my Python script run a graph through three LLM calls?"
+    user_q = "How do I make my Python script run a graph through an LLM call?"
     result = engine.run(ng.RunConfig(
         thread_id="hybrid-demo",
         input={"messages": [{"role": "user", "content": user_q}]},

--- a/examples/cookbook/ollama-provider/README.md
+++ b/examples/cookbook/ollama-provider/README.md
@@ -78,18 +78,21 @@ python via_openai_compat.py
 python via_native_api.py
 ```
 
-Both demos build a 2-node graph (`classify → respond`) and route both
-LLM calls through the local model. No external API key needed.
+Both demos build a strict one-node graph and route its `llm_call` through the
+local model. The system prompt comes from the shared
+`NodeContext.instructions`. No external API key needed.
 
 ## Output
 
 ```
-[ollama] using qwen2.5:0.5b at http://127.0.0.1:11434
-[graph] step 1 — classify: question type
-[graph] step 2 — respond:  one-sentence answer
+[ollama] using qwen2.5:0.5b at http://127.0.0.1:11434 (OpenAI-compat path)
+[user] What's the capital of France?
+       user: What's the capital of France?
+  assistant: Paris is the capital of France.
 ```
 
-(Actual completions vary with the model.)
+(Actual completions vary with the model. The native path prints
+`(native /api/chat path)` and uses its own sample question.)
 
 ## Notes
 

--- a/examples/cookbook/ollama-provider/via_native_api.py
+++ b/examples/cookbook/ollama-provider/via_native_api.py
@@ -104,17 +104,12 @@ def main() -> int:
 
     graph_def = {
         "name": "ollama-native",
+        "schema_version": 1,
         "channels": {"messages": {"reducer": "append"}},
-        "nodes": {
-            "classify": {"type": "llm_call",
-                "config": {"system": "Classify the user's question type in ONE word."}},
-            "respond":  {"type": "llm_call",
-                "config": {"system": "Answer concisely (one sentence)."}},
-        },
+        "nodes": {"answer": {"type": "llm_call"}},
         "edges": [
-            {"from": ng.START_NODE, "to": "classify"},
-            {"from": "classify",     "to": "respond"},
-            {"from": "respond",      "to": ng.END_NODE},
+            {"from": ng.START_NODE, "to": "answer"},
+            {"from": "answer",     "to": ng.END_NODE},
         ],
     }
     engine = ng.GraphEngine.compile(graph_def, ctx)

--- a/examples/cookbook/ollama-provider/via_openai_compat.py
+++ b/examples/cookbook/ollama-provider/via_openai_compat.py
@@ -54,17 +54,12 @@ def main() -> int:
 
     graph_def = {
         "name": "ollama-compat",
+        "schema_version": 1,
         "channels": {"messages": {"reducer": "append"}},
-        "nodes": {
-            "classify": {"type": "llm_call",
-                "config": {"system": "Classify the user's question type in ONE word."}},
-            "respond": {"type": "llm_call",
-                "config": {"system": "Answer the user concisely (one sentence)."}},
-        },
+        "nodes": {"answer": {"type": "llm_call"}},
         "edges": [
-            {"from": ng.START_NODE, "to": "classify"},
-            {"from": "classify",     "to": "respond"},
-            {"from": "respond",      "to": ng.END_NODE},
+            {"from": ng.START_NODE, "to": "answer"},
+            {"from": "answer",     "to": ng.END_NODE},
         ],
     }
     engine = ng.GraphEngine.compile(graph_def, ctx)


### PR DESCRIPTION
## Summary
- replace cookbook graphs that advertised ignored per-node `config.system` prompts with strict single-node `llm_call` graphs
- document that the built-in node reads `NodeContext.instructions`
- run all three published graph definitions against an offline capturing provider and verify their declared instructions reach the system message

## Verification
- `PYTHONPATH=build-pr python3 -m pytest bindings/python/tests/test_llm_call_contract.py -q` (5 passed)
- independent review found no remaining correctness issues

Fixes #116