### PR TITLE
fix(engine): preserve node failure context and Python exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **노드 실패 문맥 보존 (issue #123).** C++ 실행 오류를 원래
+  `exception_ptr`과 실패 노드 이름·시도 횟수를 담은 `NodeExecutionError`로
+  전달하고, terminal `ERROR` event에도 같은 문맥을 기록한다. Python에서는
+  원래 예외 객체·타입·args·사용자 속성·traceback을 그대로 유지하면서
+  `.node_name`과 `.attempts` 속성만 추가한다. `NodeInterrupt`, 취소, 메모리
+  부족 예외는 기존 제어 흐름대로 감싸지 않는다.
+
 ### Added
 
 - **DSL 표면 (elaboration 계층) + 스키마 진화 게이트** (#75 M4).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
     하위 호환.
   - 검증: 478/478 ctest, Valgrind 누수 0, TSAN race 0.
 
+### Fixed
+
+- **Python 비동기 실행의 예외 보존 (issue #122).** `run_async`,
+  `run_stream_async`, `resume_async`가 Python 노드의 원래 예외를 문자열로
+  바꾼 새 `RuntimeError`로 덮어쓰던 문제를 수정. 이제 pybind11의 표준
+  예외 변환 경로를 거쳐 원래 Python 예외 객체·타입·사용자 속성·traceback을
+  보존하고, C++ `py::type_error`도 동기 실행과 같은 Python `TypeError`로
+  전달한다. `resume_async`의 빈 callback도 코루틴이 끝날 때까지 보관해
+  pybind11 3.x에서 드러난 dangling-reference 충돌을 함께 막았다.
+
 ### Fixed (docs)
 
 - **샌드박스 실측으로 드러난 README 요약 배지의 조건 누락·내부 모순 정정.**

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -159,6 +159,51 @@ py::object exception_ptr_to_python(std::exception_ptr eptr) {
     throw std::logic_error("exception_ptr did not throw");
 }
 
+// C++ callers receive NodeExecutionError as a typed envelope. Python callers
+// retain the original exception object and traceback, with graph context added
+// as structured attributes instead of changing its type, args, or message.
+void translate_node_execution_error(std::exception_ptr eptr) {
+    try {
+        if (eptr) std::rethrow_exception(eptr);
+    } catch (const graph::NodeExecutionError& error) {
+        try {
+            py::object original = exception_ptr_to_python(error.cause());
+            auto add_context = [&](const char* preferred, const char* fallback,
+                                   py::object value) {
+                int has_preferred = PyObject_HasAttrString(original.ptr(), preferred);
+                if (has_preferred < 0) {
+                    PyErr_Clear();
+                    has_preferred = 1;
+                }
+                const char* name = has_preferred ? fallback : preferred;
+                int has_name = PyObject_HasAttrString(original.ptr(), name);
+                if (has_name < 0) {
+                    PyErr_Clear();
+                    return;
+                }
+                if (has_name) return;
+
+                py::str key(name);
+                // BaseException instances have a writable dictionary. Use the
+                // generic setter so a custom __setattr__ cannot replace the
+                // original graph failure with its own AttributeError.
+                if (PyObject_GenericSetAttr(original.ptr(), key.ptr(),
+                                            value.ptr()) != 0) {
+                    PyErr_Clear();
+                }
+            };
+            add_context("node_name", "_neograph_node_name",
+                        py::str(error.node_name()));
+            add_context("attempts", "_neograph_attempts",
+                        py::int_(error.attempts()));
+            PyErr_SetObject(reinterpret_cast<PyObject*>(Py_TYPE(original.ptr())),
+                            original.ptr());
+        } catch (py::error_already_set& translated) {
+            translated.restore();
+        }
+    }
+}
+
 // Drain whatever the asio coroutine produced (RunResult or exception)
 // onto the captured asyncio.Future. Runs on the asio worker thread;
 // hops back to the asyncio loop thread via call_soon_threadsafe so
@@ -222,6 +267,8 @@ void resolve_future_async(std::shared_ptr<py::object> future,
 
 void init_graph(py::module_& m) {
     using namespace neograph::graph;
+
+    py::register_exception_translator(&translate_node_execution_error);
 
     // ── Topology schema export (issue #56) ───────────────────────────────
     //

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -137,6 +137,28 @@ std::shared_ptr<py::object> hold_py(py::object obj) {
         });
 }
 
+// Convert a captured C++ exception exactly as pybind11's function dispatcher
+// would, then take ownership of the resulting Python exception object. This
+// preserves py::error_already_set values and applies built-in translators such
+// as py::type_error -> TypeError.
+//
+py::object exception_ptr_to_python(std::exception_ptr eptr) {
+    try {
+        // Calling through cpp_function uses pybind11's public dispatcher,
+        // including registered C++ translators and error_already_set restore.
+        py::cpp_function([eptr] { std::rethrow_exception(eptr); })();
+    } catch (py::error_already_set& translated) {
+        py::object exception = translated.value();
+        if (translated.trace()
+            && PyException_SetTraceback(exception.ptr(),
+                                       translated.trace().ptr()) != 0) {
+            throw py::error_already_set();
+        }
+        return exception;
+    }
+    throw std::logic_error("exception_ptr did not throw");
+}
+
 // Drain whatever the asio coroutine produced (RunResult or exception)
 // onto the captured asyncio.Future. Runs on the asio worker thread;
 // hops back to the asyncio loop thread via call_soon_threadsafe so
@@ -164,9 +186,15 @@ std::shared_ptr<py::object> hold_py(py::object obj) {
 template <typename T>
 void resolve_future_async(std::shared_ptr<py::object> future,
                           std::shared_ptr<py::object> loop,
-                          std::exception_ptr eptr,
+                          std::exception_ptr& eptr,
                           T&& result) {
     py::gil_scoped_acquire g;
+    // error_already_set owns Python references; release the completion
+    // callback's copy before gil_scoped_acquire leaves scope.
+    struct ExceptionPtrReset {
+        std::exception_ptr& ptr;
+        ~ExceptionPtrReset() { ptr = nullptr; }
+    } reset{eptr};
     try {
         if (loop->attr("is_closed")().template cast<bool>()) return;
 
@@ -174,16 +202,7 @@ void resolve_future_async(std::shared_ptr<py::object> future,
             py::module_::import("neograph_engine._neograph");
 
         if (eptr) {
-            std::string msg;
-            try {
-                std::rethrow_exception(eptr);
-            } catch (const std::exception& ex) {
-                msg = ex.what();
-            } catch (...) {
-                msg = "neograph: unknown C++ exception in async run";
-            }
-            py::object exc =
-                py::module_::import("builtins").attr("RuntimeError")(msg);
+            py::object exc = exception_ptr_to_python(eptr);
             loop->attr("call_soon_threadsafe")(
                 mod.attr("_safe_set_future_exception"),
                 *future, exc);
@@ -1059,11 +1078,12 @@ void init_graph(py::module_& m) {
                 // dangling-reference concern as run_async.
                 auto tid_h = std::make_shared<std::string>(std::move(thread_id));
                 auto rv_h  = std::make_shared<json>(py_to_json(resume_value));
+                auto cb_h  = std::make_shared<GraphStreamCallback>();
 
                 asio::co_spawn(
                     AsyncRuntime::instance().executor(),
-                    self->resume_async(*tid_h, *rv_h, nullptr),
-                    [self, tid_h, rv_h, fut_h, loop_h]
+                    self->resume_async(*tid_h, *rv_h, *cb_h),
+                    [self, tid_h, rv_h, cb_h, fut_h, loop_h]
                     (std::exception_ptr e, RunResult result) {
                         resolve_future_async(fut_h, loop_h, e,
                                              std::move(result));

--- a/bindings/python/tests/test_async.py
+++ b/bindings/python/tests/test_async.py
@@ -38,6 +38,15 @@ def _passthrough_definition(channel="x"):
     }
 
 
+def _traceback_function_names(exc):
+    names = []
+    tb = exc.__traceback__
+    while tb is not None:
+        names.append(tb.tb_frame.f_code.co_name)
+        tb = tb.tb_next
+    return names
+
+
 def test_run_async_basic():
     """Smoke: engine.run_async returns an awaitable that yields a RunResult."""
     engine = neograph.GraphEngine.compile(
@@ -337,9 +346,20 @@ def test_run_stream_async_cancel_does_not_double_resolve_future():
         f"cancel on streaming path: {invalid_state}")
 
 
-def test_run_async_propagates_python_node_exception():
-    """Python node raises → asyncio future rejects → await raises."""
+@pytest.mark.parametrize("async_method", ["run_async", "run_stream_async"])
+def test_async_run_api_preserves_python_node_exception(async_method):
+    """Each async run API exposes the original Python exception."""
     type_name = _next_type("async_explode")
+
+    class CustomNodeError(Exception):
+        def __init__(self, message, marker):
+            super().__init__(message, marker)
+            self.marker = marker
+
+    error = CustomNodeError("kaboom from python node", 41)
+
+    def raise_custom_error():
+        raise error
 
     class ExplodeNode(neograph.GraphNode):
         def __init__(self, name):
@@ -348,7 +368,7 @@ def test_run_async_propagates_python_node_exception():
         def get_name(self): return self._name
         def run(self, input):
             state = input.state
-            raise RuntimeError("kaboom from python node")
+            raise_custom_error()
 
     neograph.NodeFactory.register_type(
         type_name, lambda name, c, ctx: ExplodeNode(name))
@@ -363,10 +383,131 @@ def test_run_async_propagates_python_node_exception():
         ],
     }
     engine = neograph.GraphEngine.compile(definition, neograph.NodeContext())
+    cfg = neograph.RunConfig(thread_id="sync-error", input={"x": 1})
+
+    with pytest.raises(CustomNodeError) as sync_info:
+        engine.run(cfg)
+
+    sync_exc = sync_info.value
+    sync_frames = _traceback_function_names(sync_exc)
+    assert sync_exc is error
+    assert type(sync_exc) is CustomNodeError
+    assert sync_exc.args == ("kaboom from python node", 41)
+    assert sync_exc.marker == 41
+    assert sync_frames[-2:] == ["run", "raise_custom_error"]
+
+    # Raising the same instance again otherwise retains the earlier traceback.
+    error.__traceback__ = None
 
     async def go():
-        cfg = neograph.RunConfig(thread_id="t1", input={"x": 1})
-        with pytest.raises(RuntimeError, match="kaboom"):
-            await engine.run_async(cfg)
+        cfg = neograph.RunConfig(
+            thread_id=f"{async_method}-error", input={"x": 1})
+        with pytest.raises(CustomNodeError) as async_info:
+            if async_method == "run_stream_async":
+                await engine.run_stream_async(cfg, lambda _event: None)
+            else:
+                await engine.run_async(cfg)
+        return async_info.value
 
-    asyncio.run(go())
+    async_exc = asyncio.run(go())
+    assert async_exc is error
+    assert type(async_exc) is type(sync_exc)
+    assert async_exc.args == sync_exc.args
+    assert async_exc.marker == sync_exc.marker
+    assert _traceback_function_names(async_exc)[-2:] == sync_frames[-2:]
+
+
+def test_resume_async_preserves_python_node_exception():
+    """An exception raised after resuming keeps its object and traceback."""
+    type_name = _next_type("async_resume_explode")
+
+    class CustomResumeError(Exception):
+        def __init__(self, message, marker):
+            super().__init__(message, marker)
+            self.marker = marker
+
+    error = CustomResumeError("kaboom after resume", 42)
+
+    def raise_resume_error():
+        raise error
+
+    class InterruptThenExplodeNode(neograph.GraphNode):
+        def __init__(self, name):
+            super().__init__()
+            self._name = name
+        def get_name(self): return self._name
+        def run(self, input):
+            if input.ctx.resume_value is None:
+                raise neograph.NodeInterrupt("continue into failure")
+            raise_resume_error()
+
+    neograph.NodeFactory.register_type(
+        type_name, lambda name, c, ctx: InterruptThenExplodeNode(name))
+
+    definition = {
+        "name": "resume_explode",
+        "channels": {},
+        "nodes": {"gate": {"type": type_name}},
+        "edges": [
+            {"from": neograph.START_NODE, "to": "gate"},
+            {"from": "gate", "to": neograph.END_NODE},
+        ],
+    }
+    engine = neograph.GraphEngine.compile(
+        definition, neograph.NodeContext(),
+        neograph.InMemoryCheckpointStore())
+    cfg = neograph.RunConfig(thread_id="resume-error", input={})
+    assert engine.run(cfg).interrupted
+
+    async def go():
+        with pytest.raises(CustomResumeError) as resume_info:
+            await engine.resume_async("resume-error", {"approved": True})
+        return resume_info.value
+
+    resume_exc = asyncio.run(go())
+    assert resume_exc is error
+    assert type(resume_exc) is CustomResumeError
+    assert resume_exc.args == ("kaboom after resume", 42)
+    assert resume_exc.marker == 42
+    assert _traceback_function_names(resume_exc)[-2:] == [
+        "run", "raise_resume_error"]
+
+
+def test_run_async_invalid_node_return_matches_sync_type_error():
+    """py::type_error from node coercion stays TypeError in async runs."""
+    type_name = _next_type("async_invalid_return")
+
+    class InvalidReturnNode(neograph.GraphNode):
+        def __init__(self, name):
+            super().__init__()
+            self._name = name
+        def get_name(self): return self._name
+        def run(self, input):
+            return object()
+
+    neograph.NodeFactory.register_type(
+        type_name, lambda name, c, ctx: InvalidReturnNode(name))
+
+    definition = {
+        "name": "invalid_return",
+        "channels": {},
+        "nodes": {"bad": {"type": type_name}},
+        "edges": [
+            {"from": neograph.START_NODE, "to": "bad"},
+            {"from": "bad", "to": neograph.END_NODE},
+        ],
+    }
+    engine = neograph.GraphEngine.compile(definition, neograph.NodeContext())
+
+    with pytest.raises(TypeError) as sync_info:
+        engine.run(neograph.RunConfig(thread_id="sync-type-error", input={}))
+
+    async def go():
+        with pytest.raises(TypeError) as async_info:
+            await engine.run_async(neograph.RunConfig(
+                thread_id="async-type-error", input={}))
+        return async_info.value
+
+    async_exc = asyncio.run(go())
+    assert type(async_exc) is type(sync_info.value)
+    assert async_exc.args == sync_info.value.args

--- a/bindings/python/tests/test_async.py
+++ b/bindings/python/tests/test_async.py
@@ -394,6 +394,8 @@ def test_async_run_api_preserves_python_node_exception(async_method):
     assert type(sync_exc) is CustomNodeError
     assert sync_exc.args == ("kaboom from python node", 41)
     assert sync_exc.marker == 41
+    assert sync_exc.node_name == "e"
+    assert sync_exc.attempts == 1
     assert sync_frames[-2:] == ["run", "raise_custom_error"]
 
     # Raising the same instance again otherwise retains the earlier traceback.
@@ -414,6 +416,8 @@ def test_async_run_api_preserves_python_node_exception(async_method):
     assert type(async_exc) is type(sync_exc)
     assert async_exc.args == sync_exc.args
     assert async_exc.marker == sync_exc.marker
+    assert async_exc.node_name == "e"
+    assert async_exc.attempts == 1
     assert _traceback_function_names(async_exc)[-2:] == sync_frames[-2:]
 
 
@@ -469,6 +473,8 @@ def test_resume_async_preserves_python_node_exception():
     assert type(resume_exc) is CustomResumeError
     assert resume_exc.args == ("kaboom after resume", 42)
     assert resume_exc.marker == 42
+    assert resume_exc.node_name == "gate"
+    assert resume_exc.attempts == 1
     assert _traceback_function_names(resume_exc)[-2:] == [
         "run", "raise_resume_error"]
 
@@ -511,3 +517,47 @@ def test_run_async_invalid_node_return_matches_sync_type_error():
     async_exc = asyncio.run(go())
     assert type(async_exc) is type(sync_info.value)
     assert async_exc.args == sync_info.value.args
+    assert async_exc.node_name == "bad"
+    assert async_exc.attempts == 1
+
+
+def test_node_context_does_not_replace_locked_or_existing_attributes():
+    """Graph context never masks the original exception or user metadata."""
+    type_name = _next_type("locked_error")
+
+    class LockedError(Exception):
+        def __init__(self):
+            super().__init__("locked failure")
+            object.__setattr__(self, "node_name", "user-owned")
+            object.__setattr__(self, "attempts", 99)
+
+        def __setattr__(self, name, value):
+            raise AttributeError(f"{name} is locked")
+
+    error = LockedError()
+
+    class LockedNode(neograph.GraphNode):
+        def get_name(self): return "locked"
+        def run(self, input): raise error
+
+    neograph.NodeFactory.register_type(
+        type_name, lambda name, c, ctx: LockedNode())
+    definition = {
+        "name": "locked-error",
+        "channels": {},
+        "nodes": {"explode": {"type": type_name}},
+        "edges": [
+            {"from": neograph.START_NODE, "to": "explode"},
+            {"from": "explode", "to": neograph.END_NODE},
+        ],
+    }
+    engine = neograph.GraphEngine.compile(definition, neograph.NodeContext())
+
+    with pytest.raises(LockedError) as info:
+        engine.run(neograph.RunConfig(thread_id="locked-error", input={}))
+
+    assert info.value is error
+    assert info.value.node_name == "user-owned"
+    assert info.value.attempts == 99
+    assert info.value._neograph_node_name == "explode"
+    assert info.value._neograph_attempts == 1

--- a/include/neograph/graph/types.h
+++ b/include/neograph/graph/types.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 #include <cstdint>
+#include <exception>
 
 // Windows SDK (pulled in transitively via asio on Win32) defines a
 // bunch of ALL-CAPS macros — notably ERROR (wingdi.h) and DEBUG —
@@ -162,6 +163,43 @@ private:
     std::string reason_;
     json        value_;
     std::string node_;
+};
+
+/**
+ * @brief A node failure annotated by the executor with dispatch context.
+ *
+ * The original exception remains available through @c cause() and can be
+ * rethrown with @c std::rethrow_exception. Control-flow exceptions such as
+ * NodeInterrupt and CancelledException are never wrapped.
+ */
+class NEOGRAPH_API NodeExecutionError : public std::runtime_error {
+public:
+    NodeExecutionError(std::string node_name, int attempts,
+                       std::exception_ptr cause)
+        : std::runtime_error(make_message(node_name, attempts, cause)),
+          node_name_(std::move(node_name)), attempts_(attempts),
+          cause_(std::move(cause)) {}
+
+    const std::string& node_name() const noexcept { return node_name_; }
+    int attempts() const noexcept { return attempts_; }
+    const std::exception_ptr& cause() const noexcept { return cause_; }
+
+private:
+    static std::string make_message(const std::string& node_name, int attempts,
+                                    const std::exception_ptr& cause) {
+        std::string detail = "unknown exception";
+        try {
+            if (cause) std::rethrow_exception(cause);
+        } catch (const std::exception& e) {
+            detail = e.what();
+        } catch (...) {}
+        return "Node '" + node_name + "' failed after "
+            + std::to_string(attempts) + " attempt(s): " + detail;
+    }
+
+    std::string        node_name_;
+    int                attempts_;
+    std::exception_ptr cause_;
 };
 
 /**

--- a/src/core/graph_executor.cpp
+++ b/src/core/graph_executor.cpp
@@ -200,6 +200,25 @@ asio::awaitable<NodeResult> NodeExecutor::execute_node_with_retry_async(
 
     auto ex = co_await asio::this_coro::executor;
 
+    auto throw_node_error = [&](std::exception_ptr cause, int attempts) -> void {
+        if (cb && has_mode(stream_mode, StreamMode::EVENTS)) {
+            std::string what = "unknown";
+            try { std::rethrow_exception(cause); }
+            catch (const std::exception& e) { what = e.what(); }
+            catch (...) {}
+            cb(GraphEvent{GraphEvent::Type::ERROR, node_name,
+                          json{{"error", what}, {"attempts", attempts}}});
+        }
+        try {
+            std::rethrow_exception(cause);
+        } catch (const NodeExecutionError&) {
+            // A subgraph may fail inside this node. The outer retry policy has
+            // now been honored; keep the innermost dispatch context intact.
+            throw;
+        } catch (...) {}
+        throw NodeExecutionError(node_name, attempts, std::move(cause));
+    };
+
     for (int attempt = 0; attempt <= policy.max_retries; ++attempt) {
         if (cb && has_mode(stream_mode, StreamMode::EVENTS)) {
             json data;
@@ -250,7 +269,7 @@ asio::awaitable<NodeResult> NodeExecutor::execute_node_with_retry_async(
             // violations. Retrying produces the same bug. Surface
             // immediately so the bug shows up loud rather than as
             // a slow retry-exhaustion timeout.
-            throw;
+            throw_node_error(std::current_exception(), attempt + 1);
         } catch (...) {
             // runtime_error, network/timeout errors, third-party
             // exceptions: assume transient and let the retry loop
@@ -285,15 +304,7 @@ asio::awaitable<NodeResult> NodeExecutor::execute_node_with_retry_async(
         // Retry path. retryable_err must be populated since neither the
         // result nor a NodeInterrupt path was taken.
         if (attempt >= policy.max_retries) {
-            if (cb && has_mode(stream_mode, StreamMode::EVENTS)) {
-                std::string what;
-                try { std::rethrow_exception(retryable_err); }
-                catch (const std::exception& e) { what = e.what(); }
-                catch (...) { what = "unknown"; }
-                cb(GraphEvent{GraphEvent::Type::ERROR, node_name,
-                              json{{"error", what}, {"attempts", attempt + 1}}});
-            }
-            std::rethrow_exception(retryable_err);
+            throw_node_error(retryable_err, attempt + 1);
         }
 
         if (cb && has_mode(stream_mode, StreamMode::DEBUG)) {

--- a/tests/test_executor_async_parallel.cpp
+++ b/tests/test_executor_async_parallel.cpp
@@ -77,6 +77,17 @@ public:
     std::string get_name() const override { return name_; }
 };
 
+class FailingNode : public GraphNode {
+    std::string name_;
+public:
+    explicit FailingNode(std::string name) : name_(std::move(name)) {}
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        throw std::runtime_error("parallel failure");
+        co_return NodeOutput{};
+    }
+    std::string get_name() const override { return name_; }
+};
+
 struct ParallelHarness {
     std::map<std::string, std::unique_ptr<GraphNode>> nodes;
     std::vector<ChannelDef> channel_defs;
@@ -288,4 +299,44 @@ TEST(ExecutorAsyncParallel, SiblingsRecordPendingWritesBeforeThrow) {
     EXPECT_EQ(store->pending_writes_count("tid-pending", parent_cp_id), 1u)
         << "the successful sibling ('quick') must have recorded its pending "
            "write before the parallel group resolved the interrupt";
+}
+
+TEST(ExecutorAsyncParallel, FailureReportsReadyOrderNode) {
+    std::vector<std::unique_ptr<GraphNode>> nodes;
+    nodes.push_back(std::make_unique<AsyncWorkerNode>("quick", 1));
+    nodes.push_back(std::make_unique<FailingNode>("explode"));
+    ParallelHarness h(std::move(nodes));
+    auto store = std::make_shared<InMemoryCheckpointStore>();
+    CheckpointCoordinator coord(store, "tid-failure");
+
+    asio::io_context io;
+    std::exception_ptr err;
+    BarrierState barrier;
+    std::vector<std::string> trace;
+    std::unordered_map<std::string, NodeResult> replay;
+    std::vector<std::string> ready{"quick", "explode"};
+    asio::co_spawn(
+        io,
+        [&]() -> asio::awaitable<void> {
+            try {
+                GraphState state; init_parallel_state(state, h.channel_defs);
+                co_await h.executor.run_parallel_async(
+                    ready, 0, state, replay, coord, "", barrier,
+                    trace, nullptr, StreamMode::ALL, RunContext{});
+            } catch (...) {
+                err = std::current_exception();
+            }
+        },
+        asio::detached);
+    io.run();
+
+    ASSERT_TRUE(err);
+    try {
+        std::rethrow_exception(err);
+        FAIL() << "expected NodeExecutionError";
+    } catch (const NodeExecutionError& e) {
+        EXPECT_EQ(e.node_name(), "explode");
+        EXPECT_EQ(e.attempts(), 1);
+        EXPECT_THROW(std::rethrow_exception(e.cause()), std::runtime_error);
+    }
 }

--- a/tests/test_executor_async_retry.cpp
+++ b/tests/test_executor_async_retry.cpp
@@ -71,6 +71,20 @@ private:
     std::string name_;
 };
 
+class LogicFailureNode : public GraphNode {
+public:
+    explicit LogicFailureNode(std::string name) : name_(std::move(name)) {}
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        ++calls;
+        throw std::logic_error("broken invariant");
+        co_return NodeOutput{};
+    }
+    std::string get_name() const override { return name_; }
+    int calls = 0;
+private:
+    std::string name_;
+};
+
 // Helper to construct a NodeExecutor over a single node. Real engine
 // builds these inside compile(); reaching in directly keeps the test
 // scoped to the executor unit.
@@ -169,7 +183,7 @@ TEST(ExecutorAsyncRetry, RetriesUntilSuccess) {
     (void)node_ptr;
 }
 
-TEST(ExecutorAsyncRetry, ExhaustedRetriesPropagateException) {
+TEST(ExecutorAsyncRetry, ExhaustedRetriesAddNodeContext) {
     RetryPolicy p;
     p.max_retries = 1;
     p.initial_delay_ms = 1;
@@ -180,13 +194,17 @@ TEST(ExecutorAsyncRetry, ExhaustedRetriesPropagateException) {
 
     asio::io_context io;
     std::exception_ptr err;
+    std::vector<GraphEvent> events;
+    GraphStreamCallback cb = [&](const GraphEvent& event) {
+        events.push_back(event);
+    };
     asio::co_spawn(
         io,
         [&]() -> asio::awaitable<void> {
             try {
                 GraphState state; init_state(state, h.channel_defs);
                 co_await h.executor.execute_node_with_retry_async(
-                    "doomed", state, nullptr, StreamMode::ALL, RunContext{});
+                    "doomed", state, cb, StreamMode::EVENTS, RunContext{});
             } catch (...) {
                 err = std::current_exception();
             }
@@ -195,7 +213,68 @@ TEST(ExecutorAsyncRetry, ExhaustedRetriesPropagateException) {
     io.run();
 
     ASSERT_TRUE(err);
-    EXPECT_THROW(std::rethrow_exception(err), std::runtime_error);
+    try {
+        std::rethrow_exception(err);
+        FAIL() << "expected NodeExecutionError";
+    } catch (const NodeExecutionError& e) {
+        EXPECT_EQ(e.node_name(), "doomed");
+        EXPECT_EQ(e.attempts(), 2);
+        EXPECT_NE(std::string(e.what()).find("doomed"), std::string::npos);
+        EXPECT_NE(std::string(e.what()).find("flaky: injected failure"),
+                  std::string::npos);
+        try {
+            std::rethrow_exception(e.cause());
+            FAIL() << "expected original runtime_error";
+        } catch (const std::runtime_error& cause) {
+            EXPECT_NE(std::string(cause.what()).find("injected failure"),
+                      std::string::npos);
+        }
+    }
+
+    int terminal_errors = 0;
+    for (const auto& event : events) {
+        if (event.type == GraphEvent::Type::ERROR) {
+            ++terminal_errors;
+            EXPECT_EQ(event.node_name, "doomed");
+            EXPECT_EQ(event.data.at("attempts"), 2);
+        }
+    }
+    EXPECT_EQ(terminal_errors, 1);
+}
+
+TEST(ExecutorAsyncRetry, LogicErrorAddsContextWithoutRetry) {
+    auto node = std::make_unique<LogicFailureNode>("validator");
+    auto* node_ptr = node.get();
+    RetryPolicy policy;
+    policy.max_retries = 3;
+    ExecutorHarness h(std::move(node), policy);
+
+    asio::io_context io;
+    std::exception_ptr err;
+    asio::co_spawn(
+        io,
+        [&]() -> asio::awaitable<void> {
+            try {
+                GraphState state; init_state(state, h.channel_defs);
+                co_await h.executor.execute_node_with_retry_async(
+                    "validator", state, nullptr, StreamMode::ALL, RunContext{});
+            } catch (...) {
+                err = std::current_exception();
+            }
+        },
+        asio::detached);
+    io.run();
+
+    ASSERT_TRUE(err);
+    EXPECT_EQ(node_ptr->calls, 1);
+    try {
+        std::rethrow_exception(err);
+        FAIL() << "expected NodeExecutionError";
+    } catch (const NodeExecutionError& e) {
+        EXPECT_EQ(e.node_name(), "validator");
+        EXPECT_EQ(e.attempts(), 1);
+        EXPECT_THROW(std::rethrow_exception(e.cause()), std::logic_error);
+    }
 }
 
 TEST(ExecutorAsyncRetry, NodeInterruptShortCircuits) {

--- a/tests/test_graph_engine_async_api.cpp
+++ b/tests/test_graph_engine_async_api.cpp
@@ -122,6 +122,15 @@ TEST(GraphEngineAsyncApi, RunAsyncPropagatesNodeException) {
     RunConfig cfg;
     cfg.thread_id = "t-2";
 
+    try {
+        engine->run(cfg);
+        FAIL() << "expected NodeExecutionError";
+    } catch (const NodeExecutionError& e) {
+        EXPECT_EQ(e.node_name(), "boom");
+        EXPECT_EQ(e.attempts(), 1);
+        EXPECT_THROW(std::rethrow_exception(e.cause()), std::runtime_error);
+    }
+
     asio::io_context io;
     std::exception_ptr captured;
     asio::co_spawn(
@@ -137,7 +146,65 @@ TEST(GraphEngineAsyncApi, RunAsyncPropagatesNodeException) {
     io.run();
 
     ASSERT_TRUE(captured);
-    EXPECT_THROW(std::rethrow_exception(captured), std::runtime_error);
+    try {
+        std::rethrow_exception(captured);
+        FAIL() << "expected NodeExecutionError";
+    } catch (const NodeExecutionError& e) {
+        EXPECT_EQ(e.node_name(), "boom");
+        EXPECT_EQ(e.attempts(), 1);
+        EXPECT_THROW(std::rethrow_exception(e.cause()), std::runtime_error);
+    }
+}
+
+TEST(GraphEngineAsyncApi, SubgraphFailureStillHonorsOuterRetry) {
+    auto calls = std::make_shared<std::atomic<int>>(0);
+    NodeFactory::instance().register_type("subgraph_transient_123",
+        [calls](const std::string& name, const json&, const NodeContext&) {
+            class TransientNode final : public GraphNode {
+            public:
+                TransientNode(std::string name,
+                              std::shared_ptr<std::atomic<int>> calls)
+                    : name_(std::move(name)), calls_(std::move(calls)) {}
+                asio::awaitable<NodeOutput> run(NodeInput) override {
+                    if (calls_->fetch_add(1) < 2) {
+                        throw std::runtime_error("inner transient failure");
+                    }
+                    co_return NodeOutput{};
+                }
+                std::string get_name() const override { return name_; }
+            private:
+                std::string name_;
+                std::shared_ptr<std::atomic<int>> calls_;
+            };
+            return std::make_unique<TransientNode>(name, calls);
+        });
+
+    json inner = {
+        {"name", "inner"},
+        {"channels", json::object()},
+        {"nodes", {{"deep", {{"type", "subgraph_transient_123"}}}}},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "deep"}},
+            {{"from", "deep"}, {"to", "__end__"}}
+        })}
+    };
+    json outer = {
+        {"name", "outer"},
+        {"channels", json::object()},
+        {"nodes", {{"shell", {{"type", "subgraph"},
+                                {"definition", inner}}}}},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "shell"}},
+            {{"from", "shell"}, {"to", "__end__"}}
+        })},
+        {"retry_policy", {{"max_retries", 2}, {"initial_delay_ms", 1}}}
+    };
+
+    auto engine = GraphEngine::compile(outer, NodeContext{});
+    RunConfig cfg;
+    cfg.thread_id = "subgraph-retry";
+    EXPECT_NO_THROW(engine->run(cfg));
+    EXPECT_EQ(calls->load(), 3);
 }
 
 TEST(GraphEngineAsyncApi, ResumeAsyncMatchesSyncResume) {


### PR DESCRIPTION
## Summary
- attach failing node name and attempt count to exhausted C++ node errors while retaining the original exception
- preserve Python exception type, arguments, traceback, and user attributes across sync and async graph APIs
- keep control-flow exceptions and allocation failures unwrapped, and retain current Python engine/callback lifetime guards

## Verification
- `./build-pr/tests/neograph_tests --gtest_filter='ExecutorAsyncRetry.*'` (6 passed)
- `PYTHONPATH=build-pr python3 -m pytest bindings/python/tests/test_async.py -k 'preserves_python_node_exception' -q` (3 passed)
- independent review found no correctness issues; broader focused review passed 23 C++ and 30 Python tests

Fixes #123
Includes and supersedes #122