### PR TITLE
fix(compiler): reject malformed topology containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **토폴로지 최상위 컨테이너 형식 검증 (#126).** `channels`/`nodes`는
+  객체가 아니면 모든 모드에서 거부한다. `edges`/`conditional_edges`의
+  배열 검증은 strict 모드에서 강제하며, legacy의 keyed edge map 호환성은
+  유지한다. 오류에는 전체 입력 대신 경로와 JSON 종류만 기록한다.
+
 - **`set_worker_count` / `set_worker_count_auto` docstring 정정
   (issue #62, PR #63).** v1.0 prep 사이클에 `compile()` 의 worker pool
   기본값을 `set_worker_count(hardware_concurrency())` 에서

--- a/bindings/python/tests/test_topology_container_types.py
+++ b/bindings/python/tests/test_topology_container_types.py
@@ -1,0 +1,73 @@
+import pytest
+
+import neograph_engine as ng
+
+
+CASES = [
+    pytest.param(
+        field,
+        valid_empty,
+        wrong_empty,
+        schema_version,
+        expected,
+        schema_version is not None or expected == "object",
+        id=f"{mode}-{field}",
+    )
+    for mode, schema_version in (("legacy", None), ("strict", 1))
+    for field, valid_empty, wrong_empty, expected in (
+        ("channels", {}, [], "object"),
+        ("nodes", {}, [], "object"),
+        ("edges", [], {}, "array"),
+        ("conditional_edges", [], {}, "array"),
+    )
+]
+
+
+@pytest.mark.parametrize(
+    "field,valid_empty,wrong_empty,schema_version,expected,rejects_wrong", CASES
+)
+def test_compile_rejects_wrong_top_level_container(
+    field, valid_empty, wrong_empty, schema_version, expected, rejects_wrong
+):
+    definition = {field: wrong_empty}
+    if schema_version is not None:
+        definition["schema_version"] = schema_version
+
+    if rejects_wrong:
+        with pytest.raises(RuntimeError, match=rf"\$\.{field}.*{expected}"):
+            ng.GraphEngine.compile(definition, ng.NodeContext())
+    else:
+        ng.GraphEngine.compile(definition, ng.NodeContext())
+
+
+@pytest.mark.parametrize(
+    "field,valid_empty,wrong_empty,schema_version,expected,rejects_wrong", CASES
+)
+def test_compile_accepts_valid_empty_top_level_container(
+    field, valid_empty, wrong_empty, schema_version, expected, rejects_wrong
+):
+    definition = {field: valid_empty}
+    if schema_version is not None:
+        definition["schema_version"] = schema_version
+
+    ng.GraphEngine.compile(definition, ng.NodeContext())
+
+
+@pytest.mark.parametrize("schema_version", [None, 1], ids=["legacy", "strict"])
+@pytest.mark.parametrize("field", ["edges", "conditional_edges"])
+@pytest.mark.parametrize("value", [None, "not a container", 7, True])
+def test_edge_fields_reject_scalar_values(field, value, schema_version):
+    definition = {field: value}
+    if schema_version is not None:
+        definition["schema_version"] = schema_version
+
+    with pytest.raises(RuntimeError, match=rf"\$\.{field}.*array"):
+        ng.GraphEngine.compile(definition, ng.NodeContext())
+
+
+def test_legacy_edges_keep_keyed_object_compatibility():
+    definition = {
+        "nodes": {},
+        "edges": {"direct": {"from": ng.START_NODE, "to": ng.END_NODE}},
+    }
+    ng.GraphEngine.compile(definition, ng.NodeContext())

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -1271,14 +1271,14 @@ Compiles a graph from a JSON definition and returns an engine ready for executio
 ```json
 {
   "name": "my_graph",
-  "channels": [
-    {"name": "messages", "type": "append"},
-    {"name": "status", "type": "overwrite", "initial": "idle"}
-  ],
-  "nodes": [
-    {"name": "llm", "type": "llm_call"},
-    {"name": "tools", "type": "tool_dispatch"}
-  ],
+  "channels": {
+    "messages": {"reducer": "append"},
+    "status": {"reducer": "overwrite", "initial": "idle"}
+  },
+  "nodes": {
+    "llm": {"type": "llm_call"},
+    "tools": {"type": "tool_dispatch"}
+  },
   "edges": [
     {"from": "__start__", "to": "llm"},
     {"from": "tools", "to": "llm"}
@@ -2920,14 +2920,14 @@ int main() {
 
     json definition = {
         {"name", "assistant_graph"},
-        {"channels", json::array({
-            {{"name", "messages"}, {"type", "append"}},
-            {{"name", "status"},   {"type", "overwrite"}, {"initial", "idle"}}
-        })},
-        {"nodes", json::array({
-            {{"name", "llm"},   {"type", "llm_call"}},
-            {{"name", "tools"}, {"type", "tool_dispatch"}}
-        })},
+        {"channels", {
+            {"messages", {{"reducer", "append"}}},
+            {"status",   {{"reducer", "overwrite"}, {"initial", "idle"}}}
+        }},
+        {"nodes", {
+            {"llm",   {{"type", "llm_call"}}},
+            {"tools", {{"type", "tool_dispatch"}}}
+        }},
         {"edges", json::array({
             {{"from", "__start__"}, {"to", "llm"}},
             {{"from", "tools"},     {"to", "llm"}}

--- a/src/core/graph_compiler.cpp
+++ b/src/core/graph_compiler.cpp
@@ -160,6 +160,31 @@ CompiledGraph GraphCompiler::compile(const json& definition,
     }
     const bool strict = cg.schema_version >= 1;
 
+    auto require_container = [&](const char* field, bool expects_object,
+                                 bool legacy_object_allowed = false) {
+        if (!definition.contains(field)) return;
+        const auto& value = definition[field];
+        if (legacy_object_allowed && !strict && value.is_object()) return;
+        if (expects_object ? !value.is_object() : !value.is_array()) {
+            const char* expected = expects_object ? "object" : "array";
+            const char* actual = value.is_object() ? "object"
+                               : value.is_array()  ? "array"
+                               : value.is_string() ? "string"
+                               : value.is_number() ? "number"
+                               : value.is_bool()   ? "boolean"
+                                                   : "null";
+            throw std::runtime_error(
+                "topology '$." + std::string(field) + "' must be an "
+                + expected + ", got " + actual);
+        }
+    };
+    require_container("channels", true);
+    require_container("nodes", true);
+    // Legacy accepted keyed edge maps and some users rely on that shape.
+    // Strict mode follows the exported schema and requires arrays.
+    require_container("edges", false, true);
+    require_container("conditional_edges", false, true);
+
     cg.name = definition.value("name", "unnamed_graph");
     top_consumed.insert("name");
 

--- a/tests/test_compiler.cpp
+++ b/tests/test_compiler.cpp
@@ -39,6 +39,52 @@ void ensure_noop_registered() {
 
 } // namespace
 
+TEST(TopLevelContainerTypes, RejectsMalformedContainers) {
+    auto expect_error = [](const char* field, json value, bool strict,
+                           const char* expected) {
+        json def = json::object();
+        if (strict) def["schema_version"] = 1;
+        def[field] = std::move(value);
+        try {
+            GraphCompiler::compile(def, NodeContext{});
+            FAIL() << "expected $." << field << " to reject malformed input";
+        } catch (const std::runtime_error& e) {
+            const std::string message = e.what();
+            EXPECT_NE(message.find("$." + std::string(field)), std::string::npos);
+            EXPECT_NE(message.find(expected), std::string::npos);
+        }
+    };
+
+    for (bool strict : {false, true}) {
+        expect_error("channels", json::array(), strict, "object");
+        expect_error("nodes", json::array(), strict, "object");
+        for (const char* field : {"edges", "conditional_edges"}) {
+            if (strict) expect_error(field, json::object(), true, "array");
+            expect_error(field, json("not a container"), strict, "array");
+            expect_error(field, json(nullptr), strict, "array");
+        }
+    }
+}
+
+TEST(TopLevelContainerTypes, AcceptsValidAndLegacyCompatibleContainers) {
+    for (bool strict : {false, true}) {
+        json def = {
+            {"channels", json::object()},
+            {"nodes", json::object()},
+            {"edges", json::array()},
+            {"conditional_edges", json::array()}
+        };
+        if (strict) def["schema_version"] = 1;
+        EXPECT_NO_THROW(GraphCompiler::compile(def, NodeContext{}));
+    }
+
+    json legacy = {
+        {"nodes", json::object()},
+        {"edges", {{"direct", {{"from", "__start__"}, {"to", "__end__"}}}}}
+    };
+    EXPECT_NO_THROW(GraphCompiler::compile(legacy, NodeContext{}));
+}
+
 // =========================================================================
 // Defaults
 // =========================================================================


### PR DESCRIPTION
## Summary
- reject non-object `nodes` and `channels` before legacy compilation can produce an unusable engine
- reject scalar edge containers while preserving legacy keyed-object compatibility for regular and conditional edges
- correct stale reference examples and add C++/Python regression coverage for malformed and compatible shapes

## Verification
- `./build-pr/tests/neograph_tests --gtest_filter='TopLevelContainerTypes.*:TranslationValidation.*'` (7 passed)
- `PYTHONPATH=build-pr python3 -m pytest -q bindings/python/tests/test_topology_container_types.py` (34 passed)
- independent final review found no correctness, API, or ABI issues

Fixes #126