### PR TITLE
fix(llm): make provider startup exception-safe

### DIFF
--- a/src/llm/openai_provider.cpp
+++ b/src/llm/openai_provider.cpp
@@ -26,8 +26,10 @@ OpenAIProvider::OpenAIProvider(Config config)
     // throw-away io_context per call, so the pool can't live there.
     http_io_ = std::make_unique<asio::io_context>();
     http_work_.emplace(asio::make_work_guard(*http_io_));
-    http_thread_ = std::thread([io = http_io_.get()]{ io->run(); });
     conn_pool_ = std::make_unique<async::ConnPool>(http_io_->get_executor());
+    // Start the thread only after every other constructor step succeeds.
+    // A joinable std::thread aborts the process if a later step throws.
+    http_thread_ = std::thread([io = http_io_.get()]{ io->run(); });
 }
 
 OpenAIProvider::~OpenAIProvider()

--- a/src/llm/schema_provider.cpp
+++ b/src/llm/schema_provider.cpp
@@ -48,7 +48,6 @@ SchemaProvider::SchemaProvider(Config config, json schema)
     // successive calls to the same model host now amortise TCP+TLS.
     http_io_ = std::make_unique<asio::io_context>();
     http_work_.emplace(asio::make_work_guard(*http_io_));
-    http_thread_ = std::thread([io = http_io_.get()]{ io->run(); });
     conn_pool_ = std::make_unique<async::ConnPool>(http_io_->get_executor());
     if (user_config_.prefer_libcurl) {
         curl_pool_ = std::make_unique<async::CurlH2Pool>();
@@ -58,7 +57,22 @@ SchemaProvider::SchemaProvider(Config config, json schema)
     // See header comment on `bridge_io_` for the rationale.
     bridge_io_ = std::make_unique<asio::io_context>();
     bridge_work_.emplace(asio::make_work_guard(*bridge_io_));
-    bridge_thread_ = std::thread([io = bridge_io_.get()]{ io->run(); });
+
+    // Threads come last so resource setup failures unwind normally. If the
+    // second thread cannot start, explicitly stop and join the first one;
+    // destroying a joinable std::thread would otherwise call std::terminate.
+    try {
+        http_thread_ = std::thread([io = http_io_.get()]{ io->run(); });
+        bridge_thread_ = std::thread([io = bridge_io_.get()]{ io->run(); });
+    } catch (...) {
+        http_work_.reset();
+        bridge_work_.reset();
+        http_io_->stop();
+        bridge_io_->stop();
+        if (http_thread_.joinable()) http_thread_.join();
+        if (bridge_thread_.joinable()) bridge_thread_.join();
+        throw;
+    }
 }
 
 SchemaProvider::~SchemaProvider()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,10 @@ if(NEOGRAPH_BUILD_SQLITE)
     target_compile_definitions(neograph_tests PRIVATE NEOGRAPH_TESTS_HAVE_SQLITE)
 endif()
 
+if(NOT NEOGRAPH_USE_LIBCURL)
+    target_sources(neograph_tests PRIVATE test_provider_constructor_exception_safety.cpp)
+endif()
+
 target_link_libraries(neograph_tests PRIVATE
     neograph::core
     neograph::llm

--- a/tests/test_provider_constructor_exception_safety.cpp
+++ b/tests/test_provider_constructor_exception_safety.cpp
@@ -1,0 +1,25 @@
+#include <neograph/llm/schema_provider.h>
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+#include <string>
+
+using neograph::llm::SchemaProvider;
+
+TEST(ProviderConstructorExceptionSafety,
+     NoLibcurlPreferencePropagatesOriginalError) {
+    SchemaProvider::Config config;
+    config.schema_path = "openai";
+    config.api_key = "test-key";
+    config.prefer_libcurl = true;
+
+    try {
+        auto provider = SchemaProvider::create(config);
+        (void)provider;
+        FAIL() << "expected the unavailable libcurl backend to throw";
+    } catch (const std::runtime_error& error) {
+        EXPECT_NE(std::string(error.what()).find("libcurl backend not compiled"),
+                  std::string::npos);
+    }
+}


### PR DESCRIPTION
## Summary
- construct provider-owned pools and I/O resources before starting joinable worker threads
- roll back and join the first SchemaProvider thread if the second thread cannot start
- preserve public class layout and turn no-libcurl setup failure from process termination into the original exception

## Verification
- libcurl OFF: `ctest --test-dir build-pr-off --output-on-failure` (646/646 passed)
- libcurl ON: `ctest --test-dir build-pr-on --output-on-failure` (645/645 passed)
- independent final review found no correctness, integration, API, ABI, or ownership issue

## Residual risks
- allocation and `std::thread` creation failures are verified by code inspection rather than product-code fault-injection seams
- a pre-existing CurlH2Pool handle leak on thread-creation failure is unchanged and does not cause this terminate path

Fixes #128