### PR TITLE
fix(llm): surface OpenAI stream failures

### DIFF
--- a/src/llm/openai_provider.cpp
+++ b/src/llm/openai_provider.cpp
@@ -10,6 +10,7 @@
 #include <asio/this_coro.hpp>
 
 #include <charconv>
+#include <exception>
 #include <iostream>
 #include <stdexcept>
 #include <sstream>
@@ -193,27 +194,52 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
 
     // Buffer for partial SSE lines across chunk boundaries
     std::string line_buffer;
+    std::exception_ptr stream_error;
 
-    auto res = cli.Post(
-        prefix + "/v1/chat/completions", headers, body.dump(), "application/json",
-        [&](const char* data, size_t len) -> bool {
-            line_buffer.append(data, len);
+    int response_status = 0;
+    httplib::Request request;
+    request.method = "POST";
+    request.path = prefix + "/v1/chat/completions";
+    request.headers = headers;
+    request.body = body.dump();
+    request.set_header("Content-Type", "application/json");
+    request.response_handler = [&](const httplib::Response& response) {
+        response_status = response.status;
+        return response.status == 200;
+    };
+    request.content_receiver =
+        [&](const char* data, size_t len, size_t, size_t) -> bool {
+            try {
+                line_buffer.append(data, len);
 
-            // Process complete lines only
-            size_t pos;
-            while ((pos = line_buffer.find('\n')) != std::string::npos) {
-                std::string line = line_buffer.substr(0, pos);
-                line_buffer.erase(0, pos + 1);
+                // Process complete lines only
+                size_t pos;
+                while ((pos = line_buffer.find('\n')) != std::string::npos) {
+                    std::string line = line_buffer.substr(0, pos);
+                    line_buffer.erase(0, pos + 1);
 
-                // Remove \r
-                if (!line.empty() && line.back() == '\r') line.pop_back();
+                    // Remove \r
+                    if (!line.empty() && line.back() == '\r') line.pop_back();
 
-                if (line.rfind("data: ", 0) != 0) continue;
-                std::string payload = line.substr(6);
-                if (payload == "[DONE]") continue;
+                    if (line.rfind("data:", 0) != 0) continue;
+                    std::string payload = line.substr(5);
+                    if (!payload.empty() && payload.front() == ' ') {
+                        payload.erase(0, 1);
+                    }
+                    if (payload.empty() || payload == "[DONE]") continue;
 
-                try {
-                    auto j = json::parse(payload);
+                    json j;
+                    try {
+                        j = json::parse(payload);
+                    } catch (const json::parse_error& error) {
+                        throw std::runtime_error(
+                            "Malformed SSE data JSON: " + payload +
+                            " (" + error.what() + ")");
+                    }
+
+                    if (j.is_object() && j.contains("error")) {
+                        throw std::runtime_error("API stream error: " + payload);
+                    }
 
                     // The final chunk (after include_usage=true) has
                     // usage populated but an empty choices array. Capture
@@ -232,9 +258,7 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
                     }
 
                     if (!j.contains("choices") || !j["choices"].is_array()
-                        || j["choices"].empty()) {
-                        continue;
-                    }
+                        || j["choices"].empty()) continue;
                     auto delta = j["choices"][0]["delta"];
 
                     // Content token
@@ -259,13 +283,24 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
                             }
                         }
                     }
-                } catch (...) {
-                    // Skip malformed chunks
                 }
+            } catch (...) {
+                stream_error = std::current_exception();
+                return false;
             }
             return true; // continue receiving
-        }
-    );
+        };
+
+    auto res = cli.send(request);
+
+    if (response_status != 0 && response_status != 200) {
+        throw std::runtime_error(
+            "API error (HTTP " + std::to_string(response_status) + ")");
+    }
+
+    // Returning false from httplib's receiver becomes Error::Canceled.
+    // Preserve the actual parser, API, or user callback exception instead.
+    if (stream_error) std::rethrow_exception(stream_error);
 
     if (!res) {
         throw std::runtime_error("HTTP request failed: " + httplib::to_string(res.error()));

--- a/src/llm/openai_provider.cpp
+++ b/src/llm/openai_provider.cpp
@@ -314,6 +314,11 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
         throw std::runtime_error("HTTP request failed: " + httplib::to_string(res.error()));
     }
 
+    if (!line_buffer.empty()) {
+        throw std::runtime_error(
+            "Malformed SSE stream: unterminated line: " + line_buffer);
+    }
+
     if (res->status != 200) {
         throw std::runtime_error(
             "API error (HTTP " + std::to_string(res->status) + "): " + res->body);

--- a/src/llm/openai_provider.cpp
+++ b/src/llm/openai_provider.cpp
@@ -197,6 +197,7 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
     std::exception_ptr stream_error;
 
     int response_status = 0;
+    std::string error_body;
     httplib::Request request;
     request.method = "POST";
     request.path = prefix + "/v1/chat/completions";
@@ -205,10 +206,14 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
     request.set_header("Content-Type", "application/json");
     request.response_handler = [&](const httplib::Response& response) {
         response_status = response.status;
-        return response.status == 200;
+        return true;
     };
     request.content_receiver =
         [&](const char* data, size_t len, size_t, size_t) -> bool {
+            if (response_status != 200) {
+                error_body.append(data, len);
+                return true;
+            }
             try {
                 line_buffer.append(data, len);
 
@@ -295,7 +300,8 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
 
     if (response_status != 0 && response_status != 200) {
         throw std::runtime_error(
-            "API error (HTTP " + std::to_string(response_status) + ")");
+            "API error (HTTP " + std::to_string(response_status) + "): " +
+            error_body);
     }
 
     // Returning false from httplib's receiver becomes Error::Canceled.

--- a/tests/test_openai_provider_async.cpp
+++ b/tests/test_openai_provider_async.cpp
@@ -201,22 +201,6 @@ TEST(OpenAIProviderStream, MalformedDataIsNotSilentlySkipped) {
                  std::runtime_error);
 }
 
-TEST(OpenAIProviderStream, CallbackExceptionPropagates) {
-    MockServer mock;
-    mock.body = "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n"
-                "data: [DONE]\n\n";
-
-    auto provider = llm::OpenAIProvider::create(make_config(mock));
-    try {
-        provider->complete_stream(make_params(), [](const std::string&) {
-            throw std::runtime_error("callback failed");
-        });
-        FAIL() << "expected the callback error to propagate";
-    } catch (const std::runtime_error& error) {
-        EXPECT_STREQ(error.what(), "callback failed");
-    }
-}
-
 TEST(OpenAIProviderStream, EmptyChoicesRemainAValidEmptyCompletion) {
     MockServer mock;
     mock.body = "data: {\"choices\":[]}\n\ndata: [DONE]\n\n";

--- a/tests/test_openai_provider_async.cpp
+++ b/tests/test_openai_provider_async.cpp
@@ -176,3 +176,72 @@ TEST(OpenAIProviderAsync, NonRateLimitErrorSurfacesAsRuntimeError) {
 
     EXPECT_THROW(provider->complete(params), std::runtime_error);
 }
+
+TEST(OpenAIProviderStream, TopLevelErrorIsNotAnEmptySuccess) {
+    MockServer mock;
+    mock.body = "data: {\"error\":\"STREAM_EXPLODED\"}\n\n"
+                "data: [DONE]\n\n";
+
+    auto provider = llm::OpenAIProvider::create(make_config(mock));
+    try {
+        provider->complete_stream(make_params(), {});
+        FAIL() << "expected the stream error to propagate";
+    } catch (const std::runtime_error& error) {
+        EXPECT_NE(std::string(error.what()).find("STREAM_EXPLODED"),
+                  std::string::npos);
+    }
+}
+
+TEST(OpenAIProviderStream, MalformedDataIsNotSilentlySkipped) {
+    MockServer mock;
+    mock.body = "data: {not-json}\n\ndata: [DONE]\n\n";
+
+    auto provider = llm::OpenAIProvider::create(make_config(mock));
+    EXPECT_THROW(provider->complete_stream(make_params(), {}),
+                 std::runtime_error);
+}
+
+TEST(OpenAIProviderStream, CallbackExceptionPropagates) {
+    MockServer mock;
+    mock.body = "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n"
+                "data: [DONE]\n\n";
+
+    auto provider = llm::OpenAIProvider::create(make_config(mock));
+    try {
+        provider->complete_stream(make_params(), [](const std::string&) {
+            throw std::runtime_error("callback failed");
+        });
+        FAIL() << "expected the callback error to propagate";
+    } catch (const std::runtime_error& error) {
+        EXPECT_STREQ(error.what(), "callback failed");
+    }
+}
+
+TEST(OpenAIProviderStream, EmptyChoicesRemainAValidEmptyCompletion) {
+    MockServer mock;
+    mock.body = "data: {\"choices\":[]}\n\ndata: [DONE]\n\n";
+
+    auto provider = llm::OpenAIProvider::create(make_config(mock));
+    auto completion = provider->complete_stream(make_params(), {});
+    EXPECT_TRUE(completion.message.content.empty());
+    EXPECT_TRUE(completion.message.tool_calls.empty());
+}
+
+TEST(OpenAIProviderStream, HttpStatusTakesPrecedenceOverSseBody) {
+    MockServer mock;
+    mock.status = 500;
+    mock.body = "data: {\"choices\":[{\"delta\":{\"content\":\"must-not-leak\"}}]}\n\n";
+
+    auto provider = llm::OpenAIProvider::create(make_config(mock));
+    int callback_count = 0;
+    try {
+        provider->complete_stream(make_params(), [&](const std::string&) {
+            ++callback_count;
+        });
+        FAIL() << "expected the HTTP error to propagate";
+    } catch (const std::runtime_error& error) {
+        EXPECT_NE(std::string(error.what()).find("HTTP 500"),
+                  std::string::npos);
+    }
+    EXPECT_EQ(callback_count, 0);
+}

--- a/tests/test_openai_provider_async.cpp
+++ b/tests/test_openai_provider_async.cpp
@@ -242,6 +242,8 @@ TEST(OpenAIProviderStream, HttpStatusTakesPrecedenceOverSseBody) {
     } catch (const std::runtime_error& error) {
         EXPECT_NE(std::string(error.what()).find("HTTP 500"),
                   std::string::npos);
+        EXPECT_NE(std::string(error.what()).find("must-not-leak"),
+                  std::string::npos);
     }
     EXPECT_EQ(callback_count, 0);
 }

--- a/tests/test_openai_provider_async.cpp
+++ b/tests/test_openai_provider_async.cpp
@@ -192,6 +192,26 @@ TEST(OpenAIProviderStream, TopLevelErrorIsNotAnEmptySuccess) {
     }
 }
 
+TEST(OpenAIProviderStream, ErrorAfterContentStillFailsTheCompletion) {
+    MockServer mock;
+    mock.body = "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n"
+                "data: {\"error\":\"STREAM_EXPLODED\"}\n\n"
+                "data: [DONE]\n\n";
+
+    auto provider = llm::OpenAIProvider::create(make_config(mock));
+    std::string streamed_content;
+    try {
+        provider->complete_stream(make_params(), [&](const std::string& chunk) {
+            streamed_content += chunk;
+        });
+        FAIL() << "expected the stream error to propagate";
+    } catch (const std::runtime_error& error) {
+        EXPECT_NE(std::string(error.what()).find("STREAM_EXPLODED"),
+                  std::string::npos);
+    }
+    EXPECT_EQ(streamed_content, "partial");
+}
+
 TEST(OpenAIProviderStream, MalformedDataIsNotSilentlySkipped) {
     MockServer mock;
     mock.body = "data: {not-json}\n\ndata: [DONE]\n\n";
@@ -199,6 +219,36 @@ TEST(OpenAIProviderStream, MalformedDataIsNotSilentlySkipped) {
     auto provider = llm::OpenAIProvider::create(make_config(mock));
     EXPECT_THROW(provider->complete_stream(make_params(), {}),
                  std::runtime_error);
+}
+
+TEST(OpenAIProviderStream, UnterminatedDataIsNotAnEmptySuccess) {
+    MockServer mock;
+    mock.body = "data: {\"error\":\"STREAM_EXPLODED\"}";
+
+    auto provider = llm::OpenAIProvider::create(make_config(mock));
+    EXPECT_THROW(provider->complete_stream(make_params(), {}),
+                 std::runtime_error);
+}
+
+TEST(OpenAIProviderStream, SuccessfulContentAndUsageRemainIntact) {
+    MockServer mock;
+    mock.body = "data: {\"choices\":[{\"delta\":{\"content\":\"pong\"}}]}\n\n"
+                "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":7,"
+                "\"completion_tokens\":2,\"total_tokens\":9}}\n\n"
+                "data: [DONE]\n\n";
+
+    auto provider = llm::OpenAIProvider::create(make_config(mock));
+    std::string streamed_content;
+    auto completion = provider->complete_stream(
+        make_params(), [&](const std::string& chunk) {
+            streamed_content += chunk;
+        });
+
+    EXPECT_EQ(streamed_content, "pong");
+    EXPECT_EQ(completion.message.content, "pong");
+    EXPECT_EQ(completion.usage.prompt_tokens, 7);
+    EXPECT_EQ(completion.usage.completion_tokens, 2);
+    EXPECT_EQ(completion.usage.total_tokens, 9);
 }
 
 TEST(OpenAIProviderStream, EmptyChoicesRemainAValidEmptyCompletion) {


### PR DESCRIPTION
## Summary
- reject top-level OpenAI-compatible SSE error objects instead of returning an empty successful completion
- surface malformed or truncated SSE data and preserve the underlying parser/API error instead of httplib cancellation
- preserve non-200 response bodies while preventing them from reaching stream callbacks
- retain valid empty and usage-only events

## Verification
- `./build/tests/neograph_tests --gtest_filter='OpenAIProviderStream.*'` (7/7 passed)
- `ctest --test-dir build --output-on-failure` (535/535 passed; 3 expected live tests skipped)
- independent read-only review: no blocking findings

Closes #124