### PR TITLE
fix(jarvis): restore dependency-free mock build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,8 @@ jobs:
             -DCMAKE_BUILD_TYPE=Debug \
             -DNEOGRAPH_BUILD_TESTS=ON \
             -DNEOGRAPH_BUILD_EXAMPLES=ON \
+            -DNEOGRAPH_BUILD_COOKBOOK_JARVIS=ON \
+            -DNEOGRAPH_JARVIS_FORCE_MOCK=ON \
             -DNEOGRAPH_BUILD_BENCHMARKS=OFF \
             -DNEOGRAPH_BUILD_POSTGRES=ON \
             -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -O1" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **JARVIS mock 빌드 복구 (issue #130).** 음성 의존성이 없을 때
+  `MicCapture`가 불완전한 타입으로 남아 `cookbook_jarvis` 컴파일이 실패하던
+  문제를 수정했다. `NEOGRAPH_JARVIS_FORCE_MOCK`을 추가해 ASan CI가 runner의
+  설치 패키지와 관계없이 외부 음성 의존성 없는 mock 구성을 항상 빌드한다.
+
 ### Added
 
 - **DSL 표면 (elaboration 계층) + 스키마 진화 게이트** (#75 M4).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1189,13 +1189,12 @@ if(NEOGRAPH_BUILD_EXAMPLES)
             endif()
         endif()
 
-        # JARVIS voice meta-orchestrator cookbook — 골격(skeleton) 단계.
-        # whisper.cpp + onnxruntime + miniaudio + supertonic helper + 모델 가중치
-        # (~250MB) 가 필요. 기본 OFF — ON 으로 켜면 jarvis 의 자체 CMakeLists 가
-        # 의존성 못 찾으면 조용히 return() 해서 본체 빌드를 깨뜨리지 않음.
+        # JARVIS voice meta-orchestrator cookbook.
+        # 라이브 음성에는 whisper.cpp + onnxruntime + miniaudio + supertonic helper
+        # + 모델 가중치가 필요하다. 외부 의존성이 없으면 mock으로 빌드.
         # MCP / A2A / LLM 셋 다 켜져 있어야 의미가 있음.
         option(NEOGRAPH_BUILD_COOKBOOK_JARVIS
-            "Build JARVIS voice cookbook (needs whisper.cpp + onnxruntime + miniaudio + 250MB models)"
+            "Build JARVIS voice cookbook (mock fallback without voice dependencies)"
             OFF)
         if(NEOGRAPH_BUILD_COOKBOOK_JARVIS
            AND NEOGRAPH_BUILD_LLM

--- a/examples/cookbook/jarvis/CMakeLists.txt
+++ b/examples/cookbook/jarvis/CMakeLists.txt
@@ -43,25 +43,30 @@ endforeach()
 
 # ── 외부 의존 — 없어도 빌드 계속 (mock-first 전략) ──────────────────────────
 
+option(NEOGRAPH_JARVIS_FORCE_MOCK
+    "Build JARVIS without optional voice dependencies" OFF)
+
 # 프로젝트 로컬 third_party 경로 (시스템 의존 0 — 모두 cookbook 안)
 set(_jarvis_local_tp "${CMAKE_CURRENT_LIST_DIR}/third_party")
 
 # onnxruntime — 없으면 JARVIS_HAVE_ONNXRUNTIME=OFF, 빌드는 계속
 set(JARVIS_HAVE_ONNXRUNTIME OFF)
-find_package(onnxruntime QUIET CONFIG)
-if(onnxruntime_FOUND)
-    set(JARVIS_HAVE_ONNXRUNTIME ON)
-else()
-    # third_party/onnxruntime 우선, 없으면 시스템 경로
-    find_path(ONNXRUNTIME_INCLUDE_DIR
-        NAMES onnxruntime_cxx_api.h
-        HINTS ${_jarvis_local_tp}/onnxruntime/include
-        PATH_SUFFIXES onnxruntime)
-    find_library(ONNXRUNTIME_LIB
-        NAMES onnxruntime libonnxruntime
-        HINTS ${_jarvis_local_tp}/onnxruntime/lib)
-    if(ONNXRUNTIME_INCLUDE_DIR AND ONNXRUNTIME_LIB)
+if(NOT NEOGRAPH_JARVIS_FORCE_MOCK)
+    find_package(onnxruntime QUIET CONFIG)
+    if(onnxruntime_FOUND)
         set(JARVIS_HAVE_ONNXRUNTIME ON)
+    else()
+        # third_party/onnxruntime 우선, 없으면 시스템 경로
+        find_path(ONNXRUNTIME_INCLUDE_DIR
+            NAMES onnxruntime_cxx_api.h
+            HINTS ${_jarvis_local_tp}/onnxruntime/include
+            PATH_SUFFIXES onnxruntime)
+        find_library(ONNXRUNTIME_LIB
+            NAMES onnxruntime libonnxruntime
+            HINTS ${_jarvis_local_tp}/onnxruntime/lib)
+        if(ONNXRUNTIME_INCLUDE_DIR AND ONNXRUNTIME_LIB)
+            set(JARVIS_HAVE_ONNXRUNTIME ON)
+        endif()
     endif()
 endif()
 if(NOT JARVIS_HAVE_ONNXRUNTIME)
@@ -72,17 +77,19 @@ endif()
 
 # whisper.cpp — 없으면 JARVIS_HAVE_WHISPER=OFF, 빌드는 계속
 set(JARVIS_HAVE_WHISPER OFF)
-find_package(whisper QUIET CONFIG)
-if(whisper_FOUND)
-    set(JARVIS_HAVE_WHISPER ON)
-else()
-    # third_party/whisper_install 우선
-    find_path(WHISPER_INCLUDE_DIR NAMES whisper.h
-        HINTS ${_jarvis_local_tp}/whisper_install/include)
-    find_library(WHISPER_LIB NAMES whisper
-        HINTS ${_jarvis_local_tp}/whisper_install/lib)
-    if(WHISPER_INCLUDE_DIR AND WHISPER_LIB)
+if(NOT NEOGRAPH_JARVIS_FORCE_MOCK)
+    find_package(whisper QUIET CONFIG)
+    if(whisper_FOUND)
         set(JARVIS_HAVE_WHISPER ON)
+    else()
+        # third_party/whisper_install 우선
+        find_path(WHISPER_INCLUDE_DIR NAMES whisper.h
+            HINTS ${_jarvis_local_tp}/whisper_install/include)
+        find_library(WHISPER_LIB NAMES whisper
+            HINTS ${_jarvis_local_tp}/whisper_install/lib)
+        if(WHISPER_INCLUDE_DIR AND WHISPER_LIB)
+            set(JARVIS_HAVE_WHISPER ON)
+        endif()
     endif()
 endif()
 if(NOT JARVIS_HAVE_WHISPER)
@@ -94,17 +101,19 @@ endif()
 # supertonic helper.cpp — assets/download.sh 가 third_party/supertonic/ 에 받음
 set(_jarvis_supertonic_helper "${_jarvis_local_tp}/supertonic/helper.cpp")
 set(JARVIS_HAVE_SUPERTONIC OFF)
-if(EXISTS "${_jarvis_supertonic_helper}")
+if(NOT NEOGRAPH_JARVIS_FORCE_MOCK AND EXISTS "${_jarvis_supertonic_helper}")
     set(JARVIS_HAVE_SUPERTONIC ON)
     message(STATUS "[jarvis] supertonic helper OK — ${_jarvis_supertonic_helper}")
 endif()
 
 # miniaudio — 헤더 하나. 없으면 stub 헤더 생성 후 계속 진행.
 set(JARVIS_HAVE_MINIAUDIO OFF)
-find_path(MINIAUDIO_INCLUDE_DIR NAMES miniaudio.h
-    HINTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party
-          ${CMAKE_CURRENT_SOURCE_DIR}/third_party/miniaudio)
-if(MINIAUDIO_INCLUDE_DIR)
+if(NOT NEOGRAPH_JARVIS_FORCE_MOCK)
+    find_path(MINIAUDIO_INCLUDE_DIR NAMES miniaudio.h
+        HINTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party
+              ${CMAKE_CURRENT_SOURCE_DIR}/third_party/miniaudio)
+endif()
+if(MINIAUDIO_INCLUDE_DIR AND NOT NEOGRAPH_JARVIS_FORCE_MOCK)
     set(JARVIS_HAVE_MINIAUDIO ON)
 else()
     # stub 헤더 생성 — mic_input.cpp / tts_output.cpp 가 #ifdef 없이

--- a/examples/cookbook/jarvis/src/audio/mic_input.cpp
+++ b/examples/cookbook/jarvis/src/audio/mic_input.cpp
@@ -296,6 +296,10 @@ class MicCapture {
     std::atomic<bool>                 listening_{false};  // 듣는 중에만 발화 큐잉
     std::thread                       worker_;
 };
+#else
+// Keep the pimpl type complete when live audio dependencies are absent.
+// Mock mode never constructs it, but unique_ptr still instantiates its deleter.
+class MicCapture {};
 #endif  // JARVIS_LIVE_MIC
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- complete the mock-only `MicCapture` type so `unique_ptr` deletion compiles without live microphone dependencies
- add `NEOGRAPH_JARVIS_FORCE_MOCK` to make dependency-free coverage deterministic
- compile the forced-mock JARVIS target in sanitizer CI
- update the option description and changelog

## Verification
- normal dependency discovery fallback: `cookbook_jarvis` built successfully with GCC 13 Debug
- `NEOGRAPH_JARVIS_FORCE_MOCK=ON`: `cookbook_jarvis` built successfully with GCC 13 Debug
- `git diff --check`: clean
- independent read-only review: no findings

Closes #130