### PR TITLE
fix(llm): make abandoned stream bridges teardown-safe

### DIFF
--- a/include/neograph/llm/schema_provider.h
+++ b/include/neograph/llm/schema_provider.h
@@ -151,12 +151,13 @@ class NEOGRAPH_API SchemaProvider : public Provider {
     /// no nested `run_sync`, no shared-state race against the
     /// awaiter's io_context.
     ///
-    /// For the HTTP/SSE path (httplib synchronous) it defers to
-    /// `Provider::complete_stream_async`'s base implementation, which
-    /// post-#4 spawns a dedicated worker thread for `complete_stream`
-    /// and dispatches tokens back onto the awaiter's executor — so
-    /// the engine's io_context worker stays responsive and the user
-    /// `on_chunk` runs single-threaded with the awaiting coroutine.
+    /// For the HTTP/SSE path (httplib synchronous) it dispatches
+    /// `complete_stream` onto the provider's long-lived bridge thread.
+    /// That thread writes tokens to a private queue; the awaiting
+    /// coroutine drains the queue on its own executor. The engine's
+    /// io_context stays responsive, user callbacks remain single-
+    /// threaded with the awaiter, and abandoned calls never dispatch
+    /// back into a destroyed outer io_context.
     asio::awaitable<ChatCompletion>
     complete_stream_async(const CompletionParams& params,
                           const StreamCallback& on_chunk) override;

--- a/include/neograph/provider.h
+++ b/include/neograph/provider.h
@@ -199,12 +199,13 @@ class NEOGRAPH_API Provider {
      * @brief Async streaming completion. Awaitable peer of @ref complete_stream.
      *
      * Default implementation (post-#4): spawns a dedicated worker
-     * thread that runs the synchronous `complete_stream`, dispatches
-     * each token onto the awaiting coroutine's executor (so the
-     * user's `on_chunk` runs single-threaded with the awaiter — no
-     * reentrancy), and resumes the coroutine via a one-shot
-     * `steady_timer.cancel()` posted on the awaiter's executor when
-     * streaming finishes. Subclasses with a fully async streaming
+     * thread that runs the synchronous `complete_stream` and writes
+     * tokens and completion state to a private queue. The awaiting
+     * coroutine polls that queue and invokes the user's `on_chunk` on
+     * its own executor (single-threaded with the awaiter — no
+     * reentrancy). If the coroutine is abandoned, late tokens are
+     * discarded and the worker finishes independently without using
+     * the awaiter's executor. Subclasses with a fully async streaming
      * transport (WebSocket Responses, native SSE coroutine, etc.)
      * SHOULD override this to drop the worker thread and stream
      * tokens straight onto the coroutine's executor.
@@ -231,8 +232,15 @@ class NEOGRAPH_API Provider {
      * an extra worker thread per call. Subclasses whose
      * `complete_stream` is purely synchronous (e.g. blocking httplib)
      * can leave the default bridge in place — it routes the sync work
-     * onto a worker thread and dispatches tokens back onto the
-     * awaiter's executor.
+     * onto a worker thread and lets the awaiting coroutine drain the
+     * token queue on its own executor.
+     *
+     * @warning The default bridge calls the virtual `complete_stream`
+     * through this Provider object. If the returned awaitable is
+     * abandoned, the Provider must remain alive until that synchronous
+     * transport call returns. Abandoning the awaitable or destroying
+     * its `io_context` does not wait for the worker, and therefore does
+     * not extend the Provider object's lifetime.
      *
      * @note **`asio::io_context.run()` placement for the awaiter**
      * (issue #16): drive the outer `asio::io_context.run()` from

--- a/src/core/provider.cpp
+++ b/src/core/provider.cpp
@@ -12,7 +12,6 @@
 #include <neograph/async/run_sync.h>
 #include <neograph/graph/cancel.h>
 
-#include <asio/dispatch.hpp>
 #include <asio/redirect_error.hpp>
 #include <asio/steady_timer.hpp>
 #include <asio/this_coro.hpp>
@@ -21,8 +20,10 @@
 #include <chrono>
 #include <exception>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <thread>
+#include <vector>
 
 namespace neograph {
 
@@ -80,12 +81,11 @@ Provider::complete_stream_async(const CompletionParams& params,
     // thread.
     //
     // New default: spawn a dedicated worker thread to run the
-    // synchronous `complete_stream`, and dispatch each token onto the
-    // *awaiter's* executor so the caller's `on_chunk` runs single-
-    // threaded with the coroutine that issued the await — same
-    // invariant the engine already gives node bodies. Completion is
-    // signalled via a one-shot `steady_timer.cancel()` posted onto
-    // the awaiter's executor.
+    // synchronous `complete_stream`. The worker only writes to shared
+    // state; the awaiting coroutine polls and drains queued tokens on
+    // its own executor. This keeps `on_chunk` single-threaded with the
+    // awaiter without letting the worker retain or use that executor
+    // after its io_context begins teardown.
     //
     // Subclasses with a fully async streaming transport (e.g.
     // SchemaProvider's WebSocket Responses path) SHOULD override this
@@ -94,46 +94,77 @@ Provider::complete_stream_async(const CompletionParams& params,
     auto exec = co_await asio::this_coro::executor;
 
     struct Shared {
+        std::mutex mutex;
+        bool abandoned = false;
+        bool finished = false;
+        std::vector<std::string> chunks;
         std::optional<ChatCompletion> result;
         std::exception_ptr err;
     };
     auto shared = std::make_shared<Shared>();
 
-    // expires_at::max + cancel() == one-shot completion signal. Same
-    // pattern graph_executor.cpp uses for retry-wait timers.
-    auto done = std::make_shared<asio::steady_timer>(exec);
-    done->expires_at(std::chrono::steady_clock::time_point::max());
-
-    // Wrap the user's on_chunk so each chunk is dispatched onto the
-    // awaiter's executor (not the worker thread). Restores the
-    // single-threaded-with-the-awaiter invariant.
-    StreamCallback wrapped = [exec, on_chunk](const std::string& chunk) {
-        if (!on_chunk) return;
-        asio::dispatch(exec, [on_chunk, chunk]() { on_chunk(chunk); });
+    StreamCallback wrapped = [shared](const std::string& chunk) {
+        std::lock_guard lock(shared->mutex);
+        if (!shared->abandoned) shared->chunks.push_back(chunk);
     };
+
+    struct AbandonGuard {
+        std::shared_ptr<Shared> shared;
+        ~AbandonGuard() {
+            std::lock_guard lock(shared->mutex);
+            shared->abandoned = true;
+            shared->chunks.clear();
+        }
+    } abandon_guard{shared};
 
     // params is captured by value so the worker thread doesn't
     // outlive the caller's stack-allocated CompletionParams. The
     // CancelToken inside params (shared_ptr) keeps its target alive
     // through the worker.
-    std::thread([this, params, wrapped, shared, done, exec]() mutable {
+    std::thread([this, params, wrapped, shared]() mutable {
+        std::optional<ChatCompletion> result;
+        std::exception_ptr err;
         try {
-            shared->result = this->complete_stream(params, wrapped);
+            result = this->complete_stream(params, wrapped);
         } catch (...) {
-            shared->err = std::current_exception();
+            err = std::current_exception();
         }
-        // Wake the awaiter on its executor.
-        asio::dispatch(exec, [done]() { done->cancel(); });
+        {
+            std::lock_guard lock(shared->mutex);
+            shared->result = std::move(result);
+            shared->err = err;
+            shared->finished = true;
+        }
     }).detach();
 
-    // Suspend until the worker fires cancel(). async_wait completes
-    // with operation_aborted on cancel — we don't care about the ec
-    // value, only that we resumed.
-    asio::error_code ec;
-    co_await done->async_wait(asio::redirect_error(asio::use_awaitable, ec));
+    asio::steady_timer poll(exec);
+    for (;;) {
+        std::vector<std::string> chunks;
+        std::optional<ChatCompletion> result;
+        std::exception_ptr err;
+        bool finished = false;
+        {
+            std::lock_guard lock(shared->mutex);
+            chunks.swap(shared->chunks);
+            finished = shared->finished;
+            if (finished) {
+                result = std::move(shared->result);
+                err = shared->err;
+            }
+        }
 
-    if (shared->err) std::rethrow_exception(shared->err);
-    co_return std::move(*shared->result);
+        if (on_chunk) {
+            for (const auto& chunk : chunks) on_chunk(chunk);
+        }
+        if (finished) {
+            if (err) std::rethrow_exception(err);
+            co_return std::move(*result);
+        }
+
+        poll.expires_after(std::chrono::milliseconds(1));
+        asio::error_code ec;
+        co_await poll.async_wait(asio::redirect_error(asio::use_awaitable, ec));
+    }
 }
 
 // v1.0 unified invoke() — additive virtual that future-proofs the

--- a/src/llm/schema_provider.cpp
+++ b/src/llm/schema_provider.cpp
@@ -1654,43 +1654,84 @@ SchemaProvider::complete_stream_async(const CompletionParams& params,
     // `http_thread_`): the thread is warm after the first call, all
     // subsequent calls reuse the warmed state.
     //
-    // Tokens are still dispatched onto the awaiter's executor (so the
-    // user's `on_chunk` runs single-threaded with the awaiting
-    // coroutine — same invariant the post-PR-#10 base default
-    // provides).
+    // The bridge thread only writes to shared state. The awaiting
+    // coroutine drains queued tokens on its own executor, preserving
+    // the callback-thread invariant without letting late bridge work
+    // retain or use an executor whose io_context may be gone.
     auto exec = co_await asio::this_coro::executor;
     auto bridge_exec = bridge_io_->get_executor();
 
     struct Shared {
+        std::mutex mutex;
+        bool abandoned = false;
+        bool finished = false;
+        std::vector<std::string> chunks;
         std::optional<ChatCompletion> result;
         std::exception_ptr err;
     };
     auto shared = std::make_shared<Shared>();
 
-    auto done = std::make_shared<asio::steady_timer>(exec);
-    done->expires_at(std::chrono::steady_clock::time_point::max());
-
-    StreamCallback wrapped = [exec, on_chunk](const std::string& chunk) {
-        asio::dispatch(exec, [on_chunk, chunk]() { on_chunk(chunk); });
+    StreamCallback wrapped = [shared](const std::string& chunk) {
+        std::lock_guard lock(shared->mutex);
+        if (!shared->abandoned) shared->chunks.push_back(chunk);
     };
+
+    struct AbandonGuard {
+        std::shared_ptr<Shared> shared;
+        ~AbandonGuard() {
+            std::lock_guard lock(shared->mutex);
+            shared->abandoned = true;
+            shared->chunks.clear();
+        }
+    } abandon_guard{shared};
 
     // params copied by value so the bridge thread's work item doesn't
     // outlive the caller's stack-allocated CompletionParams.
     asio::dispatch(bridge_exec,
-        [this, params, wrapped, shared, done, exec]() mutable {
+        [this, params, wrapped, shared]() mutable {
+            std::optional<ChatCompletion> result;
+            std::exception_ptr err;
             try {
-                shared->result = this->complete_stream(params, wrapped);
+                result = this->complete_stream(params, wrapped);
             } catch (...) {
-                shared->err = std::current_exception();
+                err = std::current_exception();
             }
-            asio::dispatch(exec, [done]() { done->cancel(); });
+            {
+                std::lock_guard lock(shared->mutex);
+                shared->result = std::move(result);
+                shared->err = err;
+                shared->finished = true;
+            }
         });
 
-    asio::error_code ec;
-    co_await done->async_wait(asio::redirect_error(asio::use_awaitable, ec));
+    asio::steady_timer poll(exec);
+    for (;;) {
+        std::vector<std::string> chunks;
+        std::optional<ChatCompletion> result;
+        std::exception_ptr err;
+        bool finished = false;
+        {
+            std::lock_guard lock(shared->mutex);
+            chunks.swap(shared->chunks);
+            finished = shared->finished;
+            if (finished) {
+                result = std::move(shared->result);
+                err = shared->err;
+            }
+        }
 
-    if (shared->err) std::rethrow_exception(shared->err);
-    co_return std::move(*shared->result);
+        if (on_chunk) {
+            for (const auto& chunk : chunks) on_chunk(chunk);
+        }
+        if (finished) {
+            if (err) std::rethrow_exception(err);
+            co_return std::move(*result);
+        }
+
+        poll.expires_after(std::chrono::milliseconds(1));
+        asio::error_code ec;
+        co_await poll.async_wait(asio::redirect_error(asio::use_awaitable, ec));
+    }
 }
 
 // ============================================================================

--- a/tests/test_provider_async_default.cpp
+++ b/tests/test_provider_async_default.cpp
@@ -25,6 +25,10 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <future>
+#include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <thread>
 #include <vector>
@@ -337,4 +341,131 @@ TEST(ProviderAsyncDefault, StreamAsyncBridgeRethrowsWorkerException) {
 
     ASSERT_TRUE(caught);
     EXPECT_THROW(std::rethrow_exception(caught), std::runtime_error);
+}
+
+struct WorkerExitState {
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool exited = false;
+};
+
+struct WorkerExitToken {
+    std::shared_ptr<WorkerExitState> state;
+
+    ~WorkerExitToken() {
+        std::lock_guard lock(state->mutex);
+        state->exited = true;
+        state->cv.notify_all();
+    }
+};
+
+struct WorkerExitError {
+    std::shared_ptr<WorkerExitToken> token;
+};
+
+class AbandonedStreamingProvider : public Provider {
+  public:
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool entered = false;
+    bool released = false;
+    std::shared_ptr<WorkerExitState> exit_state =
+        std::make_shared<WorkerExitState>();
+
+    ChatCompletion complete(const CompletionParams&) override { return {}; }
+
+    ChatCompletion complete_stream(const CompletionParams&,
+                                   const StreamCallback& on_chunk) override {
+        {
+            std::unique_lock lock(mutex);
+            entered = true;
+            cv.notify_all();
+            cv.wait(lock, [&] { return released; });
+        }
+
+        on_chunk("late");
+        throw WorkerExitError{std::make_shared<WorkerExitToken>(exit_state)};
+    }
+
+    std::string get_name() const override { return "abandoned-stream"; }
+};
+
+void retain_until_worker_exit(
+    std::shared_ptr<AbandonedStreamingProvider> provider) {
+    auto state = provider->exit_state;
+    std::thread([provider = std::move(provider), state] {
+        std::unique_lock lock(state->mutex);
+        state->cv.wait(lock, [&] { return state->exited; });
+    }).detach();
+}
+
+// Issue #127: stopping and destroying the outer io_context abandons the
+// coroutine while its synchronous stream worker is still running. The worker
+// must neither retain that io_context nor make its destruction wait for the
+// blocking stream to finish.
+TEST(ProviderAsyncDefault, AbandonedStreamNeverTouchesDestroyedIoContext) {
+    auto provider = std::make_shared<AbandonedStreamingProvider>();
+    CompletionParams params;
+    std::atomic<int> callbacks{0};
+    auto io = std::make_unique<asio::io_context>();
+
+    asio::co_spawn(
+        *io,
+        [&]() -> asio::awaitable<void> {
+            (void)co_await provider->complete_stream_async(
+                params, [&](const std::string&) { ++callbacks; });
+        },
+        asio::detached);
+
+    std::thread runner([&] { io->run(); });
+    bool entered = false;
+    {
+        std::unique_lock lock(provider->mutex);
+        entered = provider->cv.wait_for(
+            lock, std::chrono::seconds(2), [&] { return provider->entered; });
+    }
+    if (!entered) {
+        {
+            std::lock_guard lock(provider->mutex);
+            provider->released = true;
+        }
+        provider->cv.notify_all();
+        io->stop();
+        runner.join();
+        retain_until_worker_exit(std::move(provider));
+        ADD_FAILURE() << "stream worker did not start";
+        return;
+    }
+
+    io->stop();
+    runner.join();
+
+    auto destroyed = std::async(std::launch::async, [&] { io.reset(); });
+    EXPECT_EQ(destroyed.wait_for(std::chrono::seconds(1)),
+              std::future_status::ready)
+        << "io_context destruction waited for a blocking stream";
+
+    {
+        std::lock_guard lock(provider->mutex);
+        provider->released = true;
+    }
+    provider->cv.notify_all();
+
+    // The thrown exception remains owned by the bridge's shared state until
+    // the detached worker releases its last reference. Its token therefore
+    // gives the test a deterministic worker-exit signal without exposing a
+    // production synchronization hook.
+    auto exit_state = provider->exit_state;
+    bool exited = false;
+    {
+        std::unique_lock lock(exit_state->mutex);
+        exited = exit_state->cv.wait_for(
+            lock, std::chrono::seconds(2), [&] { return exit_state->exited; });
+    }
+    if (!exited) {
+        retain_until_worker_exit(std::move(provider));
+        ADD_FAILURE() << "stream worker did not exit";
+        return;
+    }
+    EXPECT_EQ(callbacks.load(), 0);
 }

--- a/tests/test_schema_provider_stream_async_outer_io.cpp
+++ b/tests/test_schema_provider_stream_async_outer_io.cpp
@@ -9,9 +9,8 @@
 // modes ended up racing on shared SchemaProvider state).
 //
 // Post-#10:
-//   - HTTP/SSE branch → `Provider::complete_stream_async`'s new default
-//     (dedicated worker thread for sync `complete_stream`, tokens
-//     dispatched back onto the awaiter's executor via `asio::dispatch`).
+//   - HTTP/SSE branch → SchemaProvider's long-lived bridge thread runs
+//     sync `complete_stream`; the awaiting coroutine drains queued tokens.
 //   - WS branch → `complete_stream_ws_responses` co_awaited directly,
 //     no worker thread (separate test:
 //     `test_schema_provider_ws_responses.cpp`).
@@ -40,6 +39,9 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <future>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -69,6 +71,52 @@ struct ResponsesMock {
         }
     }
     ~ResponsesMock() { svr.stop(); if (t.joinable()) t.join(); }
+};
+
+struct BlockingResponsesMock {
+    httplib::Server svr;
+    std::thread t;
+    int port = 0;
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool entered = false;
+    bool released = false;
+    bool finished = false;
+
+    explicit BlockingResponsesMock(std::string sse_body) {
+        svr.Post("/v1/responses",
+            [this, body = std::move(sse_body)]
+            (const httplib::Request&, httplib::Response& res) {
+                {
+                    std::unique_lock lock(mutex);
+                    entered = true;
+                    cv.notify_all();
+                    cv.wait(lock, [&] { return released; });
+                }
+                res.set_header("Content-Type", "text/event-stream");
+                res.set_content(body, "text/event-stream");
+                {
+                    std::lock_guard lock(mutex);
+                    finished = true;
+                    cv.notify_all();
+                }
+            });
+        port = svr.bind_to_any_port("127.0.0.1");
+        t = std::thread([this] { svr.listen_after_bind(); });
+        for (int i = 0; i < 200 && !svr.is_running(); ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+
+    ~BlockingResponsesMock() {
+        {
+            std::lock_guard lock(mutex);
+            released = true;
+        }
+        cv.notify_all();
+        svr.stop();
+        if (t.joinable()) t.join();
+    }
 };
 
 llm::SchemaProvider::Config cfg_for(int port) {
@@ -270,4 +318,78 @@ TEST(SchemaProviderStreamAsyncOuterIo, ConcurrentOuterCoroutinesDoNotRace) {
     for (int i = 0; i < kCallers; ++i) {
         EXPECT_EQ(finals[i], kKoreanFull) << "caller " << i;
     }
+}
+
+// Issue #127: destroying the outer io_context must abandon callback delivery
+// without waiting for a blocked synchronous HTTP/SSE request. SchemaProvider
+// itself remains alive until its owned bridge thread finishes.
+TEST(SchemaProviderStreamAsyncOuterIo,
+     AbandonedHttpStreamNeverTouchesDestroyedIoContext) {
+    BlockingResponsesMock mock{make_korean_sse()};
+    ASSERT_GT(mock.port, 0);
+
+    auto provider = llm::SchemaProvider::create(cfg_for(mock.port));
+    ASSERT_TRUE(provider);
+    std::atomic<int> callbacks{0};
+    auto io = std::make_unique<asio::io_context>();
+
+    asio::co_spawn(
+        *io,
+        [&]() -> asio::awaitable<void> {
+            auto p = params_with("ping");
+            (void)co_await provider->complete_stream_async(
+                p, [&](const std::string&) { ++callbacks; });
+        },
+        asio::detached);
+
+    std::thread runner([&] { io->run(); });
+    bool entered = false;
+    {
+        std::unique_lock lock(mock.mutex);
+        entered = mock.cv.wait_for(
+            lock, std::chrono::seconds(2), [&] { return mock.entered; });
+    }
+    if (!entered) {
+        {
+            std::lock_guard lock(mock.mutex);
+            mock.released = true;
+        }
+        mock.cv.notify_all();
+        io->stop();
+        runner.join();
+        provider.reset();
+        ADD_FAILURE() << "HTTP stream did not reach the mock server";
+        return;
+    }
+
+    io->stop();
+    runner.join();
+
+    auto destroyed = std::async(std::launch::async, [&] { io.reset(); });
+    EXPECT_EQ(destroyed.wait_for(std::chrono::seconds(1)),
+              std::future_status::ready)
+        << "io_context destruction waited for a blocking HTTP stream";
+
+    {
+        std::lock_guard lock(mock.mutex);
+        mock.released = true;
+    }
+    mock.cv.notify_all();
+    bool finished = false;
+    {
+        std::unique_lock lock(mock.mutex);
+        finished = mock.cv.wait_for(
+            lock, std::chrono::seconds(2), [&] { return mock.finished; });
+    }
+    if (!finished) {
+        mock.svr.stop();
+        provider.reset();
+        ADD_FAILURE() << "HTTP stream did not finish after release";
+        return;
+    }
+
+    // Joining SchemaProvider's owned bridge thread proves all late stream work
+    // has ended before checking that no abandoned callback was delivered.
+    provider.reset();
+    EXPECT_EQ(callbacks.load(), 0);
 }


### PR DESCRIPTION
## Summary
- keep synchronous stream workers independent of the awaiting executor
- queue chunks for delivery by the live coroutine and discard them after abandonment
- apply the same teardown-safe bridge to SchemaProvider HTTP/SSE while preserving the native WebSocket path
- document the remaining Provider lifetime requirement

## Verification
- ASan teardown regressions: 20 repeated passes
- focused Provider and SchemaProvider ASan suite: 13/13
- related invoke, CompletionProvider, OpenAI, RateLimited, and OpenInference ASan suite: 32/32
- full ASan suite: 632 passed, 31 environment-dependent tests skipped
- related TSan suite: 45/45
- git diff --check

## Lifetime boundary
The generic bridge still calls virtual complete_stream() through raw this. If the awaitable is abandoned, callers must keep the Provider alive until the synchronous transport returns. The bridge intentionally does not join that worker during coroutine or io_context teardown because a stalled HTTP request could otherwise block destruction indefinitely.

Fixes #127