### PR TITLE
fix(runtime): harden async production safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **취소 작업별 상태와 게시된 emit 수명 안전성.** `GraphEngine::run`, `run_async`,
+  `run_stream`, `run_stream_async`는 호출자가 준 parent에서 실행별 child를
+  하나씩 만들고, 그 child만 내부 `co_spawn`/sync bridge에 묶으며 같은
+  child를 `RunContext`로 전달한다. 따라서 parent 하나로 동시에 실행 중인
+  여러 run을 모두 취소해도 cancellation slot이 서로 덮이지 않는다.
+  Fork된 실행 child는 기존 `shared_ptr` 소유권을 게시된 emit까지 유지해
+  엔진 작업 종료와 emit 실행 사이의 use-after-free를 막는다.
+  취소 때문에 생긴 asio `operation_aborted`는 재시도 가능한 노드 오류가
+  아니라 `CancelledException`으로 전달한다.
+  `CancelToken`의 0.11.x 객체 배치와 inline/header-only 동작은 그대로다.
+  단, 외부 코드가 직접 만든 token에 `bind_executor()`를 호출한 경우에는
+  해당 executor의 게시 작업이 끝날 때까지 token을 살려 둘 책임이 여전히
+  호출자에게 있다.
 - **JARVIS mock 빌드 복구 (issue #130).** 음성 의존성이 없을 때
   `MicCapture`가 불완전한 타입으로 남아 `cookbook_jarvis` 컴파일이 실패하던
   문제를 수정했다. `NEOGRAPH_JARVIS_FORCE_MOCK`을 추가해 ASan CI가 runner의

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   취소 때문에 생긴 asio `operation_aborted`는 재시도 가능한 노드 오류가
   아니라 `CancelledException`으로 전달한다.
   `CancelToken`의 0.11.x 객체 배치와 inline/header-only 동작은 그대로다.
+  따라서 이미 컴파일된 C++ 소비자가 갱신된 `fork()` 수명 동작까지 받으려면
+  재컴파일해야 한다. 공유 라이브러리만 교체해도 객체 배치는 호환되지만,
+  소비자 바이너리에 들어간 기존 inline 본문은 바뀌지 않는다.
   단, 외부 코드가 직접 만든 token에 `bind_executor()`를 호출한 경우에는
   해당 executor의 게시 작업이 끝날 때까지 token을 살려 둘 책임이 여전히
   호출자에게 있다.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   단, 외부 코드가 직접 만든 token에 `bind_executor()`를 호출한 경우에는
   해당 executor의 게시 작업이 끝날 때까지 token을 살려 둘 책임이 여전히
   호출자에게 있다.
+- **PostgreSQL 비동기 연결의 전역 제한 시간 정책 명문화.** 비동기 최초
+  연결·교체는 모든 host/IP를 합쳐 하나의 제한 시간을 사용한다. 양수
+  `connect_timeout`은 최소 2초로 적용하고, 미지정·0·음수이면 운영 안전
+  기본값 30초를 사용한다. libpq의 host별 동기 제한 시간과 의도적으로
+  다르며, 동기 생성·교체 동작은 바꾸지 않았다.
 - **JARVIS mock 빌드 복구 (issue #130).** 음성 의존성이 없을 때
   `MicCapture`가 불완전한 타입으로 남아 `cookbook_jarvis` 컴파일이 실패하던
   문제를 수정했다. `NEOGRAPH_JARVIS_FORCE_MOCK`을 추가해 ASan CI가 runner의

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **Provider API 영구 호환 정책 (issue #5).** `Provider::complete()`,
+  `complete_async()`, `complete_stream()`, `complete_stream_async()`와 callback 기반
+  `invoke()`의 제거 계획을 철회하고 `[[deprecated]]` 경고를 없앴다. 기존 API에는
+  호환성·보안 수정을 계속 적용한다. 새 Provider 구현과 새 직접 호출에는 각각
+  `CompletionProvider::do_invoke()`와 `invoke_request(CompletionRequest)`를 권장하며,
+  새 기능을 기존 API에 모두 역이식하는 것은 보장하지 않는다. 공개 서명, virtual
+  순서, 객체 크기와 vtable은 바뀌지 않는다.
+
 ### Removed
 
 - **폐기된 TransformerCPP 연동 예제.** 더 이상 제공되지 않는 외부 저장소에

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   호출자에게 있다.
 - **PostgreSQL 비동기 연결의 전역 제한 시간 정책 명문화.** 비동기 최초
   연결·교체는 모든 host/IP를 합쳐 하나의 제한 시간을 사용한다. 양수
-  `connect_timeout`은 최소 2초로 적용하고, 미지정·0·음수이면 운영 안전
+  connection string에 직접 쓴 `connect_timeout`은 최소 2초로 적용하고,
+  미지정·0·음수이거나 환경변수·service file로만 지정한 값이면 운영 안전
   기본값 30초를 사용한다. libpq의 host별 동기 제한 시간과 의도적으로
   다르며, 동기 생성·교체 동작은 바꾸지 않았다.
 - **JARVIS mock 빌드 복구 (issue #130).** 음성 의존성이 없을 때

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1372,6 +1372,10 @@ if(NEOGRAPH_BUILD_TESTS)
     set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
 
+    if(NEOGRAPH_BUILD_ACP)
+        target_compile_definitions(neograph_acp PRIVATE NEOGRAPH_ACP_TESTING)
+    endif()
+
     enable_testing()
     add_subdirectory(tests)
 endif()

--- a/ROADMAP_v1.md
+++ b/ROADMAP_v1.md
@@ -316,10 +316,10 @@ each**. After they land:
   safe" decision. The user overrides `run(NodeInput)`. Sync vs
   async, stream vs non-stream, writes vs full-result are all body
   shape choices — no hidden invariants tied to virtual identity.
-- **Candidate 6** (Provider 4 → 1): same collapse for `Provider`.
-  The "X is safe only when Y" trap of #4/#5 cannot recur because
-  there is no Y to violate — there's only one entry point and
-  one canonical drain pattern.
+- **Candidate 6** (Provider 4 → 1): new implementations use
+  `CompletionProvider::do_invoke()` as their one override point. The
+  existing `Provider` surface remains stable for compatibility, while
+  the new path has one explicit request mode and one drain pattern.
 
 The remaining 2 findings (#9 thread identity, #16 ODR macro) are
 *not* fixed by Candidates 1 + 6 — they're separate issue classes
@@ -373,7 +373,7 @@ the class. Candidate 1 + 6 do.
 | 3 | Hierarchical CancelToken | **Landed in v0.4** (`CancelToken::fork()` + cascade) | v0.3.2 hooks, v0.3.2 emit-vs-bind |
 | 4 | Self-evolving graph runtime hooks | Research | TODO_v0.3.md #8 |
 | 5 | pgvector RAG example | Cookbook | TODO_v0.3.md #9 |
-| 6 | Provider single dispatch | **Landed (additive + deprecation)** v0.9.0 candidate — PR #40 / #41+#42 / #43 / #44 / #45. Phase B (legacy 4 virtual 제거) v1.0.0 대기. | #4 (closed v0.7), #5 (open as v1.0 tracking item), pattern reinforced by #36 |
+| 6 | Provider single dispatch | **Landed without removal.** `CompletionProvider::do_invoke()` is the recommended one-override path. Existing `Provider::complete*` methods remain supported; deprecation warnings were withdrawn and no removal is planned. | #4 (closed v0.7), #5 (compatibility policy), pattern reinforced by #36 |
 
 ---
 
@@ -876,31 +876,26 @@ necessary, and the safety of the bridge depends on which corner of
 the cross-product you override (an invariant nothing pins at
 compile time).
 
-### Suggested direction (v1.0)
+### Landed direction
 
-Async-first single dispatch:
+The one-override path is additive rather than a replacement:
 
 ```cpp
-class Provider {
+class CompletionProvider : public Provider {
 public:
-    // Only thing native subclasses override.
-    virtual asio::awaitable<CompletionStream>
-    invoke(CompletionRequest req) = 0;
+    asio::awaitable<ChatCompletion>
+    invoke_request(CompletionRequest request);
+
+protected:
+    virtual asio::awaitable<ChatCompletion>
+    do_invoke(CompletionRequest request) = 0;
 };
 ```
 
-`CompletionStream` is a sender / awaitable / channel — the caller
-picks how to drain it (collect-to-end for sync, await-final for
-non-streaming async, iterate for streaming). Sync + non-streaming
-variants become thin base-class adapters that apply `run_sync`
-exactly once at the outermost boundary, never composed with each
-other. Native subclasses only ship the async-streaming path
-because it's a strict superset of the rest.
-
-Pair with Candidate 1 (GraphNode 8-virtual flattening) — same
-shape, same fix, should land in the same v1.0 cycle so the
-"override one virtual" contract is consistent across the public
-surface.
+`CompletionRequest` explicitly selects collect or stream mode without
+inferring transport from callback presence. Final adapters preserve all
+existing `Provider` entry points. This gives new implementations one
+override while leaving existing source and binary contracts intact.
 
 ### Adjacent — `schema_provider.cpp` split
 
@@ -913,9 +908,9 @@ split if the work happens in different PRs.
 
 ### Triggering round
 
-Issue #5 — surfaced while debugging #4. Concrete crash closed by
-PR #10; architectural cleanup deferred to v1.0 alongside
-Candidate 1.
+Issue #5 — surfaced while debugging #4. The concrete crash closed in
+PR #10; the architectural cleanup landed through the additive
+`CompletionProvider` path and a permanent compatibility policy.
 
 ### Landing log (v0.9.0 candidate cycle)
 
@@ -936,10 +931,11 @@ Candidate 1.
 기존 네 virtual과 callback 기반 `invoke()`는 final adapter를 통해 새 구현에
 연결되며, 기존 Provider subclass와 Python trampoline은 그대로 유지된다.
 
-legacy virtual 제거는 v1.0의 전제 조건이 아니다. 충분한 외부 이전 기간,
-Python 새 계약, `SOVERSION` 분리, downstream binary 검증이 모두 준비된 이후의
-주요 버전에서만 다시 판단한다. #127의 native async transport와 operation
-ownership은 이 additive API와 별도로 구현해야 한다.
+기존 virtual은 안정 API로 계속 지원하며 제거 계획이 없다. 호환성·보안 수정은
+계속 적용하지만, 새 기능을 기존 네 virtual에 모두 역이식할 의무는 없다.
+새 구현과 새 직접 호출은 각각 `do_invoke()`와 `invoke_request()`를 권장한다.
+이 정책은 기존 공개 서명, virtual 순서, 객체 크기, vtable을 바꾸지 않는다.
+#127의 native async transport와 operation ownership은 이 API 정책과 별도다.
 
 후속 작업:
 

--- a/bindings/python/neograph_engine/openinference.py
+++ b/bindings/python/neograph_engine/openinference.py
@@ -353,6 +353,8 @@ class OpenInferenceProvider(Provider):
                  *, span_name: str = "llm.complete"):
         super().__init__()
         _require_otel()
+        if inner is None:
+            raise ValueError("OpenInferenceProvider requires a non-null provider")
         self._inner = inner
         self._tracer = tracer
         self._span_name = span_name
@@ -363,30 +365,99 @@ class OpenInferenceProvider(Provider):
         except Exception:
             return "openinference(provider)"
 
-    def complete(self, params):
-        from opentelemetry.trace import Status, StatusCode
+    def _start_span(self):
+        try:
+            manager = self._tracer.start_as_current_span(self._span_name)
+            return manager, manager.__enter__()
+        except BaseException:
+            return None, None
 
-        with self._tracer.start_as_current_span(self._span_name) as span:
+    @staticmethod
+    def _end_span(manager, exc_info=(None, None, None)) -> None:
+        if manager is None:
+            return
+        try:
+            manager.__exit__(*exc_info)
+        except BaseException:
+            pass
+
+    @staticmethod
+    def _set_error(span, error: BaseException) -> None:
+        if span is None:
+            return
+        try:
+            from opentelemetry.trace import Status, StatusCode
+            span.set_status(Status(StatusCode.ERROR, str(error)))
+        except BaseException:
+            pass
+
+    def complete(self, params):
+        manager, span = self._start_span()
+        if span is not None:
             try:
                 self._record_input(span, params)
-            except Exception:
+            except BaseException:
                 pass
 
-            try:
-                result = self._inner.complete(params)
-            except Exception as e:
-                try:
-                    span.set_status(Status(StatusCode.ERROR, str(e)))
-                except Exception:
-                    pass
-                raise
+        try:
+            result = self._inner.complete(params)
+        except BaseException as error:
+            self._set_error(span, error)
+            self._end_span(
+                manager, (type(error), error, error.__traceback__))
+            raise
 
+        if span is not None:
             try:
+                from opentelemetry.trace import Status, StatusCode
                 self._record_output(span, result)
                 span.set_status(Status(StatusCode.OK))
-            except Exception:
+            except BaseException:
                 pass
-            return result
+        self._end_span(manager)
+        return result
+
+    def complete_stream(self, params, on_chunk):
+        manager, span = self._start_span()
+        if span is not None:
+            try:
+                self._record_input(span, params)
+            except BaseException:
+                pass
+
+        chunks = []
+
+        def traced_chunk(chunk):
+            try:
+                chunks.append(chunk)
+            except BaseException:
+                pass
+            if span is not None:
+                try:
+                    span.add_event("llm.token", {"chunk": chunk})
+                except BaseException:
+                    pass
+            if on_chunk is not None:
+                on_chunk(chunk)
+
+        try:
+            result = self._inner.complete_stream(params, traced_chunk)
+        except BaseException as error:
+            self._set_error(span, error)
+            self._end_span(
+                manager, (type(error), error, error.__traceback__))
+            raise
+
+        if span is not None:
+            try:
+                from opentelemetry.trace import Status, StatusCode
+                self._record_output(span, result)
+                span.set_attribute(_OI_OUTPUT_VALUE, "".join(chunks))
+                span.set_status(Status(StatusCode.OK))
+            except BaseException:
+                pass
+        self._end_span(manager)
+        return result
 
     def _record_input(self, span, params) -> None:
         span.set_attribute(_OI_SPAN_KIND, "LLM")

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -59,7 +59,6 @@
 #include <neograph/graph/sqlite_checkpoint.h>
 #endif
 
-#include <asio/bind_cancellation_slot.hpp>
 #include <asio/cancellation_signal.hpp>
 #include <asio/co_spawn.hpp>
 #include <asio/executor_work_guard.hpp>
@@ -1076,15 +1075,10 @@ void init_graph(py::module_& m) {
         // Python-defined Store / CheckpointStore trampoline instances; the
         // C++ shared_ptr alone is not enough to preserve those overrides.
         //
-        // Lifetime contract for coroutine parameters: run_async,
-        // run_stream_async, and resume_async all take parameters by
-        // const reference. Coroutine frames store the *reference*,
-        // not a copy of the referent — when the binding lambda
-        // returns, the local `cfg` (or `thread_id` / `rv`) is
-        // destroyed and the coroutine's reference dangles. We
-        // sidestep this by heap-copying inputs into a shared_ptr
-        // that the completion lambda also captures, so the storage
-        // outlives the coroutine.
+        // run_async and run_stream_async own their config/callback values in
+        // their coroutine frames. The shared_ptr holders here also keep the
+        // Python-facing objects and resume_async's reference parameters alive
+        // until the completion callback runs.
         .def("run_async",
             [](py::object self_obj, RunConfig cfg) {
                 auto self = self_obj.cast<std::shared_ptr<GraphEngine>>();
@@ -1098,8 +1092,8 @@ void init_graph(py::module_& m) {
 
                 // v0.3: ensure a cancel_token is always present on the
                 // RunConfig the engine sees. If the user supplied one
-                // we honour it; else allocate a fresh one so the asio
-                // co_spawn slot wiring below has something to bind.
+                // we honour it; else allocate a fresh parent for Future.cancel
+                // to trip. GraphEngine forks and binds an operation child.
                 if (!cfg.cancel_token) {
                     cfg.cancel_token = std::make_shared<CancelToken>();
                 }
@@ -1110,8 +1104,8 @@ void init_graph(py::module_& m) {
                 // add_done_callback fires once when the future
                 // transitions to done, including the CANCELLED state.
                 // The token then sets its atomic flag (engine super-
-                // step polls it) AND emits its asio cancellation_signal
-                // (propagates down through co_await chain to the
+                // step polls its child) AND cascades to the operation child's
+                // asio cancellation_signal (propagates down through co_await to
                 // ConnPool::async_post socket op, killing the in-
                 // flight LLM HTTP request — the v0.2.3 cost-leak fix).
                 py::cpp_function on_done(
@@ -1126,24 +1120,14 @@ void init_graph(py::module_& m) {
                     });
                 future.attr("add_done_callback")(on_done);
 
-                // Bind the cancel slot at co_spawn so asio's per-
-                // operation cancellation propagates through every
-                // co_await down to socket I/O. Token's executor is
-                // bound on first use inside the engine; the spawn
-                // executor is the same AsyncRuntime singleton.
-                cancel_tok->bind_executor(
-                    AsyncRuntime::instance().executor());
-
                 asio::co_spawn(
                     AsyncRuntime::instance().executor(),
                     self->run_async(*cfg_h),
-                    asio::bind_cancellation_slot(
-                        cancel_tok->slot(),
-                        [self, self_h, cfg_h, fut_h, loop_h, cancel_tok]
+                    [self, self_h, cfg_h, fut_h, loop_h, cancel_tok]
                         (std::exception_ptr e, RunResult result) {
                             resolve_future_async(fut_h, loop_h, e,
                                                  std::move(result));
-                        }));
+                        });
 
                 return future;
             },
@@ -1195,9 +1179,6 @@ void init_graph(py::module_& m) {
                         }
                     });
                 future.attr("add_done_callback")(on_done);
-
-                cancel_tok->bind_executor(
-                    AsyncRuntime::instance().executor());
 
                 // The user's py::function lives in a shared_ptr with
                 // a GIL-acquiring deleter so std::function copies on
@@ -1253,14 +1234,12 @@ void init_graph(py::module_& m) {
                 asio::co_spawn(
                     AsyncRuntime::instance().executor(),
                     self->run_stream_async(*cfg_h, *engine_cb_h),
-                    asio::bind_cancellation_slot(
-                        cancel_tok->slot(),
-                        [self, self_h, cfg_h, engine_cb_h, fut_h, loop_h,
-                         cancel_tok]
+                    [self, self_h, cfg_h, engine_cb_h, fut_h, loop_h,
+                          cancel_tok]
                         (std::exception_ptr e, RunResult result) {
                             resolve_future_async(fut_h, loop_h, e,
                                                  std::move(result));
-                        }));
+                        });
 
                 return future;
             },

--- a/bindings/python/src/bind_provider.cpp
+++ b/bindings/python/src/bind_provider.cpp
@@ -110,10 +110,9 @@ class PyProvider : public neograph::Provider {
             py::get_override(static_cast<const neograph::Provider*>(this),
                              "complete_stream");
         if (override) {
-            // Python on_chunk: pass a callable that re-locks the GIL
-            // before forwarding to the C++ callback so the user can
-            // call `on_chunk(token)` cleanly.
-            auto py_on_chunk = py::cpp_function([&on_chunk](const std::string& tok) {
+            // Own a callback copy so a Python override may retain the
+            // callable without dangling after this virtual call returns.
+            auto py_on_chunk = py::cpp_function([on_chunk](const std::string& tok) {
                 if (on_chunk) on_chunk(tok);
             });
             auto r = override(params, py_on_chunk);
@@ -338,6 +337,22 @@ void init_provider(py::module_& m) {
             py::arg("temperature") = 0.7,
             py::arg("max_tokens")  = -1,
             py::arg("tools")       = py::list{})
+        .def("complete_stream", [](neograph::Provider& self,
+                                    const neograph::CompletionParams& p,
+                                    py::object on_chunk) {
+            neograph::StreamCallback callback;
+            if (!on_chunk.is_none()) {
+                auto fn = on_chunk.cast<py::function>();
+                callback = [fn = std::move(fn)](const std::string& chunk) {
+                    py::gil_scoped_acquire gil;
+                    fn(chunk);
+                };
+            }
+            // Declared after callback on purpose: reverse destruction
+            // reacquires the GIL before callback releases its py::function.
+            py::gil_scoped_release release;
+            return self.complete_stream(p, callback);
+        }, py::arg("params"), py::arg("on_chunk"))
         .def("get_name", &neograph::Provider::get_name);
 
     // ── Tool base (opaque, no Python subclass yet) ───────────────────────

--- a/bindings/python/src/bind_provider.cpp
+++ b/bindings/python/src/bind_provider.cpp
@@ -22,11 +22,13 @@
 #include <neograph/tool.h>
 #include <neograph/types.h>
 
+#include <pybind11/functional.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
 #include <memory>
 #include <string>
+#include <thread>
 
 #ifdef NEOGRAPH_PYBIND_HAS_LLM
 #include <neograph/llm/openai_provider.h>
@@ -130,6 +132,50 @@ class PyProvider : public neograph::Provider {
         PYBIND11_OVERRIDE_PURE(std::string,
                                neograph::Provider, get_name,);
     }
+};
+
+class CallbackThreadProvider : public neograph::Provider {
+  public:
+    neograph::ChatCompletion
+    complete(const neograph::CompletionParams&) override {
+        return make_completion();
+    }
+
+    neograph::ChatCompletion
+    complete_stream(const neograph::CompletionParams&,
+                    const neograph::StreamCallback& on_chunk) override {
+        std::thread worker([this, callback = on_chunk]() mutable {
+            worker_started_without_gil_ = PyGILState_Check() == 0;
+            auto retained = callback;
+            callback("one");
+            retained("-");
+            callback("two");
+            retained = {};
+            callback = {};
+            worker_finished_without_gil_ = PyGILState_Check() == 0;
+        });
+        worker.join();
+        return make_completion();
+    }
+
+    std::string get_name() const override { return "callback-thread-test"; }
+    bool worker_started_without_gil() const {
+        return worker_started_without_gil_;
+    }
+    bool worker_finished_without_gil() const {
+        return worker_finished_without_gil_;
+    }
+
+  private:
+    static neograph::ChatCompletion make_completion() {
+        neograph::ChatCompletion result;
+        result.message.role = "assistant";
+        result.message.content = "one-two";
+        return result;
+    }
+
+    bool worker_started_without_gil_ = false;
+    bool worker_finished_without_gil_ = false;
 };
 
 }  // namespace
@@ -337,23 +383,26 @@ void init_provider(py::module_& m) {
             py::arg("temperature") = 0.7,
             py::arg("max_tokens")  = -1,
             py::arg("tools")       = py::list{})
+        // pybind11 v2.13.6 functional.h wraps Python callables in func_handle,
+        // which acquires the GIL for invocation, copying, and destruction.
         .def("complete_stream", [](neograph::Provider& self,
                                     const neograph::CompletionParams& p,
-                                    py::object on_chunk) {
-            neograph::StreamCallback callback;
-            if (!on_chunk.is_none()) {
-                auto fn = on_chunk.cast<py::function>();
-                callback = [fn = std::move(fn)](const std::string& chunk) {
-                    py::gil_scoped_acquire gil;
-                    fn(chunk);
-                };
-            }
-            // Declared after callback on purpose: reverse destruction
-            // reacquires the GIL before callback releases its py::function.
+                                    neograph::StreamCallback callback) {
             py::gil_scoped_release release;
             return self.complete_stream(p, callback);
         }, py::arg("params"), py::arg("on_chunk"))
         .def("get_name", &neograph::Provider::get_name);
+
+    py::class_<CallbackThreadProvider, neograph::Provider,
+               std::shared_ptr<CallbackThreadProvider>>(
+        m, "_CallbackThreadProvider")
+        .def(py::init<>())
+        .def_property_readonly(
+            "worker_started_without_gil",
+            &CallbackThreadProvider::worker_started_without_gil)
+        .def_property_readonly(
+            "worker_finished_without_gil",
+            &CallbackThreadProvider::worker_finished_without_gil);
 
     // ── Tool base (opaque, no Python subclass yet) ───────────────────────
     py::class_<neograph::Tool, std::shared_ptr<neograph::Tool>>(m, "Tool",

--- a/bindings/python/tests/test_openinference.py
+++ b/bindings/python/tests/test_openinference.py
@@ -13,6 +13,7 @@ import json
 import pytest
 
 import neograph_engine as ng
+from neograph_engine import _neograph as _native
 
 pytest.importorskip("opentelemetry")
 
@@ -394,6 +395,19 @@ def test_provider_binding_retained_stream_callback_remains_safe():
 
     assert result.message.content == "complete"
     assert received == ["late"]
+
+
+def test_native_provider_copies_and_destroys_callback_without_gil():
+    provider = _native._CallbackThreadProvider()
+    received = []
+
+    result = provider.complete_stream(
+        ng.CompletionParams(), received.append)
+
+    assert result.message.content == "one-two"
+    assert received == ["one", "-", "two"]
+    assert provider.worker_started_without_gil
+    assert provider.worker_finished_without_gil
 
 
 class _TestSpan:

--- a/bindings/python/tests/test_openinference.py
+++ b/bindings/python/tests/test_openinference.py
@@ -68,6 +68,17 @@ class _FakeProvider(ng.Provider):
         return result
 
 
+class _FakeStreamingProvider(_FakeProvider):
+    def __init__(self, chunks):
+        super().__init__(reply="".join(chunks))
+        self._chunks = chunks
+
+    def complete_stream(self, params, on_chunk):
+        for chunk in self._chunks:
+            on_chunk(chunk)
+        return self.complete(params)
+
+
 # ── A NeoGraph node that calls the provider once ────────────────────
 
 class _LLMNode(ng.GraphNode):
@@ -322,3 +333,146 @@ def test_provider_wrapper_propagates_exceptions(tracer_and_exporter):
     # Status is ERROR after we set it; OTel SDK exposes status_code via
     # status object on the readable span.
     assert spans[0].status.status_code.name == "ERROR"
+
+
+def test_provider_exposes_incremental_complete_stream(tracer_and_exporter):
+    """The Python Provider surface must retain each native stream chunk."""
+    tracer, exporter = tracer_and_exporter
+    wrapped = OpenInferenceProvider(
+        _FakeStreamingProvider(["one", "-", "two"]), tracer)
+    params = ng.CompletionParams()
+    received = []
+
+    result = wrapped.complete_stream(params, received.append)
+
+    assert result.message.content == "one-two"
+    assert received == ["one", "-", "two"]
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert [event.attributes["chunk"] for event in spans[0].events] == [
+        "one", "-", "two"]
+    assert spans[0].attributes["output.value"] == "one-two"
+
+
+def test_provider_binding_exposes_complete_stream_fallback():
+    """Concrete/native Providers can be streamed through the Python base API."""
+    inner = _FakeProvider(reply="single chunk")
+    received = []
+
+    result = ng.Provider.complete_stream(
+        inner, ng.CompletionParams(), received.append)
+
+    assert result.message.content == "single chunk"
+    assert received == ["single chunk"]
+
+
+def test_provider_binding_preserves_incremental_stream_chunks():
+    inner = _FakeStreamingProvider(["one", "-", "two"])
+    received = []
+
+    result = ng.Provider.complete_stream(
+        inner, ng.CompletionParams(), received.append)
+
+    assert result.message.content == "one-two"
+    assert received == ["one", "-", "two"]
+
+
+def test_provider_binding_retained_stream_callback_remains_safe():
+    class _RetainingProvider(_FakeProvider):
+        retained_callback = None
+
+        def complete_stream(self, params, on_chunk):
+            self.retained_callback = on_chunk
+            return self.complete(params)
+
+    inner = _RetainingProvider(reply="complete")
+    received = []
+
+    result = ng.Provider.complete_stream(
+        inner, ng.CompletionParams(), received.append)
+    inner.retained_callback("late")
+
+    assert result.message.content == "complete"
+    assert received == ["late"]
+
+
+class _TestSpan:
+    def __init__(self, failure=None):
+        self.failure = failure
+
+    def set_attribute(self, *args):
+        if self.failure == "attribute":
+            raise RuntimeError("trace attribute failed")
+
+    def set_status(self, *args):
+        if self.failure == "attribute":
+            raise RuntimeError("trace status failed")
+
+    def add_event(self, *args, **kwargs):
+        if self.failure == "attribute":
+            raise RuntimeError("trace event failed")
+
+
+class _TracingContext:
+    def __init__(self, failure=None):
+        self.failure = failure
+
+    def __enter__(self):
+        if self.failure == "enter":
+            raise RuntimeError("trace enter failed")
+        return _TestSpan(self.failure)
+
+    def __exit__(self, *args):
+        if self.failure == "exit":
+            raise RuntimeError("trace exit failed")
+
+
+class _UnreliableTracer:
+    def __init__(self, failure):
+        self.failure = failure
+
+    def start_as_current_span(self, name):
+        if self.failure == "start":
+            raise RuntimeError("trace start failed")
+        return _TracingContext(self.failure)
+
+
+class _BoomProvider(_FakeProvider):
+    def complete(self, params):
+        raise ValueError("inner failure")
+
+    def complete_stream(self, params, on_chunk):
+        raise ValueError("inner failure")
+
+
+@pytest.mark.parametrize("failure", ["start", "enter", "attribute", "exit"])
+@pytest.mark.parametrize("streaming", [False, True])
+def test_tracing_failure_does_not_block_inner_call(failure, streaming):
+    inner = (_FakeStreamingProvider(["one", "-", "two"])
+             if streaming else _FakeProvider(reply="still called"))
+    wrapped = OpenInferenceProvider(
+        inner, _UnreliableTracer(failure))
+
+    received = []
+    if streaming:
+        result = wrapped.complete_stream(
+            ng.CompletionParams(), received.append)
+    else:
+        result = wrapped.complete(ng.CompletionParams())
+
+    assert result.message.content == ("one-two" if streaming else "still called")
+    if streaming:
+        assert received == ["one", "-", "two"]
+
+
+@pytest.mark.parametrize("failure", ["start", "enter", "attribute", "exit"])
+@pytest.mark.parametrize("streaming", [False, True])
+def test_tracing_failure_does_not_replace_inner_exception(failure, streaming):
+    wrapped = OpenInferenceProvider(
+        _BoomProvider(), _UnreliableTracer(failure))
+
+    with pytest.raises(ValueError, match="inner failure"):
+        if streaming:
+            wrapped.complete_stream(ng.CompletionParams(), lambda chunk: None)
+        else:
+            wrapped.complete(ng.CompletionParams())

--- a/docs/ASYNC_GUIDE.md
+++ b/docs/ASYNC_GUIDE.md
@@ -17,7 +17,7 @@ Every synchronous I/O point in the engine now has an awaitable peer:
 
 | Layer | Sync (unchanged) | Async peer |
 |---|---|---|
-| Provider | `complete` / `complete_stream` | `complete_async` |
+| Provider | `complete` / `complete_stream` | `complete_async` / `complete_stream_async` |
 | CheckpointStore | `save` / `load_latest` / `load_by_id` / `list` / `delete_thread` / `put_writes` / `get_writes` / `clear_writes` | `*_async` for each |
 | GraphNode | `execute` / `execute_stream` / `execute_full` / `execute_full_stream` | `*_async` for each |
 | GraphEngine | `run` / `run_stream` / `resume` | `run_async` / `run_stream_async` / `resume_async` |
@@ -31,7 +31,7 @@ invocations without dedicating an OS thread per run — the concurrency
 model that motivated the whole refactor.
 
 Sync surfaces are preserved. Existing code that calls `engine->run(cfg)`
-or `provider->complete(params)` keeps working bit-for-bit. The 276+
+or any `provider->complete*` entry point remains supported. The 276+
 test cases that existed before Stage 3 still pass against the sync
 path.
 
@@ -116,18 +116,22 @@ calling `io.run()` — see `examples/27_async_concurrent_runs.cpp`.
 
 ### 3.2 Writing a new async provider
 
-Implement only `complete_async`. The sync `complete` comes free
-through the base-class bridge (fresh `io_context` per call), so
-users that call your provider through the sync API still work.
+Derive from `CompletionProvider` and implement only `do_invoke()`.
+Its final adapters keep every existing `Provider` entry point working,
+while `CompletionRequest` makes collect versus stream mode explicit.
 
 ```cpp
-class MyProvider : public Provider {
+class MyProvider : public CompletionProvider {
   public:
     asio::awaitable<ChatCompletion>
-    complete_async(const CompletionParams& params) override {
+    do_invoke(CompletionRequest request) override {
         auto ex = co_await asio::this_coro::executor;
+        const auto& params = request.params();
         auto res = co_await neograph::async::async_post(
             ex, host, port, path, body, headers, /*tls=*/true);
+        if (request.streaming() && request.on_chunk()) {
+            // Deliver parsed chunks through request.on_chunk().
+        }
         co_return parse_response(res);
     }
 
@@ -470,7 +474,7 @@ guide tells you which member of the contract to implement.
 | Async-I/O `GraphNode`, no `Command` / `Send` | `execute_async()` | sync `execute()` + both `_full` variants (but see §9.2.2 pitfall #2) |
 | Async-I/O `GraphNode` that emits `Command` / `Send` | `execute_full_async()` | every other peer |
 | Streaming LLM node (cb-driven token emission) | see §9.2 quadrant table | — |
-| Custom `Provider` (real HTTP/LLM backend) | `complete_async()` | sync `complete()` bridges via `run_sync` |
+| New custom LLM backend | inherit `CompletionProvider`, override `do_invoke()` | all existing `Provider` entry points are final adapters |
 | Custom `CheckpointStore`, async-capable backend | all eight `*_async` peers | sync peers bridge via `run_sync` |
 | Custom `CheckpointStore`, sync-only backend | all eight sync peers | async peers bridge via `run_sync` |
 | Custom sync `Tool` | inherit `Tool`, override `execute()` | — |
@@ -546,20 +550,23 @@ stack-overflows.
 
 ### 9.3 `Provider`
 
-Three virtuals: `complete`, `complete_async`, `complete_stream`
-(sync-only — no `complete_stream_async`).
+Existing `Provider` subclasses may keep using the four sync/async collect/stream
+virtuals. They are stable compatibility APIs with no removal planned and no
+deprecation warnings. Each pair still requires at least one override:
 
 | Override | Behaviour |
 |---|---|
 | `complete()` only | Sync works directly; async `complete_async` bridges via the base-class default `co_return complete()`. Fine for CPU-only mock providers. |
-| `complete_async()` only (**recommended** for real backends) | Async works directly; sync `complete` bridges via `run_sync(complete_async())`. One fresh `io_context` per sync call — acceptable for the admin-tool sync surface, would be wasteful for hot loops. |
-| Both | Hand-tune both paths. Only worth it if the async peer needs to avoid `run_sync` init overhead on the sync path. |
+| `complete_async()` only | Async works directly; sync `complete` bridges via `run_sync(complete_async())`. |
+| `complete_stream()` only | Sync streaming works directly; the async peer runs it on a worker thread and delivers callbacks on the awaiting executor. |
+| `complete_stream_async()` only | Native async streaming works directly; implement a sync peer too if direct sync streaming calls must avoid the default collect fallback. |
 
-`complete_stream(params, cb)` is sync-only by design — SSE delivery
-is inherently per-chunk, and the cb-based shape maps poorly to
-awaitable-returning wrappers. The default delegates to `complete()`
-and invokes `cb` once with the full result. Override when your
-backend natively streams and you want per-token emission.
+For a **new** backend, do not choose among these pairs. Derive from
+`CompletionProvider`, implement `do_invoke(CompletionRequest)`, and use
+`request.streaming()` to select the transport. New direct callers should use
+`invoke_request()` with `CompletionRequest::collect(...)` or
+`CompletionRequest::stream(...)`. Compatibility and security fixes continue on
+the old entry points, but new capabilities may be explicit-request-only.
 
 ### 9.4 `CheckpointStore`
 

--- a/docs/ASYNC_GUIDE.md
+++ b/docs/ASYNC_GUIDE.md
@@ -352,9 +352,9 @@ and so on.
 - [ ] If your custom nodes do real I/O → override `execute_async`.
 - [ ] If your tools do real I/O → derive from `AsyncTool`, override
       `execute_async`.
-- [ ] If you use the Postgres checkpoint store → still sync under
-      the hood (Sem 3.3 pending); expect a future breaking change
-      when libpq pipeline mode lands.
+- [ ] If you use the Postgres checkpoint store → use its `*_async`
+      methods on shared event loops. They use libpq's nonblocking wire
+      protocol and a coroutine-friendly connection pool.
 - [ ] Measure. The value axis is concurrency; if your workload
       isn't concurrency-bound, don't migrate.
 
@@ -362,9 +362,9 @@ and so on.
 
 ## 7. What's not covered yet
 
-* **Postgres checkpoint store** — still uses libpqxx sync; its
-  `save_async` routes through `run_sync`. A full libpq-pipeline
-  rewrite is tracked as Sem 3.3.
+* **Postgres pipeline mode** — async checkpoint methods already use
+  nonblocking libpq I/O, but they do not yet batch multiple commands
+  through libpq pipeline mode.
 * **`async::HttpResponse` headers map** — the response surface only
   exposes status / body / retry_after / location. Arbitrary header
   access (e.g. MCP session ID header tracking) is a Sem 1

--- a/docs/migration-v0.4-to-v1.0.md
+++ b/docs/migration-v0.4-to-v1.0.md
@@ -282,51 +282,39 @@ grep -lE 'execute\(const GraphState' src/**/*.cpp
 
 ---
 
-# Migration 2: 옛 4 `Provider` virtual → 새 `Provider::invoke()` (v0.9 → v1.0)
+# Migration 2: `Provider` 호환 정책과 새 명시적 요청 API (v0.9+)
 
-GraphNode 8 virtual → `run(NodeInput)` 와 같은 모양의 두 번째 통합.
-ROADMAP_v1.md **Candidate 6** 에 해당. v0.9.0 에서 새 `invoke()` 가
-landing + 옛 4 virtual 이 `[[deprecated]]` 마킹됨. v1.0.0 에서 옛
-4 virtual 삭제.
+기존 `Provider::complete*` 네 메서드와 callback 기반 `invoke()`는 안정 API로
+계속 지원하며 제거 계획이 없다. 기존 구현과 호출자는 옮기지 않아도 된다.
+다만 새 Provider 구현에는 `CompletionProvider::do_invoke()` 하나를 재정의하는
+방식을, 새 직접 호출에는 `invoke_request(CompletionRequest)`를 권장한다.
 
-## 시그니처 매핑
+## 기존 호출과 권장 새 호출
 
-| 옛 virtual | 새 모양 |
+| 안정 호환 API | `CompletionProvider`를 직접 쓸 때 권장하는 API |
 |---|---|
-| `complete(params)` | `co_await invoke(params, nullptr)` (코루틴) 또는 `neograph::async::run_sync(invoke(params, nullptr))` (sync) |
-| `complete_async(params)` | `co_await invoke(params, nullptr)` |
-| `complete_stream(params, on_chunk)` | `neograph::async::run_sync(invoke(params, on_chunk))` |
-| `complete_stream_async(params, on_chunk)` | `co_await invoke(params, on_chunk)` |
+| `complete(params)` | `run_sync(invoke_request(CompletionRequest::collect(params)))` |
+| `complete_async(params)` | `co_await invoke_request(CompletionRequest::collect(params))` |
+| `complete_stream(params, on_chunk)` | `run_sync(invoke_request(CompletionRequest::stream(params, on_chunk)))` |
+| `complete_stream_async(params, on_chunk)` | `co_await invoke_request(CompletionRequest::stream(params, on_chunk))` |
 
-**핵심 규칙**: `on_chunk == nullptr` 이면 비스트리밍, `on_chunk` 가 있으면
-스트리밍. 한 메서드가 두 케이스 다 처리.
+`CompletionRequest`는 callback 유무와 전송 방식을 분리한다. 따라서 callback이
+없어도 `CompletionRequest::stream(params)`로 streaming 전송을 명시할 수 있다.
+`Provider&`나 `Provider*`만 가진 코드는 기존 `complete*`를 그대로 쓰면 된다.
 
 ## 케이스별 변환
 
-### Provider 호출하는 사용자 코드
+### Provider를 호출하는 사용자 코드
 
 ```cpp
-// 옛 — async 컨텍스트에서
+// 안정 호환 API — 계속 지원됨
 auto completion = co_await provider->complete_async(params);
-
-// 새 — 같은 의미
-auto completion = co_await provider->invoke(params, nullptr);
 ```
 
 ```cpp
-// 옛 — sync 함수 안에서
-auto completion = provider->complete(params);
-
-// 새 — async 어웨이트할 io_context 가 없으면 run_sync 로 brige
-auto completion = neograph::async::run_sync(provider->invoke(params, nullptr));
-```
-
-```cpp
-// 옛 — 스트리밍
-auto completion = co_await provider->complete_stream_async(params, on_chunk);
-
-// 새 — invoke 가 같은 분기를 자기 안에서 함
-auto completion = co_await provider->invoke(params, on_chunk);
+// CompletionProvider를 직접 쓰는 새 코드 — mode가 명시적
+auto completion = co_await provider.invoke_request(
+    CompletionRequest::collect(params));
 ```
 
 ### 사용자 정의 Provider subclass
@@ -388,7 +376,7 @@ auto streamed_without_observer = co_await provider.invoke_request(
     CompletionRequest::stream(params));
 ```
 
-기존 네 virtual과 `invoke(params, on_chunk)`는 호환 기간 동안 그대로 동작한다.
+기존 네 virtual과 `invoke(params, on_chunk)`는 계속 지원된다.
 `CompletionProvider`의 final adapter가 모든 기존 진입점을 `do_invoke()`로 한 번만
 연결하므로 상호 재귀가 생기지 않는다.
 
@@ -409,14 +397,13 @@ explicit cancel_token 안 주면 그냥 cancel 못 받음 (예전과 동일).
 
 ## 마이그레이션 안 하면
 
-현재 호환 기간:
-- 옛 4 virtual override 그대로 동작
-- `-Wdeprecated-declarations` warning 이 user override / 호출 사이트에 visible
-- engine 내부 forwarder 는 `NEOGRAPH_PUSH_IGNORE_DEPRECATED` 가드 됨 — internal warning 0
+아무 조치도 필요 없다:
+- 기존 네 virtual 재정의와 직접 호출은 그대로 동작한다.
+- Provider 관련 `-Wdeprecated-declarations` 경고는 더 이상 발생하지 않는다.
+- 호환성·보안 수정은 기존 API에도 적용한다.
 
-제거 버전은 정하지 않았다. 실제 외부 Provider와 Python subclass의 이전 기간,
-별도 SONAME, downstream binary 검증을 갖춘 뒤 주요 버전에서만 검토한다.
-경고는 이전을 권장하지만 즉시 삭제를 뜻하지 않는다.
+기존 API 제거 계획은 없다. 다만 새 기능은 명시적 요청 계약에만 추가될 수
+있으므로, 새 구현은 `CompletionProvider`로 작성하는 편이 낫다.
 
 ## 자동 변환 가능?
 
@@ -429,8 +416,8 @@ grep -rnE '->complete(_async|_stream|_stream_async)?\(' your/code
 # 그 다음 케이스별로 손편집 (위 매핑표 참고).
 ```
 
-Provider subclass 의 4 virtual override → invoke() 통합은 로직이 섞여
-있어서 손편집 필수.
+기존 Provider subclass를 `CompletionProvider::do_invoke()` 하나로 합치는 작업은
+선택 사항이며, 로직이 섞여 있어서 손편집이 필요하다.
 
 ## 관련 문서 / 이슈
 
@@ -440,8 +427,8 @@ Provider subclass 의 4 virtual override → invoke() 통합은 로직이 섞여
   flattening) 의 상세 설계 메모
 - [troubleshooting.md](troubleshooting.md) — 실제 옮기다 부딪치는
   컴파일 에러 / 런타임 차이 정리
-- [Issue #5](https://github.com/fox1245/NeoGraph/issues/5) — 같은 패턴
-  을 `Provider` 에도 적용하는 v1.0 Candidate 6 추적용
+- [Issue #5](https://github.com/fox1245/NeoGraph/issues/5) — Provider의
+  한 메서드 구현 경로와 영구 호환 정책 결정 기록
 
 ---
 

--- a/docs/python-binding.md
+++ b/docs/python-binding.md
@@ -463,12 +463,12 @@ LangGraph Python — surfaced here so you don't hit them mid-port:
   with declared fields (Pydantic v2) for typed access:
   `class ChatState(ng.StateView): messages: list[dict] = []` then
   `engine.get_state_view(thread_id, model=ChatState)`.
-- **Python `Provider` subclasses bind only `complete` (sync)** —
-  `Provider.complete_async` is not bound on Python user-defined
-  Provider subclasses, so a custom Python Provider always serves
-  through the sync entry. For async-native provider integrations
-  (HTTP/2 multiplexing, true overlap with other coroutines), stay
-  in C++ and subclass `neograph::llm::Provider` there.
+- **Python `Provider` subclasses bind only the sync `complete` and
+  `complete_stream` methods** — async virtuals are not bound on Python
+  user-defined Provider subclasses, so custom Python providers serve through
+  sync entries. For async-native provider integrations (HTTP/2 multiplexing,
+  true overlap with other coroutines), stay in C++ and derive from
+  `neograph::CompletionProvider` there.
 - **One-line token emit** — `from neograph_engine.streaming import
   emit_token`, then `emit_token(cb, self._name, token)` inside a
   streaming node. Replaces the 4-line `GraphEvent` construction

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -1138,6 +1138,13 @@ Cooperative cancel primitive shared between caller and engine. Construct
 via `std::make_shared<CancelToken>()`, hand to `RunConfig.cancel_token`,
 and call `cancel()` from any thread to abort the in-flight run —
 including the LLM HTTP socket if a node is mid-`provider.complete_async`.
+Each engine run forks its own operation child, so one parent can safely cancel
+multiple concurrent runs without sharing an asio cancellation slot.
+
+Engine operation children retain themselves until their posted cancellation
+emit executes. If application code calls `bind_executor()` directly on a token
+it constructed itself, the application must keep that token alive until the
+executor drains; the engine cannot supply ownership for an external object.
 
 ```cpp
 class CancelToken {

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -283,15 +283,15 @@ of missing fields.
 
 ## 2. Provider Interface
 
-**Header:** `<neograph/provider.h>`
+**Headers:** `<neograph/provider.h>`, `<neograph/completion_provider.h>`
 **Namespace:** `neograph`
 
 The abstract interface for LLM backends. Implement this to add support for any LLM API.
 
-> **Writing a custom Provider subclass?** See
-> [`ASYNC_GUIDE.md` §9.3](ASYNC_GUIDE.md#93-provider) for the
-> decision matrix on whether to override `complete()`,
-> `complete_async()`, or both.
+> **Writing a new Provider implementation?** Derive from
+> `CompletionProvider` and implement `do_invoke()`. Existing `Provider`
+> subclasses and `complete*` callers remain supported with no removal planned.
+> See [`ASYNC_GUIDE.md` §9.3](ASYNC_GUIDE.md#93-provider).
 
 ### StreamCallback
 
@@ -328,7 +328,9 @@ struct CompletionParams {
 
 ### Provider
 
-Abstract base class for LLM providers. All LLM backends must implement this interface.
+Stable compatibility base class for LLM providers. Existing implementations and
+callers may continue to use this interface. New implementations should prefer
+`CompletionProvider` below.
 
 ```cpp
 class Provider {
@@ -345,16 +347,20 @@ public:
     virtual asio::awaitable<ChatCompletion>
     complete_async(const CompletionParams& params);
 
-    // Streaming completion (sync). Default body bridges to async peer.
+    // Streaming completion (sync). Default emits the collected result once.
     virtual ChatCompletion complete_stream(const CompletionParams& params,
                                            const StreamCallback& on_chunk);
 
-    // Async streaming peer. Added in audit Round 4 so async-native
-    // backends can override only this side. Default body bridges to
-    // complete_stream via run_sync.
+    // Async streaming peer. The default runs complete_stream on a worker
+    // thread and delivers callbacks on the awaiting executor.
     virtual asio::awaitable<ChatCompletion>
     complete_stream_async(const CompletionParams& params,
                           const StreamCallback& on_chunk);
+
+    // Stable callback-selected compatibility entry point.
+    virtual asio::awaitable<ChatCompletion>
+    invoke(const CompletionParams& params,
+           StreamCallback on_chunk = nullptr);
 
     // Only pure virtual on this interface — every backend must name
     // itself.
@@ -368,12 +374,50 @@ public:
 | `complete_async(params)` | Coroutine peer. Default `co_return complete(params)`. |
 | `complete_stream(params, on_chunk)` | Streaming completion. Calls `on_chunk` per chunk, returns the assembled `ChatCompletion`. |
 | `complete_stream_async(params, on_chunk)` | Async streaming peer (Round 4). Same `on_chunk` semantics. |
+| `invoke(params, on_chunk)` | Callback-selected compatibility entry point used by existing engine code. |
 | `get_name()` | Human-readable provider identifier (only pure virtual). |
 
 **Override-at-least-one-side contract**: each `(sync, async)` pair
 defaults to the other; overriding neither yields infinite mutual
 recursion at call time. Same shape as `CheckpointStore`'s sync↔async
 bridge below.
+
+These methods have no planned removal and no deprecation warnings. Compatibility
+and security fixes continue to apply; new capabilities may be exposed only through
+the explicit request API.
+
+### CompletionProvider
+
+Recommended base class for new C++ provider implementations. It preserves every
+`Provider` entry point through final adapters while giving implementations one
+request-mode-aware override.
+
+```cpp
+class MyProvider : public neograph::CompletionProvider {
+public:
+    asio::awaitable<ChatCompletion>
+    do_invoke(CompletionRequest request) override {
+        if (request.streaming()) {
+            // Use the streaming transport even when no observer is attached.
+            // If present, request.on_chunk() receives incremental text.
+        } else {
+            // Use the collect transport.
+        }
+        co_return result;
+    }
+
+    std::string get_name() const override { return "my-provider"; }
+};
+```
+
+New direct calls should make transport mode explicit:
+
+```cpp
+auto full = co_await provider.invoke_request(
+    CompletionRequest::collect(params));
+auto streamed = co_await provider.invoke_request(
+    CompletionRequest::stream(params, on_chunk));
+```
 
 ---
 

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -1145,6 +1145,9 @@ Engine operation children retain themselves until their posted cancellation
 emit executes. If application code calls `bind_executor()` directly on a token
 it constructed itself, the application must keep that token alive until the
 executor drains; the engine cannot supply ownership for an external object.
+Because these methods are inline in the public header, existing C++ consumers
+must be recompiled to receive the updated `fork()` lifetime behavior. The
+`CancelToken` object layout remains binary-compatible with 0.11.x.
 
 ```cpp
 class CancelToken {

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -3243,7 +3243,10 @@ defaults. **Full reference:**
 `<neograph/graph/sqlite_checkpoint.h>`
 `PostgresCheckpointStore` — libpq-based, 3-table schema (`neograph_*`)
 with channel-blob deduplication keyed on
-`(thread_id, channel, version)`; LangGraph `PostgresSaver` parity.
+`(thread_id, channel, version)`; LangGraph `PostgresSaver` parity. Async
+initial/replacement connections use one global deadline across all hosts:
+positive `connect_timeout` (minimum 2s), otherwise a 30s safety default.
+Synchronous libpq connection timeout behavior is unchanged.
 `SqliteCheckpointStore` — same shape, single-file backend, fits the
 edge / single-host deployments.
 **Full reference:**

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -3248,7 +3248,9 @@ defaults. **Full reference:**
 with channel-blob deduplication keyed on
 `(thread_id, channel, version)`; LangGraph `PostgresSaver` parity. Async
 initial/replacement connections use one global deadline across all hosts:
-positive `connect_timeout` (minimum 2s), otherwise a 30s safety default.
+positive `connect_timeout` written directly in the connection string (minimum
+2s), otherwise a 30s safety default. Environment and service-file timeout
+values are not available before initial connection setup and use that default.
 Synchronous libpq connection timeout behavior is unchanged.
 `SqliteCheckpointStore` — same shape, single-file backend, fits the
 edge / single-host deployments.

--- a/docs/reference-ko.md
+++ b/docs/reference-ko.md
@@ -185,15 +185,15 @@ ChatMessage parse_response_message(const json& choice);
 
 ## 2. Provider 인터페이스
 
-**헤더:** `neograph/provider.h`
+**헤더:** `neograph/provider.h`, `neograph/completion_provider.h`
 **네임스페이스:** `neograph`
 
 LLM provider의 추상 인터페이스를 정의한다. OpenAI, Claude, Gemini 등 모든 provider가 이 인터페이스를 구현한다.
 
-> **커스텀 Provider를 작성하신다면?**
-> [`ASYNC_GUIDE.md` §9.3](ASYNC_GUIDE.md#93-provider) 의
-> 결정표 참조 — `complete()`, `complete_async()`, 혹은 둘 다
-> override할지 결정 가이드.
+> **새 커스텀 Provider를 작성하신다면?** `CompletionProvider`를 상속하고
+> `do_invoke()` 하나를 재정의하세요. 기존 `Provider` 구현과 `complete*` 호출은
+> 제거 계획 없이 계속 지원합니다. 자세한 내용은
+> [`ASYNC_GUIDE.md` §9.3](ASYNC_GUIDE.md#93-provider)을 참고하세요.
 
 ### 2.1 StreamCallback
 
@@ -223,19 +223,30 @@ struct CompletionParams {
 
 ### 2.3 Provider (추상 클래스)
 
+기존 구현과 호출자를 위한 안정 호환 인터페이스다. 컴파일러 폐기 경고가 없고
+제거 계획도 없다. 새 구현에는 아래 `CompletionProvider`를 권장한다.
+
 ```cpp
 class Provider {
 public:
     virtual ~Provider() = default;
 
-    // 동기 호출
-    virtual ChatCompletion complete(const CompletionParams& params) = 0;
+    virtual ChatCompletion complete(const CompletionParams& params);
 
-    // 스트리밍 호출: 토큰마다 on_chunk를 호출하고, 완료 시 전체 결과를 반환
+    virtual asio::awaitable<ChatCompletion>
+    complete_async(const CompletionParams& params);
+
     virtual ChatCompletion complete_stream(const CompletionParams& params,
-                                           const StreamCallback& on_chunk) = 0;
+                                           const StreamCallback& on_chunk);
 
-    // provider 이름 (예: "openai", "claude", "gemini")
+    virtual asio::awaitable<ChatCompletion>
+    complete_stream_async(const CompletionParams& params,
+                          const StreamCallback& on_chunk);
+
+    virtual asio::awaitable<ChatCompletion>
+    invoke(const CompletionParams& params,
+           StreamCallback on_chunk = nullptr);
+
     virtual std::string get_name() const = 0;
 };
 ```
@@ -243,32 +254,46 @@ public:
 | 메서드 | 설명 |
 |--------|------|
 | `complete()` | 블로킹 호출. 전체 응답이 생성된 후 반환 |
+| `complete_async()` | 코루틴 기반 비동기 호출 |
 | `complete_stream()` | 토큰이 생성될 때마다 `on_chunk`를 호출. 최종 `ChatCompletion`도 반환 |
+| `complete_stream_async()` | 비동기 스트리밍 호출 |
+| `invoke()` | callback 유무로 수집/스트리밍을 고르는 기존 호환 진입점 |
 | `get_name()` | provider 식별 문자열 |
 
-**커스텀 provider 구현 예:**
+각 동기/비동기 짝 중 적어도 하나는 재정의해야 한다. 기존 구현은 이 계약을
+그대로 사용해도 된다. 호환성·보안 수정은 계속 적용하지만, 새 기능은 명시적
+요청 API에만 추가될 수 있다.
+
+### 2.4 CompletionProvider (새 구현에 권장)
+
+`CompletionRequest`가 수집과 스트리밍을 명시적으로 구분하므로 callback이 없는
+스트리밍 요청도 표현할 수 있다. 구현자는 `do_invoke()` 하나만 재정의한다.
 
 ```cpp
-class MyProvider : public neograph::Provider {
+class MyProvider : public neograph::CompletionProvider {
 public:
-    neograph::ChatCompletion complete(const neograph::CompletionParams& params) override {
-        // HTTP 호출 등 구현
-        neograph::ChatCompletion result;
-        result.message.role = "assistant";
-        result.message.content = "응답 내용";
-        return result;
-    }
-
-    neograph::ChatCompletion complete_stream(
-        const neograph::CompletionParams& params,
-        const neograph::StreamCallback& on_chunk) override {
-        auto result = complete(params);
-        if (on_chunk) on_chunk(result.message.content);
-        return result;
+    asio::awaitable<neograph::ChatCompletion>
+    do_invoke(neograph::CompletionRequest request) override {
+        if (request.streaming()) {
+            // callback이 없어도 스트리밍 전송을 사용한다.
+            // callback이 있으면 request.on_chunk()(chunk)로 전달한다.
+        } else {
+            // 수집 전송으로 전체 응답을 받는다.
+        }
+        co_return result;
     }
 
     std::string get_name() const override { return "my_provider"; }
 };
+```
+
+새 직접 호출은 전송 방식을 명시한다.
+
+```cpp
+auto full = co_await provider.invoke_request(
+    neograph::CompletionRequest::collect(params));
+auto streamed = co_await provider.invoke_request(
+    neograph::CompletionRequest::stream(params, on_chunk));
 ```
 
 ---

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -366,9 +366,12 @@ The provider must support streaming. Currently:
 | `SchemaProvider("claude")` | ✓ SSE |
 | Custom Python `Provider` subclass | depends on your `complete_stream` impl |
 
-If you're using a custom provider, override `complete_stream_async` or
-the engine falls back to non-streaming `complete_async` and your
-TOKENS callback won't fire.
+For a custom Python `Provider`, override `complete_stream`; Python subclasses
+do not expose an async virtual override. For a new C++ backend, derive from
+`CompletionProvider` and handle `request.streaming()` in `do_invoke()`. Existing
+C++ `Provider` subclasses may continue to override `complete_stream()` or
+`complete_stream_async()`. Without a streaming implementation, the default emits
+the collected response as one chunk rather than incremental tokens.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -296,6 +296,25 @@ them — or use the `key=value` form:
 host=localhost user=neo password=p@ss dbname=neograph
 ```
 
+### Async Postgres reconnect times out after 30 seconds
+
+Async initial/replacement connections use one production-safety deadline for
+the entire attempt. A positive libpq `connect_timeout=N` sets that global
+budget in seconds, with `connect_timeout=1` rounded up to PostgreSQL's minimum
+of two seconds. If `connect_timeout` is absent, zero, or negative, NeoGraph
+uses 30 seconds.
+
+The budget spans every host and resolved IP in a multi-host connection string;
+it is not multiplied per host. This differs intentionally from synchronous
+libpq, where `connect_timeout` applies separately to each host. Synchronous
+`PostgresCheckpointStore` construction and replacement are unchanged.
+
+For example, this gives the complete async replacement attempt 60 seconds:
+
+```
+host=pg-a,pg-b dbname=neograph connect_timeout=60
+```
+
 ### Postgres `relation "neograph_checkpoints" does not exist`
 
 The store creates its tables on first use (`CREATE TABLE IF NOT EXISTS`).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -299,10 +299,13 @@ host=localhost user=neo password=p@ss dbname=neograph
 ### Async Postgres reconnect times out after 30 seconds
 
 Async initial/replacement connections use one production-safety deadline for
-the entire attempt. A positive libpq `connect_timeout=N` sets that global
-budget in seconds, with `connect_timeout=1` rounded up to PostgreSQL's minimum
-of two seconds. If `connect_timeout` is absent, zero, or negative, NeoGraph
-uses 30 seconds.
+the entire attempt. A positive `connect_timeout=N` written directly in the
+connection string sets that global budget in seconds, with `connect_timeout=1`
+rounded up to PostgreSQL's minimum of two seconds. If the explicit value is
+absent, zero, or negative, NeoGraph uses 30 seconds. `PGCONNECT_TIMEOUT` and
+service-file timeout values are resolved too late to bound the initial async
+connection step, so they also use the 30-second default; put the value directly
+in the connection string when the async deadline must differ.
 
 The budget spans every host and resolved IP in a multi-host connection string;
 it is not multiplied per host. This differs intentionally from synchronous

--- a/examples/49_openinference.cpp
+++ b/examples/49_openinference.cpp
@@ -170,15 +170,13 @@ int main() {
     PrintTracer tracer;
 
     // The session opens the CHAIN root span at construction. It must
-    // outlive the run; we hold it in a shared_ptr so the
-    // OpenInferenceProvider's parent_lookup lambda can grab it.
+    // outlive the run. The provider copies a safe child-span starter from it.
     auto session = std::make_shared<obs::OpenInferenceTracerSession>(
         obs::openinference_tracer(tracer));
 
     auto inner = std::make_shared<MockProvider>();
     auto traced = std::make_shared<obs::OpenInferenceProvider>(
-        inner, tracer,
-        [session]() -> obs::Span* { return session->current_parent(); });
+        inner, tracer, *session);
 
     NodeFactory::instance().register_type("talk",
         [traced](const std::string&, const json&, const NodeContext&) {

--- a/include/neograph/acp/server.h
+++ b/include/neograph/acp/server.h
@@ -41,6 +41,7 @@
 namespace neograph::acp {
 
 class ACPServer;
+struct ACPServerTestAccess;
 
 /**
  * @brief Map between ACP `ContentBlock[]` and the engine's channels.
@@ -284,6 +285,13 @@ class NEOGRAPH_API ACPServer {
                                     = std::chrono::seconds(30));
 
   private:
+    friend struct ACPServerTestAccess;
+
+    // Defined only in test builds. Kept private so the deterministic thread
+    // failure seams are not part of the production ACP API.
+    void fail_next_worker_launch_for_testing();
+    void fail_next_handle_message_for_testing();
+
     struct Impl;
     std::unique_ptr<Impl> impl_;
 };

--- a/include/neograph/async/run_sync.h
+++ b/include/neograph/async/run_sync.h
@@ -30,7 +30,9 @@
 #include <asio/bind_cancellation_slot.hpp>
 #include <asio/co_spawn.hpp>
 #include <asio/detached.hpp>
+#include <asio/error.hpp>
 #include <asio/io_context.hpp>
+#include <asio/system_error.hpp>
 #include <asio/thread_pool.hpp>
 
 #include <cstddef>
@@ -39,6 +41,63 @@
 #include <utility>
 
 namespace neograph::async {
+
+namespace detail {
+
+// Drive an engine operation using the exact child token already forked by the
+// GraphEngine entry point. The public run_sync(awaitable, CancelToken*) path
+// below intentionally forks because its raw token is a caller-owned parent;
+// using it here would create a grandchild and make RunContext's token differ
+// from the slot bound to the operation's co_spawn.
+template <typename T>
+T run_sync_operation(
+    asio::awaitable<T> aw,
+    std::shared_ptr<neograph::graph::CancelToken> operation) {
+    if (operation) {
+        operation->throw_if_cancelled("run_sync operation entry");
+    }
+
+    asio::io_context io;
+    std::optional<T> result;
+    std::exception_ptr err;
+
+    auto body = [&]() -> asio::awaitable<void> {
+        try {
+            result.emplace(co_await std::move(aw));
+        } catch (...) {
+            err = std::current_exception();
+        }
+        co_return;
+    };
+
+    if (operation) {
+        operation->bind_executor(io.get_executor());
+        asio::co_spawn(
+            io, body(),
+            asio::bind_cancellation_slot(operation->slot(), asio::detached));
+    } else {
+        asio::co_spawn(io, body(), asio::detached);
+    }
+    io.run();
+
+    if (err) {
+        if (operation && operation->is_cancelled()) {
+            try {
+                std::rethrow_exception(err);
+            } catch (const asio::system_error& error) {
+                if (error.code() == asio::error::operation_aborted) {
+                    throw neograph::graph::CancelledException(
+                        "run_sync operation aborted");
+                }
+            } catch (...) {
+            }
+        }
+        std::rethrow_exception(err);
+    }
+    return std::move(*result);
+}
+
+} // namespace detail
 
 /// Run @p aw to completion on a fresh single-threaded io_context
 /// and return its result. Any exception thrown inside the coroutine

--- a/include/neograph/completion_provider.h
+++ b/include/neograph/completion_provider.h
@@ -70,6 +70,8 @@ class NEOGRAPH_API CompletionRequest {
  *
  * This is a separate derived interface: Provider's object layout and vtable
  * are unchanged, and existing Provider subclasses require no source changes.
+ * The final methods below are stable adapters for existing callers. New direct
+ * calls should prefer invoke_request() so transport mode remains explicit.
  */
 class NEOGRAPH_API CompletionProvider : public Provider {
   public:
@@ -78,25 +80,20 @@ class NEOGRAPH_API CompletionProvider : public Provider {
     asio::awaitable<ChatCompletion>
     invoke_request(CompletionRequest request);
 
-    [[deprecated("use invoke_request(CompletionRequest::collect(...))")]]
     ChatCompletion complete(const CompletionParams& params) final override;
 
-    [[deprecated("use invoke_request(CompletionRequest::collect(...))")]]
     asio::awaitable<ChatCompletion>
     complete_async(const CompletionParams& params) final override;
 
-    [[deprecated("use invoke_request(CompletionRequest::stream(...))")]]
     ChatCompletion complete_stream(
         const CompletionParams& params,
         const StreamCallback& on_chunk) final override;
 
-    [[deprecated("use invoke_request(CompletionRequest::stream(...))")]]
     asio::awaitable<ChatCompletion>
     complete_stream_async(
         const CompletionParams& params,
         const StreamCallback& on_chunk) final override;
 
-    [[deprecated("use invoke_request() with an explicit CompletionRequest")]]
     asio::awaitable<ChatCompletion>
     invoke(const CompletionParams& params,
            StreamCallback on_chunk = nullptr) final override;

--- a/include/neograph/graph/cancel.h
+++ b/include/neograph/graph/cancel.h
@@ -93,6 +93,11 @@ public:
      * Safe to call before ``bind_executor()``: in that case only the
      * polling flag is set; whoever later binds the executor will
      * notice via ``is_cancelled()`` before any HTTP work has begun.
+     *
+     * Engine-created operation children retain themselves until a posted
+     * emit executes. A directly constructed token has no such ownership
+     * source: callers that use ``bind_executor()`` themselves must keep that
+     * token alive until the executor has drained all posted work.
      */
     void cancel() noexcept {
         if (cancelled_.exchange(true, std::memory_order_acq_rel)) {
@@ -107,12 +112,15 @@ public:
             ex_snapshot = ex_;
         }
         if (ex_snapshot) {
-            // Post the emit onto the strand that owns the signal —
-            // emit() is documented as not thread-safe across executors.
-            // The engine binds the same executor it co_spawns on.
-            asio::post(ex_snapshot, [this]() {
-                sig_.emit(asio::cancellation_type::all);
-            });
+            // A forked operation child records a weak self-reference and can
+            // retain itself through this posted emit. Directly constructed
+            // tokens return an empty keep_alive and preserve the 0.11.x
+            // caller-owned lifetime contract.
+            auto keep_alive = self_keep_alive_for_post();
+            asio::post(ex_snapshot,
+                       [this, keep_alive = std::move(keep_alive)]() {
+                           sig_.emit(asio::cancellation_type::all);
+                       });
         }
 
         // v1.0 (9c): the legacy ``add_cancel_hook`` / hooks_ iteration
@@ -130,7 +138,7 @@ public:
             std::lock_guard<std::mutex> lk(children_mu_);
             live_children.reserve(children_.size());
             for (auto& w : children_) {
-                if (auto sp = w.lock()) {
+                if (auto sp = w.lock(); sp && sp.get() != this) {
                     live_children.push_back(std::move(sp));
                 }
             }
@@ -156,6 +164,9 @@ public:
      * before the run started) the bind also schedules an immediate
      * emit so the just-spawned coroutine unwinds at its first
      * co_await checkpoint.
+     *
+     * @warning Outside GraphEngine, the caller owns the lifetime contract:
+     * keep a directly constructed token alive until the bound executor drains.
      */
     void bind_executor(asio::any_io_executor ex) {
         bool fire_immediately = false;
@@ -165,11 +176,17 @@ public:
             fire_immediately = cancelled_.load(std::memory_order_acquire);
         }
         if (fire_immediately) {
-            std::lock_guard<std::mutex> lk(mu_);
-            if (ex_) {
-                asio::post(ex_, [this]() {
-                    sig_.emit(asio::cancellation_type::all);
-                });
+            asio::any_io_executor ex_snapshot;
+            {
+                std::lock_guard<std::mutex> lk(mu_);
+                ex_snapshot = ex_;
+            }
+            if (ex_snapshot) {
+                auto keep_alive = self_keep_alive_for_post();
+                asio::post(ex_snapshot,
+                           [this, keep_alive = std::move(keep_alive)]() {
+                               sig_.emit(asio::cancellation_type::all);
+                           });
             }
         }
     }
@@ -207,12 +224,13 @@ public:
      * ``cancel()`` on the parent walks the live children list and
      * cascades — every child's signal fires on its own bound executor.
      *
-     *
      * **Lifetime / ownership**: returns a ``shared_ptr<CancelToken>``;
      * the parent stores a ``weak_ptr`` so a forked child that goes
      * out of scope is automatically pruned from the cascade list on
-     * the next ``cancel()`` / ``fork()``. The parent itself can outlive
-     * its children freely.
+     * the next ``cancel()`` / ``fork()``. A forked child also records a
+     * weak self-reference in its existing child list. A posted signal emit
+     * locks and captures that reference, retaining engine operation children
+     * until the emit has executed without changing ``CancelToken``'s layout.
      *
      * **Eager-cancel safety**: if the parent is already cancelled at
      * the time of ``fork()``, the new child is constructed with its
@@ -235,6 +253,14 @@ public:
         // shared_ptr ctor allocates the control block; cheap relative
         // to a real cancel scope (one io_context spin-up downstream).
         auto child = std::shared_ptr<CancelToken>(new CancelToken());
+
+        // Preserve the 0.11.x object layout by using the existing weak-child
+        // list as the ownership source for posted emits. cancel() excludes this
+        // self entry from parent-to-child propagation.
+        {
+            std::lock_guard<std::mutex> lk(child->children_mu_);
+            child->children_.push_back(child);
+        }
 
         {
             std::lock_guard<std::mutex> lk(children_mu_);
@@ -264,16 +290,25 @@ public:
     }
 
 private:
+    std::shared_ptr<CancelToken> self_keep_alive_for_post() {
+        std::lock_guard<std::mutex> lk(children_mu_);
+        for (auto& candidate : children_) {
+            if (auto self = candidate.lock(); self.get() == this) {
+                return self;
+            }
+        }
+        return {};
+    }
+
     std::atomic<bool>        cancelled_{false};
     mutable std::mutex       mu_;        // guards ex_ vs cancel() race
     asio::any_io_executor    ex_;        // bound by engine before HTTP I/O
     asio::cancellation_signal sig_;      // for asio operation cancel
 
-    // Hierarchical cascade list. Each entry is a child token
-    // produced by ``fork()``. ``cancel()`` walks live children and
-    // cascades. Stored as ``weak_ptr`` so a child that goes out of
-    // scope (its run_sync returned, run completed) is automatically
-    // pruned on the next ``cancel()`` / ``fork()`` traversal.
+    // Hierarchical cascade list. Entries are children produced by fork(); a
+    // forked token also keeps one weak self-entry so posted emits can retain
+    // the operation without adding a data member or changing the 0.11.x ABI.
+    // cancel() skips that self-entry while cascading.
     mutable std::mutex children_mu_;
     std::vector<std::weak_ptr<CancelToken>> children_;
 };

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -49,9 +49,10 @@ struct RunConfig {
      *
      * When set, the engine super-step loop polls
      * ``cancel_token->is_cancelled()`` between steps and bails with
-     * ``CancelledException``. The pybind binding additionally binds
-     * the token's ``cancellation_slot`` to the run's ``co_spawn`` so
-     * an in-flight LLM HTTP request gets aborted at the socket layer.
+     * ``CancelledException``. Each engine entry point forks an operation
+     * child and binds only that child's ``cancellation_slot`` to its internal
+     * work, so an in-flight LLM HTTP request gets aborted at the socket layer
+     * without sharing one slot across concurrent runs.
      *
      * Default ``nullptr`` → no cancellation; existing behaviour
      * unchanged for callers that haven't opted in.
@@ -120,8 +121,8 @@ struct RunConfig {
  * (Candidate 2: "Explicit RunContext for per-run metadata").
  */
 struct RunContext {
-    /// Cooperative cancel handle. Mirrors ``RunConfig::cancel_token``.
-    /// Null when the caller did not opt in.
+    /// Cooperative cancel handle. This is the operation child forked from
+    /// ``RunConfig::cancel_token``. Null when the caller did not opt in.
     std::shared_ptr<CancelToken> cancel_token;
 
     /// Token accounting sink for this run (issue #88). The engine always sets

--- a/include/neograph/graph/postgres_checkpoint.h
+++ b/include/neograph/graph/postgres_checkpoint.h
@@ -106,6 +106,18 @@ struct PgConn {
  * the connection eagerly and runs `ensure_schema()` so callers get
  * an immediate failure if credentials or DDL permissions are wrong,
  * rather than a delayed surprise on first save().
+ *
+ * ## Async connection deadline
+ *
+ * Async initial/replacement connection attempts use one NeoGraph-wide
+ * deadline for the complete attempt, including every host and resolved IP.
+ * A positive libpq `connect_timeout` supplies the deadline in seconds, with
+ * libpq's documented two-second minimum. If it is absent, zero, or negative,
+ * NeoGraph applies a 30-second production-safety default. This intentionally
+ * differs from libpq's synchronous per-host timeout semantics: an async
+ * multi-host attempt receives one budget rather than one budget per host.
+ * Synchronous construction and synchronous replacement retain native libpq
+ * behavior and are unchanged by this policy.
  */
 class NEOGRAPH_API PostgresCheckpointStore : public CheckpointStore {
 public:
@@ -159,9 +171,9 @@ public:
     // concurrent save_async calls across pool slots actually overlap
     // instead of serialising on the main worker thread.
     //
-    // Behaviour identical to the sync peers (same retry semantics,
-    // same broken-connection auto-replacement, same schema). Only the
-    // wire-level wait is non-blocking.
+    // Successful operations use the same storage schema and values as the
+    // sync peers. Async connection setup/replacement additionally follows
+    // the global deadline policy documented on this class.
 
     asio::awaitable<void> save_async(const Checkpoint& cp) override;
     asio::awaitable<std::optional<Checkpoint>>
@@ -225,6 +237,8 @@ private:
     static asio::awaitable<bool> wait_socket_either_for_test(int fd);
     static void set_async_connection_test_seams(int poll_delay_ms,
                                                 int timeout_ms);
+    static int async_connection_timeout_ms_for_test(
+        const std::string& conn_str);
 
     /// Original connection string, retained so individual pool slots
     /// can be rebuilt on demand after a broken-connection detection.

--- a/include/neograph/graph/postgres_checkpoint.h
+++ b/include/neograph/graph/postgres_checkpoint.h
@@ -220,6 +220,7 @@ private:
     asio::awaitable<size_t> acquire_slot_async();
     void release_slot(size_t idx);
     void rebuild_slot(size_t idx);
+    asio::awaitable<void> rebuild_slot_async(size_t idx);
     size_t waiter_count_for_test();
 
     /// Original connection string, retained so individual pool slots

--- a/include/neograph/graph/postgres_checkpoint.h
+++ b/include/neograph/graph/postgres_checkpoint.h
@@ -231,14 +231,14 @@ private:
     std::vector<std::unique_ptr<PgConn>> pool_;
 
     /// Free slot indices, drained on acquire and refilled on release.
-    /// Guarded by `pool_mutex_`; sync callers wait on `pool_cv_` while
-    /// async callers queue in `async_waiters_` without blocking an executor.
+    /// Guarded by `pool_mutex_`; sync and async callers join `waiters_`
+    /// in one FIFO order. Sync callers block on their waiter condition;
+    /// async callers suspend without blocking an executor.
     std::queue<size_t> free_;
     std::mutex pool_mutex_;
-    std::condition_variable pool_cv_;
 
-    struct AsyncSlotWaiter;
-    std::deque<std::shared_ptr<AsyncSlotWaiter>> async_waiters_;
+    struct SlotWaiter;
+    std::deque<std::shared_ptr<SlotWaiter>> waiters_;
 
     /// Cumulative count of connection slot replacements.
     /// Atomic so monitoring threads can read without taking the pool

--- a/include/neograph/graph/postgres_checkpoint.h
+++ b/include/neograph/graph/postgres_checkpoint.h
@@ -121,6 +121,11 @@ struct PgConn {
  * multi-host attempt receives one budget rather than one budget per host.
  * Synchronous construction and synchronous replacement retain native libpq
  * behavior and are unchanged by this policy.
+ *
+ * Cancelling an in-flight async query quarantines its pool connection and
+ * sends PostgreSQL's out-of-band cancel request on NeoGraph's bounded worker
+ * pool before closing that connection. The cancelled operation is never
+ * retried; the empty slot is rebuilt lazily by the next operation.
  */
 class NEOGRAPH_API PostgresCheckpointStore : public CheckpointStore {
 public:

--- a/include/neograph/graph/postgres_checkpoint.h
+++ b/include/neograph/graph/postgres_checkpoint.h
@@ -68,6 +68,7 @@
 #include <neograph/graph/checkpoint.h>
 #include <atomic>
 #include <condition_variable>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -79,6 +80,10 @@
 struct pg_conn;
 
 namespace neograph::graph {
+
+namespace test_access {
+class PostgresCheckpointStoreTestAccess;
+}
 
 /// RAII wrapper around a libpq PGconn. Owns the connection; closes
 /// via PQfinish in the destructor. Non-copyable, non-movable to match
@@ -115,7 +120,7 @@ public:
                                       size_t pool_size = 8);
 
     /// Number of times a pool slot's connection was replaced after a
-    /// broken-connection detection. Cumulative across the whole store;
+    /// broken connection or an interrupted async exchange. Cumulative;
     /// useful for monitoring (e.g. Prometheus gauge) and for tests that
     /// want to assert the retry path fired.
     size_t reconnect_count() const { return reconnect_count_; }
@@ -190,6 +195,11 @@ public:
     size_t blob_count();
 
 private:
+    // Constructs only the slot scheduler for deterministic pool tests.
+    // The friend test helper never calls a method that dereferences pool_.
+    struct PoolOnlyTag {};
+    explicit PostgresCheckpointStore(PoolOnlyTag, size_t pool_size);
+
     void ensure_schema();
 
     /// Execute a closure with the connection mutex held. Centralises
@@ -208,7 +218,9 @@ private:
     /// Acquire a free pool slot index (blocks if none available).
     /// MUST be paired with `release_slot`.
     size_t acquire_slot();
+    asio::awaitable<size_t> acquire_slot_async();
     void release_slot(size_t idx);
+    void rebuild_slot(size_t idx);
 
     /// Original connection string, retained so individual pool slots
     /// can be rebuilt on demand after a broken-connection detection.
@@ -219,15 +231,21 @@ private:
     std::vector<std::unique_ptr<PgConn>> pool_;
 
     /// Free slot indices, drained on acquire and refilled on release.
-    /// Guarded by `pool_mutex_`; callers wait on `pool_cv_` when empty.
+    /// Guarded by `pool_mutex_`; sync callers wait on `pool_cv_` while
+    /// async callers queue in `async_waiters_` without blocking an executor.
     std::queue<size_t> free_;
     std::mutex pool_mutex_;
     std::condition_variable pool_cv_;
 
-    /// Cumulative count of broken-connection-driven slot replacements.
+    struct AsyncSlotWaiter;
+    std::deque<std::shared_ptr<AsyncSlotWaiter>> async_waiters_;
+
+    /// Cumulative count of connection slot replacements.
     /// Atomic so monitoring threads can read without taking the pool
     /// mutex.
     std::atomic<size_t> reconnect_count_{0};
+
+    friend class test_access::PostgresCheckpointStoreTestAccess;
 };
 
 } // namespace neograph::graph

--- a/include/neograph/graph/postgres_checkpoint.h
+++ b/include/neograph/graph/postgres_checkpoint.h
@@ -222,6 +222,9 @@ private:
     void rebuild_slot(size_t idx);
     asio::awaitable<void> rebuild_slot_async(size_t idx);
     size_t waiter_count_for_test();
+    static asio::awaitable<bool> wait_socket_either_for_test(int fd);
+    static void set_async_connection_test_seams(int poll_delay_ms,
+                                                int timeout_ms);
 
     /// Original connection string, retained so individual pool slots
     /// can be rebuilt on demand after a broken-connection detection.

--- a/include/neograph/graph/postgres_checkpoint.h
+++ b/include/neograph/graph/postgres_checkpoint.h
@@ -68,7 +68,6 @@
 #include <neograph/graph/checkpoint.h>
 #include <atomic>
 #include <condition_variable>
-#include <deque>
 #include <memory>
 #include <mutex>
 #include <queue>
@@ -221,6 +220,7 @@ private:
     asio::awaitable<size_t> acquire_slot_async();
     void release_slot(size_t idx);
     void rebuild_slot(size_t idx);
+    size_t waiter_count_for_test();
 
     /// Original connection string, retained so individual pool slots
     /// can be rebuilt on demand after a broken-connection detection.
@@ -231,14 +231,11 @@ private:
     std::vector<std::unique_ptr<PgConn>> pool_;
 
     /// Free slot indices, drained on acquire and refilled on release.
-    /// Guarded by `pool_mutex_`; sync and async callers join `waiters_`
-    /// in one FIFO order. Sync callers block on their waiter condition;
-    /// async callers suspend without blocking an executor.
+    /// Guarded by `pool_mutex_`. Fair mixed waiter state lives in an
+    /// out-of-object sidecar so this exported class keeps its original ABI.
     std::queue<size_t> free_;
     std::mutex pool_mutex_;
-
-    struct SlotWaiter;
-    std::deque<std::shared_ptr<SlotWaiter>> waiters_;
+    std::condition_variable pool_cv_;  // Retained at its original ABI offset.
 
     /// Cumulative count of connection slot replacements.
     /// Atomic so monitoring threads can read without taking the pool

--- a/include/neograph/graph/postgres_checkpoint.h
+++ b/include/neograph/graph/postgres_checkpoint.h
@@ -111,9 +111,12 @@ struct PgConn {
  *
  * Async initial/replacement connection attempts use one NeoGraph-wide
  * deadline for the complete attempt, including every host and resolved IP.
- * A positive libpq `connect_timeout` supplies the deadline in seconds, with
- * libpq's documented two-second minimum. If it is absent, zero, or negative,
- * NeoGraph applies a 30-second production-safety default. This intentionally
+ * A positive `connect_timeout` written directly in @p conn_str supplies the
+ * deadline in seconds, with libpq's documented two-second minimum. Values from
+ * `PGCONNECT_TIMEOUT` or a service file are not available before the initial
+ * nonblocking connection step and therefore use NeoGraph's 30-second default.
+ * If the explicit value is absent, zero, or negative, NeoGraph also applies
+ * that production-safety default. This intentionally
  * differs from libpq's synchronous per-host timeout semantics: an async
  * multi-host attempt receives one budget rather than one budget per host.
  * Synchronous construction and synchronous replacement retain native libpq

--- a/include/neograph/llm/openai_provider.h
+++ b/include/neograph/llm/openai_provider.h
@@ -91,13 +91,10 @@ class NEOGRAPH_API OpenAIProvider : public Provider {
     ChatCompletion complete_stream(const CompletionParams& params,
                                    const StreamCallback& on_chunk) override;
 
-    /// v1.0 single-dispatch override (Candidate 6 PR6). Native invoke()
-    /// that directly drives the ConnPool — no extra hop through
-    /// `complete_stream_async`'s default worker-thread bridge for
-    /// streaming, no extra hop through `complete_async` for non-
-    /// streaming. The 4 legacy overrides above stay as thin adapters
-    /// over invoke() through the v0.9 deprecation window; v1.0 deletes
-    /// them along with the base-class virtuals.
+    /// Callback-selected compatibility override used by existing engine
+    /// code. It routes through the stable complete* methods above so the
+    /// async connection pool and streaming worker-thread bridge retain
+    /// their existing behavior.
     asio::awaitable<ChatCompletion>
     invoke(const CompletionParams& params, StreamCallback on_chunk) override;
 

--- a/include/neograph/llm/rate_limited_provider.h
+++ b/include/neograph/llm/rate_limited_provider.h
@@ -82,19 +82,15 @@ public:
     asio::awaitable<ChatCompletion>
     complete_async(const CompletionParams& params) override;
 
-    /// Streaming retry path remains synchronous — `complete_stream()`
-    /// has no awaitable peer on Provider, and async streaming through
-    /// the schema/openai providers still uses httplib. Once those
-    /// migrate this method can grow an awaitable cousin.
+    /// Synchronous streaming retry path. The inherited
+    /// `complete_stream_async()` peer runs this method through Provider's
+    /// worker-thread bridge so it does not block the awaiting executor.
     ChatCompletion complete_stream(const CompletionParams& params,
                                    const StreamCallback& on_chunk) override;
 
-    /// v1.0 single-dispatch override (Candidate 6 PR6). Anchors invoke()
-    /// on this decorator so engine `provider->invoke(...)` calls hit
-    /// retry/backoff directly. v0.9 body routes through the existing
-    /// 4-virtual overrides (which already wrap the inner provider with
-    /// retry); v1.0 folds the retry loop into invoke() and deletes the
-    /// legacy methods.
+    /// Callback-selected compatibility override. Engine
+    /// `provider->invoke(...)` calls route through the stable complete*
+    /// methods above and keep their retry/backoff behavior.
     asio::awaitable<ChatCompletion>
     invoke(const CompletionParams& params, StreamCallback on_chunk) override;
 

--- a/include/neograph/llm/schema_provider.h
+++ b/include/neograph/llm/schema_provider.h
@@ -162,13 +162,9 @@ class NEOGRAPH_API SchemaProvider : public Provider {
     complete_stream_async(const CompletionParams& params,
                           const StreamCallback& on_chunk) override;
 
-    /// v1.0 single-dispatch override (Candidate 6 PR6). Anchors the
-    /// dispatch surface — engine `provider->invoke(...)` calls land
-    /// here directly instead of bouncing through the base default that
-    /// re-forwards to the 4-virtual chain. v0.9 body routes through
-    /// existing native overrides (no behavioural change); v1.0 will
-    /// fold complete_async + complete_stream_async bodies into invoke()
-    /// and delete the legacy methods.
+    /// Callback-selected compatibility override. Engine
+    /// `provider->invoke(...)` calls land here and route through the
+    /// stable native overrides above without changing their behavior.
     asio::awaitable<ChatCompletion>
     invoke(const CompletionParams& params, StreamCallback on_chunk) override;
 

--- a/include/neograph/observability/openinference.h
+++ b/include/neograph/observability/openinference.h
@@ -62,7 +62,9 @@ namespace neograph::observability {
  * `close()` is also called by the destructor — explicit close is
  * recommended only when the user wants to inspect the tracer's
  * exported spans before the session goes out of scope (e.g. in
- * tests). Double-close is a no-op.
+ * tests). Double-close is a no-op. Copies of `cb` are safe to retain:
+ * they become no-ops after close/destruction, and `close()` waits for
+ * callbacks that already entered before finalizing their spans.
  */
 class NEOGRAPH_API OpenInferenceTracerSession {
 public:
@@ -72,7 +74,7 @@ public:
     OpenInferenceTracerSession();
     ~OpenInferenceTracerSession();
 
-    // Non-copyable, movable.
+    // Non-copyable, movable. Move assignment closes the target first.
     OpenInferenceTracerSession(const OpenInferenceTracerSession&) = delete;
     OpenInferenceTracerSession& operator=(const OpenInferenceTracerSession&) = delete;
     OpenInferenceTracerSession(OpenInferenceTracerSession&&) noexcept;

--- a/include/neograph/observability/openinference.h
+++ b/include/neograph/observability/openinference.h
@@ -191,13 +191,10 @@ public:
     complete_stream_async(const CompletionParams& params,
                           const StreamCallback& on_chunk) override;
 
-    /// v1.0 single-dispatch override (Candidate 6 PR6). Anchors
-    /// invoke() so engine `provider->invoke(...)` calls land here
-    /// directly and emit one span, instead of the base default
-    /// re-forwarding to the 4-virtual chain (which would still emit
-    /// a span via the 4-virtual override but go through one extra
-    /// vtable hop). v1.0 collapses the 4 overrides' span-recording
-    /// bodies into invoke().
+    /// Callback-selected compatibility override. Engine
+    /// `provider->invoke(...)` calls land here and route through the
+    /// stable complete* tracing methods above so each request emits
+    /// exactly one span.
     asio::awaitable<ChatCompletion>
     invoke(const CompletionParams& params, StreamCallback on_chunk) override;
 

--- a/include/neograph/observability/openinference.h
+++ b/include/neograph/observability/openinference.h
@@ -160,10 +160,11 @@ class NEOGRAPH_API OpenInferenceProvider : public Provider {
 public:
     /// @param inner         Provider to delegate to.
     /// @param tracer        Tracer for span emission. Must outlive `*this`.
-    /// @param parent_lookup Legacy raw-parent callback. It is invoked for
-    ///                      compatibility, but its unleased pointer is not
-    ///                      attached because concurrent close could invalidate
-    ///                      it. Use the session overload for parent attachment.
+    /// @param parent_lookup Optional callback returning the parent span. The
+    ///                      caller must keep that span alive until this tracer's
+    ///                      `start_span` returns. Do not bind `current_parent()`
+    ///                      when close may run concurrently; use the session
+    ///                      overload below for teardown-safe parent attachment.
     /// @param span_name     Span name for each LLM call (default "llm.complete").
     OpenInferenceProvider(std::shared_ptr<Provider> inner,
                           Tracer& tracer,

--- a/include/neograph/observability/openinference.h
+++ b/include/neograph/observability/openinference.h
@@ -40,8 +40,10 @@
 #include <neograph/observability/tracer.h>
 #include <neograph/provider.h>
 
+#include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 
 namespace neograph::observability {
 
@@ -68,6 +70,9 @@ namespace neograph::observability {
  */
 class NEOGRAPH_API OpenInferenceTracerSession {
 public:
+    using ChildSpanStarter =
+        std::function<std::unique_ptr<Span>(Tracer&, std::string_view)>;
+
     /// Engine event callback. Pass to `engine.run_stream()`.
     graph::GraphStreamCallback cb;
 
@@ -101,9 +106,14 @@ public:
     /// (`PrintTracer`) for the canonical shape.
     void close();
 
-    /// Internal — exposed so `OpenInferenceProvider` can open LLM
-    /// child spans under the currently-active node span.
+    /// Snapshot of the current span. The pointer is only valid until another
+    /// session operation or `close()`; use `child_span_starter()` when opening
+    /// a child concurrently with session teardown.
     Span* current_parent() const noexcept;
+
+    /// Return a copied operation that opens a child while leasing the current
+    /// parent through `Tracer::start_span`. Safe across close/destruction.
+    ChildSpanStarter child_span_starter() const;
 
 private:
     struct Impl;
@@ -150,15 +160,21 @@ class NEOGRAPH_API OpenInferenceProvider : public Provider {
 public:
     /// @param inner         Provider to delegate to.
     /// @param tracer        Tracer for span emission. Must outlive `*this`.
-    /// @param parent_lookup Optional callback returning the current node
-    ///                      span the LLM call should nest under (e.g.
-    ///                      bound to an `OpenInferenceTracerSession::current_parent`).
-    ///                      May be null — null parent opens the LLM
-    ///                      span as a root.
+    /// @param parent_lookup Legacy raw-parent callback. It is invoked for
+    ///                      compatibility, but its unleased pointer is not
+    ///                      attached because concurrent close could invalidate
+    ///                      it. Use the session overload for parent attachment.
     /// @param span_name     Span name for each LLM call (default "llm.complete").
     OpenInferenceProvider(std::shared_ptr<Provider> inner,
                           Tracer& tracer,
                           std::function<Span*()> parent_lookup = nullptr,
+                          std::string span_name = "llm.complete");
+
+    /// Safe parent-aware overload. The copied starter does not retain the
+    /// session object and becomes a root-span starter after session teardown.
+    OpenInferenceProvider(std::shared_ptr<Provider> inner,
+                          Tracer& tracer,
+                          const OpenInferenceTracerSession& session,
                           std::string span_name = "llm.complete");
     ~OpenInferenceProvider() override;
 

--- a/include/neograph/provider.h
+++ b/include/neograph/provider.h
@@ -118,8 +118,10 @@ struct CompletionParams {
 /**
  * @brief Abstract base class for LLM providers.
  *
- * Subclass this to integrate any LLM backend (OpenAI, Claude, Gemini, etc.).
- * Both synchronous and streaming completion must be implemented.
+ * Existing subclasses may continue to implement any supported sync/async pair.
+ * These entry points are stable compatibility APIs with no removal planned.
+ * New backends should normally derive from `CompletionProvider` and implement
+ * its explicit request contract instead.
  *
  * @see neograph::llm::OpenAIProvider
  * @see neograph::llm::SchemaProvider
@@ -139,11 +141,7 @@ class NEOGRAPH_API Provider {
      * @param params Completion parameters including model, messages, and tools.
      * @return The full completion response with message and usage statistics.
      *
-     * @deprecated New Provider implementations should derive from
-     * `CompletionProvider` and implement its explicit request contract.
-     * This method remains supported during the compatibility window.
      */
-    [[deprecated("legacy Provider API: new implementations should use CompletionProvider")]]
     virtual ChatCompletion complete(const CompletionParams& params);
 
     /**
@@ -166,9 +164,7 @@ class NEOGRAPH_API Provider {
      * @param params Completion parameters.
      * @return An awaitable yielding the full completion response.
      *
-     * @deprecated New implementations should use `CompletionProvider`.
      */
-    [[deprecated("legacy Provider API: new implementations should use CompletionProvider")]]
     virtual asio::awaitable<ChatCompletion>
     complete_async(const CompletionParams& params);
 
@@ -189,9 +185,7 @@ class NEOGRAPH_API Provider {
      * @param on_chunk Callback invoked per received token.
      * @return The full completion response after streaming is complete.
      *
-     * @deprecated New implementations should use `CompletionProvider`.
      */
-    [[deprecated("legacy Provider API: new implementations should use CompletionProvider")]]
     virtual ChatCompletion complete_stream(const CompletionParams& params,
                                            const StreamCallback& on_chunk);
 
@@ -258,15 +252,13 @@ class NEOGRAPH_API Provider {
      *                 internal worker thread).
      * @return Awaitable resolving to the full completion response.
      *
-     * @deprecated New implementations should use `CompletionProvider`.
      */
-    [[deprecated("legacy Provider API: new implementations should use CompletionProvider")]]
     virtual asio::awaitable<ChatCompletion>
     complete_stream_async(const CompletionParams& params,
                           const StreamCallback& on_chunk);
 
     /**
-     * @brief Legacy callback-selected async completion entry point.
+     * @brief Compatibility callback-selected async completion entry point.
      *
      * Existing Provider subclasses may override this method to combine the
      * legacy async collect and stream paths. New implementations should derive
@@ -286,8 +278,10 @@ class NEOGRAPH_API Provider {
      *
      * The default implementation forwards to `complete_stream_async()` when
      * `on_chunk` is set and to `complete_async()` otherwise, preserving every
-     * existing Provider subclass. The legacy methods remain available during
-     * the compatibility window; no removal version is currently scheduled.
+     * existing Provider subclass. These compatibility methods remain supported
+     * with no removal planned. Compatibility and security fixes apply to them;
+     * new capabilities may be available only through `CompletionProvider`'s
+     * explicit request API.
      *
      * @param params   Completion parameters (model, messages, tools, ...).
      * @param on_chunk Optional per-chunk callback. `nullptr` for non-

--- a/src/acp/server.cpp
+++ b/src/acp/server.cpp
@@ -12,6 +12,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <unordered_map>
 
@@ -176,6 +177,29 @@ struct ACPServer::Impl {
     int                                           inflight_count = 0;
     std::set<std::string>                         inflight_sessions;
     int                                           max_inflight_prompts = 32;
+#if defined(NEOGRAPH_ACP_TESTING)
+    std::atomic<bool>                             fail_next_worker_launch{false};
+    std::atomic<bool>                             fail_next_handle_message{false};
+#endif
+
+    struct WorkerReservation {
+        Impl*       owner;
+        std::string session_id;
+        bool        active = false;
+
+        WorkerReservation(Impl* owner_in, std::string session_id_in)
+            : owner(owner_in), session_id(std::move(session_id_in)) {}
+
+        ~WorkerReservation() {
+            if (!active) return;
+            std::lock_guard lk(owner->workers_mu);
+            --owner->inflight_count;
+            owner->inflight_sessions.erase(session_id);
+            // Keep notify under the lock. A waiter cannot destroy the cv
+            // after seeing count==0 while this notify is still executing.
+            owner->workers_cv.notify_all();
+        }
+    };
 
     /// Cached client handle returned by ACPServer::client().
     std::shared_ptr<ACPClient>                    client_handle;
@@ -197,6 +221,19 @@ struct ACPServer::Impl {
         // this thread keeps the old callable alive until it returns.
         auto s = std::atomic_load_explicit(&sink_, std::memory_order_acquire);
         if (s && *s) (*s)(env);
+    }
+
+    void emit_internal_error(const neograph::json& id,
+                             const char* prefix,
+                             const char* detail = nullptr) noexcept {
+        try {
+            std::string message(prefix);
+            if (detail) message += detail;
+            emit(jsonrpc_error(-32603, message, id));
+        } catch (...) {
+            // A failing transport/sink cannot be used to report its own
+            // failure, but it must never escape a detached worker.
+        }
     }
 };
 
@@ -287,25 +324,31 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
     // and unbounded-grow the worker tracking, or (b) race two prompts
     // on the same session_id, which the engine's checkpoint store
     // (keyed by thread_id) cannot disambiguate.
+    neograph::json rejection;
+    auto reservation = std::make_shared<WorkerReservation>(
+        this, req.session_id);
     {
         std::lock_guard lk(workers_mu);
         if (inflight_count >= max_inflight_prompts) {
             // -32000 Server error per JSON-RPC §5.1 (server-defined range).
-            emit(jsonrpc_error(-32000,
+            rejection = jsonrpc_error(-32000,
                 std::string("ACP server overloaded: ")
                 + std::to_string(max_inflight_prompts)
-                + " concurrent prompts in flight; retry shortly", id));
-            return;
-        }
-        if (inflight_sessions.count(req.session_id)) {
-            emit(jsonrpc_error(-32000,
+                + " concurrent prompts in flight; retry shortly", id);
+        } else if (inflight_sessions.count(req.session_id)) {
+            rejection = jsonrpc_error(-32000,
                 std::string("session_id ") + req.session_id
                 + " already has a prompt in flight; ACP requires "
-                  "single-flight per session", id));
-            return;
+                  "single-flight per session", id);
+        } else {
+            inflight_sessions.insert(req.session_id);
+            ++inflight_count;
+            reservation->active = true;
         }
-        ++inflight_count;
-        inflight_sessions.insert(req.session_id);
+    }
+    if (!rejection.is_null()) {
+        emit(rejection);
+        return;
     }
 
     // Run the engine on a detached worker so the run-loop reader can
@@ -314,75 +357,106 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
     // The thread is detached because completed workers don't need
     // joining individually; the dtor / drain path waits on
     // inflight_count via workers_cv instead.
-    std::thread worker([this, req = std::move(req), id, my_cancel]() mutable {
-        auto& a = *adapter;
+    try {
+#if defined(NEOGRAPH_ACP_TESTING)
+        if (fail_next_worker_launch.exchange(false, std::memory_order_acq_rel)) {
+            throw std::system_error(
+                std::make_error_code(std::errc::resource_unavailable_try_again),
+                "injected ACP worker launch failure");
+        }
+#endif
+        std::thread worker(
+            [this, req = std::move(req), id, my_cancel, reservation]() mutable {
+                try {
+                    auto& a = *adapter;
 
-        neograph::graph::RunConfig cfg;
-        cfg.thread_id = req.session_id;
-        cfg.input     = a.build_initial_state(req.prompt, req.session_id);
+                    neograph::graph::RunConfig cfg;
+                    cfg.thread_id = req.session_id;
 
-        StopReason  stop          = StopReason::EndTurn;
-        bool        graph_failed  = false;
-        std::string agent_text;
+                    StopReason  stop         = StopReason::EndTurn;
+                    bool        graph_failed = false;
+                    std::string agent_text;
+                    std::string graph_error;
+
+                    try {
+                        cfg.input = a.build_initial_state(
+                            req.prompt, req.session_id);
+                        auto rr = engine->run(cfg);
+                        agent_text = a.extract_agent_text(rr.output);
+                    } catch (const std::exception& e) {
+                        graph_failed = true;
+                        graph_error = e.what();
+                    } catch (...) {
+                        graph_failed = true;
+                        graph_error = "unknown exception";
+                    }
+
+                    if (graph_failed) {
+                        // ACP's StopReason vocabulary has no generic error
+                        // value. Preserve the existing protocol shape:
+                        // diagnostic update, then a normal end_turn response.
+                        SessionNotification n;
+                        n.session_id = req.session_id;
+                        n.update.session_update = "agent_message_chunk";
+                        n.update.content = ContentBlock::text_block(
+                            std::string("(graph error: ") + graph_error + ")");
+                        neograph::json nj;
+                        to_json(nj, n);
+                        emit(jsonrpc_notify("session/update", std::move(nj)));
+                    } else {
+                        bool was_cancelled = my_cancel->exchange(
+                            false, std::memory_order_acq_rel);
+                        if (was_cancelled) {
+                            stop = StopReason::Cancelled;
+                        } else {
+                            SessionNotification n;
+                            n.session_id = req.session_id;
+                            n.update.session_update = "agent_message_chunk";
+                            n.update.content =
+                                ContentBlock::text_block(agent_text);
+                            neograph::json nj;
+                            to_json(nj, n);
+                            emit(jsonrpc_notify(
+                                "session/update", std::move(nj)));
+                        }
+                    }
+
+                    PromptResponse resp;
+                    resp.stop_reason = stop;
+                    neograph::json rj;
+                    to_json(rj, resp);
+                    emit(jsonrpc_result(std::move(rj), id));
+                } catch (const std::exception& e) {
+                    emit_internal_error(
+                        id, "ACP prompt worker failed: ", e.what());
+                } catch (...) {
+                    emit_internal_error(
+                        id, "ACP prompt worker failed: unknown exception");
+                }
+                // The captured reservation is the last owner after dispatch
+                // returns. Its destructor cleans every worker exit path.
+            });
 
         try {
-            auto rr = engine->run(cfg);
-            agent_text = a.extract_agent_text(rr.output);
-        } catch (const std::exception& e) {
-            // ACP's StopReason vocabulary doesn't include a generic
-            // "error" value — surface engine failures as a final
-            // agent_message_chunk and end the turn normally. The chunk
-            // text carries the diagnostic.
-            SessionNotification n;
-            n.session_id = req.session_id;
-            n.update.session_update = "agent_message_chunk";
-            n.update.content = ContentBlock::text_block(
-                std::string("(graph error: ") + e.what() + ")");
-            neograph::json nj; to_json(nj, n);
-            emit(jsonrpc_notify("session/update", std::move(nj)));
-            graph_failed = true;
-        }
-
-        if (!graph_failed) {
-            bool was_cancelled = my_cancel->exchange(
-                false, std::memory_order_acq_rel);
-            if (was_cancelled) {
-                stop = StopReason::Cancelled;
-            } else {
-                SessionNotification n;
-                n.session_id = req.session_id;
-                n.update.session_update = "agent_message_chunk";
-                n.update.content = ContentBlock::text_block(agent_text);
-                neograph::json nj; to_json(nj, n);
-                emit(jsonrpc_notify("session/update", std::move(nj)));
+            worker.detach();
+        } catch (...) {
+            if (worker.joinable()) {
+                worker.join();
             }
+            throw;
         }
-
-        PromptResponse resp;
-        resp.stop_reason = stop;
-        neograph::json rj;
-        to_json(rj, resp);
-        emit(jsonrpc_result(std::move(rj), id));
-
-        // Decrement inflight + clear single-flight reservation.
-        // Must happen even on exception above (those are caught
-        // earlier), but use a final lock here to be sure.
-        //
-        // notify_all MUST run inside the lock — otherwise the dtor's
-        // cv.wait can wake on count==0, exit the wait scope, and tear
-        // the server down before this worker finishes notify_all,
-        // touching a destroyed cv. Linux pthread is permissive enough
-        // to limp through; macOS libc++ aborts with EINVAL. (Reproduced
-        // by ACPServer.RejectsSecondPromptOnSameSession on macos-14.)
-        {
-            std::lock_guard lk(workers_mu);
-            --inflight_count;
-            inflight_sessions.erase(req.session_id);
-            workers_cv.notify_all();
-        }
-    });
-
-    worker.detach();
+        reservation.reset();
+    } catch (const std::exception& e) {
+        // If std::thread construction fails, no worker owns the reservation.
+        // Dropping the local owner rolls back count + session before replying.
+        reservation.reset();
+        emit_internal_error(
+            id, "ACP prompt worker launch failed: ", e.what());
+    } catch (...) {
+        reservation.reset();
+        emit_internal_error(id,
+            "ACP prompt worker launch failed: unknown exception");
+    }
 }
 
 void
@@ -463,6 +537,16 @@ void ACPServer::set_notification_sink(NotificationSink sink) {
                                std::memory_order_release);
 }
 
+#if defined(NEOGRAPH_ACP_TESTING)
+void ACPServer::fail_next_worker_launch_for_testing() {
+    impl_->fail_next_worker_launch.store(true, std::memory_order_release);
+}
+
+void ACPServer::fail_next_handle_message_for_testing() {
+    impl_->fail_next_handle_message.store(true, std::memory_order_release);
+}
+#endif
+
 void ACPServer::stop() {
     impl_->stop_flag.store(true, std::memory_order_release);
 }
@@ -535,6 +619,12 @@ ACPServer::call_client(std::string method,
 
 neograph::json
 ACPServer::handle_message(const neograph::json& env) {
+#if defined(NEOGRAPH_ACP_TESTING)
+    if (impl_->fail_next_handle_message.exchange(false,
+                                                  std::memory_order_acq_rel)) {
+        throw std::runtime_error("injected ACP handle_message failure");
+    }
+#endif
     bool has_method = env.contains("method") && !env["method"].is_null();
 
     // Response to one of OUR outbound requests — fulfil the promise
@@ -594,6 +684,25 @@ void ACPServer::run(std::istream& in, std::ostream& out) {
     };
     RunningGuard running_guard{&impl_->running};
 
+    // Established before allocating/installing the run sink so every exit,
+    // including stream and dispatch exceptions, drains workers before the
+    // sink's captured output pointer can become invalid.
+    struct RunCleanupGuard {
+        Impl* impl;
+        ~RunCleanupGuard() {
+            {
+                std::unique_lock lk(impl->workers_mu);
+                impl->workers_cv.wait(lk, [this]{
+                    return impl->inflight_count == 0;
+                });
+            }
+            std::atomic_store_explicit(
+                &impl->sink_, std::shared_ptr<NotificationSink>{},
+                std::memory_order_release);
+        }
+    };
+    RunCleanupGuard cleanup_guard{impl_.get()};
+
     auto out_mu = std::make_shared<std::mutex>();
     auto out_ptr = &out;
 
@@ -625,7 +734,21 @@ void ACPServer::run(std::istream& in, std::ostream& out) {
             continue;
         }
 
-        auto resp = handle_message(env);
+        neograph::json resp;
+        try {
+            resp = handle_message(env);
+        } catch (const std::exception& e) {
+            auto request_id = env.is_object() && env.contains("id")
+                                ? env["id"] : neograph::json();
+            resp = jsonrpc_error(
+                -32603, std::string("Internal error: ") + e.what(),
+                request_id);
+        } catch (...) {
+            auto request_id = env.is_object() && env.contains("id")
+                                ? env["id"] : neograph::json();
+            resp = jsonrpc_error(
+                -32603, "Internal error: unknown exception", request_id);
+        }
         if (!resp.is_null()) {
             std::lock_guard lk(*out_mu);
             out << resp.dump() << '\n';
@@ -633,19 +756,6 @@ void ACPServer::run(std::istream& in, std::ostream& out) {
         }
     }
 
-    // Drain workers before tearing the sink down — otherwise a worker
-    // that finishes after run() returns would write through a dangling
-    // stream pointer. Workers are detached; wait on inflight_count.
-    {
-        std::unique_lock lk(impl_->workers_mu);
-        impl_->workers_cv.wait(lk, [this]{
-            return impl_->inflight_count == 0;
-        });
-    }
-
-    std::atomic_store_explicit(&impl_->sink_,
-                               std::shared_ptr<NotificationSink>{},
-                               std::memory_order_release);
 }
 
 void ACPServer::run() {

--- a/src/core/completion_provider.cpp
+++ b/src/core/completion_provider.cpp
@@ -4,8 +4,6 @@
 
 namespace neograph {
 
-NEOGRAPH_PUSH_IGNORE_DEPRECATED
-
 CompletionProvider::~CompletionProvider() = default;
 
 asio::awaitable<ChatCompletion>
@@ -71,7 +69,5 @@ invoke_completion(Provider& provider, CompletionRequest request) {
     }
     co_return co_await provider.complete_async(request.params());
 }
-
-NEOGRAPH_POP_IGNORE_DEPRECATED
 
 } // namespace neograph

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -273,8 +273,9 @@ void GraphEngine::update_state(const std::string& thread_id,
     // super-step saves propagate this for the same reason.
     new_cp.barrier_state   = cp.barrier_state;
     new_cp.step            = cp.step;
-    const auto now = std::chrono::duration_cast<std::chrono::milliseconds>(
-        std::chrono::system_clock::now().time_since_epoch()).count();
+    const int64_t now = static_cast<int64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count());
     // update_state preserves the parent's step, so millisecond timestamp ties
     // would leave durable stores unable to identify the newer checkpoint.
     new_cp.timestamp       = std::max(now, cp.timestamp + 1);

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -5,7 +5,13 @@
 
 #include <neograph/async/run_sync.h>
 
+#include <asio/bind_cancellation_slot.hpp>
+#include <asio/co_spawn.hpp>
+#include <asio/error.hpp>
+#include <asio/system_error.hpp>
+#include <asio/this_coro.hpp>
 #include <asio/thread_pool.hpp>
+#include <asio/use_awaitable.hpp>
 
 #include <stdexcept>
 #include <algorithm>
@@ -356,7 +362,13 @@ RunResult GraphEngine::run(const RunConfig& config) {
     // thread-pool hop. Parallel fan-out inside run_parallel_async /
     // run_sends_async still uses pool_ explicitly for CPU
     // parallelism (see NodeExecutor::fan_out_pool_).
-    return neograph::async::run_sync(execute_graph_async(config, nullptr));
+    RunConfig operation_config = config;
+    if (config.cancel_token) {
+        operation_config.cancel_token = config.cancel_token->fork();
+    }
+    return neograph::async::detail::run_sync_operation(
+        execute_graph_async(operation_config, nullptr),
+        operation_config.cancel_token);
 }
 
 // Public async entry — takes RunConfig BY VALUE so the coroutine frame
@@ -370,12 +382,41 @@ RunResult GraphEngine::run(const RunConfig& config) {
 // alive on their own stack frame.
 asio::awaitable<RunResult>
 GraphEngine::run_async(RunConfig config) {
-    co_return co_await execute_graph_async(config, nullptr);
+    auto operation = config.cancel_token
+        ? config.cancel_token->fork()
+        : std::shared_ptr<CancelToken>{};
+    config.cancel_token = operation;
+    if (!operation) {
+        co_return co_await execute_graph_async(config, nullptr);
+    }
+
+    auto executor = co_await asio::this_coro::executor;
+    operation->bind_executor(executor);
+    operation->throw_if_cancelled("run_async entry");
+    try {
+        co_return co_await asio::co_spawn(
+            executor,
+            execute_graph_async(config, nullptr),
+            asio::bind_cancellation_slot(
+                operation->slot(), asio::use_awaitable));
+    } catch (const asio::system_error& error) {
+        if (operation->is_cancelled() &&
+            error.code() == asio::error::operation_aborted) {
+            throw CancelledException("run_async operation aborted");
+        }
+        throw;
+    }
 }
 
 RunResult GraphEngine::run_stream(const RunConfig& config,
                                    const GraphStreamCallback& cb) {
-    return neograph::async::run_sync(execute_graph_async(config, cb));
+    RunConfig operation_config = config;
+    if (config.cancel_token) {
+        operation_config.cancel_token = config.cancel_token->fork();
+    }
+    return neograph::async::detail::run_sync_operation(
+        execute_graph_async(operation_config, cb),
+        operation_config.cancel_token);
 }
 
 asio::awaitable<RunResult>
@@ -384,7 +425,31 @@ GraphEngine::run_stream_async(RunConfig config,
     // Same lifetime concern as run_async — both config and cb might
     // be stack-local at the callsite, captured into a co_spawn'd
     // awaitable that outlives the callsite. Take both by value.
-    co_return co_await execute_graph_async(config, cb);
+    auto operation = config.cancel_token
+        ? config.cancel_token->fork()
+        : std::shared_ptr<CancelToken>{};
+    config.cancel_token = operation;
+    if (!operation) {
+        co_return co_await execute_graph_async(config, cb);
+    }
+
+    auto executor = co_await asio::this_coro::executor;
+    operation->bind_executor(executor);
+    operation->throw_if_cancelled("run_stream_async entry");
+    try {
+        co_return co_await asio::co_spawn(
+            executor,
+            execute_graph_async(config, cb),
+            asio::bind_cancellation_slot(
+                operation->slot(), asio::use_awaitable));
+    } catch (const asio::system_error& error) {
+        if (operation->is_cancelled() &&
+            error.code() == asio::error::operation_aborted) {
+            throw CancelledException(
+                "run_stream_async operation aborted");
+        }
+        throw;
+    }
 }
 
 RunResult GraphEngine::resume(const std::string& thread_id,
@@ -563,11 +628,11 @@ GraphEngine::execute_graph_async(const RunConfig& config,
         // v0.3: cooperative cancel checkpoint. Polled at the super-step
         // boundary so any future node work is suppressed; in-flight
         // HTTP work inside the just-finished step is aborted via the
-        // asio cancellation_signal bound at co_spawn time (see pybind
-        // bind_graph.cpp::run_async wiring) — both layers needed to
-        // close the cost-leak gap reported in v0.2.3.
-        if (config.cancel_token) {
-            config.cancel_token->throw_if_cancelled(
+        // operation child's asio cancellation_signal bound by run_async /
+        // run_stream_async (or the sync bridge for blocking entry points).
+        // Both layers are needed to close the cost-leak gap from v0.2.3.
+        if (ctx.cancel_token) {
+            ctx.cancel_token->throw_if_cancelled(
                 "step " + std::to_string(step));
         }
 

--- a/src/core/graph_executor.cpp
+++ b/src/core/graph_executor.cpp
@@ -7,7 +7,9 @@
 #include <asio/co_spawn.hpp>
 #include <asio/deferred.hpp>
 #include <asio/experimental/parallel_group.hpp>
+#include <asio/error.hpp>
 #include <asio/steady_timer.hpp>
+#include <asio/system_error.hpp>
 #include <asio/this_coro.hpp>
 #include <asio/use_awaitable.hpp>
 
@@ -258,6 +260,16 @@ asio::awaitable<NodeResult> NodeExecutor::execute_node_with_retry_async(
             // cancel flag, the second HTTP call would slip through,
             // and the cost leak would persist for max_retries × ~3 s.
             throw;
+        } catch (const asio::system_error& error) {
+            // Socket/timer cancellation enters node code as
+            // operation_aborted. Once this operation's token is set, that is
+            // cancellation control flow, not a retryable transport failure.
+            if (ctx.cancel_token && ctx.cancel_token->is_cancelled() &&
+                error.code() == asio::error::operation_aborted) {
+                throw CancelledException(
+                    "node " + node_name + " operation aborted");
+            }
+            retryable_err = std::current_exception();
         } catch (const std::bad_alloc&) {
             // OOM is not retryable. Sleeping then re-running won't
             // free memory; it just delays the inevitable failure

--- a/src/core/postgres_checkpoint.cpp
+++ b/src/core/postgres_checkpoint.cpp
@@ -1163,18 +1163,10 @@ asio::awaitable<void> wait_pg_socket_until(
 #endif
 }
 
-std::chrono::milliseconds async_connect_timeout(pg_conn* c) {
-    int test_timeout = connection_timeout_ms_for_test.load(
-        std::memory_order_relaxed);
-    if (test_timeout >= 0) return std::chrono::milliseconds(test_timeout);
-
+std::chrono::milliseconds connect_timeout_from_options(
+    PQconninfoOption* options) {
     constexpr auto kProjectDefault = std::chrono::seconds(30);
-    PQconninfoOption* options = PQconninfo(c);
     if (!options) return kProjectDefault;
-    struct OptionsFree {
-        PQconninfoOption* options;
-        ~OptionsFree() { PQconninfoFree(options); }
-    } free_options{options};
 
     for (auto* option = options; option->keyword; ++option) {
         if (std::strcmp(option->keyword, "connect_timeout") != 0
@@ -1190,6 +1182,34 @@ std::chrono::milliseconds async_connect_timeout(pg_conn* c) {
         break;
     }
     return kProjectDefault;
+}
+
+std::chrono::milliseconds connect_timeout_from_conninfo(
+    const std::string& conn_str) {
+    char* error = nullptr;
+    PQconninfoOption* options = PQconninfoParse(conn_str.c_str(), &error);
+    struct ParseFree {
+        PQconninfoOption* options;
+        char* error;
+        ~ParseFree() {
+            if (options) PQconninfoFree(options);
+            if (error) PQfreemem(error);
+        }
+    } free_parse{options, error};
+    return connect_timeout_from_options(options);
+}
+
+std::chrono::milliseconds async_connect_timeout(pg_conn* c) {
+    int test_timeout = connection_timeout_ms_for_test.load(
+        std::memory_order_relaxed);
+    if (test_timeout >= 0) return std::chrono::milliseconds(test_timeout);
+
+    PQconninfoOption* options = PQconninfo(c);
+    struct OptionsFree {
+        PQconninfoOption* options;
+        ~OptionsFree() { if (options) PQconninfoFree(options); }
+    } free_options{options};
+    return connect_timeout_from_options(options);
 }
 
 asio::awaitable<void> start_connection_off_executor(
@@ -1240,8 +1260,7 @@ asio::awaitable<std::unique_ptr<PgConn>> open_conn_async(
         std::memory_order_relaxed);
     auto initial_timeout = start_timeout >= 0
         ? std::chrono::milliseconds(start_timeout)
-        : std::chrono::duration_cast<std::chrono::milliseconds>(
-              std::chrono::seconds(30));
+        : connect_timeout_from_conninfo(url);
     auto attempt = std::make_shared<ConnectionAttempt>();
     co_await start_connection_off_executor(
         attempt, url, started + initial_timeout, initial_timeout);
@@ -1446,6 +1465,11 @@ void PostgresCheckpointStore::set_async_connection_test_seams(
                                              std::memory_order_relaxed);
     connection_timeout_ms_for_test.store(timeout_ms,
                                          std::memory_order_relaxed);
+}
+
+int PostgresCheckpointStore::async_connection_timeout_ms_for_test(
+    const std::string& conn_str) {
+    return static_cast<int>(connect_timeout_from_conninfo(conn_str).count());
 }
 
 // Async peer of with_conn. Template — definition here (same TU as the

--- a/src/core/postgres_checkpoint.cpp
+++ b/src/core/postgres_checkpoint.cpp
@@ -35,12 +35,14 @@
 #include <algorithm>
 #include <chrono>
 #include <cstring>
+#include <deque>
 #include <exception>
 #include <memory>
 #include <optional>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace neograph::graph {
@@ -481,6 +483,64 @@ std::unique_ptr<PgConn> open_conn(const std::string& url) {
     return std::make_unique<PgConn>(raw);
 }
 
+struct PoolSlotWaiter {
+    enum class Kind { Sync, Async };
+
+    PoolSlotWaiter() : kind(Kind::Sync) {}
+    explicit PoolSlotWaiter(asio::any_io_executor ex)
+        : kind(Kind::Async),
+          async_wake(std::in_place, std::move(ex),
+                     asio::steady_timer::time_point::max()) {}
+
+    Kind kind;
+    std::optional<size_t> slot;
+    std::condition_variable sync_wake;
+    std::optional<asio::steady_timer> async_wake;
+};
+
+struct PoolWaitState {
+    std::deque<std::shared_ptr<PoolSlotWaiter>> waiters;
+};
+
+struct PoolWaitRegistry {
+    std::mutex mutex;
+    std::unordered_map<const PostgresCheckpointStore*,
+                       std::shared_ptr<PoolWaitState>> states;
+};
+
+PoolWaitRegistry& pool_wait_registry() {
+    // Process-lifetime storage avoids static destruction racing a late store.
+    static auto* registry = new PoolWaitRegistry;
+    return *registry;
+}
+
+void register_pool_wait_state(const PostgresCheckpointStore* store) {
+    auto& registry = pool_wait_registry();
+    std::lock_guard lock(registry.mutex);
+    auto [it, inserted] = registry.states.emplace(
+        store, std::make_shared<PoolWaitState>());
+    if (!inserted) {
+        throw std::logic_error("PostgresCheckpointStore: duplicate pool sidecar");
+    }
+}
+
+std::shared_ptr<PoolWaitState> pool_wait_state(
+    const PostgresCheckpointStore* store) {
+    auto& registry = pool_wait_registry();
+    std::lock_guard lock(registry.mutex);
+    auto it = registry.states.find(store);
+    if (it == registry.states.end()) {
+        throw std::logic_error("PostgresCheckpointStore: missing pool sidecar");
+    }
+    return it->second;
+}
+
+void unregister_pool_wait_state(const PostgresCheckpointStore* store) {
+    auto& registry = pool_wait_registry();
+    std::lock_guard lock(registry.mutex);
+    registry.states.erase(store);
+}
+
 } // namespace
 
 // ── Construction / lifetime ───────────────────────────────────────────
@@ -498,6 +558,7 @@ PostgresCheckpointStore::PostgresCheckpointStore(const std::string& conn_str,
         free_.push(i);
     }
     ensure_schema();
+    register_pool_wait_state(this);
 }
 
 PostgresCheckpointStore::PostgresCheckpointStore(PoolOnlyTag,
@@ -508,24 +569,12 @@ PostgresCheckpointStore::PostgresCheckpointStore(PoolOnlyTag,
             "PostgresCheckpointStore: pool_size must be >= 1");
     }
     for (size_t i = 0; i < pool_size; ++i) free_.push(i);
+    register_pool_wait_state(this);
 }
 
-PostgresCheckpointStore::~PostgresCheckpointStore() = default;
-
-struct PostgresCheckpointStore::SlotWaiter {
-    enum class Kind { Sync, Async };
-
-    SlotWaiter() : kind(Kind::Sync) {}
-    explicit SlotWaiter(asio::any_io_executor ex)
-        : kind(Kind::Async),
-          async_wake(std::in_place, std::move(ex),
-                     asio::steady_timer::time_point::max()) {}
-
-    Kind kind;
-    std::optional<size_t> slot;
-    std::condition_variable sync_wake;
-    std::optional<asio::steady_timer> async_wake;
-};
+PostgresCheckpointStore::~PostgresCheckpointStore() {
+    unregister_pool_wait_state(this);
+}
 
 void PostgresCheckpointStore::ensure_schema() {
     // Direct call on slot 0 — only invoked at construction (and from
@@ -547,39 +596,41 @@ void PostgresCheckpointStore::drop_schema() {
 }
 
 size_t PostgresCheckpointStore::acquire_slot() {
+    auto state = pool_wait_state(this);
     std::unique_lock lock(pool_mutex_);
-    if (waiters_.empty() && !free_.empty()) {
+    if (state->waiters.empty() && !free_.empty()) {
         size_t idx = free_.front();
         free_.pop();
         return idx;
     }
 
-    auto waiter = std::make_shared<SlotWaiter>();
-    waiters_.push_back(waiter);
+    auto waiter = std::make_shared<PoolSlotWaiter>();
+    state->waiters.push_back(waiter);
     waiter->sync_wake.wait(lock, [&] { return waiter->slot.has_value(); });
     return *waiter->slot;
 }
 
 asio::awaitable<size_t> PostgresCheckpointStore::acquire_slot_async() {
     auto ex = co_await asio::this_coro::executor;
+    auto state = pool_wait_state(this);
     {
         std::lock_guard lock(pool_mutex_);
-        if (waiters_.empty() && !free_.empty()) {
+        if (state->waiters.empty() && !free_.empty()) {
             size_t idx = free_.front();
             free_.pop();
             co_return idx;
         }
     }
 
-    auto waiter = std::make_shared<SlotWaiter>(ex);
+    auto waiter = std::make_shared<PoolSlotWaiter>(ex);
     {
         std::lock_guard lock(pool_mutex_);
-        if (waiters_.empty() && !free_.empty()) {
+        if (state->waiters.empty() && !free_.empty()) {
             size_t idx = free_.front();
             free_.pop();
             co_return idx;
         }
-        waiters_.push_back(waiter);
+        state->waiters.push_back(waiter);
     }
 
     try {
@@ -589,8 +640,8 @@ asio::awaitable<size_t> PostgresCheckpointStore::acquire_slot_async() {
         if (waiter->slot) {
             co_return *waiter->slot;
         }
-        auto it = std::find(waiters_.begin(), waiters_.end(), waiter);
-        if (it != waiters_.end()) waiters_.erase(it);
+        auto it = std::find(state->waiters.begin(), state->waiters.end(), waiter);
+        if (it != state->waiters.end()) state->waiters.erase(it);
         throw;
     }
 
@@ -598,25 +649,32 @@ asio::awaitable<size_t> PostgresCheckpointStore::acquire_slot_async() {
 }
 
 void PostgresCheckpointStore::release_slot(size_t idx) {
-    std::shared_ptr<SlotWaiter> waiter;
+    auto state = pool_wait_state(this);
+    std::shared_ptr<PoolSlotWaiter> waiter;
     {
         std::lock_guard lock(pool_mutex_);
-        if (!waiters_.empty()) {
-            waiter = waiters_.front();
-            waiters_.pop_front();
+        if (!state->waiters.empty()) {
+            waiter = state->waiters.front();
+            state->waiters.pop_front();
             waiter->slot = idx;
         } else {
             free_.push(idx);
         }
     }
     if (!waiter) return;
-    if (waiter->kind == SlotWaiter::Kind::Sync) {
+    if (waiter->kind == PoolSlotWaiter::Kind::Sync) {
         waiter->sync_wake.notify_one();
     } else {
         asio::post(waiter->async_wake->get_executor(), [waiter] {
             waiter->async_wake->cancel();
         });
     }
+}
+
+size_t PostgresCheckpointStore::waiter_count_for_test() {
+    auto state = pool_wait_state(this);
+    std::lock_guard lock(pool_mutex_);
+    return state->waiters.size();
 }
 
 void PostgresCheckpointStore::rebuild_slot(size_t idx) {

--- a/src/core/postgres_checkpoint.cpp
+++ b/src/core/postgres_checkpoint.cpp
@@ -27,7 +27,6 @@
 #else
 #  include <asio/posix/stream_descriptor.hpp>
 #endif
-#include <asio/co_spawn.hpp>
 #include <asio/deferred.hpp>
 #include <asio/experimental/parallel_group.hpp>
 #include <asio/post.hpp>
@@ -42,6 +41,7 @@
 #include <cstring>
 #include <deque>
 #include <exception>
+#include <future>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -991,6 +991,41 @@ asio::thread_pool& connection_start_pool() {
     return *pool;
 }
 
+struct ConnectionAttempt {
+    std::unique_ptr<PgConn> conn;
+};
+
+[[noreturn]] void throw_connect_timeout(std::chrono::milliseconds timeout) {
+    throw std::runtime_error(
+        "PostgresCheckpointStore: connection timed out after "
+        + std::to_string(timeout.count())
+        + " ms while polling libpq");
+}
+
+template <typename Result, typename Fn>
+asio::awaitable<Result> run_connection_step_off_executor(
+    Fn fn,
+    std::chrono::steady_clock::time_point deadline,
+    std::chrono::milliseconds timeout) {
+    auto task = std::make_shared<std::packaged_task<Result()>>(std::move(fn));
+    auto result = task->get_future();
+    // The task captures ConnectionAttempt. If timeout/cancellation releases
+    // the caller, the worker still owns the PGconn until its blocking call
+    // returns, preventing both a use-after-free and a leaked connection.
+    asio::post(connection_start_pool(), [task] { (*task)(); });
+
+    auto ex = co_await asio::this_coro::executor;
+    while (result.wait_for(std::chrono::milliseconds(0))
+           != std::future_status::ready) {
+        auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) throw_connect_timeout(timeout);
+        asio::steady_timer poll_timer(
+            ex, std::min(deadline, now + std::chrono::milliseconds(2)));
+        co_await poll_timer.async_wait(asio::use_awaitable);
+    }
+    co_return result.get();
+}
+
 template <typename Socket>
 asio::awaitable<SocketReady> wait_socket_either(Socket& sock) {
     auto [order, read_error, write_error] =
@@ -1032,10 +1067,7 @@ asio::awaitable<void> wait_socket_until(
                         asio::use_awaitable);
 
     if (order[0] == 1 && !timer_error) {
-        throw std::runtime_error(
-            "PostgresCheckpointStore: connection timed out after "
-            + std::to_string(timeout.count())
-            + " ms while polling libpq");
+        throw_connect_timeout(timeout);
     }
     if (socket_error) throw asio::system_error(socket_error);
 }
@@ -1160,21 +1192,28 @@ std::chrono::milliseconds async_connect_timeout(pg_conn* c) {
     return kProjectDefault;
 }
 
-asio::awaitable<std::unique_ptr<PgConn>> start_connection_off_executor(
-    const std::string& url) {
-    co_return co_await asio::co_spawn(
-        connection_start_pool(),
-        [url]() -> asio::awaitable<std::unique_ptr<PgConn>> {
-            co_return std::make_unique<PgConn>(PQconnectStart(url.c_str()));
+asio::awaitable<void> start_connection_off_executor(
+    const std::shared_ptr<ConnectionAttempt>& attempt,
+    const std::string& url,
+    std::chrono::steady_clock::time_point deadline,
+    std::chrono::milliseconds timeout) {
+    (void)co_await run_connection_step_off_executor<int>(
+        [attempt, url] {
+            attempt->conn = std::make_unique<PgConn>(
+                PQconnectStart(url.c_str()));
+            return 0;
         },
-        asio::use_awaitable);
+        deadline,
+        timeout);
 }
 
 asio::awaitable<PostgresPollingStatusType> poll_connection_off_executor(
-    pg_conn* c) {
-    co_return co_await asio::co_spawn(
-        connection_start_pool(),
-        [c]() -> asio::awaitable<PostgresPollingStatusType> {
+    const std::shared_ptr<ConnectionAttempt>& attempt,
+    std::chrono::steady_clock::time_point deadline,
+    std::chrono::milliseconds timeout) {
+    co_return co_await run_connection_step_off_executor<
+        PostgresPollingStatusType>(
+        [attempt] {
             // Test seam models the potentially blocking hostname lookup that
             // PostgreSQL documents inside the first PQconnectPoll call.
             int delay = connection_poll_delay_ms_for_test.load(
@@ -1182,9 +1221,10 @@ asio::awaitable<PostgresPollingStatusType> poll_connection_off_executor(
             if (delay > 0) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(delay));
             }
-            co_return PQconnectPoll(c);
+            return PQconnectPoll(attempt->conn->raw);
         },
-        asio::use_awaitable);
+        deadline,
+        timeout);
 }
 
 asio::awaitable<std::unique_ptr<PgConn>> open_conn_async(
@@ -1192,10 +1232,20 @@ asio::awaitable<std::unique_ptr<PgConn>> open_conn_async(
     // PostgreSQL 16 libpq contract, consulted 2026-07-19:
     // PQconnectStart/PQconnectPoll can block on DNS without hostaddr, and
     // connect_timeout is ignored by PQconnectPoll. Both calls therefore run
-    // on the bounded sidecar above, while socket waits carry our deadline.
+    // on the bounded sidecar above; worker steps and socket waits both race
+    // our deadline.
     // https://www.postgresql.org/docs/16/libpq-connect.html
-    auto conn = co_await start_connection_off_executor(url);
-    pg_conn* raw = conn->raw;
+    auto started = std::chrono::steady_clock::now();
+    auto start_timeout = connection_timeout_ms_for_test.load(
+        std::memory_order_relaxed);
+    auto initial_timeout = start_timeout >= 0
+        ? std::chrono::milliseconds(start_timeout)
+        : std::chrono::duration_cast<std::chrono::milliseconds>(
+              std::chrono::seconds(30));
+    auto attempt = std::make_shared<ConnectionAttempt>();
+    co_await start_connection_off_executor(
+        attempt, url, started + initial_timeout, initial_timeout);
+    pg_conn* raw = attempt->conn->raw;
     if (!raw) {
         throw std::runtime_error(
             "PostgresCheckpointStore: connection failed: null PGconn");
@@ -1207,7 +1257,7 @@ asio::awaitable<std::unique_ptr<PgConn>> open_conn_async(
     }
 
     auto timeout = async_connect_timeout(raw);
-    auto deadline = std::chrono::steady_clock::now() + timeout;
+    auto deadline = started + timeout;
     auto status = PGRES_POLLING_WRITING;
     for (;;) {
         if (status == PGRES_POLLING_READING) {
@@ -1216,15 +1266,15 @@ asio::awaitable<std::unique_ptr<PgConn>> open_conn_async(
             co_await wait_pg_socket_until(raw, false, deadline, timeout);
         }
 
-        status = co_await poll_connection_off_executor(raw);
+        status = co_await poll_connection_off_executor(
+            attempt, deadline, timeout);
         if (std::chrono::steady_clock::now() >= deadline
             && status != PGRES_POLLING_OK) {
-            throw std::runtime_error(
-                "PostgresCheckpointStore: connection timed out after "
-                + std::to_string(timeout.count())
-                + " ms while polling libpq");
+            throw_connect_timeout(timeout);
         }
-        if (status == PGRES_POLLING_OK) co_return conn;
+        if (status == PGRES_POLLING_OK) {
+            co_return std::move(attempt->conn);
+        }
         if (status == PGRES_POLLING_FAILED) {
             throw std::runtime_error(
                 std::string("PostgresCheckpointStore: connection failed: ")

--- a/src/core/postgres_checkpoint.cpp
+++ b/src/core/postgres_checkpoint.cpp
@@ -27,11 +27,15 @@
 #else
 #  include <asio/posix/stream_descriptor.hpp>
 #endif
+#include <asio/post.hpp>
+#include <asio/steady_timer.hpp>
 #include <asio/this_coro.hpp>
 #include <asio/use_awaitable.hpp>
 
+#include <algorithm>
 #include <chrono>
 #include <cstring>
+#include <exception>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -93,6 +97,12 @@ bool is_broken_connection(PGresult* res, pg_conn* c) {
 // Throw on non-success result. Distinguishes broken_connection from
 // other errors so the with_conn retry layer can handle them differently.
 void check_ok(PGresult* res, pg_conn* c, const char* context) {
+    if (!res) {
+        std::string msg = context ? context : "pg exec";
+        msg += ": ";
+        msg += PQerrorMessage(c);
+        throw BrokenConnection(msg);
+    }
     ExecStatusType st = PQresultStatus(res);
     if (st == PGRES_COMMAND_OK || st == PGRES_TUPLES_OK) return;
     std::string msg = context ? context : "pg exec";
@@ -122,15 +132,15 @@ PgResult exec_params(pg_conn* c,
         bool is_null = (i < nulls.size() && nulls[i]);
         vals[i] = is_null ? nullptr : params[i].c_str();
     }
-    PGresult* r = PQexecParams(c, sql,
-                               static_cast<int>(params.size()),
-                               /*paramTypes=*/nullptr,
-                               vals.data(),
-                               /*lengths=*/nullptr,
-                               /*formats=*/nullptr,
-                               /*resultFormat=*/0);
-    check_ok(r, c, "exec_params");
-    return PgResult{r};
+    PgResult result{PQexecParams(c, sql,
+                                 static_cast<int>(params.size()),
+                                 /*paramTypes=*/nullptr,
+                                 vals.data(),
+                                 /*lengths=*/nullptr,
+                                 /*formats=*/nullptr,
+                                 /*resultFormat=*/0)};
+    check_ok(result, c, "exec_params");
+    return result;
 }
 
 PgResult exec_prepared(pg_conn* c,
@@ -142,23 +152,23 @@ PgResult exec_prepared(pg_conn* c,
         bool is_null = (i < nulls.size() && nulls[i]);
         vals[i] = is_null ? nullptr : params[i].c_str();
     }
-    PGresult* r = PQexecPrepared(c, name,
-                                 static_cast<int>(params.size()),
-                                 vals.data(),
-                                 /*lengths=*/nullptr,
-                                 /*formats=*/nullptr,
-                                 /*resultFormat=*/0);
-    check_ok(r, c, "exec_prepared");
-    return PgResult{r};
+    PgResult result{PQexecPrepared(c, name,
+                                   static_cast<int>(params.size()),
+                                   vals.data(),
+                                   /*lengths=*/nullptr,
+                                   /*formats=*/nullptr,
+                                   /*resultFormat=*/0)};
+    check_ok(result, c, "exec_prepared");
+    return result;
 }
 
 // Simple query (no params) via PQexec. Used only for DDL bundles that
 // have multiple statements separated by semicolons (PQexecParams
 // rejects that shape).
 PgResult exec_sql(pg_conn* c, const char* sql) {
-    PGresult* r = PQexec(c, sql);
-    check_ok(r, c, "exec_sql");
-    return PgResult{r};
+    PgResult result{PQexec(c, sql)};
+    check_ok(result, c, "exec_sql");
+    return result;
 }
 
 // ── Result-row accessors ──────────────────────────────────────────────
@@ -490,7 +500,25 @@ PostgresCheckpointStore::PostgresCheckpointStore(const std::string& conn_str,
     ensure_schema();
 }
 
+PostgresCheckpointStore::PostgresCheckpointStore(PoolOnlyTag,
+                                                   size_t pool_size)
+    : pool_(pool_size) {
+    if (pool_size == 0) {
+        throw std::invalid_argument(
+            "PostgresCheckpointStore: pool_size must be >= 1");
+    }
+    for (size_t i = 0; i < pool_size; ++i) free_.push(i);
+}
+
 PostgresCheckpointStore::~PostgresCheckpointStore() = default;
+
+struct PostgresCheckpointStore::AsyncSlotWaiter {
+    explicit AsyncSlotWaiter(asio::any_io_executor ex)
+        : wake(std::move(ex), asio::steady_timer::time_point::max()) {}
+
+    asio::steady_timer wake;
+    std::optional<size_t> slot;
+};
 
 void PostgresCheckpointStore::ensure_schema() {
     // Direct call on slot 0 — only invoked at construction (and from
@@ -519,12 +547,70 @@ size_t PostgresCheckpointStore::acquire_slot() {
     return idx;
 }
 
-void PostgresCheckpointStore::release_slot(size_t idx) {
+asio::awaitable<size_t> PostgresCheckpointStore::acquire_slot_async() {
+    auto ex = co_await asio::this_coro::executor;
     {
         std::lock_guard lock(pool_mutex_);
-        free_.push(idx);
+        if (!free_.empty()) {
+            size_t idx = free_.front();
+            free_.pop();
+            co_return idx;
+        }
     }
-    pool_cv_.notify_one();
+
+    auto waiter = std::make_shared<AsyncSlotWaiter>(ex);
+    {
+        std::lock_guard lock(pool_mutex_);
+        if (!free_.empty()) {
+            size_t idx = free_.front();
+            free_.pop();
+            co_return idx;
+        }
+        async_waiters_.push_back(waiter);
+    }
+
+    try {
+        co_await waiter->wake.async_wait(asio::use_awaitable);
+    } catch (...) {
+        std::lock_guard lock(pool_mutex_);
+        if (waiter->slot) {
+            co_return *waiter->slot;
+        }
+        auto it = std::find(async_waiters_.begin(), async_waiters_.end(), waiter);
+        if (it != async_waiters_.end()) async_waiters_.erase(it);
+        throw;
+    }
+
+    throw std::logic_error("PostgresCheckpointStore: pool waiter expired");
+}
+
+void PostgresCheckpointStore::release_slot(size_t idx) {
+    std::shared_ptr<AsyncSlotWaiter> waiter;
+    {
+        std::lock_guard lock(pool_mutex_);
+        if (!async_waiters_.empty()) {
+            waiter = async_waiters_.front();
+            async_waiters_.pop_front();
+            waiter->slot = idx;
+        } else {
+            free_.push(idx);
+        }
+    }
+    if (waiter) {
+        asio::post(waiter->wake.get_executor(), [waiter] {
+            waiter->wake.cancel();
+        });
+    } else {
+        pool_cv_.notify_one();
+    }
+}
+
+void PostgresCheckpointStore::rebuild_slot(size_t idx) {
+    pool_[idx].reset();
+    auto fresh = open_conn(conn_str_);
+    exec_sql(fresh->raw, kSchemaDDL);
+    pool_[idx] = std::move(fresh);
+    reconnect_count_.fetch_add(1, std::memory_order_relaxed);
 }
 
 // Borrow a slot, run fn(PGconn*) on it, release the slot. On a broken-
@@ -540,6 +626,8 @@ auto PostgresCheckpointStore::with_conn(Fn&& fn) {
         size_t idx;
         ~Releaser() { self->release_slot(idx); }
     } guard{this, idx};
+
+    if (!pool_[idx]) rebuild_slot(idx);
 
     try {
         return fn(pool_[idx]->raw);
@@ -794,6 +882,11 @@ size_t PostgresCheckpointStore::blob_count() {
 
 namespace {
 
+struct QueryNotDrained {
+    std::exception_ptr cause;
+    bool retryable;
+};
+
 asio::awaitable<PgResult> exec_params_async(
     pg_conn* c,
     const char* sql,
@@ -833,66 +926,83 @@ asio::awaitable<PgResult> exec_params_async(
         throw std::runtime_error(msg);
     }
 
-    // Wrap PQsocket without taking ownership — asio would close it
-    // on destruction otherwise, and the PGconn needs to keep it
-    // across calls. release() before unwind strips the ownership.
+    bool drained = false;
+    try {
+        // Wrap PQsocket without taking ownership — asio would close it
+        // on destruction otherwise, and the PGconn needs to keep it
+        // across calls. release() before unwind strips the ownership.
 #ifdef _WIN32
-    // On Windows PQsocket returns int but the underlying handle is
-    // a SOCKET (UINT_PTR). Explicit cast back to the asio native
-    // handle type silences the narrowing warning and keeps us safe
-    // on 64-bit where SOCKET values can exceed INT_MAX.
-    asio::ip::tcp::socket sock(ex);
-    using NativeSock = asio::ip::tcp::socket::native_handle_type;
-    sock.assign(asio::ip::tcp::v4(), static_cast<NativeSock>(PQsocket(c)));
-    struct SockRelease {
-        asio::ip::tcp::socket& s;
-        ~SockRelease() { try { (void)s.release(); } catch (...) {} }
-    } rel{sock};
-    constexpr auto kWaitWrite = asio::ip::tcp::socket::wait_write;
-    constexpr auto kWaitRead  = asio::ip::tcp::socket::wait_read;
+        // On Windows PQsocket returns int but the underlying handle is
+        // a SOCKET (UINT_PTR). Explicit cast back to the asio native
+        // handle type silences the narrowing warning and keeps us safe
+        // on 64-bit where SOCKET values can exceed INT_MAX.
+        asio::ip::tcp::socket sock(ex);
+        using NativeSock = asio::ip::tcp::socket::native_handle_type;
+        sock.assign(asio::ip::tcp::v4(), static_cast<NativeSock>(PQsocket(c)));
+        struct SockRelease {
+            asio::ip::tcp::socket& s;
+            ~SockRelease() { try { (void)s.release(); } catch (...) {} }
+        } rel{sock};
+        constexpr auto kWaitWrite = asio::ip::tcp::socket::wait_write;
+        constexpr auto kWaitRead  = asio::ip::tcp::socket::wait_read;
 #else
-    asio::posix::stream_descriptor sock(ex, PQsocket(c));
-    struct SockRelease {
-        asio::posix::stream_descriptor& s;
-        ~SockRelease() { try { s.release(); } catch (...) {} }
-    } rel{sock};
-    constexpr auto kWaitWrite = asio::posix::stream_descriptor::wait_write;
-    constexpr auto kWaitRead  = asio::posix::stream_descriptor::wait_read;
+        asio::posix::stream_descriptor sock(ex, PQsocket(c));
+        struct SockRelease {
+            asio::posix::stream_descriptor& s;
+            ~SockRelease() { try { s.release(); } catch (...) {} }
+        } rel{sock};
+        constexpr auto kWaitWrite = asio::posix::stream_descriptor::wait_write;
+        constexpr auto kWaitRead  = asio::posix::stream_descriptor::wait_read;
 #endif
 
-    // Flush loop: PQflush returns 0 (done), 1 (more to send), -1 (error).
-    while (true) {
-        int f = PQflush(c);
-        if (f == 0) break;
-        if (f < 0) {
-            std::string msg = std::string("PQflush: ") + PQerrorMessage(c);
-            if (PQstatus(c) != CONNECTION_OK) throw BrokenConnection(msg);
-            throw std::runtime_error(msg);
+        // Flush loop: PQflush returns 0 (done), 1 (more to send), -1 (error).
+        while (true) {
+            int f = PQflush(c);
+            if (f == 0) break;
+            if (f < 0) {
+                std::string msg = std::string("PQflush: ") + PQerrorMessage(c);
+                if (PQstatus(c) != CONNECTION_OK) throw BrokenConnection(msg);
+                throw std::runtime_error(msg);
+            }
+            co_await sock.async_wait(kWaitWrite, asio::use_awaitable);
         }
-        co_await sock.async_wait(kWaitWrite, asio::use_awaitable);
-    }
 
-    // Consume loop: PQisBusy returns 1 while results are still on the
-    // wire. Wait for readable, pull bytes in via PQconsumeInput, repeat.
-    while (PQisBusy(c)) {
-        co_await sock.async_wait(kWaitRead, asio::use_awaitable);
-        if (PQconsumeInput(c) != 1) {
-            std::string msg = std::string("PQconsumeInput: ")
-                            + PQerrorMessage(c);
-            if (PQstatus(c) != CONNECTION_OK) throw BrokenConnection(msg);
-            throw std::runtime_error(msg);
+        // Consume loop: PQisBusy returns 1 while results are still on the
+        // wire. Wait for readable, pull bytes in via PQconsumeInput, repeat.
+        while (PQisBusy(c)) {
+            co_await sock.async_wait(kWaitRead, asio::use_awaitable);
+            if (PQconsumeInput(c) != 1) {
+                std::string msg = std::string("PQconsumeInput: ")
+                                + PQerrorMessage(c);
+                if (PQstatus(c) != CONNECTION_OK) throw BrokenConnection(msg);
+                throw std::runtime_error(msg);
+            }
         }
-    }
 
-    // Collect the single result (non-pipeline sends produce exactly
-    // one). Drain defensively in case the wire had spurious extras.
-    PGresult* res = PQgetResult(c);
-    while (auto* next = PQgetResult(c)) PQclear(next);
-    if (!res) {
-        throw std::runtime_error("PQgetResult: no result");
+        // Collect the single result (non-pipeline sends produce exactly
+        // one). Drain defensively in case the wire had spurious extras.
+        PgResult result{PQgetResult(c)};
+        while (auto* next = PQgetResult(c)) PQclear(next);
+        drained = true;
+        if (!result.raw) {
+            throw std::runtime_error("PQgetResult: no result");
+        }
+        check_ok(result, c, "exec_params_async");
+        co_return result;
+    } catch (...) {
+        if (!drained) {
+            auto cause = std::current_exception();
+            bool retryable = false;
+            try {
+                std::rethrow_exception(cause);
+            } catch (const BrokenConnection&) {
+                retryable = true;
+            } catch (...) {
+            }
+            throw QueryNotDrained{cause, retryable};
+        }
+        throw;
     }
-    check_ok(res, c, "exec_params_async");  // throws BrokenConnection or runtime_error
-    co_return PgResult{res};
 }
 
 } // namespace
@@ -905,36 +1015,60 @@ asio::awaitable<PgResult> exec_params_async(
 template <typename Fn>
 auto PostgresCheckpointStore::with_conn_async(Fn fn)
     -> decltype(fn(std::declval<pg_conn*>())) {
-    size_t idx = acquire_slot();
+    size_t idx = co_await acquire_slot_async();
     struct Releaser {
         PostgresCheckpointStore* self;
         size_t idx;
         ~Releaser() { self->release_slot(idx); }
     } guard{this, idx};
 
+    if (!pool_[idx]) rebuild_slot(idx);
+
+    std::exception_ptr first_error;
     bool need_retry = false;
     // First attempt under try — any co_await happens here, not in catch.
     try {
         co_return co_await fn(pool_[idx]->raw);
+    } catch (const QueryNotDrained& error) {
+        first_error = error.cause;
+        need_retry = error.retryable;
     } catch (const BrokenConnection&) {
+        first_error = std::current_exception();
         need_retry = true;
     }
 
-    // need_retry == true (otherwise co_return above already happened).
-    // Replace the slot's connection synchronously. Open the fresh
-    // connection into a local first; only swap into pool_[idx] after
-    // both open AND DDL succeed, so a recurring transient failure
-    // doesn't leave the slot holding an empty unique_ptr that the
-    // next acquirer would dereference (covered by the audit's
-    // "with_conn poisons slot if reconnection itself throws"
-    // finding). On open/DDL failure the original (broken) connection
-    // stays in the slot, the exception propagates, and the next
-    // acquirer naturally retries the recovery.
-    auto fresh = open_conn(conn_str_);
-    exec_sql(fresh->raw, kSchemaDDL);
-    pool_[idx] = std::move(fresh);
-    reconnect_count_.fetch_add(1, std::memory_order_relaxed);
-    co_return co_await fn(pool_[idx]->raw);
+    // Once PQsendQueryParams succeeded, an interrupted exchange leaves
+    // unread protocol data on the connection. Close it before opening a
+    // replacement; a cancelled write may already have reached PostgreSQL,
+    // so cancellation is propagated without sending the operation again.
+    try {
+        rebuild_slot(idx);
+    } catch (...) {
+        if (!need_retry) std::rethrow_exception(first_error);
+        throw;
+    }
+    if (!need_retry) std::rethrow_exception(first_error);
+
+    // One retry is retained for a genuine broken connection. The second
+    // attempt is never retried, but it still quarantines an undrained slot.
+    std::exception_ptr second_error;
+    bool must_discard = false;
+    try {
+        co_return co_await fn(pool_[idx]->raw);
+    } catch (const QueryNotDrained& error) {
+        second_error = error.cause;
+        must_discard = true;
+    } catch (const BrokenConnection&) {
+        second_error = std::current_exception();
+    }
+
+    try {
+        rebuild_slot(idx);
+    } catch (...) {
+        if (must_discard) std::rethrow_exception(second_error);
+        throw;
+    }
+    std::rethrow_exception(second_error);
 }
 
 // ── Async method overrides ────────────────────────────────────────────

--- a/src/core/postgres_checkpoint.cpp
+++ b/src/core/postgres_checkpoint.cpp
@@ -483,6 +483,10 @@ std::unique_ptr<PgConn> open_conn(const std::string& url) {
     return std::make_unique<PgConn>(raw);
 }
 
+asio::awaitable<std::unique_ptr<PgConn>> open_conn_async(
+    const std::string& url);
+asio::awaitable<void> exec_sql_async(pg_conn* c, const char* sql);
+
 struct PoolSlotWaiter {
     enum class Kind { Sync, Async };
 
@@ -681,6 +685,14 @@ void PostgresCheckpointStore::rebuild_slot(size_t idx) {
     pool_[idx].reset();
     auto fresh = open_conn(conn_str_);
     exec_sql(fresh->raw, kSchemaDDL);
+    pool_[idx] = std::move(fresh);
+    reconnect_count_.fetch_add(1, std::memory_order_relaxed);
+}
+
+asio::awaitable<void> PostgresCheckpointStore::rebuild_slot_async(size_t idx) {
+    pool_[idx].reset();
+    auto fresh = co_await open_conn_async(conn_str_);
+    co_await exec_sql_async(fresh->raw, kSchemaDDL);
     pool_[idx] = std::move(fresh);
     reconnect_count_.fetch_add(1, std::memory_order_relaxed);
 }
@@ -959,23 +971,75 @@ struct QueryNotDrained {
     bool retryable;
 };
 
-asio::awaitable<PgResult> exec_params_async(
-    pg_conn* c,
-    const char* sql,
-    const std::vector<std::string>& params,
-    const std::vector<bool>& nulls = {}) {
-
+asio::awaitable<void> wait_pg_socket(pg_conn* c, bool reading) {
     auto ex = co_await asio::this_coro::executor;
-
-    std::vector<const char*> vals(params.size(), nullptr);
-    for (size_t i = 0; i < params.size(); ++i) {
-        bool is_null = (i < nulls.size() && nulls[i]);
-        vals[i] = is_null ? nullptr : params[i].c_str();
+    int fd = PQsocket(c);
+    if (fd < 0) {
+        throw BrokenConnection(
+            std::string("PQsocket: ") + PQerrorMessage(c));
     }
 
-    // Flip to nonblocking for this exchange; restore on every exit
-    // (exception, cancellation, normal return) so subsequent sync
-    // calls on this slot still work.
+#ifdef _WIN32
+    asio::ip::tcp::socket sock(ex);
+    using NativeSock = asio::ip::tcp::socket::native_handle_type;
+    sock.assign(asio::ip::tcp::v4(), static_cast<NativeSock>(fd));
+    struct SockRelease {
+        asio::ip::tcp::socket& s;
+        ~SockRelease() { try { (void)s.release(); } catch (...) {} }
+    } rel{sock};
+    co_await sock.async_wait(
+        reading ? asio::ip::tcp::socket::wait_read
+                : asio::ip::tcp::socket::wait_write,
+        asio::use_awaitable);
+#else
+    asio::posix::stream_descriptor sock(ex, fd);
+    struct SockRelease {
+        asio::posix::stream_descriptor& s;
+        ~SockRelease() { try { s.release(); } catch (...) {} }
+    } rel{sock};
+    co_await sock.async_wait(
+        reading ? asio::posix::stream_descriptor::wait_read
+                : asio::posix::stream_descriptor::wait_write,
+        asio::use_awaitable);
+#endif
+}
+
+asio::awaitable<std::unique_ptr<PgConn>> open_conn_async(
+    const std::string& url) {
+    pg_conn* raw = PQconnectStart(url.c_str());
+    if (!raw) {
+        throw std::runtime_error(
+            "PostgresCheckpointStore: connection failed: null PGconn");
+    }
+    auto conn = std::make_unique<PgConn>(raw);
+    if (PQstatus(raw) == CONNECTION_BAD) {
+        throw std::runtime_error(
+            std::string("PostgresCheckpointStore: connection failed: ")
+            + PQerrorMessage(raw));
+    }
+
+    auto status = PGRES_POLLING_WRITING;
+    for (;;) {
+        if (status == PGRES_POLLING_READING) {
+            co_await wait_pg_socket(raw, true);
+        } else if (status == PGRES_POLLING_WRITING) {
+            co_await wait_pg_socket(raw, false);
+        }
+
+        status = PQconnectPoll(raw);
+        if (status == PGRES_POLLING_OK) co_return conn;
+        if (status == PGRES_POLLING_FAILED) {
+            throw std::runtime_error(
+                std::string("PostgresCheckpointStore: connection failed: ")
+                + PQerrorMessage(raw));
+        }
+    }
+}
+
+template <typename Send>
+asio::awaitable<std::vector<PgResult>> exec_async_results(
+    pg_conn* c, const char* context, Send send) {
+
     if (PQsetnonblocking(c, 1) != 0) {
         throw std::runtime_error(
             std::string("PQsetnonblocking(1): ") + PQerrorMessage(c));
@@ -985,48 +1049,14 @@ asio::awaitable<PgResult> exec_params_async(
         ~ModeRestore() { PQsetnonblocking(c, 0); }
     } restore{c};
 
-    int send_r = PQsendQueryParams(c, sql,
-                                    static_cast<int>(params.size()),
-                                    /*paramTypes=*/nullptr, vals.data(),
-                                    /*lengths=*/nullptr,
-                                    /*formats=*/nullptr,
-                                    /*resultFormat=*/0);
-    if (send_r != 1) {
-        std::string msg = std::string("PQsendQueryParams: ")
-                        + PQerrorMessage(c);
+    if (send() != 1) {
+        std::string msg = std::string(context) + ": " + PQerrorMessage(c);
         if (PQstatus(c) != CONNECTION_OK) throw BrokenConnection(msg);
         throw std::runtime_error(msg);
     }
 
     bool drained = false;
     try {
-        // Wrap PQsocket without taking ownership — asio would close it
-        // on destruction otherwise, and the PGconn needs to keep it
-        // across calls. release() before unwind strips the ownership.
-#ifdef _WIN32
-        // On Windows PQsocket returns int but the underlying handle is
-        // a SOCKET (UINT_PTR). Explicit cast back to the asio native
-        // handle type silences the narrowing warning and keeps us safe
-        // on 64-bit where SOCKET values can exceed INT_MAX.
-        asio::ip::tcp::socket sock(ex);
-        using NativeSock = asio::ip::tcp::socket::native_handle_type;
-        sock.assign(asio::ip::tcp::v4(), static_cast<NativeSock>(PQsocket(c)));
-        struct SockRelease {
-            asio::ip::tcp::socket& s;
-            ~SockRelease() { try { (void)s.release(); } catch (...) {} }
-        } rel{sock};
-        constexpr auto kWaitWrite = asio::ip::tcp::socket::wait_write;
-        constexpr auto kWaitRead  = asio::ip::tcp::socket::wait_read;
-#else
-        asio::posix::stream_descriptor sock(ex, PQsocket(c));
-        struct SockRelease {
-            asio::posix::stream_descriptor& s;
-            ~SockRelease() { try { s.release(); } catch (...) {} }
-        } rel{sock};
-        constexpr auto kWaitWrite = asio::posix::stream_descriptor::wait_write;
-        constexpr auto kWaitRead  = asio::posix::stream_descriptor::wait_read;
-#endif
-
         // Flush loop: PQflush returns 0 (done), 1 (more to send), -1 (error).
         while (true) {
             int f = PQflush(c);
@@ -1036,31 +1066,33 @@ asio::awaitable<PgResult> exec_params_async(
                 if (PQstatus(c) != CONNECTION_OK) throw BrokenConnection(msg);
                 throw std::runtime_error(msg);
             }
-            co_await sock.async_wait(kWaitWrite, asio::use_awaitable);
+            co_await wait_pg_socket(c, false);
         }
 
-        // Consume loop: PQisBusy returns 1 while results are still on the
-        // wire. Wait for readable, pull bytes in via PQconsumeInput, repeat.
-        while (PQisBusy(c)) {
-            co_await sock.async_wait(kWaitRead, asio::use_awaitable);
-            if (PQconsumeInput(c) != 1) {
-                std::string msg = std::string("PQconsumeInput: ")
-                                + PQerrorMessage(c);
-                if (PQstatus(c) != CONNECTION_OK) throw BrokenConnection(msg);
-                throw std::runtime_error(msg);
+        // PQgetResult is nonblocking only after PQisBusy says the next
+        // result is ready. Repeat that readiness cycle for every result;
+        // multi-statement schema setup can produce more than one.
+        std::vector<PgResult> results;
+        for (;;) {
+            while (PQisBusy(c)) {
+                co_await wait_pg_socket(c, true);
+                if (PQconsumeInput(c) != 1) {
+                    std::string msg = std::string("PQconsumeInput: ")
+                                    + PQerrorMessage(c);
+                    if (PQstatus(c) != CONNECTION_OK) throw BrokenConnection(msg);
+                    throw std::runtime_error(msg);
+                }
             }
+            auto* next = PQgetResult(c);
+            if (!next) break;
+            results.emplace_back(next);
         }
-
-        // Collect the single result (non-pipeline sends produce exactly
-        // one). Drain defensively in case the wire had spurious extras.
-        PgResult result{PQgetResult(c)};
-        while (auto* next = PQgetResult(c)) PQclear(next);
         drained = true;
-        if (!result.raw) {
+        if (results.empty()) {
             throw std::runtime_error("PQgetResult: no result");
         }
-        check_ok(result, c, "exec_params_async");
-        co_return result;
+        for (auto& result : results) check_ok(result, c, context);
+        co_return results;
     } catch (...) {
         if (!drained) {
             auto cause = std::current_exception();
@@ -1075,6 +1107,57 @@ asio::awaitable<PgResult> exec_params_async(
         }
         throw;
     }
+}
+
+asio::awaitable<PgResult> exec_params_async(
+    pg_conn* c,
+    const char* sql,
+    const std::vector<std::string>& params,
+    const std::vector<bool>& nulls = {}) {
+    std::vector<const char*> vals(params.size(), nullptr);
+    for (size_t i = 0; i < params.size(); ++i) {
+        bool is_null = (i < nulls.size() && nulls[i]);
+        vals[i] = is_null ? nullptr : params[i].c_str();
+    }
+
+    auto results = co_await exec_async_results(c, "exec_params_async", [&] {
+        return PQsendQueryParams(c, sql,
+                                 static_cast<int>(params.size()),
+                                 /*paramTypes=*/nullptr, vals.data(),
+                                 /*lengths=*/nullptr,
+                                 /*formats=*/nullptr,
+                                 /*resultFormat=*/0);
+    });
+    co_return std::move(results.front());
+}
+
+asio::awaitable<void> exec_sql_async(pg_conn* c, const char* sql) {
+    (void)co_await exec_async_results(c, "exec_sql_async", [&] {
+        return PQsendQuery(c, sql);
+    });
+}
+
+asio::awaitable<Checkpoint> finish_load_async(pg_conn* c, LoadedShell ls) {
+    std::map<std::string, json> blobs;
+    if (ls.channel_versions.is_object() && !ls.channel_versions.empty()) {
+        std::vector<std::string> params{
+            ls.cp.thread_id, ls.channel_versions.dump()};
+        auto result = co_await exec_params_async(c,
+            "SELECT b.channel, b.blob_data "
+            "FROM neograph_checkpoint_blobs AS b "
+            "JOIN jsonb_each_text($2::jsonb) AS cv(channel, version) "
+            "  ON b.channel = cv.channel "
+            " AND b.version = cv.version::bigint "
+            "WHERE b.thread_id = $1",
+            params);
+        for (int row = 0; row < PQntuples(result); ++row) {
+            blobs.emplace(col_text(result, row, 0),
+                          parse_jsonb_text(col_text(result, row, 1)));
+        }
+    }
+    ls.cp.channel_values = materialize_channel_values(
+        ls.channel_versions, blobs, static_cast<uint64_t>(ls.global_version));
+    co_return std::move(ls.cp);
 }
 
 } // namespace
@@ -1094,7 +1177,7 @@ auto PostgresCheckpointStore::with_conn_async(Fn fn)
         ~Releaser() { self->release_slot(idx); }
     } guard{this, idx};
 
-    if (!pool_[idx]) rebuild_slot(idx);
+    if (!pool_[idx]) co_await rebuild_slot_async(idx);
 
     std::exception_ptr first_error;
     bool need_retry = false;
@@ -1113,8 +1196,9 @@ auto PostgresCheckpointStore::with_conn_async(Fn fn)
     // unread protocol data on the connection. Close it before opening a
     // replacement; a cancelled write may already have reached PostgreSQL,
     // so cancellation is propagated without sending the operation again.
+    pool_[idx].reset();
     try {
-        rebuild_slot(idx);
+        co_await rebuild_slot_async(idx);
     } catch (...) {
         if (!need_retry) std::rethrow_exception(first_error);
         throw;
@@ -1134,8 +1218,9 @@ auto PostgresCheckpointStore::with_conn_async(Fn fn)
         second_error = std::current_exception();
     }
 
+    pool_[idx].reset();
     try {
-        rebuild_slot(idx);
+        co_await rebuild_slot_async(idx);
     } catch (...) {
         if (must_discard) std::rethrow_exception(second_error);
         throw;
@@ -1211,11 +1296,7 @@ PostgresCheckpointStore::load_latest_async(const std::string& thread_id) {
         [&, sql, params](pg_conn* c) -> asio::awaitable<std::optional<Checkpoint>> {
             auto res = co_await exec_params_async(c, sql.c_str(), params);
             if (PQntuples(res) == 0) co_return std::nullopt;
-            // Blob fetch still sync on the same connection — keeps
-            // the load hot path simple. For a thread with 10+ channels
-            // a future pipeline-mode batch could reduce round-trips,
-            // but typical channel counts are 2-5 so it's not load-bearing.
-            co_return finish_load(c, row_to_loaded(res, 0));
+            co_return co_await finish_load_async(c, row_to_loaded(res, 0));
         });
 }
 
@@ -1229,7 +1310,7 @@ PostgresCheckpointStore::load_by_id_async(const std::string& id) {
         [&, sql, params](pg_conn* c) -> asio::awaitable<std::optional<Checkpoint>> {
             auto res = co_await exec_params_async(c, sql.c_str(), params);
             if (PQntuples(res) == 0) co_return std::nullopt;
-            co_return finish_load(c, row_to_loaded(res, 0));
+            co_return co_await finish_load_async(c, row_to_loaded(res, 0));
         });
 }
 
@@ -1247,7 +1328,8 @@ PostgresCheckpointStore::list_async(const std::string& thread_id, int limit) {
             int n = PQntuples(res);
             out.reserve(n);
             for (int i = 0; i < n; ++i) {
-                out.push_back(finish_load(c, row_to_loaded(res, i)));
+                out.push_back(co_await finish_load_async(
+                    c, row_to_loaded(res, i)));
             }
             co_return out;
         });

--- a/src/core/postgres_checkpoint.cpp
+++ b/src/core/postgres_checkpoint.cpp
@@ -27,13 +27,18 @@
 #else
 #  include <asio/posix/stream_descriptor.hpp>
 #endif
+#include <asio/co_spawn.hpp>
+#include <asio/deferred.hpp>
+#include <asio/experimental/parallel_group.hpp>
 #include <asio/post.hpp>
 #include <asio/steady_timer.hpp>
+#include <asio/thread_pool.hpp>
 #include <asio/this_coro.hpp>
 #include <asio/use_awaitable.hpp>
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <deque>
 #include <exception>
@@ -42,6 +47,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -971,6 +977,96 @@ struct QueryNotDrained {
     bool retryable;
 };
 
+enum class SocketReady { Read, Write };
+
+std::atomic<int> connection_poll_delay_ms_for_test{0};
+std::atomic<int> connection_timeout_ms_for_test{-1};
+
+asio::thread_pool& connection_start_pool() {
+    // PQconnectStart/PQconnectPoll can perform blocking hostname lookup.
+    // Keep that work off user executors on a bounded, process-lifetime pool.
+    // The intentional process-lifetime allocation also avoids shutdown racing
+    // a resolver call that the platform API does not let us cancel.
+    static auto* pool = new asio::thread_pool(2);
+    return *pool;
+}
+
+template <typename Socket>
+asio::awaitable<SocketReady> wait_socket_either(Socket& sock) {
+    auto [order, read_error, write_error] =
+        co_await asio::experimental::make_parallel_group(
+            [&](auto token) {
+                return sock.async_wait(Socket::wait_read, std::move(token));
+            },
+            [&](auto token) {
+                return sock.async_wait(Socket::wait_write, std::move(token));
+            })
+            .async_wait(asio::experimental::wait_for_one(),
+                        asio::use_awaitable);
+
+    // If both readiness notifications completed before cancellation reached
+    // the loser, prefer read so server NOTICE traffic cannot be starved.
+    if (!read_error) co_return SocketReady::Read;
+    if (order[0] == 1 && !write_error) co_return SocketReady::Write;
+    throw asio::system_error(order[0] == 0 ? read_error : write_error);
+}
+
+template <typename Socket>
+asio::awaitable<void> wait_socket_until(
+    Socket& sock,
+    bool reading,
+    std::chrono::steady_clock::time_point deadline,
+    std::chrono::milliseconds timeout) {
+    auto ex = co_await asio::this_coro::executor;
+    asio::steady_timer timer(ex, deadline);
+    auto wait_type = reading ? Socket::wait_read : Socket::wait_write;
+    auto [order, socket_error, timer_error] =
+        co_await asio::experimental::make_parallel_group(
+            [&](auto token) {
+                return sock.async_wait(wait_type, std::move(token));
+            },
+            [&](auto token) {
+                return timer.async_wait(std::move(token));
+            })
+            .async_wait(asio::experimental::wait_for_one(),
+                        asio::use_awaitable);
+
+    if (order[0] == 1 && !timer_error) {
+        throw std::runtime_error(
+            "PostgresCheckpointStore: connection timed out after "
+            + std::to_string(timeout.count())
+            + " ms while polling libpq");
+    }
+    if (socket_error) throw asio::system_error(socket_error);
+}
+
+asio::awaitable<SocketReady> wait_pg_socket_either(pg_conn* c) {
+    auto ex = co_await asio::this_coro::executor;
+    int fd = PQsocket(c);
+    if (fd < 0) {
+        throw BrokenConnection(
+            std::string("PQsocket: ") + PQerrorMessage(c));
+    }
+
+#ifdef _WIN32
+    asio::ip::tcp::socket sock(ex);
+    using NativeSock = asio::ip::tcp::socket::native_handle_type;
+    sock.assign(asio::ip::tcp::v4(), static_cast<NativeSock>(fd));
+    struct SockRelease {
+        asio::ip::tcp::socket& s;
+        ~SockRelease() { try { (void)s.release(); } catch (...) {} }
+    } rel{sock};
+    co_return co_await wait_socket_either(sock);
+#else
+    asio::posix::stream_descriptor sock(ex, fd);
+    struct SockRelease {
+        asio::posix::stream_descriptor& s;
+        ~SockRelease() { try { s.release(); } catch (...) {} }
+    } rel{sock};
+    co_return co_await wait_socket_either(sock);
+#endif
+}
+
 asio::awaitable<void> wait_pg_socket(pg_conn* c, bool reading) {
     auto ex = co_await asio::this_coro::executor;
     int fd = PQsocket(c);
@@ -1004,29 +1100,130 @@ asio::awaitable<void> wait_pg_socket(pg_conn* c, bool reading) {
 #endif
 }
 
+asio::awaitable<void> wait_pg_socket_until(
+    pg_conn* c,
+    bool reading,
+    std::chrono::steady_clock::time_point deadline,
+    std::chrono::milliseconds timeout) {
+    auto ex = co_await asio::this_coro::executor;
+    int fd = PQsocket(c);
+    if (fd < 0) {
+        throw BrokenConnection(
+            std::string("PQsocket: ") + PQerrorMessage(c));
+    }
+
+#ifdef _WIN32
+    asio::ip::tcp::socket sock(ex);
+    using NativeSock = asio::ip::tcp::socket::native_handle_type;
+    sock.assign(asio::ip::tcp::v4(), static_cast<NativeSock>(fd));
+    struct SockRelease {
+        asio::ip::tcp::socket& s;
+        ~SockRelease() { try { (void)s.release(); } catch (...) {} }
+    } rel{sock};
+    co_await wait_socket_until(sock, reading, deadline, timeout);
+#else
+    asio::posix::stream_descriptor sock(ex, fd);
+    struct SockRelease {
+        asio::posix::stream_descriptor& s;
+        ~SockRelease() { try { s.release(); } catch (...) {} }
+    } rel{sock};
+    co_await wait_socket_until(sock, reading, deadline, timeout);
+#endif
+}
+
+std::chrono::milliseconds async_connect_timeout(pg_conn* c) {
+    int test_timeout = connection_timeout_ms_for_test.load(
+        std::memory_order_relaxed);
+    if (test_timeout >= 0) return std::chrono::milliseconds(test_timeout);
+
+    constexpr auto kProjectDefault = std::chrono::seconds(30);
+    PQconninfoOption* options = PQconninfo(c);
+    if (!options) return kProjectDefault;
+    struct OptionsFree {
+        PQconninfoOption* options;
+        ~OptionsFree() { PQconninfoFree(options); }
+    } free_options{options};
+
+    for (auto* option = options; option->keyword; ++option) {
+        if (std::strcmp(option->keyword, "connect_timeout") != 0
+            || !option->val || !*option->val) {
+            continue;
+        }
+        char* end = nullptr;
+        long seconds = std::strtol(option->val, &end, 10);
+        if (end && *end == '\0' && seconds > 0) {
+            // libpq documents a two-second minimum for connect_timeout.
+            return std::chrono::seconds(std::max(2L, seconds));
+        }
+        break;
+    }
+    return kProjectDefault;
+}
+
+asio::awaitable<std::unique_ptr<PgConn>> start_connection_off_executor(
+    const std::string& url) {
+    co_return co_await asio::co_spawn(
+        connection_start_pool(),
+        [url]() -> asio::awaitable<std::unique_ptr<PgConn>> {
+            co_return std::make_unique<PgConn>(PQconnectStart(url.c_str()));
+        },
+        asio::use_awaitable);
+}
+
+asio::awaitable<PostgresPollingStatusType> poll_connection_off_executor(
+    pg_conn* c) {
+    co_return co_await asio::co_spawn(
+        connection_start_pool(),
+        [c]() -> asio::awaitable<PostgresPollingStatusType> {
+            // Test seam models the potentially blocking hostname lookup that
+            // PostgreSQL documents inside the first PQconnectPoll call.
+            int delay = connection_poll_delay_ms_for_test.load(
+                std::memory_order_relaxed);
+            if (delay > 0) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(delay));
+            }
+            co_return PQconnectPoll(c);
+        },
+        asio::use_awaitable);
+}
+
 asio::awaitable<std::unique_ptr<PgConn>> open_conn_async(
     const std::string& url) {
-    pg_conn* raw = PQconnectStart(url.c_str());
+    // PostgreSQL 16 libpq contract, consulted 2026-07-19:
+    // PQconnectStart/PQconnectPoll can block on DNS without hostaddr, and
+    // connect_timeout is ignored by PQconnectPoll. Both calls therefore run
+    // on the bounded sidecar above, while socket waits carry our deadline.
+    // https://www.postgresql.org/docs/16/libpq-connect.html
+    auto conn = co_await start_connection_off_executor(url);
+    pg_conn* raw = conn->raw;
     if (!raw) {
         throw std::runtime_error(
             "PostgresCheckpointStore: connection failed: null PGconn");
     }
-    auto conn = std::make_unique<PgConn>(raw);
     if (PQstatus(raw) == CONNECTION_BAD) {
         throw std::runtime_error(
             std::string("PostgresCheckpointStore: connection failed: ")
             + PQerrorMessage(raw));
     }
 
+    auto timeout = async_connect_timeout(raw);
+    auto deadline = std::chrono::steady_clock::now() + timeout;
     auto status = PGRES_POLLING_WRITING;
     for (;;) {
         if (status == PGRES_POLLING_READING) {
-            co_await wait_pg_socket(raw, true);
+            co_await wait_pg_socket_until(raw, true, deadline, timeout);
         } else if (status == PGRES_POLLING_WRITING) {
-            co_await wait_pg_socket(raw, false);
+            co_await wait_pg_socket_until(raw, false, deadline, timeout);
         }
 
-        status = PQconnectPoll(raw);
+        status = co_await poll_connection_off_executor(raw);
+        if (std::chrono::steady_clock::now() >= deadline
+            && status != PGRES_POLLING_OK) {
+            throw std::runtime_error(
+                "PostgresCheckpointStore: connection timed out after "
+                + std::to_string(timeout.count())
+                + " ms while polling libpq");
+        }
         if (status == PGRES_POLLING_OK) co_return conn;
         if (status == PGRES_POLLING_FAILED) {
             throw std::runtime_error(
@@ -1057,7 +1254,10 @@ asio::awaitable<std::vector<PgResult>> exec_async_results(
 
     bool drained = false;
     try {
-        // Flush loop: PQflush returns 0 (done), 1 (more to send), -1 (error).
+        // PostgreSQL 16 libpq contract, consulted 2026-07-19: PQflush(1)
+        // requires waiting for read OR write readiness. Read-ready must call
+        // PQconsumeInput so server NOTICE backpressure cannot deadlock writes.
+        // https://www.postgresql.org/docs/16/libpq-async.html
         while (true) {
             int f = PQflush(c);
             if (f == 0) break;
@@ -1066,7 +1266,13 @@ asio::awaitable<std::vector<PgResult>> exec_async_results(
                 if (PQstatus(c) != CONNECTION_OK) throw BrokenConnection(msg);
                 throw std::runtime_error(msg);
             }
-            co_await wait_pg_socket(c, false);
+            if (co_await wait_pg_socket_either(c) == SocketReady::Read
+                && PQconsumeInput(c) != 1) {
+                std::string msg = std::string("PQconsumeInput during flush: ")
+                                + PQerrorMessage(c);
+                if (PQstatus(c) != CONNECTION_OK) throw BrokenConnection(msg);
+                throw std::runtime_error(msg);
+            }
         }
 
         // PQgetResult is nonblocking only after PQisBusy says the next
@@ -1161,6 +1367,36 @@ asio::awaitable<Checkpoint> finish_load_async(pg_conn* c, LoadedShell ls) {
 }
 
 } // namespace
+
+asio::awaitable<bool>
+PostgresCheckpointStore::wait_socket_either_for_test(int fd) {
+    auto ex = co_await asio::this_coro::executor;
+#ifdef _WIN32
+    asio::ip::tcp::socket sock(ex);
+    using NativeSock = asio::ip::tcp::socket::native_handle_type;
+    sock.assign(asio::ip::tcp::v4(), static_cast<NativeSock>(fd));
+    struct SockRelease {
+        asio::ip::tcp::socket& s;
+        ~SockRelease() { try { (void)s.release(); } catch (...) {} }
+    } rel{sock};
+    co_return co_await wait_socket_either(sock) == SocketReady::Read;
+#else
+    asio::posix::stream_descriptor sock(ex, fd);
+    struct SockRelease {
+        asio::posix::stream_descriptor& s;
+        ~SockRelease() { try { s.release(); } catch (...) {} }
+    } rel{sock};
+    co_return co_await wait_socket_either(sock) == SocketReady::Read;
+#endif
+}
+
+void PostgresCheckpointStore::set_async_connection_test_seams(
+    int poll_delay_ms, int timeout_ms) {
+    connection_poll_delay_ms_for_test.store(poll_delay_ms,
+                                             std::memory_order_relaxed);
+    connection_timeout_ms_for_test.store(timeout_ms,
+                                         std::memory_order_relaxed);
+}
 
 // Async peer of with_conn. Template — definition here (same TU as the
 // only instantiation points) so the Fn → awaitable<T> inference works

--- a/src/core/postgres_checkpoint.cpp
+++ b/src/core/postgres_checkpoint.cpp
@@ -27,6 +27,8 @@
 #else
 #  include <asio/posix/stream_descriptor.hpp>
 #endif
+#include <asio/bind_cancellation_slot.hpp>
+#include <asio/cancellation_state.hpp>
 #include <asio/deferred.hpp>
 #include <asio/experimental/parallel_group.hpp>
 #include <asio/post.hpp>
@@ -598,6 +600,7 @@ void PostgresCheckpointStore::drop_schema() {
     // We can safely take pool_mutex_ here because drop_schema is
     // test-only and never called concurrently with regular ops.
     std::unique_lock lock(pool_mutex_);
+    if (!pool_[0]) rebuild_slot(0);
     exec_sql(pool_[0]->raw, kDropDDL);
     exec_sql(pool_[0]->raw, kSchemaDDL);
     // No prepared statements to re-register — the libpq rewrite sends
@@ -1026,6 +1029,30 @@ asio::awaitable<Result> run_connection_step_off_executor(
     co_return result.get();
 }
 
+bool is_operation_aborted(const std::exception_ptr& error) {
+    try {
+        std::rethrow_exception(error);
+    } catch (const asio::system_error& e) {
+        return e.code() == asio::error::operation_aborted;
+    } catch (...) {
+        return false;
+    }
+}
+
+void discard_cancelled_connection_off_executor(std::unique_ptr<PgConn> conn) {
+    if (!conn) return;
+    auto owned = std::shared_ptr<PgConn>(conn.release());
+    asio::post(connection_start_pool(), [owned] {
+        auto cancel = std::unique_ptr<PGcancel, decltype(&PQfreeCancel)>(
+            PQgetCancel(owned->raw), PQfreeCancel);
+        if (cancel) {
+            char error[256]{};
+            (void)PQcancel(cancel.get(), error, sizeof(error));
+        }
+        // `owned` closes the original connection only after PQcancel returns.
+    });
+}
+
 template <typename Socket>
 asio::awaitable<SocketReady> wait_socket_either(Socket& sock) {
     auto [order, read_error, write_error] =
@@ -1101,6 +1128,7 @@ asio::awaitable<SocketReady> wait_pg_socket_either(pg_conn* c) {
 
 asio::awaitable<void> wait_pg_socket(pg_conn* c, bool reading) {
     auto ex = co_await asio::this_coro::executor;
+    auto cancellation = co_await asio::this_coro::cancellation_state;
     int fd = PQsocket(c);
     if (fd < 0) {
         throw BrokenConnection(
@@ -1118,7 +1146,8 @@ asio::awaitable<void> wait_pg_socket(pg_conn* c, bool reading) {
     co_await sock.async_wait(
         reading ? asio::ip::tcp::socket::wait_read
                 : asio::ip::tcp::socket::wait_write,
-        asio::use_awaitable);
+        asio::bind_cancellation_slot(
+            cancellation.slot(), asio::use_awaitable));
 #else
     asio::posix::stream_descriptor sock(ex, fd);
     struct SockRelease {
@@ -1128,7 +1157,8 @@ asio::awaitable<void> wait_pg_socket(pg_conn* c, bool reading) {
     co_await sock.async_wait(
         reading ? asio::posix::stream_descriptor::wait_read
                 : asio::posix::stream_descriptor::wait_write,
-        asio::use_awaitable);
+        asio::bind_cancellation_slot(
+            cancellation.slot(), asio::use_awaitable));
 #endif
 }
 
@@ -1491,48 +1521,66 @@ auto PostgresCheckpointStore::with_conn_async(Fn fn)
 
     std::exception_ptr first_error;
     bool need_retry = false;
+    bool cancel_before_close = false;
     // First attempt under try — any co_await happens here, not in catch.
     try {
         co_return co_await fn(pool_[idx]->raw);
     } catch (const QueryNotDrained& error) {
         first_error = error.cause;
         need_retry = error.retryable;
+        cancel_before_close = !need_retry && is_operation_aborted(error.cause);
     } catch (const BrokenConnection&) {
         first_error = std::current_exception();
         need_retry = true;
     }
 
     // Once PQsendQueryParams succeeded, an interrupted exchange leaves
-    // unread protocol data on the connection. Close it before opening a
-    // replacement; a cancelled write may already have reached PostgreSQL,
-    // so cancellation is propagated without sending the operation again.
+    // unread protocol data on the connection. A cancelled write may already
+    // have reached PostgreSQL, so transfer that dirty connection to the
+    // bounded worker that sends PQcancel before closing it. Reconnection is
+    // deferred to the next operation and the write is never retried.
+    if (!need_retry) {
+        if (cancel_before_close) {
+            discard_cancelled_connection_off_executor(std::move(pool_[idx]));
+        } else {
+            pool_[idx].reset();
+        }
+        std::rethrow_exception(first_error);
+    }
     pool_[idx].reset();
     try {
         co_await rebuild_slot_async(idx);
     } catch (...) {
-        if (!need_retry) std::rethrow_exception(first_error);
         throw;
     }
-    if (!need_retry) std::rethrow_exception(first_error);
 
     // One retry is retained for a genuine broken connection. The second
     // attempt is never retried, but it still quarantines an undrained slot.
     std::exception_ptr second_error;
     bool must_discard = false;
+    bool cancel_second_before_close = false;
     try {
         co_return co_await fn(pool_[idx]->raw);
     } catch (const QueryNotDrained& error) {
         second_error = error.cause;
         must_discard = true;
+        cancel_second_before_close = is_operation_aborted(error.cause);
     } catch (const BrokenConnection&) {
         second_error = std::current_exception();
     }
 
+    if (must_discard) {
+        if (cancel_second_before_close) {
+            discard_cancelled_connection_off_executor(std::move(pool_[idx]));
+        } else {
+            pool_[idx].reset();
+        }
+        std::rethrow_exception(second_error);
+    }
     pool_[idx].reset();
     try {
         co_await rebuild_slot_async(idx);
     } catch (...) {
-        if (must_discard) std::rethrow_exception(second_error);
         throw;
     }
     std::rethrow_exception(second_error);

--- a/src/core/postgres_checkpoint.cpp
+++ b/src/core/postgres_checkpoint.cpp
@@ -512,12 +512,19 @@ PostgresCheckpointStore::PostgresCheckpointStore(PoolOnlyTag,
 
 PostgresCheckpointStore::~PostgresCheckpointStore() = default;
 
-struct PostgresCheckpointStore::AsyncSlotWaiter {
-    explicit AsyncSlotWaiter(asio::any_io_executor ex)
-        : wake(std::move(ex), asio::steady_timer::time_point::max()) {}
+struct PostgresCheckpointStore::SlotWaiter {
+    enum class Kind { Sync, Async };
 
-    asio::steady_timer wake;
+    SlotWaiter() : kind(Kind::Sync) {}
+    explicit SlotWaiter(asio::any_io_executor ex)
+        : kind(Kind::Async),
+          async_wake(std::in_place, std::move(ex),
+                     asio::steady_timer::time_point::max()) {}
+
+    Kind kind;
     std::optional<size_t> slot;
+    std::condition_variable sync_wake;
+    std::optional<asio::steady_timer> async_wake;
 };
 
 void PostgresCheckpointStore::ensure_schema() {
@@ -541,43 +548,49 @@ void PostgresCheckpointStore::drop_schema() {
 
 size_t PostgresCheckpointStore::acquire_slot() {
     std::unique_lock lock(pool_mutex_);
-    pool_cv_.wait(lock, [this] { return !free_.empty(); });
-    size_t idx = free_.front();
-    free_.pop();
-    return idx;
+    if (waiters_.empty() && !free_.empty()) {
+        size_t idx = free_.front();
+        free_.pop();
+        return idx;
+    }
+
+    auto waiter = std::make_shared<SlotWaiter>();
+    waiters_.push_back(waiter);
+    waiter->sync_wake.wait(lock, [&] { return waiter->slot.has_value(); });
+    return *waiter->slot;
 }
 
 asio::awaitable<size_t> PostgresCheckpointStore::acquire_slot_async() {
     auto ex = co_await asio::this_coro::executor;
     {
         std::lock_guard lock(pool_mutex_);
-        if (!free_.empty()) {
+        if (waiters_.empty() && !free_.empty()) {
             size_t idx = free_.front();
             free_.pop();
             co_return idx;
         }
     }
 
-    auto waiter = std::make_shared<AsyncSlotWaiter>(ex);
+    auto waiter = std::make_shared<SlotWaiter>(ex);
     {
         std::lock_guard lock(pool_mutex_);
-        if (!free_.empty()) {
+        if (waiters_.empty() && !free_.empty()) {
             size_t idx = free_.front();
             free_.pop();
             co_return idx;
         }
-        async_waiters_.push_back(waiter);
+        waiters_.push_back(waiter);
     }
 
     try {
-        co_await waiter->wake.async_wait(asio::use_awaitable);
+        co_await waiter->async_wake->async_wait(asio::use_awaitable);
     } catch (...) {
         std::lock_guard lock(pool_mutex_);
         if (waiter->slot) {
             co_return *waiter->slot;
         }
-        auto it = std::find(async_waiters_.begin(), async_waiters_.end(), waiter);
-        if (it != async_waiters_.end()) async_waiters_.erase(it);
+        auto it = std::find(waiters_.begin(), waiters_.end(), waiter);
+        if (it != waiters_.end()) waiters_.erase(it);
         throw;
     }
 
@@ -585,23 +598,24 @@ asio::awaitable<size_t> PostgresCheckpointStore::acquire_slot_async() {
 }
 
 void PostgresCheckpointStore::release_slot(size_t idx) {
-    std::shared_ptr<AsyncSlotWaiter> waiter;
+    std::shared_ptr<SlotWaiter> waiter;
     {
         std::lock_guard lock(pool_mutex_);
-        if (!async_waiters_.empty()) {
-            waiter = async_waiters_.front();
-            async_waiters_.pop_front();
+        if (!waiters_.empty()) {
+            waiter = waiters_.front();
+            waiters_.pop_front();
             waiter->slot = idx;
         } else {
             free_.push(idx);
         }
     }
-    if (waiter) {
-        asio::post(waiter->wake.get_executor(), [waiter] {
-            waiter->wake.cancel();
-        });
+    if (!waiter) return;
+    if (waiter->kind == SlotWaiter::Kind::Sync) {
+        waiter->sync_wake.notify_one();
     } else {
-        pool_cv_.notify_one();
+        asio::post(waiter->async_wake->get_executor(), [waiter] {
+            waiter->async_wake->cancel();
+        });
     }
 }
 
@@ -1242,15 +1256,16 @@ asio::awaitable<void> PostgresCheckpointStore::put_writes_async(
                 insert_params);
 
             (void)co_await exec_params_async(c, "COMMIT", empty_params);
-        } catch (...) {
-            // Best-effort rollback. Can't co_await inside catch (GCC 13
-            // ICE), so use the sync exec_sql helper — fast path since
-            // connection is still nonblocking-set but PQexec works on
-            // either mode.
-            PQsetnonblocking(c, 0);
-            PGresult* r = PQexec(c, "ROLLBACK");
-            if (r) PQclear(r);
+        } catch (const QueryNotDrained&) {
             throw;
+        } catch (const BrokenConnection&) {
+            throw;
+        } catch (...) {
+            // A cancellation may land between transaction statements, and
+            // an operation exception may mean unread protocol data remains.
+            // Never issue a blocking rollback on that uncertain connection;
+            // force with_conn_async to close it and preserve the cause.
+            throw QueryNotDrained{std::current_exception(), false};
         }
         co_return;
     });

--- a/src/core/provider.cpp
+++ b/src/core/provider.cpp
@@ -27,17 +27,6 @@
 
 namespace neograph {
 
-// Candidate 6 PR4: the 4 legacy virtuals (complete / complete_async /
-// complete_stream / complete_stream_async) are now [[deprecated]]; this
-// TU is the canonical default-chain implementation that legitimately
-// calls them on behalf of legacy subclasses + the new invoke() default
-// (which forwards into the 4-virtual chain through the deprecation
-// window). Bracket the whole namespace body so internal forwarders
-// don't drown the build in self-warnings; user code overriding the
-// 4 virtuals or calling them externally still sees the marker on its
-// own override / call site.
-NEOGRAPH_PUSH_IGNORE_DEPRECATED
-
 ChatCompletion Provider::complete(const CompletionParams& params) {
     // v1.0 (9d): the legacy `current_cancel_token()` thread_local
     // fallback is gone. Callers must pin `params.cancel_token` if they
@@ -167,17 +156,10 @@ Provider::complete_stream_async(const CompletionParams& params,
     }
 }
 
-// v1.0 unified invoke() — additive virtual that future-proofs the
-// Provider dispatch surface. New providers override THIS one method;
-// legacy providers (OpenAIProvider's complete_async + complete_stream_async
-// overrides, SchemaProvider's same pair, RateLimitedProvider's 4-method
-// delegation, every user-written Provider subclass) keep working
-// unchanged because the default body below forwards to the legacy
-// 4-virtual chain — preserving the current cross-product fallback.
-//
-// Subsequent Candidate 6 PRs migrate native subclasses to override
-// invoke() directly; the 4 legacy virtuals then gain [[deprecated]]
-// markers; v1.0 deletes them. See ROADMAP_v1.md Candidate 6.
+// Compatibility callback-selected entry point. Existing providers keep
+// working because this default forwards to the stable 4-virtual chain.
+// New providers should derive from CompletionProvider, where explicit
+// CompletionRequest mode selection reaches one do_invoke() override.
 //
 // v1.0 (9d): invoke() default is now the simple single-dispatch
 // forward — `params.cancel_token` is the only cancel channel. Engine-
@@ -192,7 +174,5 @@ Provider::invoke(const CompletionParams& params, StreamCallback on_chunk) {
     }
     co_return co_await complete_async(params);
 }
-
-NEOGRAPH_POP_IGNORE_DEPRECATED
 
 } // namespace neograph

--- a/src/llm/openai_provider.cpp
+++ b/src/llm/openai_provider.cpp
@@ -332,14 +332,11 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
     return completion;
 }
 
-// Candidate 6 PR6: v1.0 single-dispatch native override. Anchors the
-// dispatch surface — by overriding invoke() here, the engine's
+// Compatibility callback-selected override. The engine's
 // `provider_->invoke(...)` calls land on this method directly instead
 // of bouncing through the base-class default that re-forwards to the
-// 4-virtual chain. Body still routes through the existing native
-// overrides for v0.9 (no behavioural change); v1.0 will collapse the
-// complete_async + complete_stream bodies into invoke() and delete
-// the legacy methods.
+// 4-virtual chain. The body routes through the existing native
+// overrides without changing their supported public behavior.
 //
 // Streaming branch deliberately uses `complete_stream_async` (not
 // the sync `complete_stream` directly) because OpenAI's streaming
@@ -347,7 +344,6 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
 // default spawns a worker thread and dispatches tokens onto the
 // awaiter's executor, which is the issue #4 fix. Skipping that
 // bridge would re-introduce the engine io_context blocker.
-NEOGRAPH_PUSH_IGNORE_DEPRECATED
 asio::awaitable<ChatCompletion>
 OpenAIProvider::invoke(const CompletionParams& params, StreamCallback on_chunk) {
     if (on_chunk) {
@@ -355,6 +351,5 @@ OpenAIProvider::invoke(const CompletionParams& params, StreamCallback on_chunk) 
     }
     co_return co_await complete_async(params);
 }
-NEOGRAPH_POP_IGNORE_DEPRECATED
 
 } // namespace neograph::llm

--- a/src/llm/rate_limited_provider.cpp
+++ b/src/llm/rate_limited_provider.cpp
@@ -11,14 +11,6 @@
 
 namespace neograph::llm {
 
-// Candidate 6 PR4: inner Provider's 4 legacy virtuals are now
-// [[deprecated]]. RateLimitedProvider is a delegating decorator that
-// wraps the legacy surface for retry/backoff; it MUST keep forwarding
-// to the inner's legacy methods through the deprecation window.
-// Bracket the whole TU so internal forwarders don't drown in self-
-// warnings; v1.0 collapses these to a single invoke() override.
-NEOGRAPH_PUSH_IGNORE_DEPRECATED
-
 RateLimitedProvider::RateLimitedProvider(std::shared_ptr<Provider> inner,
                                          Config cfg)
     : inner_(std::move(inner)), cfg_(cfg) {
@@ -124,11 +116,8 @@ RateLimitedProvider::complete_stream(const CompletionParams& params,
     }
 }
 
-// Candidate 6 PR6: v1.0 single-dispatch native override. Routes
-// through existing 4-virtual overrides (each wraps inner with
-// retry/backoff). v1.0 will fold the retry loop into invoke()
-// and delete the legacy methods. Already inside the file-wide
-// PUSH_IGNORE block so legacy calls below don't re-warn.
+// Compatibility callback-selected override. It routes through the stable
+// existing overrides so each path keeps its retry/backoff behavior.
 asio::awaitable<ChatCompletion>
 RateLimitedProvider::invoke(const CompletionParams& params, StreamCallback on_chunk) {
     if (on_chunk) {
@@ -137,7 +126,5 @@ RateLimitedProvider::invoke(const CompletionParams& params, StreamCallback on_ch
     }
     co_return co_await complete_async(params);
 }
-
-NEOGRAPH_POP_IGNORE_DEPRECATED
 
 } // namespace neograph::llm

--- a/src/llm/schema_provider.cpp
+++ b/src/llm/schema_provider.cpp
@@ -2017,15 +2017,12 @@ SchemaProvider::complete_stream_ws_responses(const CompletionParams& params,
     co_return completion;
 }
 
-// Candidate 6 PR6: v1.0 single-dispatch native override. Routes
-// through the existing 4-virtual native overrides for v0.9 (no
-// behavioural change). Streaming branch goes to
+// Compatibility callback-selected override. It routes through the
+// existing native overrides without changing their supported behavior.
+// The streaming branch goes to
 // `complete_stream_async` not the sync `complete_stream` so the
 // WebSocket Responses native-async path + the HTTP/SSE worker-thread
-// bridge stay in effect (issue #4 protection). v1.0 collapses
-// complete_async + complete_stream_async bodies into invoke() and
-// deletes the legacy methods.
-NEOGRAPH_PUSH_IGNORE_DEPRECATED
+// bridge stay in effect (issue #4 protection).
 asio::awaitable<ChatCompletion>
 SchemaProvider::invoke(const CompletionParams& params, StreamCallback on_chunk) {
     if (on_chunk) {
@@ -2033,6 +2030,5 @@ SchemaProvider::invoke(const CompletionParams& params, StreamCallback on_chunk) 
     }
     co_return co_await complete_async(params);
 }
-NEOGRAPH_POP_IGNORE_DEPRECATED
 
 } // namespace neograph::llm

--- a/src/observability/openinference.cpp
+++ b/src/observability/openinference.cpp
@@ -152,6 +152,8 @@ struct OpenInferenceTracerSession::Impl {
             if (batch.root) {
                 try { batch.root->end(); } catch (...) {}
             }
+            batch.spans.clear();
+            batch.root.reset();
             if (batch.closes_state) {
                 std::lock_guard<std::mutex> lock(mu);
                 finalized = true;
@@ -678,13 +680,11 @@ std::shared_ptr<ProviderSpanState> start_provider_span(
         if (child_span_starter) {
             span = child_span_starter(*tracer, span_name);
         } else {
-            // A raw parent callback cannot carry a lifetime lease. Invoke it
-            // for compatibility, but open a root span rather than racing a
-            // concurrent session close with a dangling parent pointer.
+            Span* parent = nullptr;
             if (parent_lookup) {
-                try { (void)parent_lookup(); } catch (...) {}
+                try { parent = parent_lookup(); } catch (...) {}
             }
-            span = tracer->start_span(span_name, nullptr);
+            span = tracer->start_span(span_name, parent);
         }
     } catch (...) {
         return {};

--- a/src/observability/openinference.cpp
+++ b/src/observability/openinference.cpp
@@ -164,24 +164,30 @@ struct OpenInferenceTracerSession::Impl {
         }
 
         void release_operation() noexcept {
-            FinalizeBatch batch;
-            {
-                std::lock_guard<std::mutex> lock(mu);
-                const auto owner = std::this_thread::get_id();
-                auto it = operation_owners.find(owner);
-                if (it != operation_owners.end()) {
-                    if (--it->second == 0) operation_owners.erase(it);
-                }
-                if (in_flight > 0) --in_flight;
-                if (in_flight == 0) {
-                    if (closed && !finalizing && !finalized) {
-                        batch = collect_locked(true);
-                    } else if (!closed && !retired.empty()) {
+            while (true) {
+                FinalizeBatch batch;
+                bool keep_lease = false;
+                {
+                    std::lock_guard<std::mutex> lock(mu);
+                    if (!closed && in_flight == 1 && !retired.empty()) {
                         batch = collect_locked(false);
+                        keep_lease = true;
+                    } else {
+                        const auto owner = std::this_thread::get_id();
+                        auto it = operation_owners.find(owner);
+                        if (it != operation_owners.end()) {
+                            if (--it->second == 0) operation_owners.erase(it);
+                        }
+                        if (in_flight > 0) --in_flight;
+                        if (in_flight == 0 && closed
+                            && !finalizing && !finalized) {
+                            batch = collect_locked(true);
+                        }
                     }
                 }
+                run_batch(std::move(batch));
+                if (!keep_lease) return;
             }
-            run_batch(std::move(batch));
         }
 
         void close() {

--- a/src/observability/openinference.cpp
+++ b/src/observability/openinference.cpp
@@ -394,15 +394,8 @@ void record_output(Span* span, const ChatCompletion& result) {
 
 } // namespace
 
-// Candidate 6 PR4: inner Provider's 4 legacy virtuals are now
-// [[deprecated]]. OpenInferenceProvider is a tracing decorator that
-// MUST keep wrapping all 4 surfaces through the deprecation window so
-// downstream code calling any legacy method on a wrapped provider
-// still gets a span. The 4 overrides below legitimately forward to
-// `impl_->inner->complete*()` — bracket the region so the build
-// doesn't drown in self-warnings. v1.0 collapses these to a single
-// `invoke()` override.
-NEOGRAPH_PUSH_IGNORE_DEPRECATED
+// Keep wrapping every stable Provider entry point so callers get the same
+// tracing behavior regardless of which compatibility surface they use.
 
 ChatCompletion OpenInferenceProvider::complete(const CompletionParams& params) {
     Span* parent = impl_->parent_lookup ? impl_->parent_lookup() : nullptr;
@@ -521,11 +514,8 @@ OpenInferenceProvider::complete_stream_async(
     }
 }
 
-// Candidate 6 PR6: v1.0 single-dispatch native override. Routes
-// through the existing 4-virtual native overrides so each call still
-// emits exactly one span (already inside the file-wide PUSH_IGNORE
-// block). v1.0 will fold the span-recording into a single invoke()
-// body and delete the legacy methods.
+// Compatibility callback-selected override. Route through the existing
+// overrides so each call still emits exactly one span.
 asio::awaitable<ChatCompletion>
 OpenInferenceProvider::invoke(const CompletionParams& params, StreamCallback on_chunk) {
     if (on_chunk) {
@@ -533,7 +523,5 @@ OpenInferenceProvider::invoke(const CompletionParams& params, StreamCallback on_
     }
     co_return co_await complete_async(params);
 }
-
-NEOGRAPH_POP_IGNORE_DEPRECATED
 
 } // namespace neograph::observability

--- a/src/observability/openinference.cpp
+++ b/src/observability/openinference.cpp
@@ -11,10 +11,11 @@
 
 #include <neograph/json.h>
 
-#include <atomic>
+#include <algorithm>
 #include <exception>
 #include <map>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -71,26 +72,66 @@ std::string node_output_blob(const std::string& node_name, const json& data) {
 // ---------------------------------------------------------------------------
 
 struct OpenInferenceTracerSession::Impl {
-    Tracer* tracer = nullptr;
-    std::string root_name;
-    std::string node_span_prefix;
-    std::unique_ptr<Span> root_span;
-    std::atomic<bool> closed{false};
+    struct State {
+        Tracer* tracer = nullptr;
+        std::string root_name;
+        std::string node_span_prefix;
+        std::unique_ptr<Span> root_span;
+        bool closed = false;
 
-    // Per-node span stacks. Stack semantics so nested fan-outs (a node
-    // re-entered before its prior NODE_END landed) close in LIFO order.
-    // Mutex-guarded — engine event callback may fire from worker pool
-    // threads.
-    std::mutex pending_mu;
-    std::map<std::string, std::vector<std::unique_ptr<Span>>> pending;
+        // Serializes complete callback executions with close(). A copied
+        // callback holds only a weak_ptr, so it becomes a no-op after the
+        // session state is destroyed.
+        mutable std::mutex callback_mu;
+        std::map<std::string, std::vector<std::unique_ptr<Span>>> pending;
+        std::vector<Span*> active_nodes;
 
-    // The currently-active node span exposed to OpenInferenceProvider
-    // via current_parent(). Tracks the most recently opened, not yet
-    // ended, node span — best-effort under fan-out (single pointer,
-    // not per-thread). For strict per-node-LLM nesting, callers should
-    // capture parent_lookup returning the right span via their own
-    // contextvar / threading.local instead.
-    std::atomic<Span*> active_node{nullptr};
+        // Best-effort current parent for callers without thread-local span
+        // context. Protected by callback_mu because ending a span invalidates
+        // this raw pointer.
+        Span* active_node = nullptr;
+
+        void add_node_span(const std::string& node,
+                           std::unique_ptr<Span> span) noexcept {
+            try {
+                auto& stack = pending[node];
+                stack.push_back(std::move(span));
+                Span* current = stack.back().get();
+                try {
+                    active_nodes.push_back(current);
+                } catch (...) {
+                    span = std::move(stack.back());
+                    stack.pop_back();
+                    if (span) {
+                        try { span->end(); } catch (...) {}
+                    }
+                    return;
+                }
+                active_node = current;
+            } catch (...) {
+                if (span) {
+                    try { span->end(); } catch (...) {}
+                }
+            }
+        }
+
+        std::unique_ptr<Span> take_node_span(const std::string& node) {
+            auto it = pending.find(node);
+            if (it == pending.end() || it->second.empty()) return {};
+
+            auto span = std::move(it->second.back());
+            it->second.pop_back();
+            if (!span) return {};
+
+            active_nodes.erase(
+                std::remove(active_nodes.begin(), active_nodes.end(), span.get()),
+                active_nodes.end());
+            active_node = active_nodes.empty() ? nullptr : active_nodes.back();
+            return span;
+        }
+    };
+
+    std::shared_ptr<State> state = std::make_shared<State>();
 };
 
 OpenInferenceTracerSession::OpenInferenceTracerSession()
@@ -101,67 +142,80 @@ OpenInferenceTracerSession::~OpenInferenceTracerSession() {
 }
 
 OpenInferenceTracerSession::OpenInferenceTracerSession(
-    OpenInferenceTracerSession&&) noexcept = default;
+    OpenInferenceTracerSession&& other) noexcept
+    : cb(std::move(other.cb)), impl_(std::move(other.impl_)) {}
+
 OpenInferenceTracerSession& OpenInferenceTracerSession::operator=(
-    OpenInferenceTracerSession&&) noexcept = default;
+    OpenInferenceTracerSession&& other) noexcept {
+    if (this == &other) return *this;
+    close();
+    cb = std::move(other.cb);
+    impl_ = std::move(other.impl_);
+    return *this;
+}
 
 void OpenInferenceTracerSession::close() {
     if (!impl_) return;
-    bool expected = false;
-    if (!impl_->closed.compare_exchange_strong(expected, true)) return;
+    auto state = impl_->state;
+    if (!state) return;
 
-    {
-        std::lock_guard<std::mutex> lock(impl_->pending_mu);
-        for (auto& [node, stack] : impl_->pending) {
-            while (!stack.empty()) {
-                try { stack.back()->end(); } catch (...) {}
-                stack.pop_back();
-            }
+    std::lock_guard<std::mutex> lock(state->callback_mu);
+    if (state->closed) return;
+    state->closed = true;
+    state->active_node = nullptr;
+    state->active_nodes.clear();
+    for (auto& [node, stack] : state->pending) {
+        while (!stack.empty()) {
+            try { stack.back()->end(); } catch (...) {}
+            stack.pop_back();
         }
-        impl_->pending.clear();
     }
-    impl_->active_node.store(nullptr);
-    if (impl_->root_span) {
-        try { impl_->root_span->end(); } catch (...) {}
-        impl_->root_span.reset();
+    state->pending.clear();
+    if (state->root_span) {
+        try { state->root_span->end(); } catch (...) {}
+        state->root_span.reset();
     }
 }
 
 Span* OpenInferenceTracerSession::current_parent() const noexcept {
     if (!impl_) return nullptr;
-    Span* node = impl_->active_node.load();
-    return node ? node : impl_->root_span.get();
+    auto state = impl_->state;
+    if (!state) return nullptr;
+    std::lock_guard<std::mutex> lock(state->callback_mu);
+    if (state->closed) return nullptr;
+    return state->active_node ? state->active_node : state->root_span.get();
 }
 
 OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
                                                 std::string root_name,
                                                 std::string node_span_prefix) {
     OpenInferenceTracerSession session;
-    auto* impl = session.impl_.get();
-    impl->tracer = &tracer;
-    impl->root_name = std::move(root_name);
-    impl->node_span_prefix = std::move(node_span_prefix);
-    impl->root_span = tracer.start_span(impl->root_name);
-    if (impl->root_span) {
+    auto state = session.impl_->state;
+    state->tracer = &tracer;
+    state->root_name = std::move(root_name);
+    state->node_span_prefix = std::move(node_span_prefix);
+    state->root_span = tracer.start_span(state->root_name);
+    if (state->root_span) {
         try {
-            impl->root_span->set_attribute(kSpanKind, "CHAIN");
+            state->root_span->set_attribute(kSpanKind, "CHAIN");
         } catch (...) {}
     }
 
-    // Capture the impl pointer (not the session, which is moved) into
-    // the callback. The session owns impl via unique_ptr; the callback
-    // is owned by std::function inside the session, lifetimes match.
-    session.cb = [impl](const graph::GraphEvent& ev) {
-        if (impl->closed.load()) return;
-        if (!impl->tracer) return;
+    std::weak_ptr<OpenInferenceTracerSession::Impl::State> weak_state = state;
+    session.cb = [weak_state](const graph::GraphEvent& ev) {
+        auto state = weak_state.lock();
+        if (!state) return;
+
+        std::lock_guard<std::mutex> callback_lock(state->callback_mu);
+        if (state->closed || !state->tracer) return;
 
         const std::string& node = ev.node_name;
         try {
             switch (ev.type) {
             case graph::GraphEvent::Type::NODE_START: {
-                Span* parent = impl->root_span.get();
-                auto span = impl->tracer->start_span(
-                    impl->node_span_prefix + node, parent);
+                Span* parent = state->root_span.get();
+                auto span = state->tracer->start_span(
+                    state->node_span_prefix + node, parent);
                 if (!span) break;
                 try {
                     span->set_attribute(kSpanKind, "CHAIN");
@@ -184,21 +238,12 @@ OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
                     span->set_attribute(kInputMime, "application/json");
                 } catch (...) {}
 
-                impl->active_node.store(span.get());
-                std::lock_guard<std::mutex> lock(impl->pending_mu);
-                impl->pending[node].push_back(std::move(span));
+                state->add_node_span(node, std::move(span));
                 break;
             }
 
             case graph::GraphEvent::Type::NODE_END: {
-                std::unique_ptr<Span> span;
-                {
-                    std::lock_guard<std::mutex> lock(impl->pending_mu);
-                    auto it = impl->pending.find(node);
-                    if (it == impl->pending.end() || it->second.empty()) break;
-                    span = std::move(it->second.back());
-                    it->second.pop_back();
-                }
+                auto span = state->take_node_span(node);
                 if (!span) break;
                 try {
                     if (ev.data.is_object()) {
@@ -220,24 +265,17 @@ OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
                     span->set_status_ok();
                 } catch (...) {}
                 try { span->end(); } catch (...) {}
-                // Best-effort: clear active_node if we just closed it.
-                Span* expected = nullptr;
-                impl->active_node.compare_exchange_strong(expected, nullptr);
                 break;
             }
 
             case graph::GraphEvent::Type::ERROR: {
-                std::unique_ptr<Span> span;
-                {
-                    std::lock_guard<std::mutex> lock(impl->pending_mu);
-                    auto it = impl->pending.find(node);
-                    if (it == impl->pending.end() || it->second.empty()) break;
-                    span = std::move(it->second.back());
-                    it->second.pop_back();
-                }
+                auto span = state->take_node_span(node);
                 if (!span) break;
-                std::string msg = ev.data.is_string()
-                    ? ev.data.get<std::string>() : ev.data.dump();
+                std::string msg = "unknown error";
+                try {
+                    msg = ev.data.is_string()
+                        ? ev.data.get<std::string>() : ev.data.dump();
+                } catch (...) {}
                 try {
                     span->set_attribute("neograph.error", msg);
                     span->set_status_error(msg);
@@ -247,14 +285,7 @@ OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
             }
 
             case graph::GraphEvent::Type::INTERRUPT: {
-                std::unique_ptr<Span> span;
-                {
-                    std::lock_guard<std::mutex> lock(impl->pending_mu);
-                    auto it = impl->pending.find(node);
-                    if (it == impl->pending.end() || it->second.empty()) break;
-                    span = std::move(it->second.back());
-                    it->second.pop_back();
-                }
+                auto span = state->take_node_span(node);
                 if (!span) break;
                 try { span->set_attribute_bool("neograph.interrupted", true); }
                 catch (...) {}
@@ -268,9 +299,8 @@ OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
                 // timeline view; OTel SDK exporters treat them as
                 // span events (not new spans) so cardinality stays
                 // bounded.
-                std::lock_guard<std::mutex> lock(impl->pending_mu);
-                auto it = impl->pending.find(node);
-                if (it == impl->pending.end() || it->second.empty()) break;
+                auto it = state->pending.find(node);
+                if (it == state->pending.end() || it->second.empty()) break;
                 Span* current = it->second.back().get();
                 if (!current) break;
                 std::string payload = ev.data.is_string()
@@ -311,6 +341,10 @@ OpenInferenceProvider::OpenInferenceProvider(
     std::function<Span*()> parent_lookup,
     std::string span_name)
     : impl_(std::make_unique<Impl>()) {
+    if (!inner) {
+        throw std::invalid_argument(
+            "OpenInferenceProvider requires a non-null inner Provider");
+    }
     impl_->inner = std::move(inner);
     impl_->tracer = &tracer;
     impl_->parent_lookup = std::move(parent_lookup);
@@ -392,52 +426,157 @@ void record_output(Span* span, const ChatCompletion& result) {
     } catch (...) {}
 }
 
+class ProviderSpanState {
+public:
+    explicit ProviderSpanState(std::unique_ptr<Span> span)
+        : span_(std::move(span)) {}
+
+    ~ProviderSpanState() { end(); }
+
+    void record(const CompletionParams& params) noexcept {
+        try {
+            std::lock_guard<std::mutex> lock(mu_);
+            if (!ended_) record_input(span_.get(), params);
+        } catch (...) {}
+    }
+
+    void add_token(const std::string& chunk) noexcept {
+        try {
+            std::lock_guard<std::mutex> lock(mu_);
+            if (!ended_ && span_) {
+                try { span_->add_event("llm.token", chunk); } catch (...) {}
+            }
+        } catch (...) {}
+    }
+
+    void finish_ok(const ChatCompletion& result,
+                   const std::string* streamed_output = nullptr) noexcept {
+        try {
+            std::lock_guard<std::mutex> lock(mu_);
+            if (ended_) return;
+            record_output(span_.get(), result);
+            if (span_ && streamed_output) {
+                try { span_->set_attribute(kOutputValue, *streamed_output); }
+                catch (...) {}
+            }
+            if (span_) {
+                try { span_->set_status_ok(); } catch (...) {}
+            }
+            end_locked();
+        } catch (...) {}
+    }
+
+    void finish_error(std::string_view message) noexcept {
+        try {
+            std::lock_guard<std::mutex> lock(mu_);
+            if (ended_) return;
+            if (span_) {
+                try { span_->set_status_error(message); } catch (...) {}
+            }
+            end_locked();
+        } catch (...) {}
+    }
+
+    void end() noexcept {
+        try {
+            std::lock_guard<std::mutex> lock(mu_);
+            end_locked();
+        } catch (...) {}
+    }
+
+private:
+    void end_locked() noexcept {
+        if (ended_) return;
+        ended_ = true;
+        if (span_) {
+            try { span_->end(); } catch (...) {}
+        }
+    }
+
+    std::mutex mu_;
+    std::unique_ptr<Span> span_;
+    bool ended_ = false;
+};
+
+class ProviderSpanGuard {
+public:
+    explicit ProviderSpanGuard(std::shared_ptr<ProviderSpanState> state)
+        : state_(std::move(state)) {}
+
+    ~ProviderSpanGuard() {
+        if (state_) state_->end();
+    }
+
+private:
+    std::shared_ptr<ProviderSpanState> state_;
+};
+
+std::shared_ptr<ProviderSpanState> start_provider_span(
+    Tracer* tracer,
+    const std::function<Span*()>& parent_lookup,
+    const std::string& span_name,
+    const CompletionParams& params) noexcept {
+    Span* parent = nullptr;
+    if (parent_lookup) {
+        try { parent = parent_lookup(); } catch (...) {}
+    }
+
+    std::unique_ptr<Span> span;
+    try {
+        span = tracer->start_span(span_name, parent);
+    } catch (...) {
+        return {};
+    }
+    if (!span) return {};
+
+    try {
+        auto state = std::make_shared<ProviderSpanState>(std::move(span));
+        state->record(params);
+        return state;
+    } catch (...) {
+        if (span) {
+            try { span->end(); } catch (...) {}
+        }
+        return {};
+    }
+}
+
 } // namespace
 
 // Keep wrapping every stable Provider entry point so callers get the same
 // tracing behavior regardless of which compatibility surface they use.
 
 ChatCompletion OpenInferenceProvider::complete(const CompletionParams& params) {
-    Span* parent = impl_->parent_lookup ? impl_->parent_lookup() : nullptr;
-    auto span = impl_->tracer->start_span(impl_->span_name, parent);
-    record_input(span.get(), params);
+    auto trace = start_provider_span(
+        impl_->tracer, impl_->parent_lookup, impl_->span_name, params);
+    ProviderSpanGuard guard(trace);
     try {
         auto result = impl_->inner->complete(params);
-        record_output(span.get(), result);
-        if (span) { try { span->set_status_ok(); } catch (...) {} }
-        if (span) { try { span->end(); } catch (...) {} }
+        if (trace) trace->finish_ok(result);
         return result;
     } catch (const std::exception& e) {
-        if (span) {
-            try { span->set_status_error(e.what()); } catch (...) {}
-            try { span->end(); } catch (...) {}
-        }
+        if (trace) trace->finish_error(e.what());
         throw;
     } catch (...) {
-        if (span) {
-            try { span->set_status_error("unknown error"); } catch (...) {}
-            try { span->end(); } catch (...) {}
-        }
+        if (trace) trace->finish_error("unknown error");
         throw;
     }
 }
 
 asio::awaitable<ChatCompletion>
 OpenInferenceProvider::complete_async(const CompletionParams& params) {
-    Span* parent = impl_->parent_lookup ? impl_->parent_lookup() : nullptr;
-    auto span = impl_->tracer->start_span(impl_->span_name, parent);
-    record_input(span.get(), params);
+    auto trace = start_provider_span(
+        impl_->tracer, impl_->parent_lookup, impl_->span_name, params);
+    ProviderSpanGuard guard(trace);
     try {
         auto result = co_await impl_->inner->complete_async(params);
-        record_output(span.get(), result);
-        if (span) { try { span->set_status_ok(); } catch (...) {} }
-        if (span) { try { span->end(); } catch (...) {} }
+        if (trace) trace->finish_ok(result);
         co_return result;
     } catch (const std::exception& e) {
-        if (span) {
-            try { span->set_status_error(e.what()); } catch (...) {}
-            try { span->end(); } catch (...) {}
-        }
+        if (trace) trace->finish_error(e.what());
+        throw;
+    } catch (...) {
+        if (trace) trace->finish_error("unknown error");
         throw;
     }
 }
@@ -445,35 +584,27 @@ OpenInferenceProvider::complete_async(const CompletionParams& params) {
 ChatCompletion OpenInferenceProvider::complete_stream(
     const CompletionParams& params,
     const StreamCallback& on_chunk) {
-    Span* parent = impl_->parent_lookup ? impl_->parent_lookup() : nullptr;
-    auto span = impl_->tracer->start_span(impl_->span_name, parent);
-    record_input(span.get(), params);
+    auto trace = start_provider_span(
+        impl_->tracer, impl_->parent_lookup, impl_->span_name, params);
+    ProviderSpanGuard guard(trace);
 
     std::string accumulated;
-    StreamCallback wrapped = [&accumulated, &on_chunk, sp = span.get()]
+    StreamCallback wrapped = [&accumulated, &on_chunk, trace]
         (const std::string& chunk) {
-        accumulated += chunk;
-        if (sp) { try { sp->add_event("llm.token", chunk); } catch (...) {} }
+        try { accumulated += chunk; } catch (...) {}
+        if (trace) trace->add_token(chunk);
         if (on_chunk) on_chunk(chunk);
     };
 
     try {
         auto result = impl_->inner->complete_stream(params, wrapped);
-        record_output(span.get(), result);
-        if (span) {
-            // Stream-specific: also surface the assembled output for
-            // backends that prefer attributes over events.
-            try { span->set_attribute(kOutputValue, accumulated); }
-            catch (...) {}
-            try { span->set_status_ok(); } catch (...) {}
-            try { span->end(); } catch (...) {}
-        }
+        if (trace) trace->finish_ok(result, &accumulated);
         return result;
     } catch (const std::exception& e) {
-        if (span) {
-            try { span->set_status_error(e.what()); } catch (...) {}
-            try { span->end(); } catch (...) {}
-        }
+        if (trace) trace->finish_error(e.what());
+        throw;
+    } catch (...) {
+        if (trace) trace->finish_error("unknown error");
         throw;
     }
 }
@@ -482,34 +613,30 @@ asio::awaitable<ChatCompletion>
 OpenInferenceProvider::complete_stream_async(
     const CompletionParams& params,
     const StreamCallback& on_chunk) {
-    Span* parent = impl_->parent_lookup ? impl_->parent_lookup() : nullptr;
-    auto span = impl_->tracer->start_span(impl_->span_name, parent);
-    record_input(span.get(), params);
+    auto trace = start_provider_span(
+        impl_->tracer, impl_->parent_lookup, impl_->span_name, params);
+    ProviderSpanGuard guard(trace);
 
-    auto accumulated = std::make_shared<std::string>();
-    Span* sp = span.get();
-    StreamCallback wrapped = [accumulated, on_chunk, sp]
+    std::shared_ptr<std::string> accumulated;
+    try { accumulated = std::make_shared<std::string>(); } catch (...) {}
+    StreamCallback wrapped = [accumulated, on_chunk, trace]
         (const std::string& chunk) {
-        *accumulated += chunk;
-        if (sp) { try { sp->add_event("llm.token", chunk); } catch (...) {} }
+        if (accumulated) {
+            try { *accumulated += chunk; } catch (...) {}
+        }
+        if (trace) trace->add_token(chunk);
         if (on_chunk) on_chunk(chunk);
     };
 
     try {
         auto result = co_await impl_->inner->complete_stream_async(params, wrapped);
-        record_output(span.get(), result);
-        if (span) {
-            try { span->set_attribute(kOutputValue, *accumulated); }
-            catch (...) {}
-            try { span->set_status_ok(); } catch (...) {}
-            try { span->end(); } catch (...) {}
-        }
+        if (trace) trace->finish_ok(result, accumulated.get());
         co_return result;
     } catch (const std::exception& e) {
-        if (span) {
-            try { span->set_status_error(e.what()); } catch (...) {}
-            try { span->end(); } catch (...) {}
-        }
+        if (trace) trace->finish_error(e.what());
+        throw;
+    } catch (...) {
+        if (trace) trace->finish_error("unknown error");
         throw;
     }
 }

--- a/src/observability/openinference.cpp
+++ b/src/observability/openinference.cpp
@@ -12,11 +12,14 @@
 #include <neograph/json.h>
 
 #include <algorithm>
+#include <condition_variable>
 #include <exception>
+#include <list>
 #include <map>
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <vector>
 
 namespace neograph::observability {
@@ -73,62 +76,207 @@ std::string node_output_blob(const std::string& node_name, const json& data) {
 
 struct OpenInferenceTracerSession::Impl {
     struct State {
+        using SpanList = std::list<std::unique_ptr<Span>>;
+
+        struct FinalizeBatch {
+            SpanList spans;
+            std::unique_ptr<Span> root;
+            bool closes_state = false;
+        };
+
         Tracer* tracer = nullptr;
         std::string root_name;
         std::string node_span_prefix;
         std::unique_ptr<Span> root_span;
         bool closed = false;
+        bool finalizing = false;
+        bool finalized = false;
+        size_t in_flight = 0;
+        std::thread::id finalizer_thread;
 
-        // Serializes complete callback executions with close(). A copied
-        // callback holds only a weak_ptr, so it becomes a no-op after the
-        // session state is destroyed.
-        mutable std::mutex callback_mu;
-        std::map<std::string, std::vector<std::unique_ptr<Span>>> pending;
+        // Session operations hold a gate, not this mutex, while invoking
+        // arbitrary tracer code. close() waits for ordinary concurrent
+        // operations, while a re-entrant close is finalized by the last
+        // operation leaving the gate.
+        mutable std::mutex mu;
+        std::condition_variable cv;
+        std::map<std::thread::id, size_t> operation_owners;
+        std::map<std::string, SpanList> pending;
+        SpanList retired;
         std::vector<Span*> active_nodes;
 
         // Best-effort current parent for callers without thread-local span
-        // context. Protected by callback_mu because ending a span invalidates
+        // context. Protected by mu because ending a span invalidates
         // this raw pointer.
         Span* active_node = nullptr;
 
+        bool acquire_operation(Span** parent = nullptr) {
+            std::lock_guard<std::mutex> lock(mu);
+            if (closed) return false;
+            try {
+                ++operation_owners[std::this_thread::get_id()];
+            } catch (...) {
+                return false;
+            }
+            ++in_flight;
+            if (parent) {
+                *parent = active_node ? active_node : root_span.get();
+            }
+            return true;
+        }
+
+        FinalizeBatch collect_locked(bool closing) {
+            FinalizeBatch batch;
+            batch.spans.splice(batch.spans.end(), retired);
+            if (closing) {
+                for (auto& [node, stack] : pending) {
+                    batch.spans.splice(batch.spans.end(), stack);
+                }
+                pending.clear();
+                active_nodes.clear();
+                active_node = nullptr;
+                batch.root = std::move(root_span);
+                batch.closes_state = true;
+                finalizing = true;
+                finalizer_thread = std::this_thread::get_id();
+            }
+            return batch;
+        }
+
+        void run_batch(FinalizeBatch batch) noexcept {
+            for (auto& span : batch.spans) {
+                if (span) {
+                    try { span->end(); } catch (...) {}
+                }
+            }
+            if (batch.root) {
+                try { batch.root->end(); } catch (...) {}
+            }
+            if (batch.closes_state) {
+                std::lock_guard<std::mutex> lock(mu);
+                finalized = true;
+                finalizing = false;
+                finalizer_thread = {};
+                cv.notify_all();
+            }
+        }
+
+        void release_operation() noexcept {
+            FinalizeBatch batch;
+            {
+                std::lock_guard<std::mutex> lock(mu);
+                const auto owner = std::this_thread::get_id();
+                auto it = operation_owners.find(owner);
+                if (it != operation_owners.end()) {
+                    if (--it->second == 0) operation_owners.erase(it);
+                }
+                if (in_flight > 0) --in_flight;
+                if (in_flight == 0) {
+                    if (closed && !finalizing && !finalized) {
+                        batch = collect_locked(true);
+                    } else if (!closed && !retired.empty()) {
+                        batch = collect_locked(false);
+                    }
+                }
+            }
+            run_batch(std::move(batch));
+        }
+
+        void close() {
+            FinalizeBatch batch;
+            {
+                std::unique_lock<std::mutex> lock(mu);
+                if (finalized) return;
+                closed = true;
+
+                const auto caller = std::this_thread::get_id();
+                const bool reentrant = operation_owners.contains(caller);
+                if (finalizing) {
+                    if (reentrant || finalizer_thread == caller) return;
+                    cv.wait(lock, [&] { return finalized; });
+                    return;
+                }
+                if (in_flight == 0) {
+                    batch = collect_locked(true);
+                } else if (reentrant) {
+                    return;
+                } else {
+                    cv.wait(lock, [&] { return finalized; });
+                    return;
+                }
+            }
+            run_batch(std::move(batch));
+        }
+
         void add_node_span(const std::string& node,
                            std::unique_ptr<Span> span) noexcept {
+            std::unique_ptr<Span> failed;
             try {
+                std::lock_guard<std::mutex> lock(mu);
                 auto& stack = pending[node];
                 stack.push_back(std::move(span));
                 Span* current = stack.back().get();
                 try {
                     active_nodes.push_back(current);
                 } catch (...) {
-                    span = std::move(stack.back());
-                    stack.pop_back();
-                    if (span) {
-                        try { span->end(); } catch (...) {}
-                    }
+                    retired.splice(retired.end(), stack, std::prev(stack.end()));
                     return;
                 }
                 active_node = current;
             } catch (...) {
-                if (span) {
-                    try { span->end(); } catch (...) {}
-                }
+                failed = std::move(span);
+            }
+            if (failed) {
+                try { failed->end(); } catch (...) {}
             }
         }
 
-        std::unique_ptr<Span> take_node_span(const std::string& node) {
+        Span* retire_node_span(const std::string& node) {
+            std::lock_guard<std::mutex> lock(mu);
             auto it = pending.find(node);
-            if (it == pending.end() || it->second.empty()) return {};
+            if (it == pending.end() || it->second.empty()) return nullptr;
 
-            auto span = std::move(it->second.back());
-            it->second.pop_back();
-            if (!span) return {};
+            Span* span = it->second.back().get();
+            if (!span) return nullptr;
 
             active_nodes.erase(
-                std::remove(active_nodes.begin(), active_nodes.end(), span.get()),
+                std::remove(active_nodes.begin(), active_nodes.end(), span),
                 active_nodes.end());
             active_node = active_nodes.empty() ? nullptr : active_nodes.back();
+            retired.splice(retired.end(), it->second, std::prev(it->second.end()));
             return span;
         }
+
+        Span* token_span(const std::string& node) const noexcept {
+            std::lock_guard<std::mutex> lock(mu);
+            auto it = pending.find(node);
+            if (it == pending.end() || it->second.empty()) return nullptr;
+            return it->second.back().get();
+        }
+
+        Span* current_parent_snapshot() const noexcept {
+            std::lock_guard<std::mutex> lock(mu);
+            if (closed) return nullptr;
+            return active_node ? active_node : root_span.get();
+        }
+    };
+
+    struct Operation {
+        explicit Operation(std::shared_ptr<State> state,
+                           bool capture_parent = false)
+            : state(std::move(state)),
+              parent(nullptr),
+              active(this->state->acquire_operation(
+                  capture_parent ? &parent : nullptr)) {}
+        ~Operation() {
+            if (active) state->release_operation();
+        }
+
+        explicit operator bool() const noexcept { return active; }
+
+        std::shared_ptr<State> state;
+        Span* parent = nullptr;
+        bool active = false;
     };
 
     std::shared_ptr<State> state = std::make_shared<State>();
@@ -158,32 +306,28 @@ void OpenInferenceTracerSession::close() {
     if (!impl_) return;
     auto state = impl_->state;
     if (!state) return;
-
-    std::lock_guard<std::mutex> lock(state->callback_mu);
-    if (state->closed) return;
-    state->closed = true;
-    state->active_node = nullptr;
-    state->active_nodes.clear();
-    for (auto& [node, stack] : state->pending) {
-        while (!stack.empty()) {
-            try { stack.back()->end(); } catch (...) {}
-            stack.pop_back();
-        }
-    }
-    state->pending.clear();
-    if (state->root_span) {
-        try { state->root_span->end(); } catch (...) {}
-        state->root_span.reset();
-    }
+    state->close();
 }
 
 Span* OpenInferenceTracerSession::current_parent() const noexcept {
     if (!impl_) return nullptr;
     auto state = impl_->state;
     if (!state) return nullptr;
-    std::lock_guard<std::mutex> lock(state->callback_mu);
-    if (state->closed) return nullptr;
-    return state->active_node ? state->active_node : state->root_span.get();
+    return state->current_parent_snapshot();
+}
+
+OpenInferenceTracerSession::ChildSpanStarter
+OpenInferenceTracerSession::child_span_starter() const {
+    std::weak_ptr<Impl::State> weak_state;
+    if (impl_) weak_state = impl_->state;
+    return [weak_state](Tracer& tracer, std::string_view name) {
+        auto state = weak_state.lock();
+        if (!state) return tracer.start_span(name, nullptr);
+
+        Impl::Operation operation(state, true);
+        if (!operation) return tracer.start_span(name, nullptr);
+        return tracer.start_span(name, operation.parent);
+    };
 }
 
 OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
@@ -206,8 +350,8 @@ OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
         auto state = weak_state.lock();
         if (!state) return;
 
-        std::lock_guard<std::mutex> callback_lock(state->callback_mu);
-        if (state->closed || !state->tracer) return;
+        OpenInferenceTracerSession::Impl::Operation operation(state);
+        if (!operation || !state->tracer) return;
 
         const std::string& node = ev.node_name;
         try {
@@ -243,7 +387,7 @@ OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
             }
 
             case graph::GraphEvent::Type::NODE_END: {
-                auto span = state->take_node_span(node);
+                Span* span = state->retire_node_span(node);
                 if (!span) break;
                 try {
                     if (ev.data.is_object()) {
@@ -259,17 +403,16 @@ OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
                                 std::string("neograph.") + kv.key(), val);
                         }
                     }
-                    span->set_attribute(kOutputValue,
-                                        node_output_blob(node, ev.data));
+                    span->set_attribute(
+                        kOutputValue, node_output_blob(node, ev.data));
                     span->set_attribute(kOutputMime, "application/json");
                     span->set_status_ok();
                 } catch (...) {}
-                try { span->end(); } catch (...) {}
                 break;
             }
 
             case graph::GraphEvent::Type::ERROR: {
-                auto span = state->take_node_span(node);
+                Span* span = state->retire_node_span(node);
                 if (!span) break;
                 std::string msg = "unknown error";
                 try {
@@ -280,16 +423,14 @@ OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
                     span->set_attribute("neograph.error", msg);
                     span->set_status_error(msg);
                 } catch (...) {}
-                try { span->end(); } catch (...) {}
                 break;
             }
 
             case graph::GraphEvent::Type::INTERRUPT: {
-                auto span = state->take_node_span(node);
+                Span* span = state->retire_node_span(node);
                 if (!span) break;
                 try { span->set_attribute_bool("neograph.interrupted", true); }
                 catch (...) {}
-                try { span->end(); } catch (...) {}
                 break;
             }
 
@@ -299,9 +440,7 @@ OpenInferenceTracerSession openinference_tracer(Tracer& tracer,
                 // timeline view; OTel SDK exporters treat them as
                 // span events (not new spans) so cardinality stays
                 // bounded.
-                auto it = state->pending.find(node);
-                if (it == state->pending.end() || it->second.empty()) break;
-                Span* current = it->second.back().get();
+                Span* current = state->token_span(node);
                 if (!current) break;
                 std::string payload = ev.data.is_string()
                     ? ev.data.get<std::string>() : ev.data.dump();
@@ -332,6 +471,7 @@ struct OpenInferenceProvider::Impl {
     std::shared_ptr<Provider> inner;
     Tracer* tracer = nullptr;
     std::function<Span*()> parent_lookup;
+    OpenInferenceTracerSession::ChildSpanStarter child_span_starter;
     std::string span_name;
 };
 
@@ -348,6 +488,22 @@ OpenInferenceProvider::OpenInferenceProvider(
     impl_->inner = std::move(inner);
     impl_->tracer = &tracer;
     impl_->parent_lookup = std::move(parent_lookup);
+    impl_->span_name = std::move(span_name);
+}
+
+OpenInferenceProvider::OpenInferenceProvider(
+    std::shared_ptr<Provider> inner,
+    Tracer& tracer,
+    const OpenInferenceTracerSession& session,
+    std::string span_name)
+    : impl_(std::make_unique<Impl>()) {
+    if (!inner) {
+        throw std::invalid_argument(
+            "OpenInferenceProvider requires a non-null inner Provider");
+    }
+    impl_->inner = std::move(inner);
+    impl_->tracer = &tracer;
+    impl_->child_span_starter = session.child_span_starter();
     impl_->span_name = std::move(span_name);
 }
 
@@ -514,16 +670,22 @@ private:
 std::shared_ptr<ProviderSpanState> start_provider_span(
     Tracer* tracer,
     const std::function<Span*()>& parent_lookup,
+    const OpenInferenceTracerSession::ChildSpanStarter& child_span_starter,
     const std::string& span_name,
     const CompletionParams& params) noexcept {
-    Span* parent = nullptr;
-    if (parent_lookup) {
-        try { parent = parent_lookup(); } catch (...) {}
-    }
-
     std::unique_ptr<Span> span;
     try {
-        span = tracer->start_span(span_name, parent);
+        if (child_span_starter) {
+            span = child_span_starter(*tracer, span_name);
+        } else {
+            // A raw parent callback cannot carry a lifetime lease. Invoke it
+            // for compatibility, but open a root span rather than racing a
+            // concurrent session close with a dangling parent pointer.
+            if (parent_lookup) {
+                try { (void)parent_lookup(); } catch (...) {}
+            }
+            span = tracer->start_span(span_name, nullptr);
+        }
     } catch (...) {
         return {};
     }
@@ -548,7 +710,8 @@ std::shared_ptr<ProviderSpanState> start_provider_span(
 
 ChatCompletion OpenInferenceProvider::complete(const CompletionParams& params) {
     auto trace = start_provider_span(
-        impl_->tracer, impl_->parent_lookup, impl_->span_name, params);
+        impl_->tracer, impl_->parent_lookup, impl_->child_span_starter,
+        impl_->span_name, params);
     ProviderSpanGuard guard(trace);
     try {
         auto result = impl_->inner->complete(params);
@@ -566,7 +729,8 @@ ChatCompletion OpenInferenceProvider::complete(const CompletionParams& params) {
 asio::awaitable<ChatCompletion>
 OpenInferenceProvider::complete_async(const CompletionParams& params) {
     auto trace = start_provider_span(
-        impl_->tracer, impl_->parent_lookup, impl_->span_name, params);
+        impl_->tracer, impl_->parent_lookup, impl_->child_span_starter,
+        impl_->span_name, params);
     ProviderSpanGuard guard(trace);
     try {
         auto result = co_await impl_->inner->complete_async(params);
@@ -585,7 +749,8 @@ ChatCompletion OpenInferenceProvider::complete_stream(
     const CompletionParams& params,
     const StreamCallback& on_chunk) {
     auto trace = start_provider_span(
-        impl_->tracer, impl_->parent_lookup, impl_->span_name, params);
+        impl_->tracer, impl_->parent_lookup, impl_->child_span_starter,
+        impl_->span_name, params);
     ProviderSpanGuard guard(trace);
 
     std::string accumulated;
@@ -614,7 +779,8 @@ OpenInferenceProvider::complete_stream_async(
     const CompletionParams& params,
     const StreamCallback& on_chunk) {
     auto trace = start_provider_span(
-        impl_->tracer, impl_->parent_lookup, impl_->span_name, params);
+        impl_->tracer, impl_->parent_lookup, impl_->child_span_starter,
+        impl_->span_name, params);
     ProviderSpanGuard guard(trace);
 
     std::shared_ptr<std::string> accumulated;

--- a/test.bat
+++ b/test.bat
@@ -1,0 +1,71 @@
+@echo off
+setlocal EnableExtensions
+
+cd /d "%~dp0"
+
+set "BUILD_DIR=build-windows"
+set "CONFIG=Release"
+set "BUILD_POSTGRES=OFF"
+set "CTEST_PARALLEL=--parallel"
+
+if /I "%~1"=="postgres" (
+    set "BUILD_POSTGRES=ON"
+    set "CTEST_PARALLEL=--parallel 1"
+)
+if not "%~1"=="" if /I not "%~1"=="postgres" goto :usage
+
+where cmake >nul 2>nul
+if errorlevel 1 (
+    echo ERROR: cmake was not found in PATH.
+    exit /b 1
+)
+
+where python >nul 2>nul
+if errorlevel 1 (
+    echo ERROR: python was not found in PATH. MCP stdio tests require it.
+    exit /b 1
+)
+
+if not defined OPENSSL_ROOT_DIR (
+    if exist "C:\Program Files\OpenSSL-Win64\include\openssl\ssl.h" (
+        set "OPENSSL_ROOT_DIR=C:\Program Files\OpenSSL-Win64"
+    )
+)
+
+if not defined OPENSSL_ROOT_DIR (
+    echo ERROR: OpenSSL was not found.
+    echo Install it with: choco install openssl -y
+    echo Or set OPENSSL_ROOT_DIR to the OpenSSL installation directory.
+    exit /b 1
+)
+
+echo Configuring NeoGraph in %BUILD_DIR%...
+cmake -S . -B "%BUILD_DIR%" ^
+    -G "Visual Studio 17 2022" -A x64 ^
+    -DOPENSSL_ROOT_DIR="%OPENSSL_ROOT_DIR%" ^
+    -DNEOGRAPH_USE_LIBCURL=OFF ^
+    -DNEOGRAPH_BUILD_LLM=ON ^
+    -DNEOGRAPH_BUILD_MCP=ON ^
+    -DNEOGRAPH_BUILD_UTIL=ON ^
+    -DNEOGRAPH_BUILD_POSTGRES=%BUILD_POSTGRES% ^
+    -DNEOGRAPH_BUILD_SQLITE=OFF ^
+    -DNEOGRAPH_BUILD_TESTS=ON ^
+    -DNEOGRAPH_BUILD_EXAMPLES=OFF
+if errorlevel 1 exit /b 1
+
+echo Building NeoGraph %CONFIG%...
+cmake --build "%BUILD_DIR%" --config "%CONFIG%" --parallel
+if errorlevel 1 exit /b 1
+
+echo Running tests...
+ctest --test-dir "%BUILD_DIR%" -C "%CONFIG%" --output-on-failure %CTEST_PARALLEL%
+if errorlevel 1 exit /b 1
+
+echo All Windows tests passed.
+exit /b 0
+
+:usage
+echo Usage: test.bat [postgres]
+echo   postgres  Build PostgreSQL support. Set NEOGRAPH_TEST_POSTGRES_URL
+echo             to run the PostgreSQL integration tests against a live server.
+exit /b 2

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -116,6 +116,11 @@ target_sources(neograph_tests PRIVATE test_async_get.cpp)
 if(NEOGRAPH_BUILD_POSTGRES)
     target_sources(neograph_tests PRIVATE test_postgres_checkpoint.cpp)
     target_compile_definitions(neograph_tests PRIVATE NEOGRAPH_TESTS_HAVE_POSTGRES)
+
+    add_executable(neograph_postgres_old_header_abi
+        test_postgres_old_header_abi.cpp)
+    target_link_libraries(neograph_postgres_old_header_abi PRIVATE
+        neograph::postgres)
 endif()
 
 if(NEOGRAPH_BUILD_SQLITE)
@@ -160,6 +165,13 @@ if(NEOGRAPH_BUILD_SQLITE)
 endif()
 
 include(GoogleTest)
+
+if(NEOGRAPH_BUILD_POSTGRES)
+    add_test(NAME PostgresCheckpointAbiTest.OldHeaderNewLibrary
+        COMMAND neograph_postgres_old_header_abi)
+    set_tests_properties(PostgresCheckpointAbiTest.OldHeaderNewLibrary
+        PROPERTIES RESOURCE_LOCK postgres_test_db)
+endif()
 
 # ThreadSanitizer ASLR notice: when CMAKE_CXX_FLAGS contains
 # `-fsanitize=thread`, the test binaries can FATAL with

--- a/tests/fixtures/postgres_checkpoint_origin.h
+++ b/tests/fixtures/postgres_checkpoint_origin.h
@@ -92,7 +92,10 @@ private:
     std::atomic<size_t> reconnect_count_{0};
 };
 
-#if defined(__linux__) && defined(__x86_64__) && INTPTR_MAX == INT64_MAX
+#if defined(__ANDROID__) && defined(__aarch64__) && INTPTR_MAX == INT64_MAX
+static_assert(sizeof(PostgresCheckpointStore) == 200);
+static_assert(alignof(PostgresCheckpointStore) == 8);
+#elif defined(__linux__) && defined(__x86_64__) && INTPTR_MAX == INT64_MAX
 static_assert(sizeof(PostgresCheckpointStore) == 240);
 static_assert(alignof(PostgresCheckpointStore) == 8);
 #elif defined(__linux__) && defined(__aarch64__) && INTPTR_MAX == INT64_MAX

--- a/tests/fixtures/postgres_checkpoint_origin.h
+++ b/tests/fixtures/postgres_checkpoint_origin.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <neograph/graph/checkpoint.h>
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <string>
+#include <vector>
+
+struct pg_conn;
+
+namespace neograph::graph {
+
+struct PgConn {
+    pg_conn* raw = nullptr;
+    PgConn() = default;
+    explicit PgConn(pg_conn* p) : raw(p) {}
+    ~PgConn();
+    PgConn(const PgConn&) = delete;
+    PgConn& operator=(const PgConn&) = delete;
+    PgConn(PgConn&&) = delete;
+    PgConn& operator=(PgConn&&) = delete;
+};
+
+// Frozen origin/master declaration used to prove old-header/new-library ABI.
+class NEOGRAPH_API PostgresCheckpointStore : public CheckpointStore {
+public:
+    explicit PostgresCheckpointStore(const std::string& conn_str,
+                                     size_t pool_size = 8);
+    size_t reconnect_count() const { return reconnect_count_; }
+    size_t pool_size() const { return pool_.size(); }
+    ~PostgresCheckpointStore() override;
+
+    PostgresCheckpointStore(const PostgresCheckpointStore&) = delete;
+    PostgresCheckpointStore& operator=(const PostgresCheckpointStore&) = delete;
+
+    void save(const Checkpoint& cp) override;
+    std::optional<Checkpoint> load_latest(const std::string& thread_id) override;
+    std::optional<Checkpoint> load_by_id(const std::string& id) override;
+    std::vector<Checkpoint> list(const std::string& thread_id,
+                                 int limit = 100) override;
+    void delete_thread(const std::string& thread_id) override;
+
+    void put_writes(const std::string& thread_id,
+                    const std::string& parent_checkpoint_id,
+                    const PendingWrite& write) override;
+    std::vector<PendingWrite> get_writes(
+        const std::string& thread_id,
+        const std::string& parent_checkpoint_id) override;
+    void clear_writes(const std::string& thread_id,
+                      const std::string& parent_checkpoint_id) override;
+
+    asio::awaitable<void> save_async(const Checkpoint& cp) override;
+    asio::awaitable<std::optional<Checkpoint>>
+    load_latest_async(const std::string& thread_id) override;
+    asio::awaitable<std::optional<Checkpoint>>
+    load_by_id_async(const std::string& id) override;
+    asio::awaitable<std::vector<Checkpoint>>
+    list_async(const std::string& thread_id, int limit = 100) override;
+    asio::awaitable<void> delete_thread_async(const std::string& thread_id) override;
+    asio::awaitable<void> put_writes_async(
+        const std::string& thread_id,
+        const std::string& parent_checkpoint_id,
+        const PendingWrite& write) override;
+    asio::awaitable<std::vector<PendingWrite>> get_writes_async(
+        const std::string& thread_id,
+        const std::string& parent_checkpoint_id) override;
+    asio::awaitable<void> clear_writes_async(
+        const std::string& thread_id,
+        const std::string& parent_checkpoint_id) override;
+
+    void drop_schema();
+    size_t blob_count();
+
+private:
+    void ensure_schema();
+    template <typename Fn> auto with_conn(Fn&& fn);
+    template <typename Fn>
+    auto with_conn_async(Fn fn) -> decltype(fn(std::declval<pg_conn*>()));
+    size_t acquire_slot();
+    void release_slot(size_t idx);
+
+    std::string conn_str_;
+    std::vector<std::unique_ptr<PgConn>> pool_;
+    std::queue<size_t> free_;
+    std::mutex pool_mutex_;
+    std::condition_variable pool_cv_;
+    std::atomic<size_t> reconnect_count_{0};
+};
+
+#if defined(__linux__) && INTPTR_MAX == INT64_MAX
+static_assert(sizeof(PostgresCheckpointStore) == 240);
+static_assert(alignof(PostgresCheckpointStore) == 8);
+#endif
+
+} // namespace neograph::graph

--- a/tests/fixtures/postgres_checkpoint_origin.h
+++ b/tests/fixtures/postgres_checkpoint_origin.h
@@ -92,8 +92,11 @@ private:
     std::atomic<size_t> reconnect_count_{0};
 };
 
-#if defined(__linux__) && INTPTR_MAX == INT64_MAX
+#if defined(__linux__) && defined(__x86_64__) && INTPTR_MAX == INT64_MAX
 static_assert(sizeof(PostgresCheckpointStore) == 240);
+static_assert(alignof(PostgresCheckpointStore) == 8);
+#elif defined(__linux__) && defined(__aarch64__) && INTPTR_MAX == INT64_MAX
+static_assert(sizeof(PostgresCheckpointStore) == 248);
 static_assert(alignof(PostgresCheckpointStore) == 8);
 #endif
 

--- a/tests/test_acp_server.cpp
+++ b/tests/test_acp_server.cpp
@@ -36,6 +36,20 @@ using neograph::graph::NodeFactory;
 using neograph::graph::NodeInput;
 using neograph::graph::NodeOutput;
 
+namespace neograph::acp {
+
+struct ACPServerTestAccess {
+    static void fail_next_worker_launch(ACPServer& server) {
+        server.fail_next_worker_launch_for_testing();
+    }
+
+    static void fail_next_handle_message(ACPServer& server) {
+        server.fail_next_handle_message_for_testing();
+    }
+};
+
+}  // namespace neograph::acp
+
 namespace {
 
 class EchoNode : public GraphNode {
@@ -76,6 +90,53 @@ std::shared_ptr<GraphEngine> build_echo_engine() {
     auto unique = GraphEngine::compile(def, ctx);
     return std::shared_ptr<GraphEngine>(std::move(unique));
 }
+
+class ThrowingAdapter : public ACPGraphAdapter {
+  public:
+    enum class Stage { BuildInitialState, ExtractAgentText };
+
+    explicit ThrowingAdapter(Stage stage) : stage_(stage) {}
+
+    neograph::json build_initial_state(
+        const std::vector<ContentBlock>& blocks,
+        const std::string& session_id) const override {
+        if (stage_ == Stage::BuildInitialState) {
+            throw std::runtime_error("build_initial_state failed");
+        }
+        return ACPGraphAdapter::build_initial_state(blocks, session_id);
+    }
+
+    std::string extract_agent_text(
+        const neograph::json& output) const override {
+        if (stage_ == Stage::ExtractAgentText) {
+            throw 42;
+        }
+        return ACPGraphAdapter::extract_agent_text(output);
+    }
+
+  private:
+    Stage stage_;
+};
+
+class BlockingAdapter : public ACPGraphAdapter {
+  public:
+    explicit BlockingAdapter(std::shared_future<void> release)
+        : release_(std::move(release)) {}
+
+    std::future<void> entered_future() { return entered_.get_future(); }
+
+    neograph::json build_initial_state(
+        const std::vector<ContentBlock>& blocks,
+        const std::string& session_id) const override {
+        entered_.set_value();
+        release_.wait();
+        return ACPGraphAdapter::build_initial_state(blocks, session_id);
+    }
+
+  private:
+    mutable std::promise<void> entered_;
+    std::shared_future<void>   release_;
+};
 
 ACPServer make_server() {
     auto engine = build_echo_engine();
@@ -199,6 +260,108 @@ TEST(ACPServer, PromptRunsGraphAndEmitsUpdate) {
     EXPECT_TRUE(saw_chunk);
 }
 
+TEST(ACPServer, BuildInitialStateExceptionIsContained) {
+    CapturingSink cap;
+    auto adapter = std::make_shared<ThrowingAdapter>(
+        ThrowingAdapter::Stage::BuildInitialState);
+    ACPServer server(build_echo_engine(),
+                     {{"name", "test-acp"}, {"version", "0.0.1"}},
+                     adapter);
+    server.set_notification_sink(cap.as_sink());
+
+    server.handle_message(make_request(1, "session/prompt",
+        {{"sessionId", "build-error-session"},
+         {"prompt", neograph::json::array({
+             neograph::json{{"type", "text"}, {"text", "hi"}}})}}));
+
+    auto resp = cap.wait_for_response(1);
+    ASSERT_TRUE(resp.contains("result")) << resp.dump();
+    EXPECT_EQ(resp["result"].value("stopReason", std::string()), "end_turn");
+
+    auto updates = cap.notifications_for("session/update");
+    ASSERT_EQ(updates.size(), 1u);
+    EXPECT_NE(updates[0]["params"]["update"]["content"]
+                  .value("text", std::string()).find("build_initial_state failed"),
+              std::string::npos);
+}
+
+TEST(ACPServer, NonStdExtractAgentTextExceptionIsContained) {
+    CapturingSink cap;
+    auto adapter = std::make_shared<ThrowingAdapter>(
+        ThrowingAdapter::Stage::ExtractAgentText);
+    ACPServer server(build_echo_engine(),
+                     {{"name", "test-acp"}, {"version", "0.0.1"}},
+                     adapter);
+    server.set_notification_sink(cap.as_sink());
+
+    server.handle_message(make_request(1, "session/prompt",
+        {{"sessionId", "extract-error-session"},
+         {"prompt", neograph::json::array({
+             neograph::json{{"type", "text"}, {"text", "hi"}}})}}));
+
+    auto resp = cap.wait_for_response(1);
+    ASSERT_TRUE(resp.contains("result")) << resp.dump();
+    EXPECT_EQ(resp["result"].value("stopReason", std::string()), "end_turn");
+
+    auto updates = cap.notifications_for("session/update");
+    ASSERT_EQ(updates.size(), 1u);
+    EXPECT_NE(updates[0]["params"]["update"]["content"]
+                  .value("text", std::string()).find("unknown exception"),
+              std::string::npos);
+}
+
+TEST(ACPServer, NotificationSinkExceptionIsContained) {
+    CapturingSink cap;
+    ACPServer server(build_echo_engine(),
+                     {{"name", "test-acp"}, {"version", "0.0.1"}});
+    auto capture = cap.as_sink();
+    std::atomic<bool> throw_once{true};
+    server.set_notification_sink([&](const neograph::json& env) {
+        if (throw_once.exchange(false, std::memory_order_acq_rel)) {
+            throw std::runtime_error("sink failed");
+        }
+        capture(env);
+    });
+
+    server.handle_message(make_request(1, "session/prompt",
+        {{"sessionId", "sink-error-session"},
+         {"prompt", neograph::json::array({
+             neograph::json{{"type", "text"}, {"text", "hi"}}})}}));
+
+    auto resp = cap.wait_for_response(1);
+    ASSERT_TRUE(resp.contains("error")) << resp.dump();
+    EXPECT_EQ(resp["error"].value("code", 0), -32603);
+    EXPECT_NE(resp["error"].value("message", std::string()).find("sink failed"),
+              std::string::npos);
+}
+
+TEST(ACPServer, WorkerLaunchFailureRollsBackReservation) {
+    CapturingSink cap;
+    ACPServer server(build_echo_engine(),
+                     {{"name", "test-acp"}, {"version", "0.0.1"}});
+    server.set_notification_sink(cap.as_sink());
+    ACPServerTestAccess::fail_next_worker_launch(server);
+
+    auto prompt = [] {
+        return neograph::json::array({
+            neograph::json{{"type", "text"}, {"text", "hi"}}});
+    };
+    server.handle_message(make_request(1, "session/prompt",
+        {{"sessionId", "launch-error-session"}, {"prompt", prompt()}}));
+
+    auto failed = cap.wait_for_response(1);
+    ASSERT_TRUE(failed.contains("error")) << failed.dump();
+    EXPECT_EQ(failed["error"].value("code", 0), -32603);
+
+    // The same session must be immediately reusable. If launch failure left
+    // its reservation behind, this would return the single-flight -32000.
+    server.handle_message(make_request(2, "session/prompt",
+        {{"sessionId", "launch-error-session"}, {"prompt", prompt()}}));
+    auto retried = cap.wait_for_response(2);
+    ASSERT_TRUE(retried.contains("result")) << retried.dump();
+    EXPECT_EQ(retried["result"].value("stopReason", std::string()), "end_turn");
+}
+
 TEST(ACPServer, CancelBeforeFinalReturnsCancelled) {
     auto server = make_server();
     CapturingSink cap;
@@ -315,6 +478,64 @@ TEST(ACPServer, RunPumpsNdjsonThroughStreams) {
     }
     EXPECT_TRUE(saw_chunk);
     EXPECT_TRUE(saw_resp);
+}
+
+TEST(ACPServer, RunExceptionDrainsWorkerAndClearsSink) {
+    std::promise<void> release;
+    auto adapter = std::make_shared<BlockingAdapter>(
+        release.get_future().share());
+    auto entered = adapter->entered_future();
+    ACPServer server(build_echo_engine(),
+                     {{"name", "test-acp"}, {"version", "0.0.1"}},
+                     adapter);
+    ACPServerTestAccess::fail_next_handle_message(server);
+
+    std::ostringstream input;
+    input << make_request(2, "initialize",
+        {{"protocolVersion", 1},
+         {"clientCapabilities", neograph::json::object()}}).dump()
+          << '\n';
+    input << make_request(1, "session/prompt",
+        {{"sessionId", "run-error-session"},
+         {"prompt", neograph::json::array({
+             neograph::json{{"type", "text"}, {"text", "hi"}}})}}).dump()
+          << '\n';
+
+    std::istringstream in(input.str());
+    std::ostringstream out;
+    auto run = std::async(std::launch::async, [&] { server.run(in, out); });
+
+    auto entered_status = entered.wait_for(std::chrono::seconds(5));
+    if (entered_status != std::future_status::ready) {
+        release.set_value();
+        FAIL() << "prompt worker did not enter the blocking adapter";
+    }
+    EXPECT_EQ(run.wait_for(std::chrono::milliseconds(100)),
+              std::future_status::timeout)
+        << "run() returned without draining the in-flight worker";
+
+    release.set_value();
+    ASSERT_EQ(run.wait_for(std::chrono::seconds(5)),
+              std::future_status::ready);
+    EXPECT_NO_THROW(run.get());
+    EXPECT_FALSE(server.is_running());
+
+    std::istringstream responses(out.str());
+    std::string line;
+    bool saw_internal_error = false;
+    while (std::getline(responses, line)) {
+        auto response = neograph::json::parse(line);
+        if (response.value("id", 0) == 2 && response.contains("error")) {
+            saw_internal_error =
+                response["error"].value("code", 0) == -32603;
+        }
+    }
+    EXPECT_TRUE(saw_internal_error) << out.str();
+
+    // run() owns and clears its stream sink after draining the worker.
+    EXPECT_THROW(server.call_client("test/no_transport", {},
+                                    std::chrono::milliseconds(1)),
+                 std::runtime_error);
 }
 
 // ---------------------------------------------------------------------------
@@ -815,11 +1036,27 @@ TEST(ACPServer, RejectsSecondPromptOnSameSession) {
     // applies to every test that wires a stack-local sink.
     CapturingSink cap;
     ACPServer server(engine, info);
-    server.set_notification_sink(cap.as_sink());
-
     auto sess_resp = server.handle_message(make_request(1, "session/new",
         {{"cwd", "."}, {"mcpServers", neograph::json::array()}}));
     auto sid = sess_resp["result"].value("sessionId", std::string());
+
+    // Re-enter prompt handling from a rejection callback. Before the fix,
+    // rejection was emitted while workers_mu was held and this callback
+    // deadlocked trying to acquire the same mutex. The one-shot flag avoids
+    // recursively submitting another prompt for the nested rejection.
+    auto capture = cap.as_sink();
+    std::atomic<bool> reenter_once{true};
+    server.set_notification_sink([&](const neograph::json& env) {
+        if (env.value("id", -1) == 3
+            && env.contains("error")
+            && reenter_once.exchange(false, std::memory_order_acq_rel)) {
+            server.handle_message(make_request(4, "session/prompt",
+                {{"sessionId", sid},
+                 {"prompt", neograph::json::array({
+                     neograph::json{{"type", "text"}, {"text", "nested"}}})}}));
+        }
+        capture(env);
+    });
 
     // First prompt — dispatched async, will stall in StallNode.
     auto first = server.handle_message(make_request(2, "session/prompt",
@@ -840,6 +1077,9 @@ TEST(ACPServer, RejectsSecondPromptOnSameSession) {
     auto err_env = cap.wait_for_response(3, std::chrono::seconds(2));
     ASSERT_TRUE(err_env.contains("error")) << "expected error envelope, got: " << err_env.dump();
     EXPECT_EQ(err_env["error"].value("code", 0), -32000);
+    auto nested_err = cap.wait_for_response(4, std::chrono::seconds(2));
+    ASSERT_TRUE(nested_err.contains("error"));
+    EXPECT_EQ(nested_err["error"].value("code", 0), -32000);
 
     // Release the stall so the first worker can finish + dtor drain works.
     stall->store(false, std::memory_order_release);

--- a/tests/test_cancel_token_fork.cpp
+++ b/tests/test_cancel_token_fork.cpp
@@ -98,6 +98,23 @@ TEST(CancelTokenFork, ChildCancelDoesNotAffectParent) {
         << "cancel() on a child must not cascade up to the parent";
 }
 
+TEST(CancelTokenFork, ForkedOperationChildOutlivesPostedEmit) {
+    // GraphEngine always binds a forked operation child, never the caller's
+    // parent. A forked child has a weak self-entry that cancel() locks and
+    // captures in the posted emit, so the engine may release its operation
+    // owner before this executor drains without touching freed storage.
+    auto parent = std::make_shared<CancelToken>();
+    asio::io_context io;
+    auto operation = parent->fork();
+    operation->bind_executor(io.get_executor());
+    parent->cancel();
+    operation.reset();
+
+    std::size_t drained = 0;
+    EXPECT_NO_THROW(drained = io.run());
+    EXPECT_EQ(drained, 1u) << "the queued emit must actually be drained";
+}
+
 TEST(CancelTokenFork, ChildSiblingsAreIndependent) {
     // Cascade is parent→children only. A child cancelling does not
     // sweep its siblings: only the parent's own cancel() does that.

--- a/tests/test_cancel_token_propagation.cpp
+++ b/tests/test_cancel_token_propagation.cpp
@@ -25,23 +25,21 @@ namespace {
 
 // Records the cancel-token pointer it observed on `state` and writes
 // the node name into a "saw_token" channel so we can assert post-run
-// that every fan-out branch saw the same parent token.
+// that every fan-out branch saw the same operation child.
 class CancelObserverNode : public GraphNode {
 public:
     explicit CancelObserverNode(std::string n,
-                                std::atomic<int>* observed_count,
-                                CancelToken* expected)
-        : n_(std::move(n)), count_(observed_count), expected_(expected) {}
+                                 std::atomic<int>* observed_count,
+                                 std::atomic<CancelToken*>* operation,
+                                 CancelToken* parent)
+        : n_(std::move(n)), count_(observed_count), operation_(operation),
+          parent_(parent) {}
 
     asio::awaitable<NodeOutput> run(NodeInput in) override {
-        // Read the token pointer; record only if it matches the parent
-        // run's token. A null or mismatched pointer is the actual bug
-        // — if the test sees that, count_ stays unchanged and the
-        // assertion below fails.
-        // NOTE: this still reads the legacy state.run_cancel_token() smuggling
-        // channel — 9d will switch it to in.ctx.cancel_token.get() (or this
-        // whole test gets superseded by the in.ctx.cancel_token coverage).
-        if (in.ctx.cancel_token.get() == expected_ && expected_ != nullptr) {
+        auto* token = in.ctx.cancel_token.get();
+        CancelToken* unset = nullptr;
+        operation_->compare_exchange_strong(unset, token);
+        if (token && token != parent_ && token == operation_->load()) {
             count_->fetch_add(1, std::memory_order_relaxed);
         }
         // Emit a small write so the engine has something to commit.
@@ -55,7 +53,8 @@ public:
 private:
     std::string n_;
     std::atomic<int>* count_;
-    CancelToken* expected_;
+    std::atomic<CancelToken*>* operation_;
+    CancelToken* parent_;
 };
 
 // Send-fan-out source that emits N Sends pointing at a worker target.
@@ -84,6 +83,7 @@ private:
 // State + counter pair needed by the factory closures.
 struct TestFixture {
     std::atomic<int> observed_count{0};
+    std::atomic<CancelToken*> operation_token{nullptr};
     std::shared_ptr<CancelToken> token;
 };
 
@@ -95,7 +95,8 @@ void register_observer_factory(const std::string& type_name,
         [fix](const std::string& name, const json&, const NodeContext&)
             -> std::unique_ptr<GraphNode> {
             return std::make_unique<CancelObserverNode>(
-                name, &fix->observed_count, fix->token.get());
+                name, &fix->observed_count, &fix->operation_token,
+                fix->token.get());
         });
 }
 
@@ -113,11 +114,10 @@ void register_fanout_factory(const std::string& type_name,
 
 // =========================================================================
 // Static parallel fan-out: a → {b, c, d} via plain edges. All three
-// workers share the parent state by reference, so the cancel token is
-// read directly off it. Was already correct in v0.3.0 — this test
-// locks it in so the optimization doesn't regress.
+// workers share one operation child by reference. The caller's parent
+// remains a fan-out handle and is never bound directly to this run.
 // =========================================================================
-TEST(CancelTokenPropagation, StaticParallelFanOutSeesParentToken) {
+TEST(CancelTokenPropagation, StaticParallelFanOutSeesOperationChild) {
     TestFixture fix;
     fix.token = std::make_shared<CancelToken>();
 
@@ -150,6 +150,7 @@ TEST(CancelTokenPropagation, StaticParallelFanOutSeesParentToken) {
 
     // a, b, c each saw the token = 3.
     EXPECT_EQ(fix.observed_count.load(), 3);
+    EXPECT_NE(fix.operation_token.load(), fix.token.get());
     EXPECT_FALSE(result.interrupted);
 }
 
@@ -158,10 +159,10 @@ TEST(CancelTokenPropagation, StaticParallelFanOutSeesParentToken) {
 // shared worker type. Each Send runs on an isolated GraphState built
 // from serialize() + restore(); without the v0.3.1 fix, run_cancel_token
 // is null in the worker's state. The observer node only increments
-// when token == expected, so a null token leaves count == 0 and the
-// assertion fails.
+// when every branch sees the operation child, so a null or parent token
+// leaves count below 4 and the assertion fails.
 // =========================================================================
-TEST(CancelTokenPropagation, MultiSendFanOutSeesParentToken) {
+TEST(CancelTokenPropagation, MultiSendFanOutSeesOperationChild) {
     TestFixture fix;
     fix.token = std::make_shared<CancelToken>();
 
@@ -189,10 +190,10 @@ TEST(CancelTokenPropagation, MultiSendFanOutSeesParentToken) {
     cfg.cancel_token = fix.token;
     auto result = engine->run(cfg);
 
-    // 4 send-spawned workers, each reading the parent cancel token
-    // off its isolated GraphState. The dispatcher is a different node
-    // type so it does not contribute. Pre-fix this would have been 0.
+    // 4 send-spawned workers all read the operation child from RunContext.
+    // The dispatcher is a different node type so it does not contribute.
     EXPECT_EQ(fix.observed_count.load(), 4);
+    EXPECT_NE(fix.operation_token.load(), fix.token.get());
     EXPECT_FALSE(result.interrupted);
 }
 

--- a/tests/test_completion_provider.cpp
+++ b/tests/test_completion_provider.cpp
@@ -166,8 +166,6 @@ TEST(CompletionProvider, RequestOwnsParamsAndCallbackAcrossSuspension) {
     EXPECT_EQ(chunks, (std::vector<std::string>{"owned-after-suspend"}));
 }
 
-NEOGRAPH_PUSH_IGNORE_DEPRECATED
-
 TEST(CompletionProvider, EveryLegacyEntryIsAOneHopAdapter) {
     RequestProvider provider;
     CompletionParams params;
@@ -183,8 +181,6 @@ TEST(CompletionProvider, EveryLegacyEntryIsAOneHopAdapter) {
               "collect");
     EXPECT_EQ(provider.calls, 5);
 }
-
-NEOGRAPH_POP_IGNORE_DEPRECATED
 
 TEST(CompletionProvider, FreeAdapterPreservesNewProviderRequest) {
     RequestProvider provider;
@@ -212,8 +208,6 @@ TEST(CompletionProvider, FreeAdapterPreservesLegacyStreamWithoutObserver) {
     EXPECT_EQ(provider.complete_calls, 0);
 }
 
-NEOGRAPH_PUSH_IGNORE_DEPRECATED
-
 TEST(CompletionProvider, LegacyAsyncStreamAcceptsEmptyCallback) {
     LegacyStreamProvider provider;
     CompletionParams params;
@@ -224,5 +218,3 @@ TEST(CompletionProvider, LegacyAsyncStreamAcceptsEmptyCallback) {
         EXPECT_EQ(result.message.content, "legacy-stream");
     });
 }
-
-NEOGRAPH_POP_IGNORE_DEPRECATED

--- a/tests/test_graph_engine_async_api.cpp
+++ b/tests/test_graph_engine_async_api.cpp
@@ -1,8 +1,6 @@
 // Stage 3 / Semester 3.6 (API surface) regression — GraphEngine now
 // exposes run_async / run_stream_async / resume_async returning
-// asio::awaitable<RunResult>. The current implementation is a thin
-// wrapper that co_returns the matching sync call (the engine internals
-// are not yet coroutine-native). These cases pin the wrapper contract:
+// asio::awaitable<RunResult>. These cases pin the public contract:
 //
 //   * run_async resolves to the same RunResult as run() on the happy
 //     path.
@@ -19,20 +17,35 @@
 
 #include <gtest/gtest.h>
 #include <neograph/neograph.h>
+#include <neograph/async/http_client.h>
 
 #include <asio/co_spawn.hpp>
 #include <asio/detached.hpp>
 #include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
+#include <asio/post.hpp>
+#include <asio/read_until.hpp>
+#include <asio/redirect_error.hpp>
+#include <asio/steady_timer.hpp>
+#include <asio/streambuf.hpp>
+#include <asio/this_coro.hpp>
+#include <asio/use_awaitable.hpp>
+#include <asio/write.hpp>
 
 #include <atomic>
+#include <chrono>
+#include <mutex>
 #include <stdexcept>
+#include <thread>
+#include <vector>
 
 using namespace neograph;
 using namespace neograph::graph;
 
 namespace {
 
-json minimal_graph(const std::string& node_name) {
+json minimal_graph(const std::string& node_name,
+                   const std::string& node_type = "custom") {
     return {
         {"name", "async_api_graph"},
         {"channels", {
@@ -40,7 +53,7 @@ json minimal_graph(const std::string& node_name) {
             {"result",   {{"reducer", "overwrite"}}},
         }},
         {"nodes", {
-            {node_name, {{"type", "custom"}}},
+            {node_name, {{"type", node_type}}},
         }},
         {"edges", {
             {{"from", "__start__"}, {"to", node_name}},
@@ -89,6 +102,125 @@ void register_thrower() {
             return std::make_unique<ThrowingNode>(name);
         });
 }
+
+struct ReleasableHttpServer {
+    asio::io_context io;
+    asio::ip::tcp::acceptor acceptor{io};
+    std::thread worker;
+    std::atomic<int> requests{0};
+    std::atomic<bool> released{false};
+    unsigned short port = 0;
+
+    ReleasableHttpServer() {
+        acceptor.open(asio::ip::tcp::v4());
+        acceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true));
+        acceptor.bind(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), 0));
+        acceptor.listen();
+        port = acceptor.local_endpoint().port();
+        asio::co_spawn(io, accept_loop(), asio::detached);
+        worker = std::thread([this] { io.run(); });
+    }
+
+    ~ReleasableHttpServer() {
+        release();
+        asio::post(io, [this] {
+            asio::error_code ec;
+            acceptor.close(ec);
+        });
+        if (worker.joinable()) worker.join();
+    }
+
+    void release() {
+        released.store(true, std::memory_order_release);
+        asio::post(io, [] {});
+    }
+
+    asio::awaitable<void> handle(asio::ip::tcp::socket socket) {
+        try {
+            asio::streambuf request;
+            co_await asio::async_read_until(
+                socket, request, "\r\n\r\n", asio::use_awaitable);
+            requests.fetch_add(1, std::memory_order_release);
+
+            asio::steady_timer poll(co_await asio::this_coro::executor);
+            while (!released.load(std::memory_order_acquire)) {
+                poll.expires_after(std::chrono::milliseconds(2));
+                co_await poll.async_wait(asio::use_awaitable);
+            }
+
+            static constexpr char response[] =
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Length: 2\r\n"
+                "Connection: close\r\n\r\n"
+                "ok";
+            co_await asio::async_write(
+                socket, asio::buffer(response, sizeof(response) - 1),
+                asio::use_awaitable);
+        } catch (...) {
+            // A cancelled client closes its socket before release(), which is
+            // the expected fixed-path outcome.
+        }
+    }
+
+    asio::awaitable<void> accept_loop() {
+        for (;;) {
+            asio::ip::tcp::socket socket{io};
+            asio::error_code ec;
+            co_await acceptor.async_accept(
+                socket, asio::redirect_error(asio::use_awaitable, ec));
+            if (ec) co_return;
+            asio::co_spawn(io, handle(std::move(socket)), asio::detached);
+        }
+    }
+};
+
+struct OperationTokensSeen {
+    std::mutex mu;
+    std::vector<CancelToken*> tokens;
+};
+
+class StallingHttpNode final : public GraphNode {
+public:
+    StallingHttpNode(std::string name, unsigned short port,
+                     OperationTokensSeen* seen)
+        : name_(std::move(name)), port_(port), seen_(seen) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        {
+            std::lock_guard<std::mutex> lock(seen_->mu);
+            seen_->tokens.push_back(in.ctx.cancel_token.get());
+        }
+        auto ex = co_await asio::this_coro::executor;
+        co_await neograph::async::async_post(
+            ex, "127.0.0.1", std::to_string(port_), "/stall", "{}",
+            {}, false, {});
+        co_return NodeOutput{};
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+    unsigned short port_;
+    OperationTokensSeen* seen_;
+};
+
+class TokenObserverNode final : public GraphNode {
+public:
+    TokenObserverNode(std::string name, std::atomic<CancelToken*>* seen)
+        : name_(std::move(name)), seen_(seen) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        seen_->store(in.ctx.cancel_token.get(), std::memory_order_release);
+        co_return NodeOutput{};
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+    std::atomic<CancelToken*>* seen_;
+};
 
 } // namespace
 
@@ -264,4 +396,166 @@ TEST(GraphEngineAsyncApi, ConcurrentRunAsyncOnSharedIoContext) {
     io.run();
 
     EXPECT_EQ(done.load(), N);
+}
+
+TEST(GraphEngineAsyncApi, SharedParentCancelsBothOperationChildren) {
+    ReleasableHttpServer server;
+    OperationTokensSeen seen;
+    NodeFactory::instance().register_type("operation_cancel_http",
+        [&server, &seen](const std::string& name, const json&,
+                         const NodeContext&) {
+            return std::make_unique<StallingHttpNode>(
+                name, server.port, &seen);
+        });
+
+    auto engine = GraphEngine::compile(
+        minimal_graph("worker", "operation_cancel_http"), NodeContext{});
+    auto parent = std::make_shared<CancelToken>();
+
+    asio::io_context io;
+    std::atomic<int> done{0};
+    std::atomic<int> cancelled{0};
+    std::atomic<int> unexpected{0};
+    std::atomic<bool> aborted_before_release{false};
+
+    for (int i = 0; i < 2; ++i) {
+        asio::co_spawn(
+            io,
+            [&, i]() -> asio::awaitable<void> {
+                RunConfig cfg;
+                cfg.thread_id = "shared-parent-" + std::to_string(i);
+                cfg.cancel_token = parent;
+                try {
+                    (void)co_await engine->run_async(std::move(cfg));
+                } catch (const CancelledException&) {
+                    cancelled.fetch_add(1, std::memory_order_relaxed);
+                } catch (...) {
+                    unexpected.fetch_add(1, std::memory_order_relaxed);
+                }
+                done.fetch_add(1, std::memory_order_release);
+            },
+            asio::detached);
+    }
+
+    std::thread canceller([&] {
+        const auto requests_deadline =
+            std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (server.requests.load(std::memory_order_acquire) < 2 &&
+               std::chrono::steady_clock::now() < requests_deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+
+        parent->cancel();
+
+        // On fixed code both operations abort before this fallback. On the
+        // old code parent cancellation is not bound inside C++ run_async, so
+        // release the mock response after a bounded wait to make the test fail
+        // by assertion rather than hang forever.
+        const auto cancel_deadline =
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
+        while (done.load(std::memory_order_acquire) < 2 &&
+               std::chrono::steady_clock::now() < cancel_deadline) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        aborted_before_release.store(
+            done.load(std::memory_order_acquire) == 2,
+            std::memory_order_release);
+        server.release();
+    });
+
+    io.run();
+    canceller.join();
+
+    EXPECT_EQ(server.requests.load(), 2);
+    EXPECT_EQ(done.load(), 2);
+    EXPECT_EQ(cancelled.load(), 2)
+        << "one parent cancel must abort both child-bound HTTP awaits";
+    EXPECT_EQ(unexpected.load(), 0)
+        << "operation_aborted must surface as CancelledException";
+    EXPECT_TRUE(aborted_before_release.load())
+        << "run_async cancellation must abort the socket await without the "
+           "mock server releasing a response";
+
+    std::lock_guard<std::mutex> lock(seen.mu);
+    ASSERT_EQ(seen.tokens.size(), 2u);
+    EXPECT_NE(seen.tokens[0], parent.get());
+    EXPECT_NE(seen.tokens[1], parent.get());
+    EXPECT_NE(seen.tokens[0], seen.tokens[1])
+        << "concurrent runs must receive distinct operation children";
+}
+
+TEST(GraphEngineAsyncApi, RunUsesOperationChild) {
+    std::atomic<CancelToken*> seen{nullptr};
+    NodeFactory::instance().register_type("operation_cancel_run_sync",
+        [&seen](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<TokenObserverNode>(name, &seen);
+        });
+
+    auto engine = GraphEngine::compile(
+        minimal_graph("worker", "operation_cancel_run_sync"), NodeContext{});
+    auto parent = std::make_shared<CancelToken>();
+    RunConfig cfg;
+    cfg.thread_id = "run-operation-child-sync";
+    cfg.cancel_token = parent;
+
+    (void)engine->run(cfg);
+
+    ASSERT_NE(seen.load(std::memory_order_acquire), nullptr);
+    EXPECT_NE(seen.load(std::memory_order_acquire), parent.get());
+}
+
+TEST(GraphEngineAsyncApi, RunStreamUsesOperationChild) {
+    std::atomic<CancelToken*> seen{nullptr};
+    NodeFactory::instance().register_type("operation_cancel_stream_sync",
+        [&seen](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<TokenObserverNode>(name, &seen);
+        });
+
+    auto engine = GraphEngine::compile(
+        minimal_graph("worker", "operation_cancel_stream_sync"),
+        NodeContext{});
+    auto parent = std::make_shared<CancelToken>();
+    RunConfig cfg;
+    cfg.thread_id = "stream-operation-child-sync";
+    cfg.cancel_token = parent;
+
+    (void)engine->run_stream(cfg, [](const GraphEvent&) {});
+
+    ASSERT_NE(seen.load(std::memory_order_acquire), nullptr);
+    EXPECT_NE(seen.load(std::memory_order_acquire), parent.get());
+}
+
+TEST(GraphEngineAsyncApi, RunStreamAsyncUsesOperationChild) {
+    std::atomic<CancelToken*> seen{nullptr};
+    NodeFactory::instance().register_type("operation_cancel_stream_async",
+        [&seen](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<TokenObserverNode>(name, &seen);
+        });
+
+    auto engine = GraphEngine::compile(
+        minimal_graph("worker", "operation_cancel_stream_async"),
+        NodeContext{});
+    auto parent = std::make_shared<CancelToken>();
+    RunConfig cfg;
+    cfg.thread_id = "stream-operation-child-async";
+    cfg.cancel_token = parent;
+
+    asio::io_context io;
+    std::exception_ptr error;
+    asio::co_spawn(
+        io,
+        [&]() -> asio::awaitable<void> {
+            try {
+                (void)co_await engine->run_stream_async(
+                    cfg, [](const GraphEvent&) {});
+            } catch (...) {
+                error = std::current_exception();
+            }
+        },
+        asio::detached);
+    io.run();
+
+    EXPECT_FALSE(error);
+    ASSERT_NE(seen.load(std::memory_order_acquire), nullptr);
+    EXPECT_NE(seen.load(std::memory_order_acquire), parent.get());
 }

--- a/tests/test_intent_classifier_streaming.cpp
+++ b/tests/test_intent_classifier_streaming.cpp
@@ -11,9 +11,6 @@
 //
 // PR 9a: this test now drives ``IntentClassifierNode::run`` with
 // and without a streaming sink to compare both code paths.
-#include <neograph/api.h>  // NEOGRAPH_PUSH_IGNORE_DEPRECATED
-NEOGRAPH_PUSH_IGNORE_DEPRECATED
-
 #include <gtest/gtest.h>
 #include <neograph/neograph.h>
 #include <neograph/async/run_sync.h>
@@ -146,5 +143,3 @@ TEST(IntentClassifierStreaming, StreamingMatchesNonStreamingRouting) {
     EXPECT_EQ(sync_out.writes[0].value.get<std::string>(),
               stream_out.writes[0].value.get<std::string>());
 }
-
-NEOGRAPH_POP_IGNORE_DEPRECATED

--- a/tests/test_openinference_cpp.cpp
+++ b/tests/test_openinference_cpp.cpp
@@ -334,6 +334,61 @@ public:
     obs::OpenInferenceTracerSession* session = nullptr;
 };
 
+struct BlockingDestructionState {
+    std::mutex mu;
+    std::condition_variable cv;
+    bool child_start_entered = false;
+    bool release_child_start = false;
+    bool root_destructor_entered = false;
+    bool release_root_destructor = false;
+};
+
+class BlockingDestructorSpan : public obs::Span {
+public:
+    BlockingDestructorSpan(std::shared_ptr<BlockingDestructionState> state,
+                           bool block_destructor)
+        : state_(std::move(state)), block_destructor_(block_destructor) {}
+
+    ~BlockingDestructorSpan() override {
+        if (!block_destructor_) return;
+        std::unique_lock lock(state_->mu);
+        state_->root_destructor_entered = true;
+        state_->cv.notify_all();
+        state_->cv.wait(lock, [&] { return state_->release_root_destructor; });
+    }
+
+    void set_attribute(std::string_view, std::string_view) override {}
+    void set_attribute(std::string_view, int64_t) override {}
+    void set_attribute(std::string_view, double) override {}
+    void set_attribute_bool(std::string_view, bool) override {}
+    void add_event(std::string_view, std::string_view) override {}
+    void set_status_ok() override {}
+    void set_status_error(std::string_view) override {}
+    void end() override {}
+
+private:
+    std::shared_ptr<BlockingDestructionState> state_;
+    bool block_destructor_;
+};
+
+class BlockingWrapperDestructionTracer : public obs::Tracer {
+public:
+    std::unique_ptr<obs::Span> start_span(std::string_view name,
+                                          obs::Span*) override {
+        if (name == "llm.complete") {
+            std::unique_lock lock(state->mu);
+            state->child_start_entered = true;
+            state->cv.notify_all();
+            state->cv.wait(lock, [&] { return state->release_child_start; });
+        }
+        return std::make_unique<BlockingDestructorSpan>(
+            state, name == "graph.run");
+    }
+
+    std::shared_ptr<BlockingDestructionState> state =
+        std::make_shared<BlockingDestructionState>();
+};
+
 class NonStdAsyncProvider : public Provider {
 public:
     ChatCompletion complete(const CompletionParams&) override { return {}; }
@@ -706,6 +761,22 @@ TEST(OpenInferenceCpp, ParentLookupFailureDoesNotBlockInnerCall) {
     EXPECT_EQ(spans[0]->end_calls, 1);
 }
 
+TEST(OpenInferenceCpp, LegacyParentLookupPreservesCallerOwnedHierarchy) {
+    InMemoryTracer tracer;
+    auto parent = tracer.start_span("caller.parent", nullptr);
+    auto inner = std::make_shared<FakeProvider>();
+    obs::OpenInferenceProvider wrapped(
+        inner, tracer, [&]() -> obs::Span* { return parent.get(); });
+
+    auto result = wrapped.complete({});
+
+    EXPECT_EQ(result.message.content, "ok");
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 2u);
+    EXPECT_EQ(spans[1]->parent, parent.get());
+    EXPECT_EQ(spans[1]->end_calls, 1);
+}
+
 TEST(OpenInferenceCpp, ParentLeaseSurvivesConcurrentCloseThroughStartSpan) {
     using namespace std::chrono_literals;
 
@@ -755,6 +826,50 @@ TEST(OpenInferenceCpp, ReentrantCloseFromStartSpanDoesNotDeadlock) {
     ASSERT_EQ(completion.wait_for(2s), std::future_status::ready);
     EXPECT_EQ(completion.get().message.content, "ok");
     EXPECT_EQ(session.current_parent(), nullptr);
+}
+
+TEST(OpenInferenceCpp, CloseWaitsForFinalSpanWrapperDestruction) {
+    using namespace std::chrono_literals;
+
+    BlockingWrapperDestructionTracer tracer;
+    auto session = obs::openinference_tracer(tracer);
+    auto inner = std::make_shared<FakeProvider>();
+    obs::OpenInferenceProvider wrapped(inner, tracer, session);
+
+    auto completion = std::async(std::launch::async, [&] {
+        return wrapped.complete({});
+    });
+    {
+        std::unique_lock lock(tracer.state->mu);
+        ASSERT_TRUE(tracer.state->cv.wait_for(lock, 2s, [&] {
+            return tracer.state->child_start_entered;
+        }));
+    }
+
+    auto closing = std::async(std::launch::async, [&] { session.close(); });
+    {
+        std::lock_guard lock(tracer.state->mu);
+        tracer.state->release_child_start = true;
+    }
+    tracer.state->cv.notify_all();
+
+    {
+        std::unique_lock lock(tracer.state->mu);
+        ASSERT_TRUE(tracer.state->cv.wait_for(lock, 2s, [&] {
+            return tracer.state->root_destructor_entered;
+        }));
+    }
+    EXPECT_EQ(closing.wait_for(50ms), std::future_status::timeout);
+
+    {
+        std::lock_guard lock(tracer.state->mu);
+        tracer.state->release_root_destructor = true;
+    }
+    tracer.state->cv.notify_all();
+
+    EXPECT_EQ(closing.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(completion.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(completion.get().message.content, "ok");
 }
 
 TEST(OpenInferenceCpp, StartSpanFailureDoesNotBlockInnerCall) {

--- a/tests/test_openinference_cpp.cpp
+++ b/tests/test_openinference_cpp.cpp
@@ -389,6 +389,58 @@ public:
         std::make_shared<BlockingDestructionState>();
 };
 
+struct BlockingTerminalState {
+    std::mutex mu;
+    std::condition_variable cv;
+    bool end_called = false;
+    bool destructor_entered = false;
+    bool release_destructor = false;
+};
+
+class BlockingTerminalSpan : public obs::Span {
+public:
+    BlockingTerminalSpan(std::shared_ptr<BlockingTerminalState> state,
+                         bool block_destructor)
+        : state_(std::move(state)), block_destructor_(block_destructor) {}
+
+    ~BlockingTerminalSpan() override {
+        if (!block_destructor_) return;
+        std::unique_lock lock(state_->mu);
+        state_->destructor_entered = true;
+        state_->cv.notify_all();
+        state_->cv.wait(lock, [&] { return state_->release_destructor; });
+    }
+
+    void set_attribute(std::string_view, std::string_view) override {}
+    void set_attribute(std::string_view, int64_t) override {}
+    void set_attribute(std::string_view, double) override {}
+    void set_attribute_bool(std::string_view, bool) override {}
+    void add_event(std::string_view, std::string_view) override {}
+    void set_status_ok() override {}
+    void set_status_error(std::string_view) override {}
+    void end() override {
+        if (!block_destructor_) return;
+        std::lock_guard lock(state_->mu);
+        state_->end_called = true;
+    }
+
+private:
+    std::shared_ptr<BlockingTerminalState> state_;
+    bool block_destructor_;
+};
+
+class BlockingTerminalTracer : public obs::Tracer {
+public:
+    std::unique_ptr<obs::Span> start_span(std::string_view name,
+                                          obs::Span*) override {
+        return std::make_unique<BlockingTerminalSpan>(
+            state, name.starts_with("node."));
+    }
+
+    std::shared_ptr<BlockingTerminalState> state =
+        std::make_shared<BlockingTerminalState>();
+};
+
 class NonStdAsyncProvider : public Provider {
 public:
     ChatCompletion complete(const CompletionParams&) override { return {}; }
@@ -870,6 +922,39 @@ TEST(OpenInferenceCpp, CloseWaitsForFinalSpanWrapperDestruction) {
     EXPECT_EQ(closing.wait_for(2s), std::future_status::ready);
     EXPECT_EQ(completion.wait_for(2s), std::future_status::ready);
     EXPECT_EQ(completion.get().message.content, "ok");
+}
+
+TEST(OpenInferenceCpp, CloseWaitsForTerminalSpanTeardown) {
+    using namespace std::chrono_literals;
+
+    BlockingTerminalTracer tracer;
+    auto session = obs::openinference_tracer(tracer);
+    session.cb({GraphEvent::Type::NODE_START, "blocked",
+                neograph::json::object()});
+
+    auto terminal = std::async(std::launch::async, [&] {
+        session.cb({GraphEvent::Type::NODE_END, "blocked",
+                    neograph::json::object()});
+    });
+    {
+        std::unique_lock lock(tracer.state->mu);
+        ASSERT_TRUE(tracer.state->cv.wait_for(lock, 2s, [&] {
+            return tracer.state->destructor_entered;
+        }));
+        EXPECT_TRUE(tracer.state->end_called);
+    }
+
+    auto closing = std::async(std::launch::async, [&] { session.close(); });
+    EXPECT_EQ(closing.wait_for(50ms), std::future_status::timeout);
+
+    {
+        std::lock_guard lock(tracer.state->mu);
+        tracer.state->release_destructor = true;
+    }
+    tracer.state->cv.notify_all();
+
+    EXPECT_EQ(closing.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(terminal.wait_for(2s), std::future_status::ready);
 }
 
 TEST(OpenInferenceCpp, StartSpanFailureDoesNotBlockInnerCall) {

--- a/tests/test_openinference_cpp.cpp
+++ b/tests/test_openinference_cpp.cpp
@@ -14,15 +14,27 @@
 
 #include <neograph/observability/openinference.h>
 #include <neograph/observability/tracer.h>
+#include <neograph/async/run_sync.h>
 #include <neograph/provider.h>
 #include <neograph/graph/types.h>
 #include <neograph/json.h>
 
+#include <asio/co_spawn.hpp>
+#include <asio/detached.hpp>
+#include <asio/io_context.hpp>
+#include <asio/steady_timer.hpp>
+#include <asio/this_coro.hpp>
+#include <asio/use_awaitable.hpp>
+
 #include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <future>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <vector>
 
@@ -56,6 +68,7 @@ struct RecordedSpan {
     std::string status = "unset";  // "unset" | "ok" | "error"
     std::string status_message;
     bool ended = false;
+    int end_calls = 0;
 };
 
 class InMemorySpan : public obs::Span {
@@ -82,7 +95,10 @@ public:
         rec_->status = "error";
         rec_->status_message = std::string(msg);
     }
-    void end() override { rec_->ended = true; }
+    void end() override {
+        rec_->ended = true;
+        ++rec_->end_calls;
+    }
 
 private:
     RecordedSpan* rec_;
@@ -169,6 +185,116 @@ public:
         return {};
     }
     std::string get_name() const override { return "throw"; }
+};
+
+class ThrowingStartTracer : public obs::Tracer {
+public:
+    std::unique_ptr<obs::Span> start_span(std::string_view,
+                                          obs::Span*) override {
+        throw std::runtime_error("trace start failed");
+    }
+};
+
+class ThrowingSpan : public obs::Span {
+public:
+    explicit ThrowingSpan(std::atomic<int>& end_calls)
+        : end_calls_(end_calls) {}
+
+    void set_attribute(std::string_view, std::string_view) override {
+        throw std::runtime_error("trace attribute failed");
+    }
+    void set_attribute(std::string_view, int64_t) override {
+        throw std::runtime_error("trace attribute failed");
+    }
+    void set_attribute(std::string_view, double) override {
+        throw std::runtime_error("trace attribute failed");
+    }
+    void set_attribute_bool(std::string_view, bool) override {
+        throw std::runtime_error("trace attribute failed");
+    }
+    void add_event(std::string_view, std::string_view) override {
+        throw std::runtime_error("trace event failed");
+    }
+    void set_status_ok() override {
+        throw std::runtime_error("trace status failed");
+    }
+    void set_status_error(std::string_view) override {
+        throw std::runtime_error("trace status failed");
+    }
+    void end() override {
+        ++end_calls_;
+        throw std::runtime_error("trace end failed");
+    }
+
+private:
+    std::atomic<int>& end_calls_;
+};
+
+class ThrowingSpanTracer : public obs::Tracer {
+public:
+    std::unique_ptr<obs::Span> start_span(std::string_view,
+                                          obs::Span*) override {
+        return std::make_unique<ThrowingSpan>(end_calls);
+    }
+
+    std::atomic<int> end_calls{0};
+};
+
+class BlockingTracer : public InMemoryTracer {
+public:
+    std::unique_ptr<obs::Span> start_span(std::string_view name,
+                                          obs::Span* parent) override {
+        if (name.starts_with("node.")) {
+            std::unique_lock lock(mu);
+            node_start_entered = true;
+            cv.notify_all();
+            cv.wait(lock, [&] { return release_node_start; });
+        }
+        return InMemoryTracer::start_span(name, parent);
+    }
+
+    std::mutex mu;
+    std::condition_variable cv;
+    bool node_start_entered = false;
+    bool release_node_start = false;
+};
+
+class NonStdAsyncProvider : public Provider {
+public:
+    ChatCompletion complete(const CompletionParams&) override { return {}; }
+
+    asio::awaitable<ChatCompletion>
+    complete_async(const CompletionParams&) override {
+        throw 42;
+        co_return ChatCompletion{};
+    }
+
+    std::string get_name() const override { return "non-std-async"; }
+};
+
+class SuspendedAsyncProvider : public Provider {
+public:
+    ChatCompletion complete(const CompletionParams&) override { return {}; }
+
+    asio::awaitable<ChatCompletion>
+    complete_async(const CompletionParams&) override {
+        auto executor = co_await asio::this_coro::executor;
+        {
+            std::lock_guard lock(mu);
+            entered = true;
+        }
+        cv.notify_all();
+        asio::steady_timer timer(executor);
+        timer.expires_after(std::chrono::hours(1));
+        co_await timer.async_wait(asio::use_awaitable);
+        co_return ChatCompletion{};
+    }
+
+    std::string get_name() const override { return "suspended-async"; }
+
+    std::mutex mu;
+    std::condition_variable cv;
+    bool entered = false;
 };
 
 } // namespace
@@ -275,6 +401,118 @@ TEST(OpenInferenceCpp, TracerCloseAlsoEndsStragglerNodeSpan) {
     EXPECT_TRUE(spans[1]->ended);  // straggler node span
 }
 
+TEST(OpenInferenceCpp, TerminalEventsRestorePreviousCurrentParent) {
+    for (auto terminal : {GraphEvent::Type::NODE_END,
+                          GraphEvent::Type::ERROR,
+                          GraphEvent::Type::INTERRUPT}) {
+        InMemoryTracer tracer;
+        auto session = obs::openinference_tracer(tracer);
+        auto* root = session.current_parent();
+        ASSERT_NE(root, nullptr);
+
+        session.cb({GraphEvent::Type::NODE_START, "outer",
+                    neograph::json::object()});
+        auto* outer = session.current_parent();
+        ASSERT_NE(outer, root);
+        session.cb({GraphEvent::Type::NODE_START, "inner",
+                    neograph::json::object()});
+        ASSERT_NE(session.current_parent(), outer);
+
+        neograph::json data = terminal == GraphEvent::Type::ERROR
+            ? neograph::json("boom") : neograph::json::object();
+        session.cb({terminal, "inner", std::move(data)});
+        EXPECT_EQ(session.current_parent(), outer);
+
+        session.cb({GraphEvent::Type::NODE_END, "outer",
+                    neograph::json::object()});
+        EXPECT_EQ(session.current_parent(), root);
+    }
+}
+
+TEST(OpenInferenceCpp, CopiedCallbackIsSafeAfterSessionDestruction) {
+    InMemoryTracer tracer;
+    neograph::graph::GraphStreamCallback copied;
+    {
+        auto session = obs::openinference_tracer(tracer);
+        copied = session.cb;
+    }
+
+    EXPECT_NO_THROW(copied({GraphEvent::Type::NODE_START, "late",
+                            neograph::json::object()}));
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 1u);
+    EXPECT_TRUE(spans[0]->ended);
+    EXPECT_EQ(spans[0]->end_calls, 1);
+}
+
+TEST(OpenInferenceCpp, CopiedCallbackIsSafeAfterExplicitClose) {
+    InMemoryTracer tracer;
+    auto session = obs::openinference_tracer(tracer);
+    auto copied = session.cb;
+    session.close();
+
+    EXPECT_NO_THROW(copied({GraphEvent::Type::NODE_START, "late",
+                            neograph::json::object()}));
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 1u);
+    EXPECT_EQ(spans[0]->end_calls, 1);
+}
+
+TEST(OpenInferenceCpp, CloseWaitsForInFlightCallbackAndEndsItsSpan) {
+    using namespace std::chrono_literals;
+
+    BlockingTracer tracer;
+    auto session = obs::openinference_tracer(tracer);
+    auto copied = session.cb;
+    std::thread callback_thread([&] {
+        copied({GraphEvent::Type::NODE_START, "blocked",
+                neograph::json::object()});
+    });
+
+    {
+        std::unique_lock lock(tracer.mu);
+        ASSERT_TRUE(tracer.cv.wait_for(lock, 2s, [&] {
+            return tracer.node_start_entered;
+        }));
+    }
+
+    auto closing = std::async(std::launch::async, [&] { session.close(); });
+    EXPECT_EQ(closing.wait_for(50ms), std::future_status::timeout);
+
+    {
+        std::lock_guard lock(tracer.mu);
+        tracer.release_node_start = true;
+    }
+    tracer.cv.notify_all();
+    callback_thread.join();
+    ASSERT_EQ(closing.wait_for(2s), std::future_status::ready);
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 2u);
+    EXPECT_TRUE(spans[0]->ended);
+    EXPECT_TRUE(spans[1]->ended);
+    EXPECT_EQ(spans[0]->end_calls, 1);
+    EXPECT_EQ(spans[1]->end_calls, 1);
+}
+
+TEST(OpenInferenceCpp, MoveAssignmentClosesTargetSession) {
+    InMemoryTracer target_tracer;
+    InMemoryTracer source_tracer;
+    auto target = obs::openinference_tracer(target_tracer);
+    target.cb({GraphEvent::Type::NODE_START, "open",
+               neograph::json::object()});
+    auto source = obs::openinference_tracer(source_tracer);
+
+    target = std::move(source);
+
+    auto old_spans = target_tracer.snapshot();
+    ASSERT_EQ(old_spans.size(), 2u);
+    EXPECT_TRUE(old_spans[0]->ended);
+    EXPECT_TRUE(old_spans[1]->ended);
+    EXPECT_EQ(old_spans[0]->end_calls, 1);
+    EXPECT_EQ(old_spans[1]->end_calls, 1);
+}
+
 // ---------------------------------------------------------------------------
 // OpenInferenceProvider — LLM span attributes
 // ---------------------------------------------------------------------------
@@ -362,4 +600,123 @@ TEST(OpenInferenceCpp, ProviderPropagatesExceptionAndMarksSpanError) {
     EXPECT_EQ(spans[0]->status, "error");
     EXPECT_NE(spans[0]->status_message.find("boom"), std::string::npos);
     EXPECT_TRUE(spans[0]->ended);
+}
+
+TEST(OpenInferenceCpp, ProviderRejectsNullInnerProvider) {
+    InMemoryTracer tracer;
+    EXPECT_THROW(obs::OpenInferenceProvider(nullptr, tracer),
+                 std::invalid_argument);
+}
+
+TEST(OpenInferenceCpp, ParentLookupFailureDoesNotBlockInnerCall) {
+    InMemoryTracer tracer;
+    auto inner = std::make_shared<FakeProvider>();
+    obs::OpenInferenceProvider wrapped(
+        inner, tracer, []() -> obs::Span* {
+            throw std::runtime_error("parent lookup failed");
+        });
+
+    auto result = wrapped.complete({});
+    EXPECT_EQ(result.message.content, "ok");
+    EXPECT_EQ(inner->calls.load(), 1);
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 1u);
+    EXPECT_EQ(spans[0]->parent, nullptr);
+    EXPECT_TRUE(spans[0]->ended);
+    EXPECT_EQ(spans[0]->end_calls, 1);
+}
+
+TEST(OpenInferenceCpp, StartSpanFailureDoesNotBlockInnerCall) {
+    ThrowingStartTracer tracer;
+    auto inner = std::make_shared<FakeProvider>();
+    obs::OpenInferenceProvider wrapped(inner, tracer);
+
+    auto result = wrapped.complete({});
+    EXPECT_EQ(result.message.content, "ok");
+    EXPECT_EQ(inner->calls.load(), 1);
+}
+
+TEST(OpenInferenceCpp, TracingFailureDoesNotReplaceInnerException) {
+    ThrowingStartTracer tracer;
+    auto inner = std::make_shared<ThrowingProvider>();
+    obs::OpenInferenceProvider wrapped(inner, tracer);
+
+    try {
+        (void)wrapped.complete({});
+        FAIL() << "inner provider exception was not propagated";
+    } catch (const std::runtime_error& error) {
+        EXPECT_STREQ(error.what(), "boom");
+    }
+}
+
+TEST(OpenInferenceCpp, SpanMethodFailuresDoNotAffectInnerCall) {
+    ThrowingSpanTracer tracer;
+    auto inner = std::make_shared<FakeProvider>();
+    obs::OpenInferenceProvider wrapped(inner, tracer);
+
+    auto result = wrapped.complete({});
+
+    EXPECT_EQ(result.message.content, "ok");
+    EXPECT_EQ(inner->calls.load(), 1);
+    EXPECT_EQ(tracer.end_calls.load(), 1);
+}
+
+TEST(OpenInferenceCpp, SpanMethodFailuresDoNotReplaceInnerException) {
+    ThrowingSpanTracer tracer;
+    auto inner = std::make_shared<ThrowingProvider>();
+    obs::OpenInferenceProvider wrapped(inner, tracer);
+
+    try {
+        (void)wrapped.complete({});
+        FAIL() << "inner provider exception was not propagated";
+    } catch (const std::runtime_error& error) {
+        EXPECT_STREQ(error.what(), "boom");
+    }
+    EXPECT_EQ(tracer.end_calls.load(), 1);
+}
+
+TEST(OpenInferenceCpp, AsyncNonStdExceptionEndsSpanExactlyOnce) {
+    InMemoryTracer tracer;
+    auto inner = std::make_shared<NonStdAsyncProvider>();
+    obs::OpenInferenceProvider wrapped(inner, tracer);
+
+    EXPECT_THROW(
+        (void)neograph::async::run_sync(wrapped.complete_async({})), int);
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 1u);
+    EXPECT_EQ(spans[0]->status, "error");
+    EXPECT_TRUE(spans[0]->ended);
+    EXPECT_EQ(spans[0]->end_calls, 1);
+}
+
+TEST(OpenInferenceCpp, AbandonedAsyncCallEndsSpanExactlyOnce) {
+    using namespace std::chrono_literals;
+
+    InMemoryTracer tracer;
+    auto inner = std::make_shared<SuspendedAsyncProvider>();
+    auto wrapped = std::make_shared<obs::OpenInferenceProvider>(inner, tracer);
+    auto io = std::make_unique<asio::io_context>();
+    asio::co_spawn(
+        *io,
+        [wrapped]() -> asio::awaitable<void> {
+            (void)co_await wrapped->complete_async({});
+        },
+        asio::detached);
+
+    std::thread runner([&] { io->run(); });
+    {
+        std::unique_lock lock(inner->mu);
+        ASSERT_TRUE(inner->cv.wait_for(lock, 2s, [&] { return inner->entered; }));
+    }
+
+    io->stop();
+    runner.join();
+    io.reset();
+
+    auto spans = tracer.snapshot();
+    ASSERT_EQ(spans.size(), 1u);
+    EXPECT_TRUE(spans[0]->ended);
+    EXPECT_EQ(spans[0]->end_calls, 1);
 }

--- a/tests/test_openinference_cpp.cpp
+++ b/tests/test_openinference_cpp.cpp
@@ -259,6 +259,81 @@ public:
     bool release_node_start = false;
 };
 
+struct ParentLifetimeState {
+    std::atomic<bool> alive{true};
+    std::atomic<bool> ended{false};
+};
+
+class ParentLifetimeSpan : public obs::Span {
+public:
+    explicit ParentLifetimeSpan(std::shared_ptr<ParentLifetimeState> state)
+        : state_(std::move(state)) {}
+    ~ParentLifetimeSpan() override { state_->alive.store(false); }
+
+    void set_attribute(std::string_view, std::string_view) override {}
+    void set_attribute(std::string_view, int64_t) override {}
+    void set_attribute(std::string_view, double) override {}
+    void set_attribute_bool(std::string_view, bool) override {}
+    void add_event(std::string_view, std::string_view) override {}
+    void set_status_ok() override {}
+    void set_status_error(std::string_view) override {}
+    void end() override { state_->ended.store(true); }
+
+private:
+    std::shared_ptr<ParentLifetimeState> state_;
+};
+
+class BlockingParentLifetimeTracer : public obs::Tracer {
+public:
+    std::unique_ptr<obs::Span> start_span(std::string_view name,
+                                          obs::Span* parent) override {
+        std::shared_ptr<ParentLifetimeState> parent_state;
+        {
+            std::lock_guard lock(mu);
+            if (parent) parent_state = state_by_span.at(parent);
+        }
+
+        if (name == "llm.complete") {
+            std::unique_lock lock(window_mu);
+            child_start_entered = true;
+            cv.notify_all();
+            cv.wait(lock, [&] { return release_child_start; });
+            parent_usable_during_start = parent_state
+                && parent_state->alive.load() && !parent_state->ended.load();
+        }
+
+        auto state = std::make_shared<ParentLifetimeState>();
+        auto span = std::make_unique<ParentLifetimeSpan>(state);
+        {
+            std::lock_guard lock(mu);
+            state_by_span.emplace(span.get(), std::move(state));
+        }
+        return span;
+    }
+
+    std::mutex window_mu;
+    std::condition_variable cv;
+    bool child_start_entered = false;
+    bool release_child_start = false;
+    bool parent_usable_during_start = false;
+
+private:
+    std::mutex mu;
+    std::unordered_map<obs::Span*, std::shared_ptr<ParentLifetimeState>>
+        state_by_span;
+};
+
+class ReentrantCloseTracer : public InMemoryTracer {
+public:
+    std::unique_ptr<obs::Span> start_span(std::string_view name,
+                                          obs::Span* parent) override {
+        if (name == "llm.complete" && session) session->close();
+        return InMemoryTracer::start_span(name, parent);
+    }
+
+    obs::OpenInferenceTracerSession* session = nullptr;
+};
+
 class NonStdAsyncProvider : public Provider {
 public:
     ChatCompletion complete(const CompletionParams&) override { return {}; }
@@ -321,6 +396,7 @@ TEST(OpenInferenceCpp, TracerOpensChainRootAndPerNodeChild) {
     EXPECT_EQ(spans[0]->name, "graph.run");
     EXPECT_EQ(spans[0]->attrs_str["openinference.span.kind"], "CHAIN");
     EXPECT_TRUE(spans[0]->ended);
+    EXPECT_EQ(spans[0]->end_calls, 1);
 
     // Node child: name "node.researcher", parent = root, CHAIN
     EXPECT_EQ(spans[1]->name, "node.researcher");
@@ -331,6 +407,7 @@ TEST(OpenInferenceCpp, TracerOpensChainRootAndPerNodeChild) {
     EXPECT_EQ(spans[1]->attrs_str["output.mime_type"], "application/json");
     EXPECT_EQ(spans[1]->status, "ok");
     EXPECT_TRUE(spans[1]->ended);
+    EXPECT_EQ(spans[1]->end_calls, 1);
 
     // input.value JSON contains node name; output.value JSON contains the data.
     auto in_json = neograph::json::parse(spans[1]->attrs_str["input.value"]);
@@ -360,11 +437,13 @@ TEST(OpenInferenceCpp, TracerSurfacesErrorAndInterrupt) {
     EXPECT_EQ(spans[1]->status_message, "kaboom");
     EXPECT_EQ(spans[1]->attrs_str["neograph.error"], "kaboom");
     EXPECT_TRUE(spans[1]->ended);
+    EXPECT_EQ(spans[1]->end_calls, 1);
 
     // b: INTERRUPT
     EXPECT_EQ(spans[2]->name, "node.b");
     EXPECT_TRUE(spans[2]->attrs_bool["neograph.interrupted"]);
     EXPECT_TRUE(spans[2]->ended);
+    EXPECT_EQ(spans[2]->end_calls, 1);
 }
 
 TEST(OpenInferenceCpp, TracerRecordsLLMTokenAsSpanEvent) {
@@ -625,6 +704,57 @@ TEST(OpenInferenceCpp, ParentLookupFailureDoesNotBlockInnerCall) {
     EXPECT_EQ(spans[0]->parent, nullptr);
     EXPECT_TRUE(spans[0]->ended);
     EXPECT_EQ(spans[0]->end_calls, 1);
+}
+
+TEST(OpenInferenceCpp, ParentLeaseSurvivesConcurrentCloseThroughStartSpan) {
+    using namespace std::chrono_literals;
+
+    BlockingParentLifetimeTracer tracer;
+    auto session = obs::openinference_tracer(tracer);
+    auto inner = std::make_shared<FakeProvider>();
+    obs::OpenInferenceProvider wrapped(inner, tracer, session);
+
+    auto completion = std::async(std::launch::async, [&] {
+        return wrapped.complete({});
+    });
+    {
+        std::unique_lock lock(tracer.window_mu);
+        ASSERT_TRUE(tracer.cv.wait_for(lock, 2s, [&] {
+            return tracer.child_start_entered;
+        }));
+    }
+
+    auto closing = std::async(std::launch::async, [&] { session.close(); });
+    EXPECT_EQ(closing.wait_for(50ms), std::future_status::timeout);
+
+    {
+        std::lock_guard lock(tracer.window_mu);
+        tracer.release_child_start = true;
+    }
+    tracer.cv.notify_all();
+
+    EXPECT_EQ(completion.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(closing.wait_for(2s), std::future_status::ready);
+    EXPECT_TRUE(tracer.parent_usable_during_start);
+    EXPECT_EQ(completion.get().message.content, "ok");
+}
+
+TEST(OpenInferenceCpp, ReentrantCloseFromStartSpanDoesNotDeadlock) {
+    using namespace std::chrono_literals;
+
+    ReentrantCloseTracer tracer;
+    auto session = obs::openinference_tracer(tracer);
+    tracer.session = &session;
+    auto inner = std::make_shared<FakeProvider>();
+    obs::OpenInferenceProvider wrapped(inner, tracer, session);
+
+    auto completion = std::async(std::launch::async, [&] {
+        return wrapped.complete({});
+    });
+
+    ASSERT_EQ(completion.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(completion.get().message.content, "ok");
+    EXPECT_EQ(session.current_parent(), nullptr);
 }
 
 TEST(OpenInferenceCpp, StartSpanFailureDoesNotBlockInnerCall) {

--- a/tests/test_postgres_checkpoint.cpp
+++ b/tests/test_postgres_checkpoint.cpp
@@ -63,7 +63,7 @@ public:
 
     static size_t waiter_count(PostgresCheckpointStore& store) {
         std::lock_guard lock(store.pool_mutex_);
-        return store.async_waiters_.size();
+        return store.waiters_.size();
     }
 };
 
@@ -83,13 +83,14 @@ struct TestPgResult {
     ~TestPgResult() { if (raw) PQclear(raw); }
 };
 
-std::optional<int> wait_for_blocked_checkpoint_lock(PGconn* observer) {
+std::optional<int> wait_for_blocked_table_lock(PGconn* observer,
+                                                const char* table) {
     auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    std::string sql = "SELECT pid FROM pg_locks WHERE relation = '"
+                    + std::string(table)
+                    + "'::regclass AND NOT granted LIMIT 1";
     while (std::chrono::steady_clock::now() < deadline) {
-        TestPgResult result{PQexec(observer,
-            "SELECT pid FROM pg_locks "
-            "WHERE relation = 'neograph_checkpoints'::regclass "
-            "  AND NOT granted LIMIT 1")};
+        TestPgResult result{PQexec(observer, sql.c_str())};
         if (result.raw && PQresultStatus(result.raw) == PGRES_TUPLES_OK
             && PQntuples(result.raw) == 1) {
             return std::stoi(PQgetvalue(result.raw, 0, 0));
@@ -249,6 +250,63 @@ TEST(PostgresCheckpointPoolTest, CancelledWaiterIsRemoved) {
     PoolTestAccess::release(*pool, occupied);
     EXPECT_EQ(PoolTestAccess::free_count(*pool), 1u)
         << "a cancelled waiter retained or lost the released pool slot";
+}
+
+TEST(PostgresCheckpointPoolTest, MixedWaitersKeepArrivalOrder) {
+    auto pool = PoolTestAccess::make_pool(/*pool_size=*/1);
+    const size_t occupied = PoolTestAccess::acquire(*pool);
+    auto wait_for_count = [&](size_t expected) {
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (PoolTestAccess::waiter_count(*pool) == expected) return true;
+            std::this_thread::sleep_for(std::chrono::milliseconds(2));
+        }
+        return false;
+    };
+
+    std::mutex order_mutex;
+    std::vector<std::string> order;
+    std::thread sync_waiter([&] {
+        size_t idx = PoolTestAccess::acquire(*pool);
+        {
+            std::lock_guard lock(order_mutex);
+            order.push_back("sync");
+        }
+        PoolTestAccess::release(*pool, idx);
+    });
+    if (!wait_for_count(1)) {
+        PoolTestAccess::release(*pool, occupied);
+        sync_waiter.join();
+        FAIL() << "sync waiter did not enter the mixed FIFO queue";
+    }
+
+    asio::io_context io;
+    std::exception_ptr async_error;
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> {
+            size_t idx = co_await PoolTestAccess::acquire_async(*pool);
+            {
+                std::lock_guard lock(order_mutex);
+                order.push_back("async");
+            }
+            PoolTestAccess::release(*pool, idx);
+        },
+        [&](std::exception_ptr error) { async_error = error; });
+    std::thread io_thread([&] { io.run(); });
+    if (!wait_for_count(2)) {
+        PoolTestAccess::release(*pool, occupied);
+        sync_waiter.join();
+        io_thread.join();
+        FAIL() << "async waiter did not join behind the sync waiter";
+    }
+
+    PoolTestAccess::release(*pool, occupied);
+    sync_waiter.join();
+    io_thread.join();
+
+    EXPECT_EQ(async_error, nullptr);
+    EXPECT_EQ(order, (std::vector<std::string>{"sync", "async"}));
+    EXPECT_EQ(PoolTestAccess::free_count(*pool), 1u);
 }
 
 TEST_F(PostgresCheckpointTest, SaveAndLoadLatestRoundTrip) {
@@ -777,7 +835,8 @@ TEST_F(PostgresCheckpointTest, CancelledAsyncQueryDiscardsConnectionWithoutRetry
             [&](std::exception_ptr error) { save_error = error; }));
     std::thread io_thread([&] { io.run(); });
 
-    auto blocked_pid = wait_for_blocked_checkpoint_lock(observer.raw);
+    auto blocked_pid = wait_for_blocked_table_lock(
+        observer.raw, "neograph_checkpoints");
     if (!blocked_pid) {
         TestPgResult result{PQexec(locker.raw, "ROLLBACK")};
         io_thread.join();
@@ -830,4 +889,73 @@ TEST_F(PostgresCheckpointTest, CancelledAsyncQueryDiscardsConnectionWithoutRetry
         ASSERT_EQ(PQresultStatus(result.raw), PGRES_COMMAND_OK)
             << PQresultErrorMessage(result.raw);
     }
+}
+
+TEST_F(PostgresCheckpointTest, CancelledAsyncPutWritesDiscardsTransactionWithoutRetry) {
+    store = std::make_unique<PostgresCheckpointStore>(pg_url(), /*pool_size=*/1);
+    store->drop_schema();
+
+    PendingWrite write;
+    write.task_id = "cancelled-task";
+    write.task_path = "cancelled-path";
+    write.node_name = "cancelled-node";
+    write.writes = json::array();
+    write.command = json();
+    write.sends = json::array();
+
+    TestPgConn locker{PQconnectdb(pg_url())};
+    ASSERT_EQ(PQstatus(locker.raw), CONNECTION_OK) << PQerrorMessage(locker.raw);
+    {
+        TestPgResult result{PQexec(locker.raw,
+            "BEGIN; LOCK TABLE neograph_checkpoint_writes "
+            "IN ACCESS EXCLUSIVE MODE")};
+        ASSERT_NE(result.raw, nullptr);
+        ASSERT_EQ(PQresultStatus(result.raw), PGRES_COMMAND_OK)
+            << PQresultErrorMessage(result.raw);
+    }
+    TestPgConn observer{PQconnectdb(pg_url())};
+    ASSERT_EQ(PQstatus(observer.raw), CONNECTION_OK) << PQerrorMessage(observer.raw);
+
+    asio::io_context io;
+    asio::cancellation_signal cancel;
+    std::exception_ptr write_error;
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> {
+            co_await store->put_writes_async(
+                "cancel-writes", "cancel-parent", write);
+        },
+        asio::bind_cancellation_slot(cancel.slot(),
+            [&](std::exception_ptr error) { write_error = error; }));
+    std::thread io_thread([&] { io.run(); });
+
+    auto blocked_pid = wait_for_blocked_table_lock(
+        observer.raw, "neograph_checkpoint_writes");
+    if (!blocked_pid) {
+        TestPgResult result{PQexec(locker.raw, "ROLLBACK")};
+        io_thread.join();
+        FAIL() << "put_writes_async never reached its transactional SELECT";
+    }
+
+    asio::post(io, [&] { cancel.emit(asio::cancellation_type::all); });
+    if (!wait_for_backend_exit(observer.raw, *blocked_pid)) {
+        TestPgResult result{PQexec(locker.raw, "ROLLBACK")};
+        io_thread.join();
+        FAIL() << "cancelled put_writes_async did not discard its backend";
+    }
+    {
+        TestPgResult result{PQexec(locker.raw, "COMMIT")};
+    }
+    io_thread.join();
+
+    ASSERT_NE(write_error, nullptr);
+    try {
+        std::rethrow_exception(write_error);
+    } catch (const asio::system_error& error) {
+        EXPECT_EQ(error.code(), asio::error::operation_aborted);
+    } catch (...) {
+        FAIL() << "cancelled put_writes_async returned an unexpected exception";
+    }
+    EXPECT_EQ(store->reconnect_count(), 1u);
+    EXPECT_TRUE(store->get_writes("cancel-writes", "cancel-parent").empty())
+        << "cancelled put_writes_async retried on the replacement connection";
 }

--- a/tests/test_postgres_checkpoint.cpp
+++ b/tests/test_postgres_checkpoint.cpp
@@ -18,10 +18,12 @@
 #include <asio/co_spawn.hpp>
 #include <asio/bind_cancellation_slot.hpp>
 #include <asio/cancellation_signal.hpp>
+#include <asio/cancellation_state.hpp>
 #include <asio/detached.hpp>
 #include <asio/io_context.hpp>
 #include <asio/ip/tcp.hpp>
 #include <asio/steady_timer.hpp>
+#include <asio/this_coro.hpp>
 
 #include <array>
 #include <atomic>
@@ -1202,10 +1204,31 @@ TEST_F(PostgresCheckpointTest, CancelledAsyncQueryDiscardsConnectionWithoutRetry
     asio::io_context io;
     asio::cancellation_signal cancel;
     std::exception_ptr save_error;
+    std::exception_ptr followup_error;
+    std::exception_ptr coroutine_error;
+    std::atomic<bool> followup_waiting{false};
+    asio::steady_timer followup_timer(io);
     asio::co_spawn(io,
-        [&]() -> asio::awaitable<void> { co_await store->save_async(cp); },
+        [&]() -> asio::awaitable<void> {
+            co_await asio::this_coro::reset_cancellation_state(
+                asio::enable_partial_cancellation());
+            try {
+                co_await store->save_async(cp);
+            } catch (...) {
+                save_error = std::current_exception();
+            }
+            if (save_error) {
+                followup_timer.expires_after(std::chrono::seconds(30));
+                followup_waiting.store(true, std::memory_order_release);
+                try {
+                    co_await followup_timer.async_wait(asio::use_awaitable);
+                } catch (...) {
+                    followup_error = std::current_exception();
+                }
+            }
+        },
         asio::bind_cancellation_slot(cancel.slot(),
-            [&](std::exception_ptr error) { save_error = error; }));
+            [&](std::exception_ptr error) { coroutine_error = error; }));
     std::thread io_thread([&] { io.run(); });
 
     auto blocked_pid = wait_for_blocked_table_lock(
@@ -1216,17 +1239,32 @@ TEST_F(PostgresCheckpointTest, CancelledAsyncQueryDiscardsConnectionWithoutRetry
         FAIL() << "async save never reached the PostgreSQL table lock";
     }
 
-    asio::post(io, [&] { cancel.emit(asio::cancellation_type::all); });
+    asio::post(io, [&] { cancel.emit(asio::cancellation_type::partial); });
     if (!wait_for_backend_exit(observer.raw, *blocked_pid)) {
         TestPgResult result{PQexec(locker.raw, "ROLLBACK")};
+        asio::post(io, [&] { cancel.emit(asio::cancellation_type::all); });
         io_thread.join();
         FAIL() << "cancelled async save did not discard its PostgreSQL backend";
     }
+    auto followup_deadline = std::chrono::steady_clock::now()
+                           + std::chrono::seconds(2);
+    while (!followup_waiting.load(std::memory_order_acquire)
+           && std::chrono::steady_clock::now() < followup_deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    if (!followup_waiting.load(std::memory_order_acquire)) {
+        TestPgResult result{PQexec(locker.raw, "ROLLBACK")};
+        asio::post(io, [&] { cancel.emit(asio::cancellation_type::all); });
+        io_thread.join();
+        FAIL() << "cancelled async save did not reach its continuation";
+    }
+    asio::post(io, [&] { cancel.emit(asio::cancellation_type::partial); });
     {
         TestPgResult result{PQexec(locker.raw, "COMMIT")};
     }
     io_thread.join();
 
+    EXPECT_EQ(coroutine_error, nullptr);
     ASSERT_NE(save_error, nullptr);
     try {
         std::rethrow_exception(save_error);
@@ -1234,6 +1272,15 @@ TEST_F(PostgresCheckpointTest, CancelledAsyncQueryDiscardsConnectionWithoutRetry
         EXPECT_EQ(error.code(), asio::error::operation_aborted);
     } catch (...) {
         FAIL() << "cancelled async query returned an unexpected exception";
+    }
+    ASSERT_NE(followup_error, nullptr)
+        << "PostgreSQL cleanup permanently disabled caller cancellation";
+    try {
+        std::rethrow_exception(followup_error);
+    } catch (const asio::system_error& error) {
+        EXPECT_EQ(error.code(), asio::error::operation_aborted);
+    } catch (...) {
+        FAIL() << "follow-up wait returned an unexpected exception";
     }
     EXPECT_EQ(store->reconnect_count(), 0u)
         << "cancelled coroutine must discard without blocking to reconnect";

--- a/tests/test_postgres_checkpoint.cpp
+++ b/tests/test_postgres_checkpoint.cpp
@@ -16,8 +16,11 @@
 #include <libpq-fe.h>
 
 #include <asio/co_spawn.hpp>
+#include <asio/bind_cancellation_slot.hpp>
+#include <asio/cancellation_signal.hpp>
 #include <asio/detached.hpp>
 #include <asio/io_context.hpp>
+#include <asio/steady_timer.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -30,7 +33,87 @@
 using namespace neograph::graph;
 using json = neograph::json;
 
+namespace neograph::graph::test_access {
+
+class PostgresCheckpointStoreTestAccess {
+public:
+    static std::unique_ptr<PostgresCheckpointStore> make_pool(size_t pool_size) {
+        return std::unique_ptr<PostgresCheckpointStore>(
+            new PostgresCheckpointStore(
+                PostgresCheckpointStore::PoolOnlyTag{}, pool_size));
+    }
+
+    static size_t acquire(PostgresCheckpointStore& store) {
+        return store.acquire_slot();
+    }
+
+    static asio::awaitable<size_t> acquire_async(
+        PostgresCheckpointStore& store) {
+        co_return co_await store.acquire_slot_async();
+    }
+
+    static void release(PostgresCheckpointStore& store, size_t idx) {
+        store.release_slot(idx);
+    }
+
+    static size_t free_count(PostgresCheckpointStore& store) {
+        std::lock_guard lock(store.pool_mutex_);
+        return store.free_.size();
+    }
+
+    static size_t waiter_count(PostgresCheckpointStore& store) {
+        std::lock_guard lock(store.pool_mutex_);
+        return store.async_waiters_.size();
+    }
+};
+
+} // namespace neograph::graph::test_access
+
 namespace {
+
+using PoolTestAccess = test_access::PostgresCheckpointStoreTestAccess;
+
+struct TestPgConn {
+    PGconn* raw = nullptr;
+    ~TestPgConn() { if (raw) PQfinish(raw); }
+};
+
+struct TestPgResult {
+    PGresult* raw = nullptr;
+    ~TestPgResult() { if (raw) PQclear(raw); }
+};
+
+std::optional<int> wait_for_blocked_checkpoint_lock(PGconn* observer) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+        TestPgResult result{PQexec(observer,
+            "SELECT pid FROM pg_locks "
+            "WHERE relation = 'neograph_checkpoints'::regclass "
+            "  AND NOT granted LIMIT 1")};
+        if (result.raw && PQresultStatus(result.raw) == PGRES_TUPLES_OK
+            && PQntuples(result.raw) == 1) {
+            return std::stoi(PQgetvalue(result.raw, 0, 0));
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return std::nullopt;
+}
+
+bool wait_for_backend_exit(PGconn* observer, int pid) {
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    std::string sql = "SELECT NOT EXISTS (SELECT 1 FROM pg_stat_activity WHERE pid = "
+                    + std::to_string(pid) + ")";
+    while (std::chrono::steady_clock::now() < deadline) {
+        TestPgResult result{PQexec(observer, sql.c_str())};
+        if (result.raw && PQresultStatus(result.raw) == PGRES_TUPLES_OK
+            && PQntuples(result.raw) == 1
+            && std::string(PQgetvalue(result.raw, 0, 0)) == "t") {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    }
+    return false;
+}
 
 const char* pg_url() {
     const char* url = std::getenv("NEOGRAPH_TEST_POSTGRES_URL");
@@ -86,6 +169,87 @@ protected:
 };
 
 } // namespace
+
+TEST(PostgresCheckpointPoolTest, AsyncWaitDoesNotBlockIoContext) {
+    auto pool = PoolTestAccess::make_pool(/*pool_size=*/1);
+    const size_t occupied = PoolTestAccess::acquire(*pool);
+
+    asio::io_context io;
+    std::optional<std::chrono::milliseconds> heartbeat_elapsed;
+    std::exception_ptr waiter_error;
+    bool waiter_done = false;
+    auto started = std::chrono::steady_clock::now();
+
+    asio::steady_timer heartbeat(io, std::chrono::milliseconds(20));
+    heartbeat.async_wait([&](const asio::error_code& ec) {
+        if (!ec) {
+            heartbeat_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - started);
+        }
+    });
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> {
+            size_t idx = co_await PoolTestAccess::acquire_async(*pool);
+            PoolTestAccess::release(*pool, idx);
+        },
+        [&](std::exception_ptr error) {
+            waiter_error = error;
+            waiter_done = true;
+        });
+
+    // A separate thread bounds the pre-fix blocking acquire. The heartbeat
+    // must run well before this releases the only slot.
+    std::thread releaser([&] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(300));
+        PoolTestAccess::release(*pool, occupied);
+    });
+
+    io.run();
+    releaser.join();
+
+    EXPECT_EQ(waiter_error, nullptr);
+    EXPECT_TRUE(waiter_done);
+    ASSERT_TRUE(heartbeat_elapsed.has_value());
+    EXPECT_LT(*heartbeat_elapsed, std::chrono::milliseconds(150))
+        << "an async pool waiter blocked the io_context heartbeat for "
+        << heartbeat_elapsed->count() << "ms";
+    EXPECT_EQ(PoolTestAccess::free_count(*pool), 1u);
+}
+
+TEST(PostgresCheckpointPoolTest, CancelledWaiterIsRemoved) {
+    auto pool = PoolTestAccess::make_pool(/*pool_size=*/1);
+    const size_t occupied = PoolTestAccess::acquire(*pool);
+
+    asio::io_context io;
+    asio::cancellation_signal cancel;
+    std::exception_ptr waiter_error;
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> {
+            (void)co_await PoolTestAccess::acquire_async(*pool);
+        },
+        asio::bind_cancellation_slot(cancel.slot(),
+            [&](std::exception_ptr error) { waiter_error = error; }));
+    asio::steady_timer cancel_timer(io, std::chrono::milliseconds(20));
+    cancel_timer.async_wait([&](const asio::error_code& ec) {
+        if (!ec) cancel.emit(asio::cancellation_type::all);
+    });
+
+    io.run();
+
+    ASSERT_NE(waiter_error, nullptr);
+    try {
+        std::rethrow_exception(waiter_error);
+    } catch (const asio::system_error& error) {
+        EXPECT_EQ(error.code(), asio::error::operation_aborted);
+    } catch (...) {
+        FAIL() << "cancelled pool waiter returned an unexpected exception";
+    }
+    EXPECT_EQ(PoolTestAccess::waiter_count(*pool), 0u);
+
+    PoolTestAccess::release(*pool, occupied);
+    EXPECT_EQ(PoolTestAccess::free_count(*pool), 1u)
+        << "a cancelled waiter retained or lost the released pool slot";
+}
 
 TEST_F(PostgresCheckpointTest, SaveAndLoadLatestRoundTrip) {
     auto cp = make_state_cp("t", 0, {{"x", {42, 1}}, {"msg", {"hi", 2}}});
@@ -554,3 +718,116 @@ TEST_F(PostgresCheckpointTest, AsyncSavesOverlapAcrossPoolSlots) {
         << "ms — likely serialising instead of overlapping";
 }
 
+TEST_F(PostgresCheckpointTest, SqlErrorsLeavePoolConnectionReusable) {
+    for (int i = 0; i < 3; ++i) {
+        EXPECT_THROW((void)store->list("sql-error", -1), std::runtime_error);
+    }
+
+    asio::io_context io;
+    std::exception_ptr async_error;
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> {
+            (void)co_await store->list_async("sql-error", -1);
+        },
+        [&](std::exception_ptr error) { async_error = error; });
+    io.run();
+
+    EXPECT_NE(async_error, nullptr);
+    EXPECT_NO_THROW((void)store->load_latest("after-sql-error"));
+}
+
+TEST_F(PostgresCheckpointTest, CancelledAsyncQueryDiscardsConnectionWithoutRetry) {
+    store = std::make_unique<PostgresCheckpointStore>(pg_url(), /*pool_size=*/1);
+    store->drop_schema();
+    auto cp = make_state_cp("cancel-write", 0, {{"x", {1, 1}}});
+
+    TestPgConn locker{PQconnectdb(pg_url())};
+    ASSERT_EQ(PQstatus(locker.raw), CONNECTION_OK) << PQerrorMessage(locker.raw);
+    {
+        TestPgResult result{PQexec(locker.raw,
+            "DROP SEQUENCE IF EXISTS neograph_cancel_attempt_seq CASCADE;"
+            "CREATE SEQUENCE neograph_cancel_attempt_seq;"
+            "CREATE OR REPLACE FUNCTION neograph_count_cancel_attempt() "
+            "RETURNS trigger LANGUAGE plpgsql AS $$"
+            "BEGIN PERFORM nextval('neograph_cancel_attempt_seq'); RETURN NEW; END"
+            "$$;"
+            "CREATE TRIGGER neograph_count_cancel_attempt "
+            "BEFORE INSERT OR UPDATE ON neograph_checkpoints "
+            "FOR EACH ROW EXECUTE FUNCTION neograph_count_cancel_attempt()")};
+        ASSERT_NE(result.raw, nullptr);
+        ASSERT_EQ(PQresultStatus(result.raw), PGRES_COMMAND_OK)
+            << PQresultErrorMessage(result.raw);
+    }
+    {
+        TestPgResult result{PQexec(locker.raw,
+            "BEGIN; LOCK TABLE neograph_checkpoints IN ACCESS EXCLUSIVE MODE")};
+        ASSERT_NE(result.raw, nullptr);
+        ASSERT_EQ(PQresultStatus(result.raw), PGRES_COMMAND_OK)
+            << PQresultErrorMessage(result.raw);
+    }
+    TestPgConn observer{PQconnectdb(pg_url())};
+    ASSERT_EQ(PQstatus(observer.raw), CONNECTION_OK) << PQerrorMessage(observer.raw);
+
+    asio::io_context io;
+    asio::cancellation_signal cancel;
+    std::exception_ptr save_error;
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> { co_await store->save_async(cp); },
+        asio::bind_cancellation_slot(cancel.slot(),
+            [&](std::exception_ptr error) { save_error = error; }));
+    std::thread io_thread([&] { io.run(); });
+
+    auto blocked_pid = wait_for_blocked_checkpoint_lock(observer.raw);
+    if (!blocked_pid) {
+        TestPgResult result{PQexec(locker.raw, "ROLLBACK")};
+        io_thread.join();
+        FAIL() << "async save never reached the PostgreSQL table lock";
+    }
+
+    asio::post(io, [&] { cancel.emit(asio::cancellation_type::all); });
+    if (!wait_for_backend_exit(observer.raw, *blocked_pid)) {
+        TestPgResult result{PQexec(locker.raw, "ROLLBACK")};
+        io_thread.join();
+        FAIL() << "cancelled async save did not discard its PostgreSQL backend";
+    }
+    {
+        TestPgResult result{PQexec(locker.raw, "COMMIT")};
+    }
+    io_thread.join();
+
+    ASSERT_NE(save_error, nullptr);
+    try {
+        std::rethrow_exception(save_error);
+    } catch (const asio::system_error& error) {
+        EXPECT_EQ(error.code(), asio::error::operation_aborted);
+    } catch (...) {
+        FAIL() << "cancelled async query returned an unexpected exception";
+    }
+    EXPECT_EQ(store->reconnect_count(), 1u);
+
+    int attempts = -1;
+    {
+        TestPgResult result{PQexec(observer.raw,
+            "SELECT CASE WHEN is_called THEN last_value ELSE 0 END "
+            "FROM neograph_cancel_attempt_seq")};
+        ASSERT_NE(result.raw, nullptr);
+        ASSERT_EQ(PQresultStatus(result.raw), PGRES_TUPLES_OK)
+            << PQresultErrorMessage(result.raw);
+        attempts = std::stoi(PQgetvalue(result.raw, 0, 0));
+    }
+    EXPECT_EQ(attempts, 0)
+        << "a cancelled write reached PostgreSQL after its connection was discarded";
+    EXPECT_FALSE(store->load_by_id(cp.id).has_value())
+        << "a cancelled write was retried on the replacement connection";
+
+    {
+        TestPgResult result{PQexec(observer.raw,
+            "DROP TRIGGER IF EXISTS neograph_count_cancel_attempt "
+            "ON neograph_checkpoints;"
+            "DROP FUNCTION IF EXISTS neograph_count_cancel_attempt();"
+            "DROP SEQUENCE IF EXISTS neograph_cancel_attempt_seq")};
+        ASSERT_NE(result.raw, nullptr);
+        ASSERT_EQ(PQresultStatus(result.raw), PGRES_COMMAND_OK)
+            << PQresultErrorMessage(result.raw);
+    }
+}

--- a/tests/test_postgres_checkpoint.cpp
+++ b/tests/test_postgres_checkpoint.cpp
@@ -471,7 +471,7 @@ TEST(PostgresCheckpointAsyncIoTest, ReconnectPollDoesNotBlockIoContext) {
 TEST(PostgresCheckpointAsyncIoTest, ResolverPollDoesNotBlockIoContext) {
     AsyncConnectionTestSeamReset reset;
     PoolTestAccess::set_async_connection_test_seams(
-        /*poll_delay_ms=*/150, /*timeout_ms=*/80);
+        /*poll_delay_ms=*/300, /*timeout_ms=*/80);
     StalledTcpServer server;
     auto store = PoolTestAccess::make_pool(/*pool_size=*/1);
     PoolTestAccess::set_conn_str(*store,
@@ -496,9 +496,12 @@ TEST(PostgresCheckpointAsyncIoTest, ResolverPollDoesNotBlockIoContext) {
         [&](std::exception_ptr error) { rebuild_error = error; });
 
     io.run();
+    auto elapsed = std::chrono::steady_clock::now() - started;
 
     ASSERT_TRUE(heartbeat_elapsed.has_value());
     EXPECT_LT(*heartbeat_elapsed, std::chrono::milliseconds(80));
+    EXPECT_LT(elapsed, std::chrono::milliseconds(200))
+        << "deadline waited for the blocking resolver worker";
     EXPECT_NE(rebuild_error, nullptr);
     EXPECT_TRUE(PoolTestAccess::slot_is_empty(*store, 0));
 }

--- a/tests/test_postgres_checkpoint.cpp
+++ b/tests/test_postgres_checkpoint.cpp
@@ -32,6 +32,13 @@
 #include <thread>
 #include <vector>
 
+#ifndef _WIN32
+#  include <cerrno>
+#  include <fcntl.h>
+#  include <sys/socket.h>
+#  include <unistd.h>
+#endif
+
 using namespace neograph::graph;
 using json = neograph::json;
 
@@ -81,6 +88,16 @@ public:
 
     static bool slot_is_empty(PostgresCheckpointStore& store, size_t idx) {
         return !store.pool_[idx];
+    }
+
+    static asio::awaitable<bool> wait_socket_either(int fd) {
+        co_return co_await PostgresCheckpointStore::wait_socket_either_for_test(fd);
+    }
+
+    static void set_async_connection_test_seams(int poll_delay_ms,
+                                                int timeout_ms) {
+        PostgresCheckpointStore::set_async_connection_test_seams(
+            poll_delay_ms, timeout_ms);
     }
 
     static Layout layout(const PostgresCheckpointStore& store) {
@@ -157,6 +174,12 @@ struct StalledTcpServer {
         io.stop();
         if (worker.joinable()) worker.join();
         client.reset();
+    }
+};
+
+struct AsyncConnectionTestSeamReset {
+    ~AsyncConnectionTestSeamReset() {
+        PoolTestAccess::set_async_connection_test_seams(0, -1);
     }
 };
 
@@ -443,6 +466,124 @@ TEST(PostgresCheckpointAsyncIoTest, ReconnectPollDoesNotBlockIoContext) {
         FAIL() << "cancelled async reconnect returned an unexpected exception";
     }
     EXPECT_TRUE(PoolTestAccess::slot_is_empty(*store, 0));
+}
+
+TEST(PostgresCheckpointAsyncIoTest, ResolverPollDoesNotBlockIoContext) {
+    AsyncConnectionTestSeamReset reset;
+    PoolTestAccess::set_async_connection_test_seams(
+        /*poll_delay_ms=*/150, /*timeout_ms=*/80);
+    StalledTcpServer server;
+    auto store = PoolTestAccess::make_pool(/*pool_size=*/1);
+    PoolTestAccess::set_conn_str(*store,
+        "hostaddr=127.0.0.1 port=" + std::to_string(server.port)
+        + " user=stall dbname=stall sslmode=disable");
+
+    asio::io_context io;
+    std::optional<std::chrono::milliseconds> heartbeat_elapsed;
+    std::exception_ptr rebuild_error;
+    auto started = std::chrono::steady_clock::now();
+    asio::steady_timer heartbeat(io, std::chrono::milliseconds(20));
+    heartbeat.async_wait([&](const asio::error_code& ec) {
+        if (!ec) {
+            heartbeat_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - started);
+        }
+    });
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> {
+            co_await PoolTestAccess::rebuild_async(*store, 0);
+        },
+        [&](std::exception_ptr error) { rebuild_error = error; });
+
+    io.run();
+
+    ASSERT_TRUE(heartbeat_elapsed.has_value());
+    EXPECT_LT(*heartbeat_elapsed, std::chrono::milliseconds(80));
+    EXPECT_NE(rebuild_error, nullptr);
+    EXPECT_TRUE(PoolTestAccess::slot_is_empty(*store, 0));
+}
+
+TEST(PostgresCheckpointAsyncIoTest, ConnectPollHonorsConninfoTimeout) {
+    AsyncConnectionTestSeamReset reset;
+    PoolTestAccess::set_async_connection_test_seams(
+        /*poll_delay_ms=*/0, /*timeout_ms=*/-1);
+    StalledTcpServer server;
+    auto store = PoolTestAccess::make_pool(/*pool_size=*/1);
+    PoolTestAccess::set_conn_str(*store,
+        "hostaddr=127.0.0.1 port=" + std::to_string(server.port)
+        + " user=stall dbname=stall sslmode=disable connect_timeout=1");
+
+    asio::io_context io;
+    std::exception_ptr rebuild_error;
+    auto started = std::chrono::steady_clock::now();
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> {
+            co_await PoolTestAccess::rebuild_async(*store, 0);
+        },
+        [&](std::exception_ptr error) { rebuild_error = error; });
+    io.run();
+    auto elapsed = std::chrono::steady_clock::now() - started;
+
+    ASSERT_NE(rebuild_error, nullptr);
+    try {
+        std::rethrow_exception(rebuild_error);
+    } catch (const std::runtime_error& error) {
+        EXPECT_NE(std::string(error.what()).find(
+            "connection timed out after 2000 ms while polling libpq"),
+            std::string::npos);
+    } catch (...) {
+        FAIL() << "timed async reconnect returned an unexpected exception";
+    }
+    EXPECT_GE(elapsed, std::chrono::milliseconds(1800));
+    EXPECT_LT(elapsed, std::chrono::milliseconds(3000));
+    EXPECT_TRUE(PoolTestAccess::slot_is_empty(*store, 0));
+}
+
+TEST(PostgresCheckpointAsyncIoTest, FlushReadinessCanWinAndCancelsWriteWait) {
+#ifdef _WIN32
+    GTEST_SKIP() << "socketpair readiness probe is POSIX-only";
+#else
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(::socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
+    struct SocketPairClose {
+        int* sockets;
+        ~SocketPairClose() {
+            if (sockets[0] >= 0) ::close(sockets[0]);
+            if (sockets[1] >= 0) ::close(sockets[1]);
+        }
+    } close_sockets{sockets};
+
+    int flags = ::fcntl(sockets[0], F_GETFL, 0);
+    ASSERT_NE(flags, -1);
+    ASSERT_NE(::fcntl(sockets[0], F_SETFL, flags | O_NONBLOCK), -1);
+    std::array<char, 4096> fill{};
+    for (;;) {
+        auto sent = ::send(sockets[0], fill.data(), fill.size(), 0);
+        if (sent >= 0) continue;
+        ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK)
+            << "failed to fill socket send buffer: errno=" << errno;
+        break;
+    }
+    const char marker = 'R';
+    ASSERT_EQ(::send(sockets[1], &marker, 1, 0), 1);
+
+    asio::io_context io;
+    std::optional<bool> read_won;
+    std::exception_ptr wait_error;
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> {
+            read_won = co_await PoolTestAccess::wait_socket_either(sockets[0]);
+        },
+        [&](std::exception_ptr error) { wait_error = error; });
+    io.run();
+
+    EXPECT_EQ(wait_error, nullptr);
+    ASSERT_TRUE(read_won.has_value());
+    EXPECT_TRUE(*read_won);
+    char received = 0;
+    ASSERT_EQ(::recv(sockets[0], &received, 1, 0), 1);
+    EXPECT_EQ(received, marker);
+#endif
 }
 
 TEST_F(PostgresCheckpointTest, SaveAndLoadLatestRoundTrip) {

--- a/tests/test_postgres_checkpoint.cpp
+++ b/tests/test_postgres_checkpoint.cpp
@@ -284,7 +284,9 @@ TEST(PostgresCheckpointAbiTest, MatchesOriginLayout) {
 
     auto store = PoolTestAccess::make_pool(/*pool_size=*/1);
     OriginPostgresLayout origin;
-#if defined(__linux__) && defined(__x86_64__) && INTPTR_MAX == INT64_MAX
+#if defined(__ANDROID__) && defined(__aarch64__) && INTPTR_MAX == INT64_MAX
+    EXPECT_EQ(sizeof(*store), 200u);
+#elif defined(__linux__) && defined(__x86_64__) && INTPTR_MAX == INT64_MAX
     EXPECT_EQ(sizeof(*store), 240u);
 #elif defined(__linux__) && defined(__aarch64__) && INTPTR_MAX == INT64_MAX
     EXPECT_EQ(sizeof(*store), 248u);

--- a/tests/test_postgres_checkpoint.cpp
+++ b/tests/test_postgres_checkpoint.cpp
@@ -100,6 +100,11 @@ public:
             poll_delay_ms, timeout_ms);
     }
 
+    static int async_connection_timeout_ms(const std::string& conn_str) {
+        return PostgresCheckpointStore::async_connection_timeout_ms_for_test(
+            conn_str);
+    }
+
     static Layout layout(const PostgresCheckpointStore& store) {
         auto base = reinterpret_cast<uintptr_t>(&store);
         return {
@@ -506,14 +511,33 @@ TEST(PostgresCheckpointAsyncIoTest, ResolverPollDoesNotBlockIoContext) {
     EXPECT_TRUE(PoolTestAccess::slot_is_empty(*store, 0));
 }
 
-TEST(PostgresCheckpointAsyncIoTest, ConnectPollHonorsConninfoTimeout) {
+TEST(PostgresCheckpointAsyncIoTest, TimeoutPolicyParsesDefaultAndMinimum) {
+    EXPECT_EQ(PoolTestAccess::async_connection_timeout_ms(
+        "host=localhost sslmode=disable"), 30000);
+    EXPECT_EQ(PoolTestAccess::async_connection_timeout_ms(
+        "host=localhost sslmode=disable connect_timeout=0"), 30000);
+    EXPECT_EQ(PoolTestAccess::async_connection_timeout_ms(
+        "host=localhost sslmode=disable connect_timeout=-1"), 30000);
+    EXPECT_EQ(PoolTestAccess::async_connection_timeout_ms(
+        "host=localhost sslmode=disable connect_timeout=1"), 2000);
+    EXPECT_EQ(PoolTestAccess::async_connection_timeout_ms(
+        "host=localhost sslmode=disable connect_timeout=60"), 60000);
+    EXPECT_EQ(PoolTestAccess::async_connection_timeout_ms(
+        "host=one,two sslmode=disable connect_timeout=3"), 3000)
+        << "multi-host conninfo must not multiply the global budget";
+}
+
+TEST(PostgresCheckpointAsyncIoTest, ConnectPollUsesOneGlobalConninfoDeadline) {
     AsyncConnectionTestSeamReset reset;
     PoolTestAccess::set_async_connection_test_seams(
         /*poll_delay_ms=*/0, /*timeout_ms=*/-1);
-    StalledTcpServer server;
+    StalledTcpServer first_server;
+    StalledTcpServer second_server;
     auto store = PoolTestAccess::make_pool(/*pool_size=*/1);
     PoolTestAccess::set_conn_str(*store,
-        "hostaddr=127.0.0.1 port=" + std::to_string(server.port)
+        "hostaddr=127.0.0.1,127.0.0.1 port="
+        + std::to_string(first_server.port) + ","
+        + std::to_string(second_server.port)
         + " user=stall dbname=stall sslmode=disable connect_timeout=1");
 
     asio::io_context io;

--- a/tests/test_postgres_checkpoint.cpp
+++ b/tests/test_postgres_checkpoint.cpp
@@ -20,6 +20,7 @@
 #include <asio/cancellation_signal.hpp>
 #include <asio/detached.hpp>
 #include <asio/io_context.hpp>
+#include <asio/ip/tcp.hpp>
 #include <asio/steady_timer.hpp>
 
 #include <array>
@@ -66,6 +67,20 @@ public:
 
     static size_t waiter_count(PostgresCheckpointStore& store) {
         return store.waiter_count_for_test();
+    }
+
+    static void set_conn_str(PostgresCheckpointStore& store,
+                             std::string conn_str) {
+        store.conn_str_ = std::move(conn_str);
+    }
+
+    static asio::awaitable<void> rebuild_async(
+        PostgresCheckpointStore& store, size_t idx) {
+        co_await store.rebuild_slot_async(idx);
+    }
+
+    static bool slot_is_empty(PostgresCheckpointStore& store, size_t idx) {
+        return !store.pool_[idx];
     }
 
     static Layout layout(const PostgresCheckpointStore& store) {
@@ -116,6 +131,33 @@ struct TestPgConn {
 struct TestPgResult {
     PGresult* raw = nullptr;
     ~TestPgResult() { if (raw) PQclear(raw); }
+};
+
+struct StalledTcpServer {
+    asio::io_context io;
+    asio::ip::tcp::acceptor acceptor{io};
+    std::shared_ptr<asio::ip::tcp::socket> client;
+    std::thread worker;
+    unsigned short port = 0;
+
+    StalledTcpServer() {
+        acceptor.open(asio::ip::tcp::v4());
+        acceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true));
+        acceptor.bind({asio::ip::tcp::v4(), 0});
+        acceptor.listen();
+        port = acceptor.local_endpoint().port();
+        auto pending = std::make_shared<asio::ip::tcp::socket>(io);
+        acceptor.async_accept(*pending, [this, pending](const asio::error_code& ec) {
+            if (!ec) client = pending;
+        });
+        worker = std::thread([this] { io.run(); });
+    }
+
+    ~StalledTcpServer() {
+        io.stop();
+        if (worker.joinable()) worker.join();
+        client.reset();
+    }
 };
 
 std::optional<int> wait_for_blocked_table_lock(PGconn* observer,
@@ -355,6 +397,52 @@ TEST(PostgresCheckpointPoolTest, MixedWaitersKeepArrivalOrder) {
     EXPECT_EQ(async_error, nullptr);
     EXPECT_EQ(order, (std::vector<std::string>{"sync", "async"}));
     EXPECT_EQ(PoolTestAccess::free_count(*pool), 1u);
+}
+
+TEST(PostgresCheckpointAsyncIoTest, ReconnectPollDoesNotBlockIoContext) {
+    StalledTcpServer server;
+    auto store = PoolTestAccess::make_pool(/*pool_size=*/1);
+    PoolTestAccess::set_conn_str(*store,
+        "hostaddr=127.0.0.1 port=" + std::to_string(server.port)
+        + " user=stall dbname=stall sslmode=disable");
+
+    asio::io_context io;
+    asio::cancellation_signal cancel;
+    std::optional<std::chrono::milliseconds> heartbeat_elapsed;
+    std::exception_ptr rebuild_error;
+    auto started = std::chrono::steady_clock::now();
+
+    asio::steady_timer heartbeat(io, std::chrono::milliseconds(20));
+    heartbeat.async_wait([&](const asio::error_code& ec) {
+        if (!ec) {
+            heartbeat_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - started);
+        }
+    });
+    asio::steady_timer cancel_timer(io, std::chrono::milliseconds(100));
+    cancel_timer.async_wait([&](const asio::error_code& ec) {
+        if (!ec) cancel.emit(asio::cancellation_type::all);
+    });
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> {
+            co_await PoolTestAccess::rebuild_async(*store, 0);
+        },
+        asio::bind_cancellation_slot(cancel.slot(),
+            [&](std::exception_ptr error) { rebuild_error = error; }));
+
+    io.run();
+
+    ASSERT_TRUE(heartbeat_elapsed.has_value());
+    EXPECT_LT(*heartbeat_elapsed, std::chrono::milliseconds(60));
+    ASSERT_NE(rebuild_error, nullptr);
+    try {
+        std::rethrow_exception(rebuild_error);
+    } catch (const asio::system_error& error) {
+        EXPECT_EQ(error.code(), asio::error::operation_aborted);
+    } catch (...) {
+        FAIL() << "cancelled async reconnect returned an unexpected exception";
+    }
+    EXPECT_TRUE(PoolTestAccess::slot_is_empty(*store, 0));
 }
 
 TEST_F(PostgresCheckpointTest, SaveAndLoadLatestRoundTrip) {
@@ -716,10 +804,12 @@ TEST_F(PostgresCheckpointTest, AsyncSaveAndLoadLatestRoundTrip) {
 
     asio::io_context io;
     std::optional<Checkpoint> loaded;
+    std::optional<Checkpoint> loaded_by_id;
     asio::co_spawn(io,
         [&]() -> asio::awaitable<void> {
             co_await store->save_async(cp);
             loaded = co_await store->load_latest_async("t-async");
+            loaded_by_id = co_await store->load_by_id_async(cp.id);
         },
         asio::detached);
     io.run();
@@ -728,6 +818,73 @@ TEST_F(PostgresCheckpointTest, AsyncSaveAndLoadLatestRoundTrip) {
     EXPECT_EQ(loaded->id, cp.id);
     EXPECT_EQ(loaded->step, 3);
     EXPECT_EQ(loaded->channel_values["channels"]["x"]["value"].get<int>(), 42);
+    ASSERT_TRUE(loaded_by_id.has_value());
+    EXPECT_EQ(loaded_by_id->id, cp.id);
+    EXPECT_EQ(loaded_by_id->channel_values["channels"]["msg"]["value"], "hi");
+}
+
+TEST_F(PostgresCheckpointTest, AsyncBlobLoadDoesNotBlockIoContext) {
+    store = std::make_unique<PostgresCheckpointStore>(pg_url(), /*pool_size=*/1);
+    store->drop_schema();
+    auto cp = make_state_cp("async-blob-heartbeat", 0, {{"x", {42, 1}}});
+    store->save(cp);
+
+    TestPgConn locker{PQconnectdb(pg_url())};
+    ASSERT_EQ(PQstatus(locker.raw), CONNECTION_OK) << PQerrorMessage(locker.raw);
+    {
+        TestPgResult result{PQexec(locker.raw,
+            "BEGIN; LOCK TABLE neograph_checkpoint_blobs "
+            "IN ACCESS EXCLUSIVE MODE")};
+        ASSERT_NE(result.raw, nullptr);
+        ASSERT_EQ(PQresultStatus(result.raw), PGRES_COMMAND_OK)
+            << PQresultErrorMessage(result.raw);
+    }
+    TestPgConn observer{PQconnectdb(pg_url())};
+    ASSERT_EQ(PQstatus(observer.raw), CONNECTION_OK) << PQerrorMessage(observer.raw);
+
+    asio::io_context io;
+    std::optional<Checkpoint> loaded;
+    std::optional<std::chrono::milliseconds> heartbeat_elapsed;
+    std::exception_ptr load_error;
+    asio::co_spawn(io,
+        [&]() -> asio::awaitable<void> {
+            loaded = co_await store->load_latest_async("async-blob-heartbeat");
+        },
+        [&](std::exception_ptr error) { load_error = error; });
+    std::thread io_thread([&] { io.run(); });
+
+    auto blocked_pid = wait_for_blocked_table_lock(
+        observer.raw, "neograph_checkpoint_blobs");
+    if (!blocked_pid) {
+        TestPgResult result{PQexec(locker.raw, "ROLLBACK")};
+        io_thread.join();
+        FAIL() << "async blob query never reached the PostgreSQL table lock";
+    }
+
+    auto started = std::chrono::steady_clock::now();
+    asio::steady_timer heartbeat(io);
+    asio::post(io, [&] {
+        heartbeat.expires_after(std::chrono::milliseconds(20));
+        heartbeat.async_wait([&](const asio::error_code& ec) {
+            if (!ec) {
+                heartbeat_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - started);
+            }
+        });
+    });
+    std::this_thread::sleep_for(std::chrono::milliseconds(300));
+    {
+        TestPgResult result{PQexec(locker.raw, "COMMIT")};
+    }
+    io_thread.join();
+
+    EXPECT_EQ(load_error, nullptr);
+    ASSERT_TRUE(loaded.has_value());
+    EXPECT_EQ(loaded->channel_values["channels"]["x"]["value"], 42);
+    ASSERT_TRUE(heartbeat_elapsed.has_value());
+    EXPECT_LT(*heartbeat_elapsed, std::chrono::milliseconds(150))
+        << "async blob materialization blocked the io_context for "
+        << heartbeat_elapsed->count() << "ms";
 }
 
 TEST_F(PostgresCheckpointTest, AsyncListReturnsNewestFirst) {
@@ -910,7 +1067,8 @@ TEST_F(PostgresCheckpointTest, CancelledAsyncQueryDiscardsConnectionWithoutRetry
     } catch (...) {
         FAIL() << "cancelled async query returned an unexpected exception";
     }
-    EXPECT_EQ(store->reconnect_count(), 1u);
+    EXPECT_EQ(store->reconnect_count(), 0u)
+        << "cancelled coroutine must discard without blocking to reconnect";
 
     int attempts = -1;
     {
@@ -924,8 +1082,19 @@ TEST_F(PostgresCheckpointTest, CancelledAsyncQueryDiscardsConnectionWithoutRetry
     }
     EXPECT_EQ(attempts, 0)
         << "a cancelled write reached PostgreSQL after its connection was discarded";
-    EXPECT_FALSE(store->load_by_id(cp.id).has_value())
+    asio::io_context recovery_io;
+    std::optional<Checkpoint> recovered;
+    std::exception_ptr recovery_error;
+    asio::co_spawn(recovery_io,
+        [&]() -> asio::awaitable<void> {
+            recovered = co_await store->load_by_id_async(cp.id);
+        },
+        [&](std::exception_ptr error) { recovery_error = error; });
+    recovery_io.run();
+    EXPECT_EQ(recovery_error, nullptr);
+    EXPECT_FALSE(recovered.has_value())
         << "a cancelled write was retried on the replacement connection";
+    EXPECT_EQ(store->reconnect_count(), 1u);
 
     {
         TestPgResult result{PQexec(observer.raw,
@@ -1003,7 +1172,21 @@ TEST_F(PostgresCheckpointTest, CancelledAsyncPutWritesDiscardsTransactionWithout
     } catch (...) {
         FAIL() << "cancelled put_writes_async returned an unexpected exception";
     }
-    EXPECT_EQ(store->reconnect_count(), 1u);
-    EXPECT_TRUE(store->get_writes("cancel-writes", "cancel-parent").empty())
+    EXPECT_EQ(store->reconnect_count(), 0u)
+        << "cancelled coroutine must discard without blocking to reconnect";
+
+    asio::io_context recovery_io;
+    std::vector<PendingWrite> recovered;
+    std::exception_ptr recovery_error;
+    asio::co_spawn(recovery_io,
+        [&]() -> asio::awaitable<void> {
+            recovered = co_await store->get_writes_async(
+                "cancel-writes", "cancel-parent");
+        },
+        [&](std::exception_ptr error) { recovery_error = error; });
+    recovery_io.run();
+    EXPECT_EQ(recovery_error, nullptr);
+    EXPECT_TRUE(recovered.empty())
         << "cancelled put_writes_async retried on the replacement connection";
+    EXPECT_EQ(store->reconnect_count(), 1u);
 }

--- a/tests/test_postgres_checkpoint.cpp
+++ b/tests/test_postgres_checkpoint.cpp
@@ -22,6 +22,7 @@
 #include <asio/io_context.hpp>
 #include <asio/steady_timer.hpp>
 
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
@@ -37,6 +38,8 @@ namespace neograph::graph::test_access {
 
 class PostgresCheckpointStoreTestAccess {
 public:
+    using Layout = std::array<size_t, 6>;
+
     static std::unique_ptr<PostgresCheckpointStore> make_pool(size_t pool_size) {
         return std::unique_ptr<PostgresCheckpointStore>(
             new PostgresCheckpointStore(
@@ -62,8 +65,19 @@ public:
     }
 
     static size_t waiter_count(PostgresCheckpointStore& store) {
-        std::lock_guard lock(store.pool_mutex_);
-        return store.waiters_.size();
+        return store.waiter_count_for_test();
+    }
+
+    static Layout layout(const PostgresCheckpointStore& store) {
+        auto base = reinterpret_cast<uintptr_t>(&store);
+        return {
+            reinterpret_cast<uintptr_t>(&store.conn_str_) - base,
+            reinterpret_cast<uintptr_t>(&store.pool_) - base,
+            reinterpret_cast<uintptr_t>(&store.free_) - base,
+            reinterpret_cast<uintptr_t>(&store.pool_mutex_) - base,
+            reinterpret_cast<uintptr_t>(&store.pool_cv_) - base,
+            reinterpret_cast<uintptr_t>(&store.reconnect_count_) - base,
+        };
     }
 };
 
@@ -72,6 +86,27 @@ public:
 namespace {
 
 using PoolTestAccess = test_access::PostgresCheckpointStoreTestAccess;
+
+struct OriginPostgresLayout : CheckpointStore {
+    std::string conn_str;
+    std::vector<std::unique_ptr<PgConn>> pool;
+    std::queue<size_t> free;
+    std::mutex pool_mutex;
+    std::condition_variable pool_cv;
+    std::atomic<size_t> reconnect_count{0};
+};
+
+PoolTestAccess::Layout origin_layout(const OriginPostgresLayout& store) {
+    auto base = reinterpret_cast<uintptr_t>(&store);
+    return {
+        reinterpret_cast<uintptr_t>(&store.conn_str) - base,
+        reinterpret_cast<uintptr_t>(&store.pool) - base,
+        reinterpret_cast<uintptr_t>(&store.free) - base,
+        reinterpret_cast<uintptr_t>(&store.pool_mutex) - base,
+        reinterpret_cast<uintptr_t>(&store.pool_cv) - base,
+        reinterpret_cast<uintptr_t>(&store.reconnect_count) - base,
+    };
+}
 
 struct TestPgConn {
     PGconn* raw = nullptr;
@@ -170,6 +205,19 @@ protected:
 };
 
 } // namespace
+
+TEST(PostgresCheckpointAbiTest, MatchesOriginLayout) {
+    static_assert(sizeof(PostgresCheckpointStore) == sizeof(OriginPostgresLayout));
+    static_assert(alignof(PostgresCheckpointStore) == alignof(OriginPostgresLayout));
+
+    auto store = PoolTestAccess::make_pool(/*pool_size=*/1);
+    OriginPostgresLayout origin;
+#if defined(__linux__) && INTPTR_MAX == INT64_MAX
+    EXPECT_EQ(sizeof(*store), 240u);
+#endif
+    EXPECT_EQ(alignof(PostgresCheckpointStore), alignof(OriginPostgresLayout));
+    EXPECT_EQ(PoolTestAccess::layout(*store), origin_layout(origin));
+}
 
 TEST(PostgresCheckpointPoolTest, AsyncWaitDoesNotBlockIoContext) {
     auto pool = PoolTestAccess::make_pool(/*pool_size=*/1);

--- a/tests/test_postgres_checkpoint.cpp
+++ b/tests/test_postgres_checkpoint.cpp
@@ -284,8 +284,10 @@ TEST(PostgresCheckpointAbiTest, MatchesOriginLayout) {
 
     auto store = PoolTestAccess::make_pool(/*pool_size=*/1);
     OriginPostgresLayout origin;
-#if defined(__linux__) && INTPTR_MAX == INT64_MAX
+#if defined(__linux__) && defined(__x86_64__) && INTPTR_MAX == INT64_MAX
     EXPECT_EQ(sizeof(*store), 240u);
+#elif defined(__linux__) && defined(__aarch64__) && INTPTR_MAX == INT64_MAX
+    EXPECT_EQ(sizeof(*store), 248u);
 #endif
     EXPECT_EQ(alignof(PostgresCheckpointStore), alignof(OriginPostgresLayout));
     EXPECT_EQ(PoolTestAccess::layout(*store), origin_layout(origin));

--- a/tests/test_postgres_old_header_abi.cpp
+++ b/tests/test_postgres_old_header_abi.cpp
@@ -1,0 +1,22 @@
+#include "fixtures/postgres_checkpoint_origin.h"
+
+#include <cstdlib>
+#include <stdexcept>
+
+int main() {
+    using neograph::graph::PostgresCheckpointStore;
+
+    try {
+        PostgresCheckpointStore invalid("unused", 0);
+        return 1;
+    } catch (const std::invalid_argument&) {
+    }
+
+    const char* dsn = std::getenv("NEOGRAPH_TEST_POSTGRES_URL");
+    if (!dsn || !*dsn) return 0;
+
+    PostgresCheckpointStore store(dsn, 1);
+    if (store.pool_size() != 1 || store.reconnect_count() != 0) return 2;
+    (void)store.load_latest("old-header-new-library");
+    return 0;
+}

--- a/tests/test_provider_invoke_default.cpp
+++ b/tests/test_provider_invoke_default.cpp
@@ -1,12 +1,11 @@
 // ROADMAP_v1.md Candidate 6 — `Provider::invoke()` regression coverage.
 //
-// `invoke(params, on_chunk)` is the v1.0 canonical single-dispatch
-// entry point that replaces the 4-virtual cross-product
-// (`complete` / `complete_async` / `complete_stream` /
-// `complete_stream_async`). This first additive PR adds `invoke()`
-// with a default body that forwards to the legacy chain so existing
-// Provider subclasses keep working unchanged. These tests pin the
-// forwarding semantics and the new override surface.
+// `invoke(params, on_chunk)` is the callback-selected compatibility
+// entry point used by existing engine code. Its default body forwards
+// to the stable 4-virtual chain so existing Provider subclasses keep
+// working unchanged. New implementations use CompletionProvider's
+// explicit request API; these tests pin the compatibility forwarding
+// and override semantics.
 
 #include <gtest/gtest.h>
 #include <neograph/provider.h>
@@ -37,7 +36,7 @@ ChatCompletion make_completion(const std::string& text) {
     return c;
 }
 
-// Legacy provider — overrides only complete_async() and complete_stream(),
+// Existing provider — overrides only complete_async() and complete_stream(),
 // the two pieces of the existing chain. Default invoke() must route to
 // the right one based on on_chunk presence.
 class LegacyChainProvider : public Provider {
@@ -61,10 +60,9 @@ class LegacyChainProvider : public Provider {
     std::string get_name() const override { return "legacy-chain"; }
 };
 
-// New-style provider — overrides invoke() directly. Legacy 4 virtuals
-// are NOT overridden. Engine code that already calls the legacy methods
-// gets the base-class default, which (in this PR) forwards through the
-// chain — but if the user calls invoke() directly, the override fires.
+// Compatibility override — invokes can still be overridden directly.
+// The 4 complete* virtuals are not overridden, so direct complete* calls
+// use the base defaults; a direct invoke() call reaches this override.
 class InvokeNativeProvider : public Provider {
   public:
     std::atomic<int> invoke_calls{0};
@@ -143,8 +141,8 @@ TEST(ProviderInvokeDefault, WithCallbackRoutesToCompleteStreamAsync) {
 }
 
 // ---------------------------------------------------------------------------
-// New-style: subclass overrides invoke() directly. Calling invoke() must
-// hit the override, not the legacy chain.
+// A subclass may still override invoke() directly. Calling invoke() must
+// hit that override, not the complete* compatibility chain.
 // ---------------------------------------------------------------------------
 
 TEST(ProviderInvokeDefault, OverriddenInvokeFires) {


### PR DESCRIPTION
## Summary
- contain ACP worker exceptions and make prompt worker teardown deterministic
- harden OpenInference callback/span lifetimes in C++ and Python
- isolate graph cancellation per operation without changing the 0.11.x ABI
- make PostgreSQL pooling, connection setup, query I/O, cancellation, and reconnect paths nonblocking and failure-safe
- document the permanent Provider compatibility policy and add a Windows verification runner

## Compatibility
- preserves Provider public signatures, virtual order, object layout, and vtable
- preserves the 0.11.x CancelToken and PostgresCheckpointStore binary layouts
- cancelled PostgreSQL writes are quarantined and never retried

## Verification
- 648 registered CTest cases passed
- PostgreSQL 16.14 live suite: 31/31 passed
- old-header/new-library PostgreSQL ABI probe passed
- ASan/UBSan PostgreSQL cancellation probes passed
- Python OpenInference/cancellation tests passed
- OpenAI gpt-4o-mini WebSocket response and tool-call live tests passed

## Platform notes
- native Windows execution of test.bat remains for CI/local Windows validation
- macOS runtime validation is provided by CI