### PR TITLE
feat(mcp): add reusable stdio server substrate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,12 @@ endif()
 # find_package() calls are skipped entirely (see line ~258).
 option(NEOGRAPH_BUILD_ASYNC    "Build neograph::async (asio::ssl HTTP/HTTPS/WS client)" ON)
 option(NEOGRAPH_BUILD_LLM      "Build neograph::llm (LLM providers)"     ON)
-option(NEOGRAPH_BUILD_MCP      "Build neograph::mcp (MCP client)"        ON)
+option(NEOGRAPH_BUILD_MCP      "Build MCP components (compatibility umbrella)" ON)
+set(_neograph_mcp_component_default ${NEOGRAPH_BUILD_MCP})
+option(NEOGRAPH_BUILD_MCP_CLIENT "Build neograph::mcp MCP client"
+       ${_neograph_mcp_component_default})
+option(NEOGRAPH_BUILD_MCP_SERVER "Build neograph::mcp_server local MCP server"
+       ${_neograph_mcp_component_default})
 option(NEOGRAPH_BUILD_A2A      "Build neograph::a2a (Agent-to-Agent client)" ON)
 option(NEOGRAPH_BUILD_ACP      "Build neograph::acp (Agent Client Protocol server)" ON)
 option(NEOGRAPH_BUILD_UTIL     "Build neograph::util (utilities)"        ON)
@@ -308,14 +313,14 @@ target_link_libraries(asio INTERFACE Threads::Threads)
 # fail loud — neograph_async is their link target and skipping it would
 # yield a confusing "undefined reference to OpenSSL::SSL" link error
 # many minutes into the build.
-if(NOT NEOGRAPH_BUILD_ASYNC AND (NEOGRAPH_BUILD_LLM OR NEOGRAPH_BUILD_MCP OR NEOGRAPH_BUILD_A2A OR NEOGRAPH_BUILD_PYBIND))
+if(NOT NEOGRAPH_BUILD_ASYNC AND (NEOGRAPH_BUILD_LLM OR NEOGRAPH_BUILD_MCP_CLIENT OR NEOGRAPH_BUILD_A2A OR NEOGRAPH_BUILD_PYBIND))
     message(FATAL_ERROR
         "NEOGRAPH_BUILD_ASYNC=OFF is incompatible with "
         "NEOGRAPH_BUILD_LLM/MCP/A2A/PYBIND=ON — those targets link "
         "against neograph_async. Either flip ASYNC back ON, or turn "
         "the dependent components OFF in the same configure call.")
 endif()
-if(NEOGRAPH_BUILD_ASYNC OR NEOGRAPH_BUILD_LLM OR NEOGRAPH_BUILD_MCP OR NEOGRAPH_BUILD_A2A)
+if(NEOGRAPH_BUILD_ASYNC OR NEOGRAPH_BUILD_LLM OR NEOGRAPH_BUILD_MCP_CLIENT OR NEOGRAPH_BUILD_A2A)
     find_package(OpenSSL REQUIRED)
 endif()
 
@@ -614,9 +619,24 @@ if(NEOGRAPH_BUILD_LLM)
 endif()
 
 # ===========================================================================
-# neograph::mcp — MCP client (JSON-RPC over HTTP/stdio)
+# MCP shared values, client, and server. The server target deliberately does
+# not link neograph::async or OpenSSL, so server-only builds stay lightweight.
 # ===========================================================================
-if(NEOGRAPH_BUILD_MCP)
+if(NEOGRAPH_BUILD_MCP_CLIENT OR NEOGRAPH_BUILD_MCP_SERVER)
+    add_library(neograph_mcp_types
+        src/mcp/types.cpp
+    )
+    target_include_directories(neograph_mcp_types
+        PUBLIC
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>
+    )
+    target_compile_definitions(neograph_mcp_types PRIVATE NEOGRAPH_BUILDING_LIBRARY)
+    target_link_libraries(neograph_mcp_types PUBLIC neograph_core)
+    add_library(neograph::mcp_types ALIAS neograph_mcp_types)
+endif()
+
+if(NEOGRAPH_BUILD_MCP_CLIENT)
     add_library(neograph_mcp
         src/mcp/client.cpp
     )
@@ -629,11 +649,27 @@ if(NEOGRAPH_BUILD_MCP)
 
     target_compile_definitions(neograph_mcp PRIVATE NEOGRAPH_BUILDING_LIBRARY)
     target_link_libraries(neograph_mcp
-        PUBLIC  neograph_core
+        PUBLIC  neograph_core neograph_mcp_types
         PRIVATE neograph_async OpenSSL::SSL OpenSSL::Crypto
     )
 
     add_library(neograph::mcp ALIAS neograph_mcp)
+endif()
+
+if(NEOGRAPH_BUILD_MCP_SERVER)
+    add_library(neograph_mcp_server
+        src/mcp/server.cpp
+    )
+    target_include_directories(neograph_mcp_server
+        PUBLIC
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>
+    )
+    target_compile_definitions(neograph_mcp_server PRIVATE NEOGRAPH_BUILDING_LIBRARY)
+    target_link_libraries(neograph_mcp_server
+        PUBLIC neograph_core neograph_mcp_types
+    )
+    add_library(neograph::mcp_server ALIAS neograph_mcp_server)
 endif()
 
 # ===========================================================================
@@ -1160,11 +1196,11 @@ if(NEOGRAPH_BUILD_EXAMPLES)
             OFF)
         if(NEOGRAPH_BUILD_COOKBOOK_JARVIS
            AND NEOGRAPH_BUILD_LLM
-           AND NEOGRAPH_BUILD_MCP)
+           AND NEOGRAPH_BUILD_MCP_CLIENT)
             add_subdirectory(examples/cookbook/jarvis)
         endif()
 
-        if(NEOGRAPH_BUILD_MCP)
+        if(NEOGRAPH_BUILD_MCP_CLIENT)
             add_executable(example_mcp_agent examples/03_mcp_agent.cpp)
             target_link_libraries(example_mcp_agent PRIVATE neograph::core neograph::llm neograph::mcp cppdotenv)
 
@@ -1301,6 +1337,13 @@ if(NEOGRAPH_BUILD_EXAMPLES)
             target_link_libraries(example_clay_chatbot PRIVATE neograph::core neograph::llm raylib cppdotenv)
             target_include_directories(example_clay_chatbot PRIVATE ${DEPS_DIR})
         endif()
+    endif()
+
+    # Reusable MCP server smoke target. It has no LLM or client dependency and
+    # is the same stdio binary used by Inspector and host interoperability tests.
+    if(NEOGRAPH_BUILD_MCP_SERVER)
+        add_executable(example_mcp_server examples/59_mcp_server.cpp)
+        target_link_libraries(example_mcp_server PRIVATE neograph::mcp_server)
     endif()
 endif()
 
@@ -1500,7 +1543,11 @@ if(NEOGRAPH_INSTALL_EXPORT)
         endif()
     endforeach()
 
-    foreach(_comp async llm mcp a2a acp util postgres sqlite)
+    if(TARGET neograph_mcp_types)
+        list(APPEND NEOGRAPH_EXPORT_TARGETS neograph_mcp_types)
+    endif()
+
+    foreach(_comp async llm mcp mcp_server a2a acp util postgres sqlite)
         if(TARGET neograph_${_comp})
             list(APPEND NEOGRAPH_EXPORT_TARGETS neograph_${_comp})
             list(APPEND NEOGRAPH_COMPONENTS_BUILT ${_comp})
@@ -1603,6 +1650,7 @@ if(NEOGRAPH_BUILD_PYBIND)
     # not be located" — which is exactly what flipping NEOGRAPH_BUILD_MCP=ON in
     # pyproject.toml without touching this list did.
     if(TARGET neograph_mcp)
+        list(APPEND NEOGRAPH_PYBIND_LIBS neograph_mcp_types)
         list(APPEND NEOGRAPH_PYBIND_LIBS neograph_mcp)
     endif()
     # neograph_a2a ships when A2A is built. Same reasoning as above:

--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ version-locked visual editor). Built-in **OpenInference tracer**, no extra link.
 vLLM/Ollama — any OpenAI-compatible API) · `SchemaProvider` (Claude, Gemini, or
 any custom vendor via JSON schema) · ReAct `Agent` loop with streaming.
 
-**Integrations** — MCP client (`neograph::mcp`, HTTP + stdio) · Agent-to-Agent
+**Integrations** — MCP client (`neograph::mcp`, HTTP + stdio) · local MCP server
+(`neograph::mcp_server`, stdio) · Agent-to-Agent
 (`neograph::a2a`, server + client + caller node) · Agent Client Protocol
 (`neograph::acp`, editor-driven) · gRPC service (`neograph::grpc`, opt-in) ·
 async HTTP/HTTPS/WS + SSE (`neograph::async`).
@@ -230,6 +231,10 @@ async HTTP/HTTPS/WS + SSE (`neograph::async`).
 **Durable state** — `PostgresCheckpointStore`, `SqliteCheckpointStore`, and
 `InMemoryCheckpointStore` behind one `CheckpointStore` interface (all
 Python-bound). Lock-free `RequestQueue` + `AsyncTool` in `neograph::util`.
+
+`NEOGRAPH_BUILD_MCP` remains the compatibility umbrella for both MCP roles.
+Use `NEOGRAPH_BUILD_MCP_CLIENT` or `NEOGRAPH_BUILD_MCP_SERVER` for a narrow
+build; the server-only target does not require `neograph::async` or OpenSSL.
 
 Full capability list and the 55+ runnable examples:
 [`examples/README.md`](examples/README.md).

--- a/examples/59_mcp_server.cpp
+++ b/examples/59_mcp_server.cpp
@@ -1,0 +1,45 @@
+#include <neograph/mcp/server.h>
+
+#include <utility>
+
+int main() {
+    neograph::mcp::MCPServerConfig config;
+    config.server_info = {
+        {"name", "neograph-example"},
+        {"version", "1.0.0"},
+    };
+    config.instructions = "Call echo to verify MCP server connectivity.";
+
+    neograph::mcp::MCPServer server(std::move(config));
+    neograph::mcp::ToolDefinition echo;
+    echo.name = "echo";
+    echo.title = "Echo";
+    echo.description = "Return the supplied message.";
+    echo.input_schema = {
+        {"type", "object"},
+        {"required", neograph::json::array({"message"})},
+        {"properties", {{"message", {{"type", "string"}}}}},
+        {"additionalProperties", false},
+    };
+    echo.output_schema = {
+        {"type", "object"},
+        {"required", neograph::json::array({"message"})},
+        {"properties", {{"message", {{"type", "string"}}}}},
+        {"additionalProperties", false},
+    };
+    echo.annotations = {{"readOnlyHint", true}, {"idempotentHint", true}};
+
+    server.register_tool(std::move(echo),
+        [](const neograph::json& arguments, const auto& cancel) {
+            cancel->throw_if_cancelled("before echo");
+            const auto message = arguments.at("message").get<std::string>();
+            neograph::mcp::CallToolResult result;
+            result.content = neograph::json::array({
+                {{"type", "text"}, {"text", message}},
+            });
+            result.structured_content = {{"message", message}};
+            return result;
+        });
+    server.run();
+    return 0;
+}

--- a/include/neograph/mcp/server.h
+++ b/include/neograph/mcp/server.h
@@ -1,0 +1,77 @@
+/**
+ * @file mcp/server.h
+ * @brief Reusable MCP 2025-11-25 stdio server substrate.
+ *
+ * This is the northbound server role. It is intentionally separate from
+ * MCPClient, which connects NeoGraph to downstream MCP servers.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/graph/cancel.h>
+#include <neograph/mcp/types.h>
+
+#include <cstddef>
+#include <functional>
+#include <istream>
+#include <memory>
+#include <ostream>
+
+namespace neograph::mcp {
+
+inline constexpr const char* MCP_PROTOCOL_VERSION = "2025-11-25";
+
+struct NEOGRAPH_API MCPServerConfig {
+    json        server_info = json::object();
+    std::string instructions;
+    std::size_t max_concurrent_calls = 4;
+    std::size_t max_pending_calls = 64;
+};
+
+/**
+ * @brief Local, stdio-first MCP server with typed tools and bounded execution.
+ *
+ * Register tools before initialization, then call run(). Tool calls execute on
+ * a fixed-size worker pool. The request-scoped CancelToken passed to a handler
+ * is cancelled by `notifications/cancelled`; handlers cooperate by polling or
+ * propagating that token into their own async work.
+ */
+class NEOGRAPH_API MCPServer {
+  public:
+    using ToolHandler = std::function<CallToolResult(
+        const json&, const std::shared_ptr<graph::CancelToken>&)>;
+
+    /// Receives complete JSON-RPC response envelopes produced asynchronously.
+    using ResponseSink = std::function<void(const json&)>;
+
+    explicit MCPServer(MCPServerConfig config);
+    ~MCPServer();
+
+    MCPServer(const MCPServer&) = delete;
+    MCPServer& operator=(const MCPServer&) = delete;
+
+    /// Add a tool. Names must be unique and registration closes at initialize.
+    void register_tool(ToolDefinition definition, ToolHandler handler);
+
+    /// Process one parsed JSON-RPC message. Tool calls may complete via sink.
+    json handle_message(const json& envelope);
+
+    /// Drive newline-delimited MCP stdio until EOF or a message-boundary stop.
+    void run(std::istream& in, std::ostream& out);
+    void run();
+
+    /// Set the destination for asynchronously completed tool-call responses.
+    void set_response_sink(ResponseSink sink);
+
+    /// Cooperatively cancel outstanding calls and drain the worker pool.
+    void stop();
+
+    bool initialized() const;
+    bool is_running() const;
+
+  private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace neograph::mcp

--- a/include/neograph/mcp/types.h
+++ b/include/neograph/mcp/types.h
@@ -66,6 +66,7 @@ struct NEOGRAPH_API ToolDefinition {
     json        raw = json::object();
 
     static ToolDefinition from_json(const json& value);
+    json to_json() const;
 };
 
 struct NEOGRAPH_API ListToolsPage {
@@ -85,6 +86,7 @@ struct NEOGRAPH_API CallToolResult {
     json raw = json::object();
 
     static CallToolResult from_json(const json& value);
+    json to_json() const;
 };
 
 } // namespace neograph::mcp

--- a/include/neograph/neograph.h
+++ b/include/neograph/neograph.h
@@ -10,6 +10,7 @@
  * #include <neograph/neograph.h>          // Core + graph engine
  * #include <neograph/llm/openai_provider.h> // OpenAI provider (optional)
  * #include <neograph/mcp/client.h>          // MCP client (optional)
+ * #include <neograph/mcp/server.h>          // MCP server (optional)
  * @endcode
  */
 #pragma once

--- a/src/mcp/client.cpp
+++ b/src/mcp/client.cpp
@@ -52,120 +52,6 @@
 
 namespace neograph::mcp {
 
-MCPError::MCPError(int code, std::string message, json data)
-  : std::runtime_error(std::move(message))
-  , code_(code)
-  , data_(std::move(data))
-{
-}
-
-InitializeResult InitializeResult::from_json(const json& value) {
-    if (!value.is_object()) {
-        throw std::invalid_argument("MCP initialize result must be an object");
-    }
-    InitializeResult result;
-    result.raw = value;
-    if (!value.contains("protocolVersion")
-        || !value["protocolVersion"].is_string()
-        || value["protocolVersion"].get<std::string>().empty()) {
-        throw std::invalid_argument(
-            "MCP initialize result must contain a non-empty protocolVersion");
-    }
-    if (!value.contains("capabilities") || !value["capabilities"].is_object()
-        || !value.contains("serverInfo") || !value["serverInfo"].is_object()) {
-        throw std::invalid_argument(
-            "MCP initialize result must contain capabilities and serverInfo objects");
-    }
-    if (value.contains("instructions") && !value["instructions"].is_string()) {
-        throw std::invalid_argument("MCP initialize instructions must be a string");
-    }
-    result.protocol_version = value["protocolVersion"].get<std::string>();
-    result.capabilities = value["capabilities"];
-    result.server_info = value["serverInfo"];
-    result.instructions = value.value("instructions", "");
-    return result;
-}
-
-ToolDefinition ToolDefinition::from_json(const json& value) {
-    if (!value.is_object()) {
-        throw std::invalid_argument("MCP tool definition must be an object");
-    }
-    ToolDefinition result;
-    result.raw = value;
-    result.name = value.value("name", "");
-    result.title = value.value("title", "");
-    result.description = value.value("description", "");
-    result.icons = value.value("icons", json::array());
-    result.input_schema = value.value("inputSchema", json::object());
-    if (value.contains("outputSchema")) result.output_schema = value["outputSchema"];
-    result.annotations = value.value("annotations", json::object());
-    result.execution = value.value("execution", json::object());
-    result.meta = value.value("_meta", json::object());
-    if (result.name.empty()) {
-        throw std::invalid_argument("MCP tool definition is missing name");
-    }
-    if (!result.input_schema.is_object()) {
-        throw std::invalid_argument("MCP tool inputSchema must be an object");
-    }
-    if (!result.output_schema.is_null() && !result.output_schema.is_object()) {
-        throw std::invalid_argument("MCP tool outputSchema must be an object");
-    }
-    if (!result.icons.is_array() || !result.annotations.is_object()
-        || !result.execution.is_object() || !result.meta.is_object()) {
-        throw std::invalid_argument("MCP tool metadata has an invalid type");
-    }
-    return result;
-}
-
-ListToolsPage ListToolsPage::from_json(const json& value) {
-    if (!value.is_object() || !value.contains("tools")
-        || !value["tools"].is_array()) {
-        throw std::invalid_argument("MCP tools/list result must contain a tools array");
-    }
-    ListToolsPage result;
-    result.raw = value;
-    for (const auto& tool : value["tools"]) {
-        result.tools.push_back(ToolDefinition::from_json(tool));
-    }
-    if (value.contains("nextCursor") && !value["nextCursor"].is_null()) {
-        if (!value["nextCursor"].is_string()) {
-            throw std::invalid_argument("MCP tools/list nextCursor must be a string");
-        }
-        result.next_cursor = value["nextCursor"].get<std::string>();
-    }
-    result.meta = value.value("_meta", json::object());
-    if (!result.meta.is_object()) {
-        throw std::invalid_argument("MCP tools/list _meta must be an object");
-    }
-    return result;
-}
-
-CallToolResult CallToolResult::from_json(const json& value) {
-    if (!value.is_object()) {
-        throw std::invalid_argument("MCP tools/call result must be an object");
-    }
-    CallToolResult result;
-    result.raw = value;
-    result.content = value.value("content", json::array());
-    if (value.contains("structuredContent")) {
-        result.structured_content = value["structuredContent"];
-    }
-    result.is_error = value.value("isError", false);
-    result.meta = value.value("_meta", json::object());
-    if (!result.content.is_array()) {
-        throw std::invalid_argument("MCP tools/call content must be an array");
-    }
-    if (!result.structured_content.is_null()
-        && !result.structured_content.is_object()) {
-        throw std::invalid_argument(
-            "MCP tools/call structuredContent must be an object");
-    }
-    if (!result.meta.is_object()) {
-        throw std::invalid_argument("MCP tools/call _meta must be an object");
-    }
-    return result;
-}
-
 namespace {
 json extract_rpc_result(const json& response, int expected_id,
                         std::string_view transport) {
@@ -1152,7 +1038,7 @@ bool schema_type_matches(const json& value, const std::string& type) {
     if (type == "number") return value.is_number();
     if (type == "integer") return value.is_number_integer();
     if (type == "string") return value.is_string();
-    return true;
+    throw std::invalid_argument("unsupported JSON Schema type: " + type);
 }
 
 void validate_schema_value(const json& value, const json& schema,

--- a/src/mcp/server.cpp
+++ b/src/mcp/server.cpp
@@ -1,0 +1,602 @@
+#include <neograph/mcp/server.h>
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <iostream>
+#include <map>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace neograph::mcp {
+namespace {
+
+json rpc_result(json result, const json& id) {
+    return {{"jsonrpc", "2.0"}, {"id", id}, {"result", std::move(result)}};
+}
+
+json rpc_error(int code, std::string message, const json& id,
+               json data = nullptr) {
+    json error = {{"code", code}, {"message", std::move(message)}};
+    if (!data.is_null()) error["data"] = std::move(data);
+    return {{"jsonrpc", "2.0"}, {"id", id}, {"error", std::move(error)}};
+}
+
+CallToolResult tool_error(std::string message) {
+    CallToolResult result;
+    result.content = json::array({{{"type", "text"}, {"text", std::move(message)}}});
+    result.is_error = true;
+    return result;
+}
+
+bool valid_request_id(const json& id) {
+    return id.is_string() || id.is_number_integer() || id.is_number_unsigned();
+}
+
+std::string request_key(const json& id) {
+    if (id.is_string()) return "s:" + id.get<std::string>();
+    return "n:" + id.dump();
+}
+
+bool schema_type_matches(const json& value, const std::string& type) {
+    if (type == "null") return value.is_null();
+    if (type == "boolean") return value.is_boolean();
+    if (type == "object") return value.is_object();
+    if (type == "array") return value.is_array();
+    if (type == "number") return value.is_number();
+    if (type == "integer") return value.is_number_integer();
+    if (type == "string") return value.is_string();
+    throw std::invalid_argument("unsupported JSON Schema type: " + type);
+}
+
+void validate_schema_shape(const json& schema, const std::string& path) {
+    if (!schema.is_object()) {
+        throw std::invalid_argument("JSON Schema at " + path + " must be an object");
+    }
+    if (schema.contains("type")) {
+        const auto validate_type = [&path](const json& type) {
+            if (!type.is_string()) {
+                throw std::invalid_argument("JSON Schema type at " + path
+                                            + " must contain strings");
+            }
+            static const std::vector<std::string> supported = {
+                "null", "boolean", "object", "array", "number", "integer", "string"
+            };
+            const auto name = type.get<std::string>();
+            if (std::find(supported.begin(), supported.end(), name) == supported.end()) {
+                throw std::invalid_argument("unsupported JSON Schema type: " + name);
+            }
+        };
+        if (schema["type"].is_string()) {
+            validate_type(schema["type"]);
+        } else if (schema["type"].is_array()) {
+            for (const auto& type : schema["type"]) validate_type(type);
+        } else {
+            throw std::invalid_argument("JSON Schema type at " + path
+                                        + " must be a string or array");
+        }
+    }
+    if (schema.contains("enum") && !schema["enum"].is_array()) {
+        throw std::invalid_argument("JSON Schema enum at " + path
+                                    + " must be an array");
+    }
+    if (schema.contains("required")) {
+        if (!schema["required"].is_array()) {
+            throw std::invalid_argument("JSON Schema required at " + path
+                                        + " must be an array");
+        }
+        for (const auto& name : schema["required"]) {
+            if (!name.is_string()) {
+                throw std::invalid_argument("JSON Schema required at " + path
+                                            + " must contain strings");
+            }
+        }
+    }
+    if (schema.contains("properties")) {
+        if (!schema["properties"].is_object()) {
+            throw std::invalid_argument("JSON Schema properties at " + path
+                                        + " must be an object");
+        }
+        for (auto it = schema["properties"].begin();
+             it != schema["properties"].end(); ++it) {
+            validate_schema_shape(it.value(), path + "/properties/" + it.key());
+        }
+    }
+    if (schema.contains("items")) {
+        validate_schema_shape(schema["items"], path + "/items");
+    }
+}
+
+void validate_value(const json& value, const json& schema,
+                    const std::string& subject, const std::string& path) {
+    if (!schema.is_object()) {
+        throw std::invalid_argument(subject + " schema at " + path
+                                    + " must be an object");
+    }
+    if (schema.contains("const") && value != schema["const"]) {
+        throw std::invalid_argument(subject + " at " + path
+                                    + " does not match const");
+    }
+    if (schema.contains("enum")) {
+        if (!schema["enum"].is_array()) {
+            throw std::invalid_argument(subject + " schema enum at " + path
+                                        + " must be an array");
+        }
+        bool matched = false;
+        for (const auto& candidate : schema["enum"]) {
+            if (candidate == value) {
+                matched = true;
+                break;
+            }
+        }
+        if (!matched) {
+            throw std::invalid_argument(subject + " at " + path
+                                        + " is not in enum");
+        }
+    }
+    if (schema.contains("type")) {
+        bool matched = false;
+        const auto& types = schema["type"];
+        if (types.is_string()) {
+            matched = schema_type_matches(value, types.get<std::string>());
+        } else if (types.is_array()) {
+            for (const auto& type : types) {
+                if (!type.is_string()) {
+                    throw std::invalid_argument(subject + " schema type at "
+                                                + path + " must contain strings");
+                }
+                if (schema_type_matches(value, type.get<std::string>())) {
+                    matched = true;
+                    break;
+                }
+            }
+        } else {
+            throw std::invalid_argument(subject + " schema type at " + path
+                                        + " must be a string or array");
+        }
+        if (!matched) {
+            throw std::invalid_argument(subject + " at " + path
+                                        + " has the wrong JSON type");
+        }
+    }
+    if (value.is_object()) {
+        if (schema.contains("required")) {
+            if (!schema["required"].is_array()) {
+                throw std::invalid_argument(subject + " schema required at "
+                                            + path + " must be an array");
+            }
+            for (const auto& name : schema["required"]) {
+                if (!name.is_string()) {
+                    throw std::invalid_argument(subject
+                        + " schema required entries must be strings");
+                }
+                const auto property = name.get<std::string>();
+                if (!value.contains(property)) {
+                    throw std::invalid_argument(subject + " at " + path
+                                                + " is missing required property "
+                                                + property);
+                }
+            }
+        }
+        const json properties = schema.value("properties", json::object());
+        if (!properties.is_object()) {
+            throw std::invalid_argument(subject + " schema properties at "
+                                        + path + " must be an object");
+        }
+        for (auto it = properties.begin(); it != properties.end(); ++it) {
+            if (value.contains(it.key())) {
+                validate_value(value[it.key()], it.value(), subject,
+                               path + "/" + it.key());
+            }
+        }
+        if (schema.value("additionalProperties", true) == false) {
+            for (auto it = value.begin(); it != value.end(); ++it) {
+                if (!properties.contains(it.key())) {
+                    throw std::invalid_argument(subject + " at " + path
+                                                + " has unexpected property "
+                                                + it.key());
+                }
+            }
+        }
+    }
+    if (value.is_array() && schema.contains("items")) {
+        for (std::size_t i = 0; i < value.size(); ++i) {
+            validate_value(value[i], schema["items"], subject,
+                           path + "/" + std::to_string(i));
+        }
+    }
+}
+
+void validate_definition(const ToolDefinition& definition) {
+    ToolDefinition::from_json(definition.to_json());
+    validate_schema_shape(definition.input_schema, "inputSchema");
+    if (!definition.output_schema.is_null()) {
+        validate_schema_shape(definition.output_schema, "outputSchema");
+    }
+}
+
+} // namespace
+
+struct MCPServer::Impl {
+    struct RegisteredTool {
+        ToolDefinition definition;
+        ToolHandler handler;
+    };
+
+    struct CallTask {
+        json id;
+        std::string key;
+        json arguments;
+        RegisteredTool tool;
+        std::shared_ptr<graph::CancelToken> cancel;
+    };
+
+    explicit Impl(MCPServerConfig value) : config(std::move(value)) {}
+
+    MCPServerConfig config;
+    std::atomic<bool> initialize_seen{false};
+    std::atomic<bool> operational{false};
+    std::atomic<bool> running{false};
+    std::atomic<bool> stopping{false};
+
+    std::mutex tools_mu;
+    std::map<std::string, RegisteredTool> tools;
+
+    std::shared_ptr<ResponseSink> sink;
+
+    std::mutex calls_mu;
+    std::condition_variable calls_cv;
+    std::deque<std::shared_ptr<CallTask>> queue;
+    std::unordered_map<std::string, std::shared_ptr<CallTask>> active;
+    std::vector<std::thread> workers;
+
+    void emit(const json& envelope) noexcept {
+        try {
+            auto current = std::atomic_load_explicit(&sink,
+                                                     std::memory_order_acquire);
+            if (current && *current) (*current)(envelope);
+        } catch (...) {
+            // A transport failure cannot safely be reported through itself.
+        }
+    }
+
+    void start_workers() {
+        workers.reserve(config.max_concurrent_calls);
+        try {
+            for (std::size_t i = 0; i < config.max_concurrent_calls; ++i) {
+                workers.emplace_back([this] { worker_loop(); });
+            }
+        } catch (...) {
+            stopping.store(true, std::memory_order_release);
+            calls_cv.notify_all();
+            for (auto& worker : workers) {
+                if (worker.joinable()) worker.join();
+            }
+            workers.clear();
+            throw;
+        }
+    }
+
+    void worker_loop() {
+        while (true) {
+            std::shared_ptr<CallTask> task;
+            {
+                std::unique_lock lk(calls_mu);
+                calls_cv.wait(lk, [this] {
+                    return stopping.load(std::memory_order_acquire)
+                        || !queue.empty();
+                });
+                if (queue.empty()) return;
+                task = std::move(queue.front());
+                queue.pop_front();
+            }
+
+            CallToolResult result;
+            try {
+                task->cancel->throw_if_cancelled("before tool execution");
+                result = task->tool.handler(task->arguments, task->cancel);
+                result = CallToolResult::from_json(result.to_json());
+                if (!result.is_error && !task->tool.definition.output_schema.is_null()) {
+                    if (result.structured_content.is_null()) {
+                        throw std::invalid_argument(
+                            "tool advertised outputSchema but returned no structuredContent");
+                    }
+                    validate_value(result.structured_content,
+                                   task->tool.definition.output_schema,
+                                   "MCP tool structuredContent", "$");
+                }
+                task->cancel->throw_if_cancelled("after tool execution");
+            } catch (const graph::CancelledException& e) {
+                result = tool_error(e.what());
+            } catch (const std::exception& e) {
+                result = tool_error(std::string("Tool execution failed: ") + e.what());
+            } catch (...) {
+                result = tool_error("Tool execution failed: unknown exception");
+            }
+
+            {
+                std::lock_guard lk(calls_mu);
+                active.erase(task->key);
+            }
+            emit(rpc_result(result.to_json(), task->id));
+        }
+    }
+
+    json handle_initialize(const json& params, const json& id) {
+        if (initialize_seen.exchange(true, std::memory_order_acq_rel)) {
+            return rpc_error(-32600, "MCP initialize may only be sent once", id);
+        }
+        if (!params.is_object()
+            || !params.contains("protocolVersion")
+            || !params["protocolVersion"].is_string()
+            || !params.contains("capabilities")
+            || !params["capabilities"].is_object()
+            || !params.contains("clientInfo")
+            || !params["clientInfo"].is_object()) {
+            initialize_seen.store(false, std::memory_order_release);
+            return rpc_error(-32602,
+                "initialize requires protocolVersion, capabilities, and clientInfo",
+                id);
+        }
+
+        json result = {
+            {"protocolVersion", MCP_PROTOCOL_VERSION},
+            {"capabilities", {{"tools", {{"listChanged", false}}}}},
+            {"serverInfo", config.server_info},
+        };
+        if (!config.instructions.empty()) {
+            result["instructions"] = config.instructions;
+        }
+        return rpc_result(std::move(result), id);
+    }
+
+    json handle_tools_list(const json& params, const json& id) {
+        if (!params.is_null() && !params.is_object()) {
+            return rpc_error(-32602, "tools/list params must be an object", id);
+        }
+        if (params.is_object() && params.contains("cursor")) {
+            return rpc_error(-32602,
+                             "tools/list cursor is invalid: this catalogue is unpaged",
+                             id);
+        }
+
+        json listed = json::array();
+        {
+            std::lock_guard lk(tools_mu);
+            for (const auto& [name, tool] : tools) {
+                (void)name;
+                listed.push_back(tool.definition.to_json());
+            }
+        }
+        return rpc_result({{"tools", std::move(listed)}}, id);
+    }
+
+    json handle_tools_call(const json& params, const json& id) {
+        if (!params.is_object() || !params.contains("name")
+            || !params["name"].is_string()
+            || params["name"].get<std::string>().empty()) {
+            return rpc_error(-32602, "tools/call requires a non-empty name", id);
+        }
+        json arguments = params.value("arguments", json::object());
+        if (!arguments.is_object()) {
+            return rpc_error(-32602, "tools/call arguments must be an object", id);
+        }
+
+        RegisteredTool tool;
+        const auto name = params["name"].get<std::string>();
+        {
+            std::lock_guard lk(tools_mu);
+            auto it = tools.find(name);
+            if (it == tools.end()) {
+                return rpc_result(tool_error("Unknown tool: " + name).to_json(), id);
+            }
+            tool = it->second;
+        }
+        try {
+            validate_value(arguments, tool.definition.input_schema,
+                           "MCP tool arguments", "$");
+        } catch (const std::exception& e) {
+            return rpc_result(tool_error(e.what()).to_json(), id);
+        }
+
+        auto task = std::make_shared<CallTask>();
+        task->id = id;
+        task->key = request_key(id);
+        task->arguments = std::move(arguments);
+        task->tool = std::move(tool);
+        task->cancel = std::make_shared<graph::CancelToken>();
+
+        {
+            std::lock_guard lk(calls_mu);
+            if (stopping.load(std::memory_order_acquire)) {
+                return rpc_error(-32000, "MCP server is stopping", id);
+            }
+            if (active.contains(task->key)) {
+                return rpc_error(-32600, "duplicate in-flight request id", id);
+            }
+            const auto capacity = config.max_concurrent_calls
+                                + config.max_pending_calls;
+            if (active.size() >= capacity) {
+                return rpc_error(-32000, "MCP tool queue is full", id,
+                                 {{"capacity", capacity}});
+            }
+            active.emplace(task->key, task);
+            queue.push_back(task);
+        }
+        calls_cv.notify_one();
+        return nullptr;
+    }
+
+    void handle_cancel(const json& params) {
+        if (!params.is_object() || !params.contains("requestId")
+            || !valid_request_id(params["requestId"])) {
+            return;
+        }
+        std::shared_ptr<CallTask> task;
+        {
+            std::lock_guard lk(calls_mu);
+            auto it = active.find(request_key(params["requestId"]));
+            if (it != active.end()) task = it->second;
+        }
+        if (task) task->cancel->cancel();
+    }
+};
+
+MCPServer::MCPServer(MCPServerConfig config)
+    : impl_(std::make_unique<Impl>(std::move(config))) {
+    if (!impl_->config.server_info.is_object()
+        || !impl_->config.server_info.contains("name")
+        || !impl_->config.server_info["name"].is_string()
+        || !impl_->config.server_info.contains("version")
+        || !impl_->config.server_info["version"].is_string()) {
+        throw std::invalid_argument(
+            "MCP server_info requires string name and version fields");
+    }
+    if (impl_->config.max_concurrent_calls == 0) {
+        throw std::invalid_argument("MCP max_concurrent_calls must be positive");
+    }
+    impl_->start_workers();
+}
+
+MCPServer::~MCPServer() {
+    stop();
+}
+
+void MCPServer::register_tool(ToolDefinition definition, ToolHandler handler) {
+    if (!handler) throw std::invalid_argument("MCP tool handler must be callable");
+    if (impl_->initialize_seen.load(std::memory_order_acquire)) {
+        throw std::logic_error("MCP tools must be registered before initialize");
+    }
+    validate_definition(definition);
+    const auto name = definition.name;
+    std::lock_guard lk(impl_->tools_mu);
+    auto [it, inserted] = impl_->tools.emplace(
+        name, Impl::RegisteredTool{std::move(definition), std::move(handler)});
+    if (!inserted) {
+        throw std::invalid_argument("duplicate MCP tool name: " + it->first);
+    }
+}
+
+json MCPServer::handle_message(const json& envelope) {
+    if (!envelope.is_object() || envelope.value("jsonrpc", "") != "2.0") {
+        return rpc_error(-32600, "Invalid JSON-RPC 2.0 request", nullptr);
+    }
+    if (!envelope.contains("method")) {
+        // The server currently sends no requests, so inbound responses have no
+        // waiter. Valid response envelopes are ignored rather than answered.
+        if (envelope.contains("id")
+            && (envelope.contains("result") || envelope.contains("error"))) {
+            return nullptr;
+        }
+        return rpc_error(-32600, "JSON-RPC request is missing method", nullptr);
+    }
+    if (!envelope["method"].is_string()) {
+        return rpc_error(-32600, "JSON-RPC method must be a string", nullptr);
+    }
+
+    const bool notification = !envelope.contains("id");
+    json id = notification ? json(nullptr) : envelope["id"];
+    if (!notification && !valid_request_id(id)) {
+        return rpc_error(-32600, "JSON-RPC id must be a string or integer", nullptr);
+    }
+    const auto method = envelope["method"].get<std::string>();
+    const json params = envelope.value("params", json(nullptr));
+
+    if (notification) {
+        if (method == "notifications/initialized") {
+            if (impl_->initialize_seen.load(std::memory_order_acquire)) {
+                impl_->operational.store(true, std::memory_order_release);
+            }
+        } else if (method == "notifications/cancelled") {
+            impl_->handle_cancel(params);
+        }
+        return nullptr;
+    }
+
+    if (method == "ping") return rpc_result(json::object(), id);
+    if (method == "initialize") return impl_->handle_initialize(params, id);
+    if (!impl_->operational.load(std::memory_order_acquire)) {
+        return rpc_error(-32002, "MCP server is not initialized", id);
+    }
+    if (method == "tools/list") return impl_->handle_tools_list(params, id);
+    if (method == "tools/call") return impl_->handle_tools_call(params, id);
+    return rpc_error(-32601, "Method not found: " + method, id);
+}
+
+void MCPServer::run(std::istream& in, std::ostream& out) {
+    if (impl_->running.exchange(true, std::memory_order_acq_rel)) {
+        throw std::logic_error("MCP server run loop is already active");
+    }
+    std::mutex output_mu;
+    set_response_sink([&out, &output_mu](const json& response) {
+        std::lock_guard lk(output_mu);
+        out << response.dump() << '\n';
+        out.flush();
+    });
+
+    std::string line;
+    while (!impl_->stopping.load(std::memory_order_acquire)
+           && std::getline(in, line)) {
+        if (line.empty()) continue;
+        json response;
+        try {
+            response = handle_message(json::parse(line));
+        } catch (const json::parse_error& e) {
+            std::cerr << "neograph MCP stdio parse error: " << e.what() << '\n';
+            response = rpc_error(-32700, "Parse error", nullptr);
+        } catch (const std::exception& e) {
+            std::cerr << "neograph MCP stdio internal error: " << e.what() << '\n';
+            response = rpc_error(-32603, "Internal error", nullptr);
+        }
+        if (!response.is_null()) {
+            std::lock_guard lk(output_mu);
+            out << response.dump() << '\n';
+            out.flush();
+        }
+    }
+    stop();
+    impl_->running.store(false, std::memory_order_release);
+}
+
+void MCPServer::run() {
+    run(std::cin, std::cout);
+}
+
+void MCPServer::set_response_sink(ResponseSink sink) {
+    std::atomic_store_explicit(
+        &impl_->sink,
+        std::make_shared<ResponseSink>(std::move(sink)),
+        std::memory_order_release);
+}
+
+void MCPServer::stop() {
+    if (!impl_ || impl_->stopping.exchange(true, std::memory_order_acq_rel)) return;
+    {
+        std::lock_guard lk(impl_->calls_mu);
+        for (auto& [key, task] : impl_->active) {
+            (void)key;
+            task->cancel->cancel();
+        }
+    }
+    impl_->calls_cv.notify_all();
+    for (auto& worker : impl_->workers) {
+        if (worker.joinable()) worker.join();
+    }
+    impl_->workers.clear();
+}
+
+bool MCPServer::initialized() const {
+    return impl_->operational.load(std::memory_order_acquire);
+}
+
+bool MCPServer::is_running() const {
+    return impl_->running.load(std::memory_order_acquire);
+}
+
+} // namespace neograph::mcp

--- a/src/mcp/types.cpp
+++ b/src/mcp/types.cpp
@@ -1,0 +1,164 @@
+#include <neograph/mcp/types.h>
+
+namespace neograph::mcp {
+
+MCPError::MCPError(int code, std::string message, json data)
+  : std::runtime_error(std::move(message))
+  , code_(code)
+  , data_(std::move(data))
+{
+}
+
+InitializeResult InitializeResult::from_json(const json& value) {
+    if (!value.is_object()) {
+        throw std::invalid_argument("MCP initialize result must be an object");
+    }
+    InitializeResult result;
+    result.raw = value;
+    if (!value.contains("protocolVersion")
+        || !value["protocolVersion"].is_string()
+        || value["protocolVersion"].get<std::string>().empty()) {
+        throw std::invalid_argument(
+            "MCP initialize result must contain a non-empty protocolVersion");
+    }
+    if (!value.contains("capabilities") || !value["capabilities"].is_object()
+        || !value.contains("serverInfo") || !value["serverInfo"].is_object()) {
+        throw std::invalid_argument(
+            "MCP initialize result must contain capabilities and serverInfo objects");
+    }
+    if (value.contains("instructions") && !value["instructions"].is_string()) {
+        throw std::invalid_argument("MCP initialize instructions must be a string");
+    }
+    result.protocol_version = value["protocolVersion"].get<std::string>();
+    result.capabilities = value["capabilities"];
+    result.server_info = value["serverInfo"];
+    result.instructions = value.value("instructions", "");
+    return result;
+}
+
+ToolDefinition ToolDefinition::from_json(const json& value) {
+    if (!value.is_object()) {
+        throw std::invalid_argument("MCP tool definition must be an object");
+    }
+    ToolDefinition result;
+    result.raw = value;
+    result.name = value.value("name", "");
+    result.title = value.value("title", "");
+    result.description = value.value("description", "");
+    result.icons = value.value("icons", json::array());
+    result.input_schema = value.value("inputSchema", json::object());
+    if (value.contains("outputSchema")) result.output_schema = value["outputSchema"];
+    result.annotations = value.value("annotations", json::object());
+    result.execution = value.value("execution", json::object());
+    result.meta = value.value("_meta", json::object());
+    if (result.name.empty()) {
+        throw std::invalid_argument("MCP tool definition is missing name");
+    }
+    if (!result.input_schema.is_object()) {
+        throw std::invalid_argument("MCP tool inputSchema must be an object");
+    }
+    if (!result.output_schema.is_null() && !result.output_schema.is_object()) {
+        throw std::invalid_argument("MCP tool outputSchema must be an object");
+    }
+    if (!result.icons.is_array() || !result.annotations.is_object()
+        || !result.execution.is_object() || !result.meta.is_object()) {
+        throw std::invalid_argument("MCP tool metadata has an invalid type");
+    }
+    return result;
+}
+
+json ToolDefinition::to_json() const {
+    json value = json::object();
+    if (raw.is_object()) {
+        for (auto it = raw.begin(); it != raw.end(); ++it) {
+            const auto& key = it.key();
+            if (key != "name" && key != "title" && key != "description"
+                && key != "icons" && key != "inputSchema"
+                && key != "outputSchema" && key != "annotations"
+                && key != "execution" && key != "_meta") {
+                value[key] = it.value();
+            }
+        }
+    }
+    value["name"] = name;
+    value["inputSchema"] = input_schema;
+    if (!title.empty()) value["title"] = title;
+    if (!description.empty()) value["description"] = description;
+    if (!icons.empty()) value["icons"] = icons;
+    if (!output_schema.is_null()) value["outputSchema"] = output_schema;
+    if (!annotations.empty()) value["annotations"] = annotations;
+    if (!execution.empty()) value["execution"] = execution;
+    if (!meta.empty()) value["_meta"] = meta;
+    return value;
+}
+
+ListToolsPage ListToolsPage::from_json(const json& value) {
+    if (!value.is_object() || !value.contains("tools")
+        || !value["tools"].is_array()) {
+        throw std::invalid_argument("MCP tools/list result must contain a tools array");
+    }
+    ListToolsPage result;
+    result.raw = value;
+    for (const auto& tool : value["tools"]) {
+        result.tools.push_back(ToolDefinition::from_json(tool));
+    }
+    if (value.contains("nextCursor") && !value["nextCursor"].is_null()) {
+        if (!value["nextCursor"].is_string()) {
+            throw std::invalid_argument("MCP tools/list nextCursor must be a string");
+        }
+        result.next_cursor = value["nextCursor"].get<std::string>();
+    }
+    result.meta = value.value("_meta", json::object());
+    if (!result.meta.is_object()) {
+        throw std::invalid_argument("MCP tools/list _meta must be an object");
+    }
+    return result;
+}
+
+CallToolResult CallToolResult::from_json(const json& value) {
+    if (!value.is_object()) {
+        throw std::invalid_argument("MCP tools/call result must be an object");
+    }
+    CallToolResult result;
+    result.raw = value;
+    result.content = value.value("content", json::array());
+    if (value.contains("structuredContent")) {
+        result.structured_content = value["structuredContent"];
+    }
+    result.is_error = value.value("isError", false);
+    result.meta = value.value("_meta", json::object());
+    if (!result.content.is_array()) {
+        throw std::invalid_argument("MCP tools/call content must be an array");
+    }
+    if (!result.structured_content.is_null()
+        && !result.structured_content.is_object()) {
+        throw std::invalid_argument(
+            "MCP tools/call structuredContent must be an object");
+    }
+    if (!result.meta.is_object()) {
+        throw std::invalid_argument("MCP tools/call _meta must be an object");
+    }
+    return result;
+}
+
+json CallToolResult::to_json() const {
+    json value = json::object();
+    if (raw.is_object()) {
+        for (auto it = raw.begin(); it != raw.end(); ++it) {
+            const auto& key = it.key();
+            if (key != "content" && key != "structuredContent"
+                && key != "isError" && key != "_meta") {
+                value[key] = it.value();
+            }
+        }
+    }
+    value["content"] = content;
+    if (!structured_content.is_null()) {
+        value["structuredContent"] = structured_content;
+    }
+    value["isError"] = is_error;
+    if (!meta.empty()) value["_meta"] = meta;
+    return value;
+}
+
+} // namespace neograph::mcp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -73,7 +73,7 @@ add_executable(neograph_tests
     test_schema_provider_stream_async_outer_io.cpp
 )
 
-if(NEOGRAPH_BUILD_MCP)
+if(NEOGRAPH_BUILD_MCP_CLIENT)
     # A stdio MCP tool used from inside a graph run — the combination nothing
     # covered, and a use-after-free until the session stopped depending on an
     # io_context it does not own.
@@ -82,6 +82,10 @@ if(NEOGRAPH_BUILD_MCP)
         test_mcp_client_async.cpp
         test_mcp_stdio_async.cpp
     )
+endif()
+
+if(NEOGRAPH_BUILD_MCP_SERVER)
+    target_sources(neograph_tests PRIVATE test_mcp_server.cpp)
 endif()
 
 if(NEOGRAPH_BUILD_A2A)
@@ -141,8 +145,12 @@ target_link_libraries(neograph_tests PRIVATE
     GTest::gtest_main
 )
 
-if(NEOGRAPH_BUILD_MCP)
+if(NEOGRAPH_BUILD_MCP_CLIENT)
     target_link_libraries(neograph_tests PRIVATE neograph::mcp)
+endif()
+
+if(NEOGRAPH_BUILD_MCP_SERVER)
+    target_link_libraries(neograph_tests PRIVATE neograph::mcp_server)
 endif()
 
 if(NEOGRAPH_BUILD_A2A)

--- a/tests/test_mcp_server.cpp
+++ b/tests/test_mcp_server.cpp
@@ -1,0 +1,418 @@
+#include <gtest/gtest.h>
+
+#include <neograph/mcp/server.h>
+
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+using neograph::json;
+using neograph::mcp::CallToolResult;
+using neograph::mcp::MCPServer;
+using neograph::mcp::MCPServerConfig;
+using neograph::mcp::ToolDefinition;
+
+json request(json id, std::string method, json params = json::object()) {
+    return {
+        {"jsonrpc", "2.0"},
+        {"id", std::move(id)},
+        {"method", std::move(method)},
+        {"params", std::move(params)},
+    };
+}
+
+json notification(std::string method, json params = json::object()) {
+    return {
+        {"jsonrpc", "2.0"},
+        {"method", std::move(method)},
+        {"params", std::move(params)},
+    };
+}
+
+MCPServerConfig config(std::size_t concurrent = 2,
+                       std::size_t pending = 4) {
+    MCPServerConfig value;
+    value.server_info = {{"name", "test-server"}, {"version", "1.2.3"}};
+    value.instructions = "Use test tools carefully.";
+    value.max_concurrent_calls = concurrent;
+    value.max_pending_calls = pending;
+    return value;
+}
+
+void initialize(MCPServer& server) {
+    auto response = server.handle_message(request(1, "initialize", {
+        {"protocolVersion", "2025-11-25"},
+        {"capabilities", json::object()},
+        {"clientInfo", {{"name", "test-client"}, {"version", "1.0"}}},
+    }));
+    ASSERT_TRUE(response.contains("result"));
+    EXPECT_TRUE(server.handle_message(
+        notification("notifications/initialized")).is_null());
+    ASSERT_TRUE(server.initialized());
+}
+
+ToolDefinition echo_definition() {
+    ToolDefinition definition;
+    definition.name = "echo";
+    definition.title = "Echo title";
+    definition.description = "Echo a value";
+    definition.icons = json::array({{{"src", "data:image/png;base64,AA=="},
+                                     {"mimeType", "image/png"}}});
+    definition.input_schema = {
+        {"type", "object"},
+        {"required", json::array({"value"})},
+        {"properties", {{"value", {{"type", "string"}}}}},
+        {"additionalProperties", false},
+    };
+    definition.output_schema = {
+        {"type", "object"},
+        {"required", json::array({"echoed"})},
+        {"properties", {{"echoed", {{"type", "string"}}}}},
+        {"additionalProperties", false},
+    };
+    definition.annotations = {{"readOnlyHint", true}};
+    definition.execution = {{"taskSupport", "forbidden"}};
+    definition.meta = {{"catalog", "test"}};
+    return definition;
+}
+
+CallToolResult echo_result(const json& arguments) {
+    const auto value = arguments.at("value").get<std::string>();
+    CallToolResult result;
+    result.content = json::array({{{"type", "text"}, {"text", value}}});
+    result.structured_content = {{"echoed", value}};
+    result.meta = {{"source", "unit"}};
+    return result;
+}
+
+struct CapturingSink {
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::vector<json> responses;
+
+    MCPServer::ResponseSink sink() {
+        return [this](const json& response) {
+            std::lock_guard lock(mutex);
+            responses.push_back(response);
+            cv.notify_all();
+        };
+    }
+
+    json wait_for(const json& id, std::chrono::milliseconds timeout = 5s) {
+        std::unique_lock lock(mutex);
+        cv.wait_for(lock, timeout, [&] {
+            for (const auto& response : responses) {
+                if (response.value("id", json(nullptr)) == id) return true;
+            }
+            return false;
+        });
+        for (const auto& response : responses) {
+            if (response.value("id", json(nullptr)) == id) return response;
+        }
+        return nullptr;
+    }
+};
+
+TEST(MCPServerTest, RequiresInitializedNotificationBeforeTools) {
+    MCPServer server(config());
+
+    auto before = server.handle_message(request(7, "tools/list"));
+    ASSERT_TRUE(before.contains("error"));
+    EXPECT_EQ(before["error"]["code"], -32002);
+
+    auto init = server.handle_message(request(8, "initialize", {
+        {"protocolVersion", "2024-11-05"},
+        {"capabilities", json::object()},
+        {"clientInfo", {{"name", "client"}, {"version", "1"}}},
+    }));
+    ASSERT_TRUE(init.contains("result"));
+    EXPECT_EQ(init["result"]["protocolVersion"], "2025-11-25");
+    EXPECT_EQ(init["result"]["serverInfo"]["name"], "test-server");
+    EXPECT_EQ(init["result"]["instructions"], "Use test tools carefully.");
+    EXPECT_FALSE(server.initialized());
+
+    auto between = server.handle_message(request(9, "tools/list"));
+    EXPECT_EQ(between["error"]["code"], -32002);
+
+    server.handle_message(notification("notifications/initialized"));
+    EXPECT_TRUE(server.initialized());
+    EXPECT_TRUE(server.handle_message(request(10, "tools/list")).contains("result"));
+
+    auto repeated = server.handle_message(request(11, "initialize", {
+        {"protocolVersion", "2025-11-25"},
+        {"capabilities", json::object()},
+        {"clientInfo", json::object()},
+    }));
+    EXPECT_EQ(repeated["error"]["code"], -32600);
+}
+
+TEST(MCPServerTest, ListsCompleteTypedToolMetadata) {
+    MCPServer server(config());
+    server.register_tool(echo_definition(),
+        [](const json& arguments, const auto&) { return echo_result(arguments); });
+    initialize(server);
+
+    auto response = server.handle_message(request("list", "tools/list"));
+    ASSERT_TRUE(response.contains("result"));
+    const auto& tools = response["result"]["tools"];
+    ASSERT_EQ(tools.size(), 1u);
+    const auto& tool = tools[0];
+    EXPECT_EQ(tool["name"], "echo");
+    EXPECT_EQ(tool["title"], "Echo title");
+    EXPECT_EQ(tool["icons"].size(), 1u);
+    EXPECT_EQ(tool["outputSchema"]["type"], "object");
+    EXPECT_TRUE(tool["annotations"]["readOnlyHint"].get<bool>());
+    EXPECT_EQ(tool["execution"]["taskSupport"], "forbidden");
+    EXPECT_EQ(tool["_meta"]["catalog"], "test");
+}
+
+TEST(MCPServerTest, CallsToolAndPreservesStructuredResult) {
+    CapturingSink captured;
+    MCPServer server(config());
+    server.set_response_sink(captured.sink());
+    server.register_tool(echo_definition(),
+        [](const json& arguments, const auto&) { return echo_result(arguments); });
+    initialize(server);
+
+    auto immediate = server.handle_message(request("call-1", "tools/call", {
+        {"name", "echo"}, {"arguments", {{"value", "hello"}}},
+    }));
+    EXPECT_TRUE(immediate.is_null());
+
+    auto response = captured.wait_for("call-1");
+    ASSERT_TRUE(response.contains("result"));
+    EXPECT_EQ(response["result"]["content"][0]["text"], "hello");
+    EXPECT_EQ(response["result"]["structuredContent"]["echoed"], "hello");
+    EXPECT_EQ(response["result"]["_meta"]["source"], "unit");
+    EXPECT_FALSE(response["result"].value("isError", false));
+}
+
+TEST(MCPServerTest, InputSchemaFailureIsToolErrorWithoutInvocation) {
+    bool invoked = false;
+    MCPServer server(config());
+    server.register_tool(echo_definition(),
+        [&invoked](const json& arguments, const auto&) {
+            invoked = true;
+            return echo_result(arguments);
+        });
+    initialize(server);
+
+    auto response = server.handle_message(request(20, "tools/call", {
+        {"name", "echo"}, {"arguments", {{"wrong", true}}},
+    }));
+    ASSERT_TRUE(response.contains("result"));
+    EXPECT_TRUE(response["result"]["isError"].get<bool>());
+    EXPECT_FALSE(invoked);
+}
+
+TEST(MCPServerTest, ProtocolAndToolExecutionErrorsRemainDistinct) {
+    CapturingSink captured;
+    MCPServer server(config());
+    server.set_response_sink(captured.sink());
+    server.register_tool(echo_definition(),
+        [](const json&, const auto&) -> CallToolResult {
+            throw std::runtime_error("handler exploded");
+        });
+    initialize(server);
+
+    auto malformed = server.handle_message(request(30, "tools/call", json::object()));
+    ASSERT_TRUE(malformed.contains("error"));
+    EXPECT_EQ(malformed["error"]["code"], -32602);
+
+    auto missing = server.handle_message(request(31, "tools/call", {
+        {"name", "missing"}, {"arguments", json::object()},
+    }));
+    ASSERT_TRUE(missing.contains("result"));
+    EXPECT_TRUE(missing["result"]["isError"].get<bool>());
+
+    EXPECT_TRUE(server.handle_message(request(32, "tools/call", {
+        {"name", "echo"}, {"arguments", {{"value", "x"}}},
+    })).is_null());
+    auto thrown = captured.wait_for(32);
+    ASSERT_TRUE(thrown.contains("result"));
+    EXPECT_TRUE(thrown["result"]["isError"].get<bool>());
+    EXPECT_NE(thrown["result"]["content"][0]["text"]
+                  .get<std::string>().find("handler exploded"),
+              std::string::npos);
+}
+
+TEST(MCPServerTest, OutputSchemaFailureBecomesToolError) {
+    CapturingSink captured;
+    MCPServer server(config());
+    server.set_response_sink(captured.sink());
+    server.register_tool(echo_definition(),
+        [](const json&, const auto&) {
+            CallToolResult result;
+            result.content = json::array({{{"type", "text"}, {"text", "bad"}}});
+            result.structured_content = {{"wrong", 1}};
+            return result;
+        });
+    initialize(server);
+
+    EXPECT_TRUE(server.handle_message(request(40, "tools/call", {
+        {"name", "echo"}, {"arguments", {{"value", "x"}}},
+    })).is_null());
+    auto response = captured.wait_for(40);
+    ASSERT_TRUE(response.contains("result"));
+    EXPECT_TRUE(response["result"]["isError"].get<bool>());
+    EXPECT_NE(response["result"]["content"][0]["text"]
+                  .get<std::string>().find("missing required property echoed"),
+              std::string::npos);
+}
+
+TEST(MCPServerTest, CancellationReachesRequestScopedToken) {
+    CapturingSink captured;
+    std::promise<void> entered;
+    auto entered_future = entered.get_future();
+    MCPServer server(config(1, 1));
+    server.set_response_sink(captured.sink());
+    server.register_tool(echo_definition(),
+        [&entered](const json&, const auto& cancel) {
+            entered.set_value();
+            while (!cancel->is_cancelled()) std::this_thread::sleep_for(1ms);
+            cancel->throw_if_cancelled("inside test tool");
+            return CallToolResult{};
+        });
+    initialize(server);
+
+    EXPECT_TRUE(server.handle_message(request("cancel-me", "tools/call", {
+        {"name", "echo"}, {"arguments", {{"value", "x"}}},
+    })).is_null());
+    ASSERT_EQ(entered_future.wait_for(2s), std::future_status::ready);
+    EXPECT_TRUE(server.handle_message(notification("notifications/cancelled", {
+        {"requestId", "cancel-me"}, {"reason", "test"},
+    })).is_null());
+
+    auto response = captured.wait_for("cancel-me");
+    ASSERT_TRUE(response.contains("result"));
+    EXPECT_TRUE(response["result"]["isError"].get<bool>());
+    EXPECT_NE(response["result"]["content"][0]["text"]
+                  .get<std::string>().find("cancelled"),
+              std::string::npos);
+}
+
+TEST(MCPServerTest, BoundedQueueRejectsExcessAndDuplicateRequestIds) {
+    CapturingSink captured;
+    std::promise<void> entered;
+    auto entered_future = entered.get_future();
+    std::promise<void> release;
+    auto release_future = release.get_future().share();
+    MCPServer server(config(1, 0));
+    server.set_response_sink(captured.sink());
+    server.register_tool(echo_definition(),
+        [&entered, release_future](const json& arguments, const auto&) {
+            entered.set_value();
+            release_future.wait();
+            return echo_result(arguments);
+        });
+    initialize(server);
+
+    EXPECT_TRUE(server.handle_message(request(50, "tools/call", {
+        {"name", "echo"}, {"arguments", {{"value", "first"}}},
+    })).is_null());
+    ASSERT_EQ(entered_future.wait_for(2s), std::future_status::ready);
+
+    auto duplicate = server.handle_message(request(50, "tools/call", {
+        {"name", "echo"}, {"arguments", {{"value", "duplicate"}}},
+    }));
+    EXPECT_EQ(duplicate["error"]["code"], -32600);
+
+    auto excess = server.handle_message(request(51, "tools/call", {
+        {"name", "echo"}, {"arguments", {{"value", "second"}}},
+    }));
+    EXPECT_EQ(excess["error"]["code"], -32000);
+    EXPECT_EQ(excess["error"]["data"]["capacity"], 1);
+
+    release.set_value();
+    EXPECT_TRUE(captured.wait_for(50).contains("result"));
+}
+
+TEST(MCPServerTest, StopCancelsRunningAndPendingCalls) {
+    CapturingSink captured;
+    std::promise<void> entered;
+    auto entered_future = entered.get_future();
+    MCPServer server(config(1, 2));
+    server.set_response_sink(captured.sink());
+    server.register_tool(echo_definition(),
+        [&entered](const json& arguments, const auto& cancel) {
+            if (arguments["value"] == "running") entered.set_value();
+            while (!cancel->is_cancelled()) std::this_thread::sleep_for(1ms);
+            cancel->throw_if_cancelled("server stopping");
+            return echo_result(arguments);
+        });
+    initialize(server);
+
+    EXPECT_TRUE(server.handle_message(request(60, "tools/call", {
+        {"name", "echo"}, {"arguments", {{"value", "running"}}},
+    })).is_null());
+    ASSERT_EQ(entered_future.wait_for(2s), std::future_status::ready);
+    EXPECT_TRUE(server.handle_message(request(61, "tools/call", {
+        {"name", "echo"}, {"arguments", {{"value", "pending"}}},
+    })).is_null());
+
+    server.stop();
+    auto running = captured.wait_for(60);
+    auto pending = captured.wait_for(61);
+    ASSERT_TRUE(running.contains("result"));
+    ASSERT_TRUE(pending.contains("result"));
+    EXPECT_TRUE(running["result"]["isError"].get<bool>());
+    EXPECT_TRUE(pending["result"]["isError"].get<bool>());
+}
+
+TEST(MCPServerTest, RejectsInvalidDefinitionsAndLateRegistration) {
+    MCPServer server(config());
+    auto invalid = echo_definition();
+    invalid.input_schema["type"] = "imaginary";
+    EXPECT_THROW(server.register_tool(invalid,
+        [](const json&, const auto&) { return CallToolResult{}; }),
+        std::invalid_argument);
+
+    initialize(server);
+    EXPECT_THROW(server.register_tool(echo_definition(),
+        [](const json&, const auto&) { return CallToolResult{}; }),
+        std::logic_error);
+}
+
+TEST(MCPServerTest, StdioWritesOnlyJsonRpcFramesAndLogsToStderr) {
+    MCPServer server(config());
+    server.register_tool(echo_definition(),
+        [](const json& arguments, const auto&) { return echo_result(arguments); });
+
+    std::stringstream input;
+    input << request(1, "initialize", {
+        {"protocolVersion", "2025-11-25"},
+        {"capabilities", json::object()},
+        {"clientInfo", {{"name", "stdio"}, {"version", "1"}}},
+    }).dump() << '\n';
+    input << notification("notifications/initialized").dump() << '\n';
+    input << request(2, "tools/list").dump() << '\n';
+    input << "{not-json\n";
+
+    std::stringstream output;
+    std::stringstream errors;
+    auto* previous = std::cerr.rdbuf(errors.rdbuf());
+    server.run(input, output);
+    std::cerr.rdbuf(previous);
+
+    std::string line;
+    std::vector<json> frames;
+    while (std::getline(output, line)) {
+        ASSERT_NO_THROW(frames.push_back(json::parse(line)));
+    }
+    ASSERT_EQ(frames.size(), 3u);
+    EXPECT_EQ(frames[0]["id"], 1);
+    EXPECT_EQ(frames[1]["id"], 2);
+    EXPECT_EQ(frames[2]["error"]["code"], -32700);
+    EXPECT_NE(errors.str().find("parse error"), std::string::npos);
+}
+
+} // namespace


### PR DESCRIPTION
## Summary

- add a distinct `neograph::mcp_server` public API and retain `NEOGRAPH_BUILD_MCP` as the compatibility umbrella
- implement MCP 2025-11-25 stdio lifecycle, typed tool discovery/calls, schema validation, bounded execution, and cooperative cancellation
- add a lightweight server-only build, shared install/export support, focused tests, and one cross-host smoke binary

## Verification

- `680/680` C++ tests passed; 3 opt-in live tests skipped
- 11 focused `MCPServerTest` cases passed
- server-only static build passed without async/OpenSSL
- shared-library install and downstream `find_package` consumer passed
- official MCP Inspector `tools/list` and `tools/call` passed
- Claude Code 2.1.185 returned `claude-host-e2e`
- Codex CLI 0.144.6 returned `codex-host-e2e`
- OpenCode 1.18.3 returned `opencode-host-e2e`

Part of #147. Implements the M1 reusable MCP server substrate; later Harness service milestones remain in the issue.