### PR TITLE
feat(mcp): add compiler-verified Harness runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1354,6 +1354,12 @@ if(NEOGRAPH_BUILD_EXAMPLES)
                 examples/60_harness_mcp_server.cpp)
             target_link_libraries(example_harness_mcp_server PRIVATE
                 neograph::mcp_server neograph::llm)
+            if(NEOGRAPH_BUILD_SQLITE)
+                target_link_libraries(example_harness_mcp_server PRIVATE
+                    neograph::sqlite)
+                target_compile_definitions(example_harness_mcp_server PRIVATE
+                    NEOGRAPH_HARNESS_HAVE_SQLITE)
+            endif()
         endif()
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -625,6 +625,7 @@ endif()
 if(NEOGRAPH_BUILD_MCP_CLIENT OR NEOGRAPH_BUILD_MCP_SERVER)
     add_library(neograph_mcp_types
         src/mcp/types.cpp
+        src/mcp/json_schema.cpp
     )
     target_include_directories(neograph_mcp_types
         PUBLIC
@@ -659,6 +660,7 @@ endif()
 if(NEOGRAPH_BUILD_MCP_SERVER)
     add_library(neograph_mcp_server
         src/mcp/server.cpp
+        src/mcp/harness.cpp
     )
     target_include_directories(neograph_mcp_server
         PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,6 +640,7 @@ endif()
 if(NEOGRAPH_BUILD_MCP_CLIENT)
     add_library(neograph_mcp
         src/mcp/client.cpp
+        src/mcp/harness_mcp_backend.cpp
     )
 
     target_include_directories(neograph_mcp
@@ -661,6 +662,7 @@ if(NEOGRAPH_BUILD_MCP_SERVER)
     add_library(neograph_mcp_server
         src/mcp/server.cpp
         src/mcp/harness.cpp
+        src/mcp/harness_provider.cpp
     )
     target_include_directories(neograph_mcp_server
         PUBLIC
@@ -683,6 +685,7 @@ if(NEOGRAPH_BUILD_A2A)
         src/a2a/client.cpp
         src/a2a/server.cpp
         src/a2a/a2a_caller_node.cpp
+        src/a2a/harness_backend.cpp
     )
 
     target_include_directories(neograph_a2a
@@ -1346,6 +1349,12 @@ if(NEOGRAPH_BUILD_EXAMPLES)
     if(NEOGRAPH_BUILD_MCP_SERVER)
         add_executable(example_mcp_server examples/59_mcp_server.cpp)
         target_link_libraries(example_mcp_server PRIVATE neograph::mcp_server)
+        if(NEOGRAPH_BUILD_LLM)
+            add_executable(example_harness_mcp_server
+                examples/60_harness_mcp_server.cpp)
+            target_link_libraries(example_harness_mcp_server PRIVATE
+                neograph::mcp_server neograph::llm)
+        endif()
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,12 +117,18 @@ option(NEOGRAPH_BUILD_MCP_CLIENT "Build neograph::mcp MCP client"
        ${_neograph_mcp_component_default})
 option(NEOGRAPH_BUILD_MCP_SERVER "Build neograph::mcp_server local MCP server"
        ${_neograph_mcp_component_default})
+option(NEOGRAPH_BUILD_MCP_HTTP_SERVER
+       "Build opt-in neograph::mcp_http_server Streamable HTTP transport"
+       OFF)
 option(NEOGRAPH_BUILD_A2A      "Build neograph::a2a (Agent-to-Agent client)" ON)
 option(NEOGRAPH_BUILD_ACP      "Build neograph::acp (Agent Client Protocol server)" ON)
 option(NEOGRAPH_BUILD_UTIL     "Build neograph::util (utilities)"        ON)
 option(NEOGRAPH_BUILD_POSTGRES "Build PostgresCheckpointStore (libpq)" ON)
 option(NEOGRAPH_BUILD_SQLITE   "Build SqliteCheckpointStore (libsqlite3)" ON)
 option(NEOGRAPH_BUILD_EXAMPLES "Build example programs"                  ON)
+option(NEOGRAPH_BUILD_HARNESS_MCP_BINARY
+       "Build and install the neograph-harness-mcp executable"
+       OFF)
 option(NEOGRAPH_BUILD_PYBIND   "Build Python bindings (pybind11)"        OFF)
 # neograph::grpc — expose a compiled GraphEngine as a gRPC service
 # (RunGraph unary + RunGraphStream server-streaming). **default OFF**
@@ -320,7 +326,8 @@ if(NOT NEOGRAPH_BUILD_ASYNC AND (NEOGRAPH_BUILD_LLM OR NEOGRAPH_BUILD_MCP_CLIENT
         "against neograph_async. Either flip ASYNC back ON, or turn "
         "the dependent components OFF in the same configure call.")
 endif()
-if(NEOGRAPH_BUILD_ASYNC OR NEOGRAPH_BUILD_LLM OR NEOGRAPH_BUILD_MCP_CLIENT OR NEOGRAPH_BUILD_A2A)
+if(NEOGRAPH_BUILD_ASYNC OR NEOGRAPH_BUILD_LLM OR NEOGRAPH_BUILD_MCP_CLIENT OR
+   NEOGRAPH_BUILD_MCP_HTTP_SERVER OR NEOGRAPH_BUILD_A2A)
     find_package(OpenSSL REQUIRED)
 endif()
 
@@ -676,6 +683,29 @@ if(NEOGRAPH_BUILD_MCP_SERVER)
     add_library(neograph::mcp_server ALIAS neograph_mcp_server)
 endif()
 
+if(NEOGRAPH_BUILD_MCP_HTTP_SERVER)
+    if(NOT NEOGRAPH_BUILD_MCP_SERVER)
+        message(FATAL_ERROR
+            "NEOGRAPH_BUILD_MCP_HTTP_SERVER=ON requires "
+            "NEOGRAPH_BUILD_MCP_SERVER=ON")
+    endif()
+    add_library(neograph_mcp_http_server
+        src/mcp/http_server.cpp
+    )
+    target_include_directories(neograph_mcp_http_server
+        PUBLIC
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>
+    )
+    target_compile_definitions(neograph_mcp_http_server PRIVATE
+        NEOGRAPH_BUILDING_LIBRARY
+        CPPHTTPLIB_OPENSSL_SUPPORT)
+    target_link_libraries(neograph_mcp_http_server
+        PUBLIC neograph_mcp_server
+        PRIVATE httplib OpenSSL::SSL OpenSSL::Crypto)
+    add_library(neograph::mcp_http_server ALIAS neograph_mcp_http_server)
+endif()
+
 # ===========================================================================
 # neograph::a2a — Agent-to-Agent client (JSON-RPC over Streamable HTTP)
 # ===========================================================================
@@ -811,6 +841,36 @@ if(NEOGRAPH_BUILD_UTIL)
     )
 
     add_library(neograph::util ALIAS neograph_util)
+endif()
+
+# ===========================================================================
+# Installable Harness MCP host. Kept opt-in so library-only and wheel builds do
+# not silently gain an executable or provider/runtime dependencies.
+# ===========================================================================
+if(NEOGRAPH_BUILD_HARNESS_MCP_BINARY)
+    if(NOT NEOGRAPH_BUILD_MCP_SERVER OR NOT NEOGRAPH_BUILD_LLM)
+        message(FATAL_ERROR
+            "NEOGRAPH_BUILD_HARNESS_MCP_BINARY=ON requires "
+            "NEOGRAPH_BUILD_MCP_SERVER=ON and NEOGRAPH_BUILD_LLM=ON")
+    endif()
+    add_executable(neograph_harness_mcp examples/60_harness_mcp_server.cpp)
+    set_target_properties(neograph_harness_mcp PROPERTIES
+        OUTPUT_NAME neograph-harness-mcp)
+    target_link_libraries(neograph_harness_mcp PRIVATE
+        neograph::mcp_server neograph::llm)
+    if(NEOGRAPH_BUILD_SQLITE)
+        target_link_libraries(neograph_harness_mcp PRIVATE neograph::sqlite)
+        target_compile_definitions(neograph_harness_mcp PRIVATE
+            NEOGRAPH_HARNESS_HAVE_SQLITE)
+    endif()
+    if(NEOGRAPH_BUILD_MCP_HTTP_SERVER)
+        target_link_libraries(neograph_harness_mcp PRIVATE
+            neograph::mcp_http_server)
+        target_compile_definitions(neograph_harness_mcp PRIVATE
+            NEOGRAPH_HARNESS_HAVE_HTTP)
+    endif()
+    install(TARGETS neograph_harness_mcp
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
 # ===========================================================================
@@ -1360,6 +1420,12 @@ if(NEOGRAPH_BUILD_EXAMPLES)
                 target_compile_definitions(example_harness_mcp_server PRIVATE
                     NEOGRAPH_HARNESS_HAVE_SQLITE)
             endif()
+            if(NEOGRAPH_BUILD_MCP_HTTP_SERVER)
+                target_link_libraries(example_harness_mcp_server PRIVATE
+                    neograph::mcp_http_server)
+                target_compile_definitions(example_harness_mcp_server PRIVATE
+                    NEOGRAPH_HARNESS_HAVE_HTTP)
+            endif()
         endif()
     endif()
 endif()
@@ -1564,7 +1630,7 @@ if(NEOGRAPH_INSTALL_EXPORT)
         list(APPEND NEOGRAPH_EXPORT_TARGETS neograph_mcp_types)
     endif()
 
-    foreach(_comp async llm mcp mcp_server a2a acp util postgres sqlite)
+    foreach(_comp async llm mcp mcp_server mcp_http_server a2a acp util postgres sqlite)
         if(TARGET neograph_${_comp})
             list(APPEND NEOGRAPH_EXPORT_TARGETS neograph_${_comp})
             list(APPEND NEOGRAPH_COMPONENTS_BUILT ${_comp})
@@ -1594,7 +1660,7 @@ if(NEOGRAPH_INSTALL_EXPORT)
     # point: an install that was built without libpq must not make its consumers
     # hunt for PostgreSQL.
     set(NEOGRAPH_CONFIG_DEPENDENCIES "find_dependency(Threads)")
-    if(TARGET neograph_async OR TARGET neograph_llm)
+    if(TARGET neograph_async OR TARGET neograph_llm OR TARGET neograph_mcp_http_server)
         string(APPEND NEOGRAPH_CONFIG_DEPENDENCIES "\nfind_dependency(OpenSSL)")
     endif()
     if(TARGET neograph_postgres)

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ vLLM/Ollama — any OpenAI-compatible API) · `SchemaProvider` (Claude, Gemini, 
 any custom vendor via JSON schema) · ReAct `Agent` loop with streaming.
 
 **Integrations** — MCP client (`neograph::mcp`, HTTP + stdio) · local MCP server
-(`neograph::mcp_server`, stdio) · Agent-to-Agent
+(`neograph::mcp_server`, stdio) · compiler-backed multi-worker
+[Harness MCP](docs/HARNESS_MCP.md) · Agent-to-Agent
 (`neograph::a2a`, server + client + caller node) · Agent Client Protocol
 (`neograph::acp`, editor-driven) · gRPC service (`neograph::grpc`, opt-in) ·
 async HTTP/HTTPS/WS + SSE (`neograph::async`).

--- a/README.md
+++ b/README.md
@@ -223,7 +223,8 @@ vLLM/Ollama — any OpenAI-compatible API) · `SchemaProvider` (Claude, Gemini, 
 any custom vendor via JSON schema) · ReAct `Agent` loop with streaming.
 
 **Integrations** — MCP client (`neograph::mcp`, HTTP + stdio) · local MCP server
-(`neograph::mcp_server`, stdio) · compiler-backed multi-worker
+(`neograph::mcp_server`, stdio) · opt-in Streamable HTTP server
+(`neograph::mcp_http_server`) · compiler-backed multi-worker
 [Harness MCP](docs/HARNESS_MCP.md) · Agent-to-Agent
 (`neograph::a2a`, server + client + caller node) · Agent Client Protocol
 (`neograph::acp`, editor-driven) · gRPC service (`neograph::grpc`, opt-in) ·
@@ -235,7 +236,8 @@ Python-bound). Lock-free `RequestQueue` + `AsyncTool` in `neograph::util`.
 
 `NEOGRAPH_BUILD_MCP` remains the compatibility umbrella for both MCP roles.
 Use `NEOGRAPH_BUILD_MCP_CLIENT` or `NEOGRAPH_BUILD_MCP_SERVER` for a narrow
-build; the server-only target does not require `neograph::async` or OpenSSL.
+build; the stdio server-only target does not require `neograph::async` or
+OpenSSL. Enable `NEOGRAPH_BUILD_MCP_HTTP_SERVER` explicitly for remote HTTP.
 
 Full capability list and the 55+ runnable examples:
 [`examples/README.md`](examples/README.md).

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -49,6 +49,58 @@ checkpoints in `checkpoints.db`. The directory survives server restarts. A
 `host_brokered` catalog entry is rejected at compile time when either store is
 missing, so a workflow cannot advertise resumability it does not have.
 
+## Streamable HTTP
+
+Remote transport is opt-in so the existing stdio-only target remains small and
+does not silently gain an HTTP/OpenSSL dependency:
+
+```bash
+cmake -S . -B build-harness-http \
+  -DNEOGRAPH_BUILD_EXAMPLES=OFF \
+  -DNEOGRAPH_BUILD_LLM=ON \
+  -DNEOGRAPH_BUILD_MCP_SERVER=ON \
+  -DNEOGRAPH_BUILD_MCP_HTTP_SERVER=ON \
+  -DNEOGRAPH_BUILD_HARNESS_MCP_BINARY=ON
+cmake --build build-harness-http --target neograph_harness_mcp -j
+cmake --install build-harness-http --prefix "$HOME/.local"
+
+export NEOGRAPH_HARNESS_TRANSPORT=http
+export NEOGRAPH_HARNESS_HTTP_HOST=127.0.0.1
+export NEOGRAPH_HARNESS_HTTP_PORT=8080
+"$HOME/.local/bin/neograph-harness-mcp"
+```
+
+The endpoint is `http://127.0.0.1:8080/mcp`. It implements the published MCP
+2025-11-25 Streamable HTTP POST contract with per-session MCP lifecycles and
+JSON responses. Notifications return HTTP 202. DELETE terminates a session.
+The optional standalone GET/SSE channel is deliberately not implemented and
+returns HTTP 405, which the transport specification explicitly permits.
+
+Security defaults are transport-level and do not couple authentication to
+`GraphEngine` or `HarnessService`:
+
+- The default bind is `127.0.0.1`; a non-loopback bind is rejected unless a
+  bearer authorizer is configured.
+- Every supplied `Origin` is rejected unless it exactly matches an entry in
+  `NEOGRAPH_HARNESS_ALLOWED_ORIGINS` (comma-separated in the executable).
+- `NEOGRAPH_HARNESS_BEARER_TOKEN` enables the executable's single-principal
+  bearer boundary. Library embeddings can use
+  `MCPHttpServerConfig::bearer_authorizer` for OAuth/JWT validation and return a
+  stable principal/scope.
+- Sessions are bound to the returned authorization scope. A different valid
+  principal cannot reuse a leaked `Mcp-Session-Id`.
+- The `MCPHttpServer` factory receives that validated scope and returns an
+  `MCPHttpServerSession` owner. Multi-tenant embeddings must use the scope to
+  select isolated Harness record/checkpoint stores; no auth state enters the
+  graph runtime itself.
+- Request payload, HTTP worker, queue, session, and response-wait limits are
+  bounded by `MCPHttpServerConfig`.
+
+For any non-loopback deployment, terminate TLS at a trusted reverse proxy and
+use its OAuth/OIDC validation or an equivalent `bearer_authorizer`. Forward the
+original `Authorization` and `Origin` headers, do not expose a cleartext public
+listener, and deploy one authorization domain per Harness state directory.
+
 ## Host Setup
 
 Use an absolute path for `SERVER`:
@@ -281,3 +333,18 @@ and A2A services remain separate trust boundaries and should enforce the same
 root policy to close filesystem time-of-check/time-of-use races.
 With `policy.read_only: true`, compilation rejects every catalog entry not
 marked `read_only: true`.
+
+## Distribution And Protocol Profiles
+
+The supported local distribution path is the installable
+`neograph-harness-mcp` binary above. Source builds can continue using the
+example target, and Python wheels remain library/runtime packages rather than
+implicitly installing a remote daemon. MCPB and official registry publication
+remain release/discovery packaging options; they are not required for the wire
+protocol and should be added only with signed release artifacts and an explicit
+remote-auth deployment manifest.
+
+NeoGraph currently publishes only the dated MCP `2025-11-25` profile. Final
+SEPs describing a future stateless protocol do not create a new wire version;
+no successor profile will be advertised until the MCP project publishes a new
+dated specification.

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -1,13 +1,14 @@
 # NeoGraph Harness MCP
 
 NeoGraph Harness compiles a bounded multi-worker workflow before it runs. The
-MCP surface stays at five tools:
+stable MCP surface stays at six tools:
 
 - `neograph_schema` discovers the installed request contract and presets.
 - `neograph_compile` elaborates, compiles, and validates without executing.
 - `neograph_start` starts a retained artifact or an inline request.
 - `neograph_get` polls compact status or dereferences a result artifact URI.
-- `neograph_cancel` cooperatively cancels a queued or running workflow.
+- `neograph_resume` validates and submits the exact pending host result.
+- `neograph_cancel` cooperatively cancels a queued, running, or waiting workflow.
 
 The shipped presets are `fanout_judge`, `pr_review_panel`, `bug_triage`, and
 `research_synthesis`. Presets produce ordinary strict-core graph artifacts, so
@@ -35,6 +36,18 @@ For host interoperability smoke tests only, set `NEOGRAPH_HARNESS_SMOKE=1`.
 That explicit mode uses a deterministic in-process provider returning a valid
 zero-findings review, requires no API key, and must not be used as an LLM
 quality test.
+
+Durable host-brokered calls require both record and checkpoint persistence.
+The example enables both with one explicit directory:
+
+```bash
+export NEOGRAPH_HARNESS_STATE_DIR="$PWD/.neograph-harness-state"
+```
+
+This stores immutable artifacts and run records as atomic JSON files and graph
+checkpoints in `checkpoints.db`. The directory survives server restarts. A
+`host_brokered` catalog entry is rejected at compile time when either store is
+missing, so a workflow cannot advertise resumability it does not have.
 
 ## Host Setup
 
@@ -180,6 +193,73 @@ The host should follow this sequence:
 4. If detail is needed, call `neograph_get` with the same `run_id` and a
    returned `neograph://runs/...` URI as `uri`. Do not pull traces into context
    by default.
+
+## Host-Brokered Resume
+
+Use `executor.kind: "host_brokered"` when the MCP host, rather than the worker
+process, owns a capability. Set `executor.interaction` to `"tool_result"`
+(default) or `"input"`. The provider executor validates the requested arguments
+and returns one of two non-terminal run states:
+
+- `awaiting_tool_results`: the host must execute the named capability.
+- `input_required`: the host must collect an input value.
+
+`neograph_get` includes a `pending` object with a unique `call_id`, `tool_id`,
+validated `arguments`, and `result_schema`. Submit exactly that call through:
+
+```json
+{
+  "run_id": "run_...",
+  "call_id": "hcall_...",
+  "result": {"answer": "validated host result"}
+}
+```
+
+`neograph_resume` rejects a mismatched call ID, a result that violates the
+declared schema, an expired call, and a late result for a non-waiting run. An
+identical duplicate is acknowledged without re-executing the graph; a
+conflicting duplicate is rejected. The accepted resume intent is persisted
+before execution is scheduled, so polling after a process crash restarts the
+resume from the `NodeInterrupt` checkpoint without repeating successful sibling
+workers.
+
+Run snapshots include `created_at`, `updated_at`, `expires_at`, and
+`poll_after_ms`. The default TTL is 24 hours and the default polling interval is
+one second; embeddings can override both through `HarnessServiceConfig`.
+
+## Experimental Tasks Profile
+
+MCP Tasks is not part of core MCP 2025-11-25 and the upstream extension still
+labels itself experimental. NeoGraph therefore keeps it disabled by default and
+separate from the stable `run_id` plus `neograph_get` polling contract.
+
+To opt in on the example server, durable state must also be enabled:
+
+```bash
+export NEOGRAPH_HARNESS_STATE_DIR="$PWD/.neograph-harness-state"
+export NEOGRAPH_HARNESS_EXPERIMENTAL_TASKS=1
+```
+
+The server then advertises `io.modelcontextprotocol/tasks`, marks
+`neograph_start` with optional task support, and serves `tasks/get`,
+`tasks/update`, and `tasks/cancel`. It returns a `CreateTaskResult` only when the
+individual `tools/call` request includes:
+
+```json
+{
+  "_meta": {
+    "io.modelcontextprotocol/clientCapabilities": {
+      "extensions": {"io.modelcontextprotocol/tasks": {}}
+    }
+  }
+}
+```
+
+Clients without that request opt-in receive the ordinary `CallToolResult` and
+continue polling `neograph_get`; enabling the profile does not alter the stable
+fallback. Task statuses are `working`, `input_required`, `completed`, `failed`,
+and `cancelled`. `tasks/update.inputResponses` is keyed by the pending
+`call_id`, and polling clients should honor `pollIntervalMs` and `ttlMs`.
 
 ## Capability Backends
 

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -1,0 +1,203 @@
+# NeoGraph Harness MCP
+
+NeoGraph Harness compiles a bounded multi-worker workflow before it runs. The
+MCP surface stays at five tools:
+
+- `neograph_schema` discovers the installed request contract and presets.
+- `neograph_compile` elaborates, compiles, and validates without executing.
+- `neograph_start` starts a retained artifact or an inline request.
+- `neograph_get` polls compact status or dereferences a result artifact URI.
+- `neograph_cancel` cooperatively cancels a queued or running workflow.
+
+The shipped presets are `fanout_judge`, `pr_review_panel`, `bug_triage`, and
+`research_synthesis`. Presets produce ordinary strict-core graph artifacts, so
+the same diagnostics and source maps apply to preset and DSL requests.
+
+## Build And Run
+
+Build the local stdio server with the OpenAI-compatible provider adapter:
+
+```bash
+cmake -S . -B build-harness \
+  -DNEOGRAPH_BUILD_EXAMPLES=ON \
+  -DNEOGRAPH_BUILD_LLM=ON \
+  -DNEOGRAPH_BUILD_MCP_SERVER=ON
+cmake --build build-harness --target example_harness_mcp_server -j
+export OPENAI_API_KEY=your-key
+export NEOGRAPH_HARNESS_MODEL=gpt-4o-mini
+```
+
+`NEOGRAPH_HARNESS_API_KEY` takes precedence over `OPENAI_API_KEY`.
+`NEOGRAPH_HARNESS_BASE_URL` selects any OpenAI-compatible endpoint. The server
+writes protocol messages only to stdout and diagnostics only to stderr.
+
+For host interoperability smoke tests only, set `NEOGRAPH_HARNESS_SMOKE=1`.
+That explicit mode uses a deterministic in-process provider returning a valid
+zero-findings review, requires no API key, and must not be used as an LLM
+quality test.
+
+## Host Setup
+
+Use an absolute path for `SERVER`:
+
+```bash
+SERVER=/absolute/path/to/build-harness/example_harness_mcp_server
+```
+
+Claude Code, local project scope:
+
+```bash
+claude mcp add --scope local --transport stdio neograph-harness -- "$SERVER"
+claude mcp get neograph-harness
+```
+
+Codex CLI:
+
+```bash
+codex mcp add neograph-harness -- "$SERVER"
+codex mcp list
+```
+
+For non-interactive `codex exec` against this trusted local server, set
+`mcp_servers.neograph-harness.default_tools_approval_mode = "approve"` in
+Codex `config.toml`. Without it, Codex correctly cancels `neograph_compile`
+because retaining an artifact is not annotated read-only. Interactive sessions
+may keep the default prompt instead.
+
+OpenCode, in project `opencode.json` or user configuration:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "neograph-harness": {
+      "type": "local",
+      "command": ["/absolute/path/to/example_harness_mcp_server"],
+      "enabled": true,
+      "environment": {
+        "OPENAI_API_KEY": "{env:OPENAI_API_KEY}",
+        "NEOGRAPH_HARNESS_MODEL": "gpt-4o-mini"
+      }
+    }
+  }
+}
+```
+
+Verify with `opencode mcp list`. These forms follow each host's official MCP
+configuration contract as reviewed on 2026-07-21.
+
+## PR Review Workflow
+
+Ask the host to collect the PR diff with its normal repository tools, then use
+the Harness tools. A suitable request is:
+
+```json
+{
+  "task": {
+    "objective": "Review this PR diff. Report only actionable correctness, security, or regression findings. Include the diff after this sentence.",
+    "acceptance": [
+      "Every finding identifies a file and line",
+      "Every finding quotes concrete evidence",
+      "Return an empty findings array when no issue is proven"
+    ]
+  },
+  "harness": {"mode": "preset", "preset": "pr_review_panel"},
+  "workers": [
+    {
+      "id": "correctness",
+      "instructions": "Review behavior, edge cases, and regressions.",
+      "tools": [],
+      "output_schema": {
+        "type": "object",
+        "required": ["status", "findings"],
+        "properties": {
+          "status": {"enum": ["ok", "partial", "failed"]},
+          "findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["file", "line", "evidence", "message"],
+              "properties": {
+                "file": {"type": "string"},
+                "line": {"type": "integer"},
+                "evidence": {"type": "string"},
+                "message": {"type": "string"}
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    {
+      "id": "security",
+      "instructions": "Review trust boundaries, validation, and unsafe side effects.",
+      "tools": [],
+      "output_schema": {
+        "type": "object",
+        "required": ["status", "findings"],
+        "properties": {
+          "status": {"enum": ["ok", "partial", "failed"]},
+          "findings": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["file", "line", "evidence", "message"],
+              "properties": {
+                "file": {"type": "string"},
+                "line": {"type": "integer"},
+                "evidence": {"type": "string"},
+                "message": {"type": "string"}
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  ],
+  "tool_catalog": [],
+  "budgets": {
+    "max_steps": 10,
+    "timeout_seconds": 600,
+    "max_parallel_workers": 2,
+    "max_worker_retries": 1
+  },
+  "policy": {
+    "read_only": true,
+    "evidence_required": ["file", "line", "evidence"]
+  }
+}
+```
+
+The host should follow this sequence:
+
+1. Call `neograph_compile` and stop if `ok` is false.
+2. Call `neograph_start` with the returned `artifact_id`.
+3. Poll `neograph_get` with `run_id`; this returns only outcome and counts.
+4. If detail is needed, call `neograph_get` with the same `run_id` and a
+   returned `neograph://runs/...` URI as `uri`. Do not pull traces into context
+   by default.
+
+## Capability Backends
+
+`make_provider_harness_executor` drives workers through any NeoGraph
+`Provider`. If a model requests a declared tool, the executor validates its
+arguments and output against the catalog before and after dispatch.
+
+Use `make_mcp_harness_capability_executor` for initialized downstream
+`MCPClient` instances, or `a2a::make_harness_capability_executor` for A2A
+agents. The request remains the authority: a worker sees only tool IDs listed
+in its `tools` array.
+
+For filesystem tools, declare every path-bearing input in `path_arguments` and
+set `policy.workspace_roots`. Relative paths resolve under the first root;
+canonical paths outside every configured root are rejected before dispatch,
+including escapes through existing symlinks. The canonical path is passed to
+the capability backend rather than the model-supplied spelling. Downstream MCP
+and A2A services remain separate trust boundaries and should enforce the same
+root policy to close filesystem time-of-check/time-of-use races.
+With `policy.read_only: true`, compilation rejects every catalog entry not
+marked `read_only: true`.

--- a/examples/60_harness_mcp_server.cpp
+++ b/examples/60_harness_mcp_server.cpp
@@ -1,10 +1,23 @@
 #include <neograph/llm/openai_provider.h>
 #include <neograph/mcp/harness.h>
 #include <neograph/mcp/server.h>
+#ifdef NEOGRAPH_HARNESS_HAVE_HTTP
+#include <neograph/mcp/http_server.h>
+
+#include <openssl/crypto.h>
+#include <openssl/sha.h>
+#endif
 #ifdef NEOGRAPH_HARNESS_HAVE_SQLITE
 #include <neograph/graph/sqlite_checkpoint.h>
 #endif
 
+#ifdef NEOGRAPH_HARNESS_HAVE_HTTP
+#include <array>
+#include <optional>
+#include <sstream>
+#include <string_view>
+#include <vector>
+#endif
 #include <cstdlib>
 #include <iostream>
 #include <string>
@@ -20,11 +33,36 @@ std::string environment(const char* primary, const char* fallback = nullptr) {
     return {};
 }
 
+#ifdef NEOGRAPH_HARNESS_HAVE_HTTP
+std::vector<std::string> split_csv(const std::string& value) {
+    std::vector<std::string> result;
+    std::istringstream       input(value);
+    std::string              item;
+    while (std::getline(input, item, ',')) {
+        if (!item.empty()) result.push_back(std::move(item));
+    }
+    return result;
+}
+
+using TokenDigest = std::array<unsigned char, SHA256_DIGEST_LENGTH>;
+
+TokenDigest digest(std::string_view value) {
+    TokenDigest result{};
+    SHA256(reinterpret_cast<const unsigned char*>(value.data()), value.size(), result.data());
+    return result;
+}
+
+bool secure_equal(const TokenDigest& expected, std::string_view candidate) {
+    const auto actual = digest(candidate);
+    return CRYPTO_memcmp(expected.data(), actual.data(), expected.size()) == 0;
+}
+#endif
+
 class SmokeReviewProvider final : public neograph::Provider {
 public:
     neograph::ChatCompletion complete(const neograph::CompletionParams&) override {
         neograph::ChatCompletion completion;
-        completion.message.role = "assistant";
+        completion.message.role    = "assistant";
         completion.message.content = R"({"status":"ok","findings":[]})";
         return completion;
     }
@@ -32,11 +70,11 @@ public:
     std::string get_name() const override { return "harness-smoke-review"; }
 };
 
-} // namespace
+}  // namespace
 
 int main() {
     const bool smoke_mode = environment("NEOGRAPH_HARNESS_SMOKE") == "1";
-    const auto api_key = environment("NEOGRAPH_HARNESS_API_KEY", "OPENAI_API_KEY");
+    const auto api_key    = environment("NEOGRAPH_HARNESS_API_KEY", "OPENAI_API_KEY");
     if (!smoke_mode && api_key.empty()) {
         std::cerr << "Set NEOGRAPH_HARNESS_API_KEY or OPENAI_API_KEY\n";
         return 2;
@@ -52,7 +90,7 @@ int main() {
     }
     std::shared_ptr<neograph::Provider> provider;
     if (smoke_mode) {
-        provider = std::make_shared<SmokeReviewProvider>();
+        provider                      = std::make_shared<SmokeReviewProvider>();
         provider_config.default_model = "harness-smoke";
     } else {
         provider = neograph::llm::OpenAIProvider::create_shared(provider_config);
@@ -60,7 +98,7 @@ int main() {
 
     neograph::mcp::HarnessProviderExecutorConfig executor_config;
     executor_config.provider = std::move(provider);
-    executor_config.model = provider_config.default_model;
+    executor_config.model    = provider_config.default_model;
     neograph::mcp::HarnessServiceConfig harness_config;
     harness_config.worker_executor =
         neograph::mcp::make_provider_harness_executor(std::move(executor_config));
@@ -79,8 +117,6 @@ int main() {
         return 2;
     }
 #endif
-    neograph::mcp::HarnessService harness(std::move(harness_config));
-
     neograph::mcp::MCPServerConfig server_config;
     server_config.server_info = {
         {"name", "neograph-harness"},
@@ -89,8 +125,66 @@ int main() {
     server_config.instructions =
         "Compile a Harness request, start the retained artifact, poll compact "
         "status, then dereference result artifact URIs only when detail is needed.";
-    neograph::mcp::MCPServer server(std::move(server_config));
-    harness.register_tools(server);
-    server.run();
-    return 0;
+
+    const auto transport = environment("NEOGRAPH_HARNESS_TRANSPORT");
+    if (transport.empty() || transport == "stdio") {
+        neograph::mcp::HarnessService harness(std::move(harness_config));
+        neograph::mcp::MCPServer      server(std::move(server_config));
+        harness.register_tools(server);
+        server.run();
+        return 0;
+    }
+    if (transport != "http") {
+        std::cerr << "NEOGRAPH_HARNESS_TRANSPORT must be stdio or http\n";
+        return 2;
+    }
+
+#ifdef NEOGRAPH_HARNESS_HAVE_HTTP
+    neograph::mcp::MCPHttpServerConfig http_config;
+    if (const auto host = environment("NEOGRAPH_HARNESS_HTTP_HOST"); !host.empty()) {
+        http_config.host = host;
+    }
+    if (const auto port = environment("NEOGRAPH_HARNESS_HTTP_PORT"); !port.empty()) {
+        try {
+            http_config.port = std::stoi(port);
+        } catch (const std::exception&) {
+            std::cerr << "NEOGRAPH_HARNESS_HTTP_PORT must be an integer\n";
+            return 2;
+        }
+    } else {
+        http_config.port = 8080;
+    }
+    http_config.allowed_origins = split_csv(environment("NEOGRAPH_HARNESS_ALLOWED_ORIGINS"));
+    if (const auto token = environment("NEOGRAPH_HARNESS_BEARER_TOKEN"); !token.empty()) {
+        const auto expected = digest(token);
+        http_config.bearer_authorizer =
+            [expected](std::string_view candidate) -> std::optional<std::string> {
+            return secure_equal(expected, candidate)
+                       ? std::optional<std::string>("configured-bearer")
+                       : std::nullopt;
+        };
+    }
+    const auto listen_host = http_config.host;
+    const auto listen_port = http_config.port;
+
+    try {
+        neograph::mcp::MCPHttpServer server(
+            [harness_config, server_config](std::string_view) {
+                auto harness = std::make_shared<neograph::mcp::HarnessService>(harness_config);
+                auto session = std::make_unique<neograph::mcp::MCPServer>(server_config);
+                harness->register_tools(*session);
+                return neograph::mcp::MCPHttpServerSession{std::move(session), std::move(harness)};
+            },
+            std::move(http_config));
+        std::cerr << "NeoGraph Harness MCP listening on http://" << listen_host << ':'
+                  << listen_port << "/mcp\n";
+        return server.start() ? 0 : 1;
+    } catch (const std::exception& error) {
+        std::cerr << "Cannot start Harness HTTP transport: " << error.what() << '\n';
+        return 2;
+    }
+#else
+    std::cerr << "HTTP transport requires NEOGRAPH_BUILD_MCP_HTTP_SERVER=ON\n";
+    return 2;
+#endif
 }

--- a/examples/60_harness_mcp_server.cpp
+++ b/examples/60_harness_mcp_server.cpp
@@ -1,0 +1,82 @@
+#include <neograph/llm/openai_provider.h>
+#include <neograph/mcp/harness.h>
+#include <neograph/mcp/server.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <utility>
+
+namespace {
+
+std::string environment(const char* primary, const char* fallback = nullptr) {
+    if (const auto* value = std::getenv(primary); value && *value) return value;
+    if (fallback) {
+        if (const auto* value = std::getenv(fallback); value && *value) return value;
+    }
+    return {};
+}
+
+class SmokeReviewProvider final : public neograph::Provider {
+public:
+    neograph::ChatCompletion complete(
+        const neograph::CompletionParams&) override {
+        neograph::ChatCompletion completion;
+        completion.message.role = "assistant";
+        completion.message.content =
+            R"({"status":"ok","findings":[]})";
+        return completion;
+    }
+
+    std::string get_name() const override { return "harness-smoke-review"; }
+};
+
+} // namespace
+
+int main() {
+    const bool smoke_mode = environment("NEOGRAPH_HARNESS_SMOKE") == "1";
+    const auto api_key = environment("NEOGRAPH_HARNESS_API_KEY", "OPENAI_API_KEY");
+    if (!smoke_mode && api_key.empty()) {
+        std::cerr << "Set NEOGRAPH_HARNESS_API_KEY or OPENAI_API_KEY\n";
+        return 2;
+    }
+
+    neograph::llm::OpenAIProvider::Config provider_config;
+    provider_config.api_key = api_key;
+    if (const auto base_url = environment("NEOGRAPH_HARNESS_BASE_URL");
+        !base_url.empty()) {
+        provider_config.base_url = base_url;
+    }
+    if (const auto model = environment("NEOGRAPH_HARNESS_MODEL");
+        !model.empty()) {
+        provider_config.default_model = model;
+    }
+    std::shared_ptr<neograph::Provider> provider;
+    if (smoke_mode) {
+        provider = std::make_shared<SmokeReviewProvider>();
+        provider_config.default_model = "harness-smoke";
+    } else {
+        provider = neograph::llm::OpenAIProvider::create_shared(provider_config);
+    }
+
+    neograph::mcp::HarnessProviderExecutorConfig executor_config;
+    executor_config.provider = std::move(provider);
+    executor_config.model = provider_config.default_model;
+    neograph::mcp::HarnessServiceConfig harness_config;
+    harness_config.worker_executor =
+        neograph::mcp::make_provider_harness_executor(std::move(executor_config));
+    neograph::mcp::HarnessService harness(std::move(harness_config));
+
+    neograph::mcp::MCPServerConfig server_config;
+    server_config.server_info = {
+        {"name", "neograph-harness"},
+        {"version", "0.3.0"},
+    };
+    server_config.instructions =
+        "Compile a Harness request, start the retained artifact, poll compact "
+        "status, then dereference result artifact URIs only when detail is needed.";
+    neograph::mcp::MCPServer server(std::move(server_config));
+    harness.register_tools(server);
+    server.run();
+    return 0;
+}

--- a/examples/60_harness_mcp_server.cpp
+++ b/examples/60_harness_mcp_server.cpp
@@ -1,6 +1,9 @@
 #include <neograph/llm/openai_provider.h>
 #include <neograph/mcp/harness.h>
 #include <neograph/mcp/server.h>
+#ifdef NEOGRAPH_HARNESS_HAVE_SQLITE
+#include <neograph/graph/sqlite_checkpoint.h>
+#endif
 
 #include <cstdlib>
 #include <iostream>
@@ -19,12 +22,10 @@ std::string environment(const char* primary, const char* fallback = nullptr) {
 
 class SmokeReviewProvider final : public neograph::Provider {
 public:
-    neograph::ChatCompletion complete(
-        const neograph::CompletionParams&) override {
+    neograph::ChatCompletion complete(const neograph::CompletionParams&) override {
         neograph::ChatCompletion completion;
         completion.message.role = "assistant";
-        completion.message.content =
-            R"({"status":"ok","findings":[]})";
+        completion.message.content = R"({"status":"ok","findings":[]})";
         return completion;
     }
 
@@ -43,12 +44,10 @@ int main() {
 
     neograph::llm::OpenAIProvider::Config provider_config;
     provider_config.api_key = api_key;
-    if (const auto base_url = environment("NEOGRAPH_HARNESS_BASE_URL");
-        !base_url.empty()) {
+    if (const auto base_url = environment("NEOGRAPH_HARNESS_BASE_URL"); !base_url.empty()) {
         provider_config.base_url = base_url;
     }
-    if (const auto model = environment("NEOGRAPH_HARNESS_MODEL");
-        !model.empty()) {
+    if (const auto model = environment("NEOGRAPH_HARNESS_MODEL"); !model.empty()) {
         provider_config.default_model = model;
     }
     std::shared_ptr<neograph::Provider> provider;
@@ -65,6 +64,21 @@ int main() {
     neograph::mcp::HarnessServiceConfig harness_config;
     harness_config.worker_executor =
         neograph::mcp::make_provider_harness_executor(std::move(executor_config));
+#ifdef NEOGRAPH_HARNESS_HAVE_SQLITE
+    if (const auto state_dir = environment("NEOGRAPH_HARNESS_STATE_DIR"); !state_dir.empty()) {
+        harness_config.record_store =
+            std::make_shared<neograph::mcp::FileHarnessRecordStore>(state_dir);
+        harness_config.checkpoint_store =
+            std::make_shared<neograph::graph::SqliteCheckpointStore>(state_dir + "/checkpoints.db");
+        harness_config.enable_experimental_tasks =
+            environment("NEOGRAPH_HARNESS_EXPERIMENTAL_TASKS") == "1";
+    }
+#else
+    if (!environment("NEOGRAPH_HARNESS_STATE_DIR").empty()) {
+        std::cerr << "Durable Harness state requires NEOGRAPH_BUILD_SQLITE=ON\n";
+        return 2;
+    }
+#endif
     neograph::mcp::HarnessService harness(std::move(harness_config));
 
     neograph::mcp::MCPServerConfig server_config;

--- a/include/neograph/a2a/harness_backend.h
+++ b/include/neograph/a2a/harness_backend.h
@@ -1,0 +1,22 @@
+/**
+ * @file a2a/harness_backend.h
+ * @brief Downstream A2A capability adapter for Harness workers.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/mcp/harness.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace neograph::a2a {
+
+class A2AClient;
+
+/// Resolve tool executor.agent against preconfigured A2A clients.
+NEOGRAPH_API mcp::HarnessCapabilityExecutor make_harness_capability_executor(
+    std::map<std::string, std::shared_ptr<A2AClient>> agents);
+
+} // namespace neograph::a2a

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -505,11 +505,26 @@ public:
                      const json& resume_value = json(),
                      const GraphStreamCallback& cb = nullptr);
 
+    /**
+     * @brief Resume while preserving caller cancellation and deadline settings.
+     *
+     * `config.thread_id` identifies the interrupted session. Input is ignored;
+     * the latest checkpoint remains the source of resumed graph state.
+     */
+    RunResult resume(const RunConfig&           config,
+                     const json&                resume_value = json(),
+                     const GraphStreamCallback& cb           = nullptr);
+
     /// Async peer of resume — non-blocking coroutine surface.
     asio::awaitable<RunResult> resume_async(
         const std::string& thread_id,
         const json& resume_value = json(),
         const GraphStreamCallback& cb = nullptr);
+
+    /// Async peer of the RunConfig-preserving resume overload.
+    asio::awaitable<RunResult> resume_async(RunConfig           config,
+                                            json                resume_value = json(),
+                                            GraphStreamCallback cb           = nullptr);
 
     // ── State inspection & manipulation (LangGraph Checkpointer API) ──
 

--- a/include/neograph/mcp/harness.h
+++ b/include/neograph/mcp/harness.h
@@ -6,14 +6,19 @@
 
 #include <neograph/api.h>
 #include <neograph/graph/cancel.h>
+#include <neograph/graph/checkpoint.h>
 #include <neograph/json.h>
 
+#include <chrono>
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 
-namespace neograph { class Provider; }
+namespace neograph {
+class Provider;
+}
 
 namespace neograph::mcp {
 
@@ -26,6 +31,8 @@ enum class HarnessWorkerResponseKind {
     TOOL_ERROR,
     TIMEOUT,
     CANCELLED,
+    AWAITING_TOOL_RESULTS,
+    INPUT_REQUIRED,
 };
 
 /** Input handed to the embedding's provider/tool execution backend. */
@@ -36,6 +43,7 @@ struct HarnessWorkerCall {
     json policy;
     std::size_t attempt = 1;
     std::string repair_feedback;
+    std::optional<json> resume_value;
 };
 
 /** Typed worker response; failure classes never masquerade as valid output. */
@@ -50,16 +58,16 @@ struct NEOGRAPH_API HarnessWorkerResponse {
     static HarnessWorkerResponse tool_error(std::string message);
     static HarnessWorkerResponse timeout(std::string message = {});
     static HarnessWorkerResponse cancelled(std::string message = {});
+    static HarnessWorkerResponse awaiting_tool_results(json pending);
+    static HarnessWorkerResponse input_required(json pending);
 };
 
 using HarnessWorkerExecutor = std::function<HarnessWorkerResponse(
-    const HarnessWorkerCall&,
-    const std::shared_ptr<graph::CancelToken>&)>;
+    const HarnessWorkerCall&, const std::shared_ptr<graph::CancelToken>&)>;
 
-using HarnessCapabilityExecutor = std::function<json(
-    const json& tool_definition,
-    const json& arguments,
-    const std::shared_ptr<graph::CancelToken>&)>;
+using HarnessCapabilityExecutor = std::function<json(const json& tool_definition,
+                                                     const json& arguments,
+                                                     const std::shared_ptr<graph::CancelToken>&)>;
 
 struct HarnessProviderExecutorConfig {
     std::shared_ptr<Provider> provider;
@@ -69,13 +77,45 @@ struct HarnessProviderExecutorConfig {
 };
 
 /// Build a worker executor that calls a NeoGraph Provider directly.
-NEOGRAPH_API HarnessWorkerExecutor make_provider_harness_executor(
-    HarnessProviderExecutorConfig config);
+NEOGRAPH_API HarnessWorkerExecutor
+make_provider_harness_executor(HarnessProviderExecutorConfig config);
+
+/** Durable storage boundary for retained Harness artifacts and run records. */
+class NEOGRAPH_API HarnessRecordStore {
+public:
+    virtual ~HarnessRecordStore() = default;
+
+    virtual void save_artifact(const std::string& artifact_id, const json& record)      = 0;
+    virtual std::optional<json> load_artifact(const std::string& artifact_id)           = 0;
+    virtual void                save_run(const std::string& run_id, const json& record) = 0;
+    virtual std::optional<json> load_run(const std::string& run_id)                     = 0;
+};
+
+/** Atomic JSON-file implementation suitable for local process restarts. */
+class NEOGRAPH_API FileHarnessRecordStore final : public HarnessRecordStore {
+public:
+    explicit FileHarnessRecordStore(std::string root_directory);
+    ~FileHarnessRecordStore() override;
+
+    void                save_artifact(const std::string& artifact_id, const json& record) override;
+    std::optional<json> load_artifact(const std::string& artifact_id) override;
+    void                save_run(const std::string& run_id, const json& record) override;
+    std::optional<json> load_run(const std::string& run_id) override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
 
 struct HarnessServiceConfig {
     HarnessWorkerExecutor worker_executor;
+    std::shared_ptr<graph::CheckpointStore> checkpoint_store;
+    std::shared_ptr<HarnessRecordStore>     record_store;
     std::size_t max_artifacts = 128;
     std::size_t max_runs = 128;
+    std::chrono::milliseconds               poll_interval{1000};
+    std::chrono::milliseconds               run_ttl{std::chrono::hours(24)};
+    bool                                    enable_experimental_tasks = false;
 };
 
 /**
@@ -92,7 +132,7 @@ public:
     HarnessService(const HarnessService&) = delete;
     HarnessService& operator=(const HarnessService&) = delete;
 
-    /// Register neograph_schema/compile/start/get/cancel on a server.
+    /// Register neograph_schema/compile/start/get/resume/cancel on a server.
     void register_tools(MCPServer& server);
 
     /// Build-specific schemas, node palette, presets, and capabilities.
@@ -104,9 +144,11 @@ public:
     /// Start from {artifact_id} or compile-and-start from {request}.
     json start(const json& arguments);
 
+    /// Resume the exact pending call with a schema-validated host result.
+    json resume(const json& arguments);
+
     /// Return a compact snapshot for a run.
-    json get(const std::string& run_id,
-             const std::string& view = "status") const;
+    json get(const std::string& run_id, const std::string& view = "status") const;
 
     /// Dereference a neograph://runs/<run_id>/<view> result URI.
     json read(const std::string& uri) const;

--- a/include/neograph/mcp/harness.h
+++ b/include/neograph/mcp/harness.h
@@ -13,6 +13,8 @@
 #include <memory>
 #include <string>
 
+namespace neograph { class Provider; }
+
 namespace neograph::mcp {
 
 class MCPServer;
@@ -31,6 +33,7 @@ struct HarnessWorkerCall {
     json task;
     json worker;
     json tool_catalog;
+    json policy;
     std::size_t attempt = 1;
     std::string repair_feedback;
 };
@@ -52,6 +55,22 @@ struct NEOGRAPH_API HarnessWorkerResponse {
 using HarnessWorkerExecutor = std::function<HarnessWorkerResponse(
     const HarnessWorkerCall&,
     const std::shared_ptr<graph::CancelToken>&)>;
+
+using HarnessCapabilityExecutor = std::function<json(
+    const json& tool_definition,
+    const json& arguments,
+    const std::shared_ptr<graph::CancelToken>&)>;
+
+struct HarnessProviderExecutorConfig {
+    std::shared_ptr<Provider> provider;
+    std::string model;
+    HarnessCapabilityExecutor capability_executor;
+    std::size_t max_tool_rounds = 8;
+};
+
+/// Build a worker executor that calls a NeoGraph Provider directly.
+NEOGRAPH_API HarnessWorkerExecutor make_provider_harness_executor(
+    HarnessProviderExecutorConfig config);
 
 struct HarnessServiceConfig {
     HarnessWorkerExecutor worker_executor;
@@ -86,7 +105,11 @@ public:
     json start(const json& arguments);
 
     /// Return a compact snapshot for a run.
-    json get(const std::string& run_id) const;
+    json get(const std::string& run_id,
+             const std::string& view = "status") const;
+
+    /// Dereference a neograph://runs/<run_id>/<view> result URI.
+    json read(const std::string& uri) const;
 
     /// Request cooperative cancellation. Returns false for unknown/terminal runs.
     bool cancel(const std::string& run_id);

--- a/include/neograph/mcp/harness.h
+++ b/include/neograph/mcp/harness.h
@@ -1,0 +1,99 @@
+/**
+ * @file mcp/harness.h
+ * @brief Compiler-backed subagent Harness service for the MCP server.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/graph/cancel.h>
+#include <neograph/json.h>
+
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace neograph::mcp {
+
+class MCPServer;
+
+enum class HarnessWorkerResponseKind {
+    VALUE,
+    EMPTY,
+    PARSE_ERROR,
+    TOOL_ERROR,
+    TIMEOUT,
+    CANCELLED,
+};
+
+/** Input handed to the embedding's provider/tool execution backend. */
+struct HarnessWorkerCall {
+    json task;
+    json worker;
+    json tool_catalog;
+    std::size_t attempt = 1;
+    std::string repair_feedback;
+};
+
+/** Typed worker response; failure classes never masquerade as valid output. */
+struct NEOGRAPH_API HarnessWorkerResponse {
+    HarnessWorkerResponseKind kind = HarnessWorkerResponseKind::VALUE;
+    json value;
+    std::string message;
+
+    static HarnessWorkerResponse success(json value);
+    static HarnessWorkerResponse empty(std::string message = {});
+    static HarnessWorkerResponse parse_error(std::string message);
+    static HarnessWorkerResponse tool_error(std::string message);
+    static HarnessWorkerResponse timeout(std::string message = {});
+    static HarnessWorkerResponse cancelled(std::string message = {});
+};
+
+using HarnessWorkerExecutor = std::function<HarnessWorkerResponse(
+    const HarnessWorkerCall&,
+    const std::shared_ptr<graph::CancelToken>&)>;
+
+struct HarnessServiceConfig {
+    HarnessWorkerExecutor worker_executor;
+    std::size_t max_artifacts = 128;
+    std::size_t max_runs = 128;
+};
+
+/**
+ * Compile, run, inspect, and cancel immutable Harness artifacts.
+ *
+ * `register_tools()` captures this service by reference; the service must
+ * outlive the MCPServer and be destroyed only after the server has stopped.
+ */
+class NEOGRAPH_API HarnessService {
+public:
+    explicit HarnessService(HarnessServiceConfig config = {});
+    ~HarnessService();
+
+    HarnessService(const HarnessService&) = delete;
+    HarnessService& operator=(const HarnessService&) = delete;
+
+    /// Register neograph_schema/compile/start/get/cancel on a server.
+    void register_tools(MCPServer& server);
+
+    /// Build-specific schemas, node palette, presets, and capabilities.
+    json schema() const;
+
+    /// Compile and retain an immutable artifact when the request is valid.
+    json compile(const json& request);
+
+    /// Start from {artifact_id} or compile-and-start from {request}.
+    json start(const json& arguments);
+
+    /// Return a compact snapshot for a run.
+    json get(const std::string& run_id) const;
+
+    /// Request cooperative cancellation. Returns false for unknown/terminal runs.
+    bool cancel(const std::string& run_id);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace neograph::mcp

--- a/include/neograph/mcp/harness_mcp_backend.h
+++ b/include/neograph/mcp/harness_mcp_backend.h
@@ -1,0 +1,22 @@
+/**
+ * @file mcp/harness_mcp_backend.h
+ * @brief Downstream MCP capability adapter for Harness workers.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/mcp/harness.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+namespace neograph::mcp {
+
+class MCPClient;
+
+/// Resolve tool executor.server_ref against preconfigured, initialized clients.
+NEOGRAPH_API HarnessCapabilityExecutor make_mcp_harness_capability_executor(
+    std::map<std::string, std::shared_ptr<MCPClient>> clients);
+
+} // namespace neograph::mcp

--- a/include/neograph/mcp/http_server.h
+++ b/include/neograph/mcp/http_server.h
@@ -1,0 +1,90 @@
+/**
+ * @file mcp/http_server.h
+ * @brief MCP 2025-11-25 Streamable HTTP transport for MCPServer.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/mcp/server.h>
+
+#include <chrono>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace neograph::mcp {
+
+struct NEOGRAPH_API MCPHttpServerSession {
+    std::unique_ptr<MCPServer> server;
+
+    /// Optional lifetime owner for handlers captured by `server`.
+    std::shared_ptr<void> owner;
+};
+
+struct NEOGRAPH_API MCPHttpServerConfig {
+    using BearerAuthorizer = std::function<std::optional<std::string>(std::string_view token)>;
+
+    std::string host     = "127.0.0.1";
+    int         port     = 0;
+    std::string endpoint = "/mcp";
+
+    std::size_t               max_sessions        = 64;
+    std::size_t               max_payload_bytes   = 1024 * 1024;
+    std::size_t               http_threads        = 8;
+    std::size_t               max_queued_requests = 64;
+    std::chrono::milliseconds response_timeout    = std::chrono::minutes(10);
+
+    /// Exact allowed Origin values. An Origin header is rejected unless listed.
+    std::vector<std::string> allowed_origins;
+
+    /**
+     * Validate a bearer token and return its stable authorization scope.
+     *
+     * Sessions are bound to this scope, so a different valid principal cannot
+     * reuse a leaked MCP-Session-Id. OAuth/JWT validation belongs here or in a
+     * trusted reverse proxy, never in GraphEngine or HarnessService.
+     */
+    BearerAuthorizer bearer_authorizer;
+};
+
+/**
+ * @brief Session-aware MCP Streamable HTTP server.
+ *
+ * This baseline returns one `application/json` response per POST and declines
+ * optional GET/SSE streams with HTTP 405. `factory` must return a fresh,
+ * registered, uninitialized MCPServer for every new HTTP session. It receives
+ * the validated authorization scope so embeddings can isolate durable stores
+ * without exposing authentication concepts to GraphEngine.
+ */
+class NEOGRAPH_API MCPHttpServer {
+public:
+    using ServerFactory = std::function<MCPHttpServerSession(std::string_view authorization_scope)>;
+
+    MCPHttpServer(ServerFactory factory, MCPHttpServerConfig config = {});
+    ~MCPHttpServer();
+
+    MCPHttpServer(const MCPHttpServer&)            = delete;
+    MCPHttpServer& operator=(const MCPHttpServer&) = delete;
+
+    /// Bind and serve until stop() is called.
+    bool start();
+
+    /// Bind and serve on a background listener thread.
+    bool start_async();
+
+    /// Stop HTTP acceptance, cancel session work, and join the listener.
+    void stop();
+
+    bool is_running() const;
+    int  port() const;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace neograph::mcp

--- a/include/neograph/mcp/json_schema.h
+++ b/include/neograph/mcp/json_schema.h
@@ -1,0 +1,23 @@
+/**
+ * @file mcp/json_schema.h
+ * @brief Small JSON Schema validator shared by MCP server services.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/json.h>
+
+#include <string>
+
+namespace neograph::mcp {
+
+/// Validate the supported JSON Schema subset and throw invalid_argument.
+NEOGRAPH_API void validate_json_schema(const json& schema,
+                                       const std::string& path = "$schema");
+
+/// Validate a value against the supported JSON Schema subset.
+NEOGRAPH_API void validate_json_value(const json& value, const json& schema,
+                                      const std::string& subject = "JSON value",
+                                      const std::string& path = "$");
+
+} // namespace neograph::mcp

--- a/include/neograph/mcp/server.h
+++ b/include/neograph/mcp/server.h
@@ -16,6 +16,7 @@
 #include <istream>
 #include <memory>
 #include <ostream>
+#include <string>
 
 namespace neograph::mcp {
 
@@ -41,6 +42,13 @@ class NEOGRAPH_API MCPServer {
     using ToolHandler = std::function<CallToolResult(
         const json&, const std::shared_ptr<graph::CancelToken>&)>;
 
+    /// Extension hook for polymorphic tool results such as CreateTaskResult.
+    using RawToolHandler =
+        std::function<json(const json&, const std::shared_ptr<graph::CancelToken>&, const json&)>;
+
+    /// Synchronous extension-method handler; the server wraps the JSON result.
+    using MethodHandler = std::function<json(const json&, const json&)>;
+
     /// Receives complete JSON-RPC response envelopes produced asynchronously.
     using ResponseSink = std::function<void(const json&)>;
 
@@ -52,6 +60,15 @@ class NEOGRAPH_API MCPServer {
 
     /// Add a tool. Names must be unique and registration closes at initialize.
     void register_tool(ToolDefinition definition, ToolHandler handler);
+
+    /// Add a tool whose result shape is selected using request metadata.
+    void register_raw_tool(ToolDefinition definition, RawToolHandler handler);
+
+    /// Register an extension JSON-RPC method before initialization.
+    void register_method(std::string method, MethodHandler handler);
+
+    /// Advertise an explicitly enabled MCP extension capability.
+    void register_extension(std::string identifier, json settings = json::object());
 
     /// Process one parsed JSON-RPC message. Tool calls may complete via sink.
     json handle_message(const json& envelope);

--- a/skills/neograph-harness-authoring/SKILL.md
+++ b/skills/neograph-harness-authoring/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: neograph-harness
+name: neograph-harness-authoring
 description: Compile and run bounded PR review, bug triage, or research synthesis panels through the NeoGraph Harness MCP tools. Use when a task benefits from multiple schema-constrained workers, strict preflight validation, read-only workspace policy, compact polling, and URI-linked detailed artifacts.
 ---
 

--- a/skills/neograph-harness-authoring/SKILL.md
+++ b/skills/neograph-harness-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: neograph-harness-authoring
-description: Compile and run bounded PR review, bug triage, or research synthesis panels through the NeoGraph Harness MCP tools. Use when a task benefits from multiple schema-constrained workers, strict preflight validation, read-only workspace policy, compact polling, and URI-linked detailed artifacts.
+description: Compile and run bounded PR review, bug triage, or research synthesis panels through the NeoGraph Harness MCP tools. Use when a task benefits from multiple schema-constrained workers, strict preflight validation, read-only workspace policy, durable host-brokered resume, compact polling, and URI-linked detailed artifacts.
 ---
 
 # NeoGraph Harness
@@ -24,12 +24,17 @@ trace or allowing an unvalidated workflow to execute.
 5. Call `neograph_compile`. If `ok` is false, fix diagnostics by `phase`,
    `path`, and `source`; never call start with a rejected request.
 6. Call `neograph_start` with the retained `artifact_id`.
-7. Poll `neograph_get` with `run_id` until status is terminal. Keep the compact
-   result in the main context.
-8. Dereference a returned `neograph://runs/...` URI through `neograph_get`
+7. Poll `neograph_get` with `run_id`. If status is `awaiting_tool_results` or
+   `input_required`, fulfill only the returned `pending` call, then call
+   `neograph_resume` with the same `run_id`, exact `call_id`, and a result that
+   conforms to `result_schema`. Treat an identical duplicate as acknowledged;
+   never substitute a different call ID.
+8. Continue polling until status is terminal. Keep the compact result in the
+   main context.
+9. Dereference a returned `neograph://runs/...` URI through `neograph_get`
    with its `run_id` only when the final answer needs worker details or the
    execution trace.
-9. Report partial, zero-findings, timeout, cancelled, max-step, and failed
+10. Report partial, zero-findings, timeout, cancelled, expired, max-step, and failed
    outcomes exactly; do not turn them into a generic success.
 
 ## Anti-Patterns
@@ -40,6 +45,10 @@ trace or allowing an unvalidated workflow to execute.
 - Do not treat malformed or empty worker output as an empty findings list.
 - Do not fetch detailed traces before the compact result proves they are needed.
 - Do not add write-capable tools to a read-only review.
+- Do not retry a host result with modified data after its call ID was consumed.
+- Do not assume MCP Tasks is core protocol support. Use stable `neograph_get`
+  polling unless the server and the individual request explicitly opt into the
+  experimental `io.modelcontextprotocol/tasks` extension.
 
 ## Example
 

--- a/skills/neograph-harness/SKILL.md
+++ b/skills/neograph-harness/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: neograph-harness
+description: Compile and run bounded PR review, bug triage, or research synthesis panels through the NeoGraph Harness MCP tools. Use when a task benefits from multiple schema-constrained workers, strict preflight validation, read-only workspace policy, compact polling, and URI-linked detailed artifacts.
+---
+
+# NeoGraph Harness
+
+## Goal
+
+Run a multi-worker panel without giving the main conversation every worker
+trace or allowing an unvalidated workflow to execute.
+
+## Procedure
+
+1. Call `neograph_schema`; use only presets and fields returned by this build.
+2. Build one request with a precise objective, acceptance criteria, bounded
+   budgets, and a JSON output schema for every worker.
+3. For review work, use `pr_review_panel`, set `policy.read_only` to true, and
+   set `policy.evidence_required` to the evidence fields required in every
+   finding schema.
+4. Give each worker only the tool IDs it needs. Mark read-only tools and list
+   path-bearing string arguments in `path_arguments`. Set explicit
+   `policy.workspace_roots` whenever such arguments exist.
+5. Call `neograph_compile`. If `ok` is false, fix diagnostics by `phase`,
+   `path`, and `source`; never call start with a rejected request.
+6. Call `neograph_start` with the retained `artifact_id`.
+7. Poll `neograph_get` with `run_id` until status is terminal. Keep the compact
+   result in the main context.
+8. Dereference a returned `neograph://runs/...` URI through `neograph_get`
+   with its `run_id` only when the final answer needs worker details or the
+   execution trace.
+9. Report partial, zero-findings, timeout, cancelled, max-step, and failed
+   outcomes exactly; do not turn them into a generic success.
+
+## Anti-Patterns
+
+- Do not skip `neograph_compile` for an inline request.
+- Do not attach a broad tool catalog to every worker.
+- Do not configure path-bearing tools without workspace roots.
+- Do not treat malformed or empty worker output as an empty findings list.
+- Do not fetch detailed traces before the compact result proves they are needed.
+- Do not add write-capable tools to a read-only review.
+
+## Example
+
+For a PR review, collect the diff with the host's repository tools, place it in
+the task objective, and use two workers with distinct correctness and security
+instructions. Require `file`, `line`, and `evidence` in each finding. See
+`docs/HARNESS_MCP.md` for the complete request and host setup commands.

--- a/src/a2a/harness_backend.cpp
+++ b/src/a2a/harness_backend.cpp
@@ -1,0 +1,29 @@
+#include <neograph/a2a/harness_backend.h>
+
+#include <neograph/a2a/client.h>
+
+#include <stdexcept>
+#include <utility>
+
+namespace neograph::a2a {
+
+mcp::HarnessCapabilityExecutor make_harness_capability_executor(
+    std::map<std::string, std::shared_ptr<A2AClient>> agents) {
+    return [agents = std::move(agents)](
+               const json& tool, const json& arguments,
+               const std::shared_ptr<graph::CancelToken>& cancel) {
+        cancel->throw_if_cancelled("before downstream A2A call");
+        const auto agent = tool["executor"]["agent"].get<std::string>();
+        auto it = agents.find(agent);
+        if (it == agents.end() || !it->second) {
+            throw std::runtime_error("unresolved A2A agent: " + agent);
+        }
+        auto task = it->second->send_message_sync(arguments.dump());
+        cancel->throw_if_cancelled("after downstream A2A call");
+        json result;
+        to_json(result, task);
+        return result;
+    };
+}
+
+} // namespace neograph::a2a

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -456,18 +456,38 @@ GraphEngine::run_stream_async(RunConfig config,
 RunResult GraphEngine::resume(const std::string& thread_id,
                                const json& resume_value,
                                const GraphStreamCallback& cb) {
-    return neograph::async::run_sync(resume_async(thread_id, resume_value, cb));
+    RunConfig config;
+    config.thread_id = thread_id;
+    return resume(config, resume_value, cb);
 }
 
-asio::awaitable<RunResult>
-GraphEngine::resume_async(const std::string& thread_id,
-                          const json& resume_value,
-                          const GraphStreamCallback& cb) {
+RunResult GraphEngine::resume(const RunConfig&           config,
+                              const json&                resume_value,
+                              const GraphStreamCallback& cb) {
+    return neograph::async::run_sync(resume_async(config, resume_value, cb));
+}
+
+asio::awaitable<RunResult> GraphEngine::resume_async(const std::string&         thread_id,
+                                                     const json&                resume_value,
+                                                     const GraphStreamCallback& cb) {
+    RunConfig config;
+    config.thread_id = thread_id;
+    co_return co_await resume_async(std::move(config), resume_value, cb);
+}
+
+asio::awaitable<RunResult> GraphEngine::resume_async(RunConfig           config,
+                                                     json                resume_value,
+                                                     GraphStreamCallback cb) {
     // Sem 3.7.5: real async resume. Mirrors sync resume() but the
     // load_latest and the downstream super-step loop go through
     // their *_async peers, so the whole resume path is non-blocking.
     if (!checkpoint_store_)
         throw std::runtime_error("Cannot resume: no checkpoint store configured");
+
+    if (config.thread_id.empty()) {
+        throw std::invalid_argument("Cannot resume: thread_id is required");
+    }
+    const auto& thread_id = config.thread_id;
 
     auto cp_opt = co_await checkpoint_store_->load_latest_async(thread_id);
     if (!cp_opt)
@@ -480,10 +500,6 @@ GraphEngine::resume_async(const std::string& thread_id,
         result.checkpoint_id = cp_opt->id;
         co_return result;
     }
-
-    RunConfig config;
-    config.thread_id = thread_id;
-    config.max_steps = 50;
 
     co_return co_await execute_graph_async(
         config, cb, cp_opt->next_nodes, &resume_value);

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -22,6 +22,7 @@
 #include <set>
 #include <sstream>
 #include <stdexcept>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -59,6 +60,7 @@ json harness_request_schema() {
                 "input_schema":{"type":"object"},
                 "output_schema":{"type":"object"},
                 "read_only":{"type":"boolean"},
+                "path_arguments":{"type":"array","items":{"type":"string"}},
                 "executor":{"type":"object","required":["kind"],"properties":{
                     "kind":{"enum":["builtin","mcp","a2a","host_brokered","script"]},
                     "tool":{"type":"string"},
@@ -73,7 +75,9 @@ json harness_request_schema() {
                 "max_worker_retries":{"type":"integer"}
             },"additionalProperties":false},
             "policy":{"type":"object","properties":{
-                "read_only":{"type":"boolean"}
+                "read_only":{"type":"boolean"},
+                "workspace_roots":{"type":"array","items":{"type":"string"}},
+                "evidence_required":{"type":"array","items":{"type":"string"}}
             },"additionalProperties":false}
         },
         "additionalProperties":false
@@ -231,6 +235,7 @@ public:
             call.task = task;
             call.worker = worker_it->second;
             call.tool_catalog = selected_tools;
+            call.policy = request_.value("policy", json::object());
             call.attempt = static_cast<std::size_t>(attempt + 1);
             call.repair_feedback = feedback;
 
@@ -412,10 +417,10 @@ void register_harness_node_types() {
     });
 }
 
-json preset_fanout_judge(const json& request) {
+json preset_fanout_judge(const json& request, const std::string& preset) {
     json core = {
         {"schema_version", 1},
-        {"name", "harness_fanout_judge"},
+        {"name", "harness_" + preset},
         {"channels", {
             {"task", {{"reducer", "overwrite"}, {"initial", json::object()}}},
             {"worker_results", {{"reducer", "append"}, {"initial", json::array()}}},
@@ -463,6 +468,16 @@ void validate_bindings(const json& request, const json& core,
     std::map<std::string, json> tools;
     std::set<std::string> duplicates;
 
+    for (const auto& root : request.value("policy", json::object())
+                                .value("workspace_roots", json::array())) {
+        if (root.get<std::string>().empty()) {
+            diagnostics.push_back(make_diagnostic(
+                "binding", "H_WORKSPACE_ROOT", "error",
+                "$.policy.workspace_roots",
+                "workspace roots must not contain empty paths"));
+        }
+    }
+
     std::size_t index = 0;
     for (const auto& worker : request["workers"]) {
         const auto id = worker.value("id", "");
@@ -485,6 +500,36 @@ void validate_bindings(const json& request, const json& core,
             "error", "$.workers", "duplicate worker id: " + id, {{"id", id}}));
     }
 
+    const auto evidence_required = request.value("policy", json::object())
+                                       .value("evidence_required", json::array());
+    if (!evidence_required.empty()) {
+        for (const auto& [id, worker] : workers) {
+            const auto properties = worker["output_schema"].value(
+                "properties", json::object());
+            const auto findings = properties.value("findings", json::object());
+            const auto item = findings.value("items", json::object());
+            const auto item_properties = item.value("properties", json::object());
+            const auto item_required = item.value("required", json::array());
+            for (const auto& field_json : evidence_required) {
+                const auto field = field_json.get<std::string>();
+                bool required = false;
+                for (const auto& required_json : item_required) {
+                    if (required_json == field_json) {
+                        required = true;
+                        break;
+                    }
+                }
+                if (!item_properties.contains(field) || !required) {
+                    diagnostics.push_back(make_diagnostic(
+                        "binding", "H_EVIDENCE_SCHEMA", "error",
+                        "$.workers." + id + ".output_schema",
+                        "worker finding schema must require evidence field: " + field,
+                        {{"worker_id", id}, {"field", field}}));
+                }
+            }
+        }
+    }
+
     index = 0;
     for (const auto& tool : request.value("tool_catalog", json::array())) {
         const auto id = tool.value("id", "");
@@ -502,6 +547,20 @@ void validate_bindings(const json& request, const json& core,
         } catch (const std::exception& error) {
             diagnostics.push_back(make_diagnostic("binding", "H_TOOL_SCHEMA",
                 "error", path, error.what()));
+        }
+
+        for (const auto& argument_json : tool.value("path_arguments", json::array())) {
+            const auto argument = argument_json.get<std::string>();
+            const auto properties = tool["input_schema"].value(
+                "properties", json::object());
+            if (!properties.contains(argument)
+                || properties[argument].value("type", "") != "string") {
+                diagnostics.push_back(make_diagnostic(
+                    "binding", "H_PATH_ARGUMENT", "error",
+                    path + ".path_arguments",
+                    "path_arguments must name string properties in input_schema",
+                    {{"tool_id", id}, {"argument", argument}}));
+            }
         }
 
         const auto executor = tool.value("executor", json::object());
@@ -529,6 +588,14 @@ void validate_bindings(const json& request, const json& core,
         if (read_only && !tool.value("read_only", false)) {
             diagnostics.push_back(make_diagnostic("binding", "H_WRITE_TOOL",
                 "error", path, "read-only harness contains a write-capable tool",
+                {{"tool_id", id}}));
+        }
+        if (!tool.value("path_arguments", json::array()).empty()
+            && request.value("policy", json::object())
+                   .value("workspace_roots", json::array()).empty()) {
+            diagnostics.push_back(make_diagnostic(
+                "binding", "H_WORKSPACE_ROOT", "error", path,
+                "path-bearing tools require policy.workspace_roots",
                 {{"tool_id", id}}));
         }
     }
@@ -564,7 +631,7 @@ void validate_bindings(const json& request, const json& core,
             } else {
                 diagnostics.push_back(make_diagnostic("binding", "H_NODE_TYPE",
                     "error", "$.harness.definition.nodes." + node_name + ".type",
-                    "M2 Harness DSL only permits compiler-backed worker and judge nodes",
+                    "Harness DSL only permits compiler-backed worker and judge nodes",
                     {{"node", node_name}, {"type", type}}));
             }
         }
@@ -643,6 +710,7 @@ struct HarnessService::Impl {
         std::string artifact_id;
         std::string status = "queued";
         json result;
+        json details;
         std::string error;
         std::shared_ptr<graph::CancelToken> cancel =
             std::make_shared<graph::CancelToken>();
@@ -696,10 +764,13 @@ struct HarnessService::Impl {
             const auto harness = request["harness"];
             const auto mode = harness.value("mode", "");
             if (mode == "preset") {
-                if (harness.value("preset", "") != "fanout_judge") {
+                static const std::set<std::string> presets = {
+                    "fanout_judge", "pr_review_panel", "bug_triage",
+                    "research_synthesis"};
+                if (presets.find(harness.value("preset", "")) == presets.end()) {
                     diagnostics.push_back(make_diagnostic("request", "H_PRESET",
                         "error", "$.harness.preset",
-                        "M2 supports the fanout_judge preset"));
+                        "unknown Harness preset"));
                 }
             } else if (mode == "dsl" && !harness.contains("definition")) {
                 diagnostics.push_back(make_diagnostic("request", "H_DSL_DEFINITION",
@@ -717,7 +788,7 @@ struct HarnessService::Impl {
             try {
                 const auto harness = request["harness"];
                 json surface = harness.value("mode", "") == "preset"
-                    ? preset_fanout_judge(request)
+                    ? preset_fanout_judge(request, harness.value("preset", ""))
                     : harness["definition"];
                 auto elaborated = graph::Elaborator::elaborate(surface);
                 core = std::move(elaborated.core);
@@ -827,8 +898,20 @@ struct HarnessService::Impl {
                 run->status = "max_steps_exhausted";
             } else {
                 run->status = "completed";
-                run->result = graph_result.channel_raw("final_result");
-                run->result["execution_trace"] = graph_result.execution_trace;
+                run->details = graph_result.channel_raw("final_result");
+                run->details["execution_trace"] = graph_result.execution_trace;
+                const auto base_uri = "neograph://runs/" + run->id;
+                run->result = {
+                    {"outcome", run->details.value("outcome", "unknown")},
+                    {"valid_workers", run->details.value("valid_workers", 0)},
+                    {"failed_workers", run->details.value("failed_workers", 0)},
+                    {"finding_count",
+                     run->details.value("findings", json::array()).size()},
+                    {"artifacts", {
+                        {"details", {{"uri", base_uri + "/details"}}},
+                        {"trace", {{"uri", base_uri + "/trace"}}},
+                    }},
+                };
             }
         } catch (const graph::CancelledException& error) {
             std::lock_guard lock(run->mutex);
@@ -869,17 +952,43 @@ HarnessService::~HarnessService() = default;
 
 json HarnessService::schema() const {
     json executor_kinds = json::array({
-        {{"kind", "builtin"}, {"availability", "binding-only-in-m2"}},
-        {{"kind", "mcp"}, {"availability", "binding-only-in-m2"}},
-        {{"kind", "a2a"}, {"availability", "binding-only-in-m2"}},
+        {{"kind", "builtin"}, {"availability", "provider-capability-adapter"}},
+        {{"kind", "mcp"}, {"availability", "downstream-client-adapter"}},
+        {{"kind", "a2a"}, {"availability", "downstream-client-adapter"}},
         {{"kind", "host_brokered"}, {"availability", "requires-neograph-resume-m4"}},
         {{"kind", "script"}, {"availability", "disabled"}},
     });
     const auto request = harness_request_schema();
     return {
         {"protocol_version", MCP_PROTOCOL_VERSION},
-        {"service", "neograph-harness-m2"},
-        {"presets", json::array({"fanout_judge"})},
+        {"service", "neograph-harness-m3"},
+        {"presets", json::array({"fanout_judge", "pr_review_panel",
+                                  "bug_triage", "research_synthesis"})},
+        {"preset_contracts", {
+            {"fanout_judge", {
+                {"topology", "parallel workers, barrier, normalized judge"},
+            }},
+            {"pr_review_panel", {
+                {"topology", "parallel review specialists, evidence judge"},
+                {"recommended_roles", json::array(
+                    {"correctness", "security", "regression"})},
+                {"recommended_policy", {
+                    {"read_only", true},
+                    {"evidence_required", json::array(
+                        {"file", "line", "evidence"})},
+                }},
+            }},
+            {"bug_triage", {
+                {"topology", "parallel hypotheses, reproduction judge"},
+                {"recommended_roles", json::array(
+                    {"reproducer", "root_cause", "fix_validator"})},
+            }},
+            {"research_synthesis", {
+                {"topology", "parallel sources, contradiction-aware judge"},
+                {"recommended_roles", json::array(
+                    {"researcher", "skeptic", "synthesizer"})},
+            }},
+        }},
         {"executor_kinds", std::move(executor_kinds)},
         {"request_schema", request},
         {"schemas", {
@@ -897,6 +1006,11 @@ json HarnessService::schema() const {
             {"semantic_validation", true},
             {"binding_validation", true},
             {"bounded_worker_repair", true},
+            {"direct_provider_workers", true},
+            {"downstream_mcp_tools", true},
+            {"downstream_a2a_tools", true},
+            {"read_only_workspace_policy", true},
+            {"compact_results", true},
             {"durable_runs", false},
         }},
     };
@@ -966,7 +1080,8 @@ json HarnessService::start(const json& arguments) {
     };
 }
 
-json HarnessService::get(const std::string& run_id) const {
+json HarnessService::get(const std::string& run_id,
+                         const std::string& view) const {
     std::shared_ptr<Impl::Run> run;
     {
         std::lock_guard lock(impl_->mutex);
@@ -982,9 +1097,42 @@ json HarnessService::get(const std::string& run_id) const {
         {"artifact_id", run->artifact_id},
         {"status", run->status},
     };
-    if (!run->result.is_null()) snapshot["result"] = run->result;
+    if (view == "status") {
+        if (!run->result.is_null()) snapshot["result"] = run->result;
+    } else if (view == "details") {
+        if (!run->details.is_null()) snapshot["result"] = run->details;
+    } else if (view == "trace") {
+        if (!run->details.is_null()) {
+            snapshot["result"] = {
+                {"execution_trace", run->details.value(
+                    "execution_trace", json::array())},
+            };
+        }
+    } else if (view == "artifacts") {
+        if (!run->result.is_null()) {
+            snapshot["result"] = run->result.value("artifacts", json::object());
+        }
+    } else {
+        throw std::invalid_argument(
+            "Harness view must be status, details, trace, or artifacts");
+    }
     if (!run->error.empty()) snapshot["error"] = run->error;
     return snapshot;
+}
+
+json HarnessService::read(const std::string& uri) const {
+    constexpr std::string_view prefix = "neograph://runs/";
+    if (uri.rfind(prefix.data(), 0) != 0) {
+        throw std::invalid_argument("unsupported Harness artifact URI: " + uri);
+    }
+    const auto remainder = uri.substr(prefix.size());
+    const auto separator = remainder.rfind('/');
+    if (separator == std::string::npos || separator == 0
+        || separator + 1 == remainder.size()) {
+        throw std::invalid_argument("malformed Harness artifact URI: " + uri);
+    }
+    return get(remainder.substr(0, separator),
+               remainder.substr(separator + 1));
 }
 
 bool HarnessService::cancel(const std::string& run_id) {
@@ -1011,7 +1159,7 @@ void HarnessService::register_tools(MCPServer& server) {
         json::parse(R"JSON({"type":"object","required":["service","request_schema","node_palette"],"properties":{"service":{"type":"string"},"request_schema":{"type":"object"},"node_palette":{"type":"object"}},"additionalProperties":true})JSON"), true),
         [this](const json&, const auto&) {
             auto value = schema();
-            return mcp_result(std::move(value), "NeoGraph Harness M2 schema");
+            return mcp_result(std::move(value), "NeoGraph Harness M3 schema");
         });
 
     server.register_tool(tool_definition(
@@ -1029,7 +1177,7 @@ void HarnessService::register_tools(MCPServer& server) {
     server.register_tool(tool_definition(
         "neograph_start", "Start Harness",
         "Start a retained artifact or compile-and-start an inline Harness request.",
-        json::parse(R"JSON({"type":"object","properties":{"artifact_id":{"type":"string"},"request":{"type":"object"}},"additionalProperties":false})JSON"),
+        json::parse(R"JSON({"type":"object","description":"Provide exactly one of artifact_id or request.","properties":{"artifact_id":{"type":"string","description":"Artifact returned by neograph_compile."},"request":{"type":"object","description":"Inline Harness request; do not also provide artifact_id."}},"additionalProperties":false})JSON"),
         json::parse(R"JSON({"type":"object","required":["started","status"],"properties":{"started":{"type":"boolean"},"run_id":{"type":"string"},"artifact_id":{"type":"string"},"status":{"type":"string"},"diagnostics":{"type":"array"},"artifacts":{"type":"object"}},"additionalProperties":true})JSON")),
         [this](const json& arguments, const auto&) {
             auto value = start(arguments);
@@ -1041,11 +1189,19 @@ void HarnessService::register_tools(MCPServer& server) {
 
     server.register_tool(tool_definition(
         "neograph_get", "Get Harness run",
-        "Read compact run status, result, and failure classification.",
-        json::parse(R"JSON({"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string"}},"additionalProperties":false})JSON"),
+        "Read compact run status or dereference a detailed neograph:// run artifact URI.",
+        json::parse(R"JSON({"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string"},"view":{"enum":["status","details","trace","artifacts"],"description":"Named view used when uri is absent."},"uri":{"type":"string","description":"Returned artifact URI. When present, its embedded view is authoritative."}},"additionalProperties":false})JSON"),
         run_snapshot_schema(), true),
         [this](const json& arguments, const auto&) {
-            auto value = get(arguments["run_id"].get<std::string>());
+            const bool has_uri = arguments.contains("uri");
+            const auto run_id = arguments["run_id"].get<std::string>();
+            auto value = has_uri
+                ? read(arguments["uri"].get<std::string>())
+                : get(run_id, arguments.value("view", "status"));
+            if (value.value("run_id", "") != run_id) {
+                throw std::invalid_argument(
+                    "Harness artifact URI does not belong to run_id");
+            }
             const auto text = "Harness run " + value.value("run_id", "")
                 + ": " + value.value("status", "unknown");
             return mcp_result(std::move(value), text);

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -1,0 +1,1068 @@
+#include <neograph/mcp/harness.h>
+
+#include <neograph/graph/compiler.h>
+#include <neograph/graph/elaborator.h>
+#include <neograph/graph/engine.h>
+#include <neograph/graph/loader.h>
+#include <neograph/graph/node.h>
+#include <neograph/graph/validator.h>
+#include <neograph/mcp/json_schema.h>
+#include <neograph/mcp/server.h>
+#include <neograph/provider.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <iomanip>
+#include <map>
+#include <mutex>
+#include <random>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace neograph::mcp {
+namespace {
+
+constexpr const char* kWorkerNodeType = "neograph_harness_worker";
+constexpr const char* kJudgeNodeType = "neograph_harness_judge";
+
+json harness_request_schema() {
+    return json::parse(R"JSON({
+        "type":"object",
+        "required":["task","harness","workers"],
+        "properties":{
+            "task":{"type":"object","required":["objective"],"properties":{
+                "objective":{"type":"string"},
+                "acceptance":{"type":"array","items":{"type":"string"}}
+            },"additionalProperties":true},
+            "harness":{"type":"object","required":["mode"],"properties":{
+                "mode":{"enum":["preset","dsl"]},
+                "preset":{"type":"string"},
+                "definition":{"type":"object"}
+            },"additionalProperties":false},
+            "workers":{"type":"array","items":{"type":"object","required":["id","instructions","output_schema"],"properties":{
+                "id":{"type":"string"},
+                "instructions":{"type":"string"},
+                "tools":{"type":"array","items":{"type":"string"}},
+                "output_schema":{"type":"object"}
+            },"additionalProperties":false}},
+            "tool_catalog":{"type":"array","items":{"type":"object","required":["id","description","input_schema","executor"],"properties":{
+                "id":{"type":"string"},
+                "description":{"type":"string"},
+                "input_schema":{"type":"object"},
+                "output_schema":{"type":"object"},
+                "read_only":{"type":"boolean"},
+                "executor":{"type":"object","required":["kind"],"properties":{
+                    "kind":{"enum":["builtin","mcp","a2a","host_brokered","script"]},
+                    "tool":{"type":"string"},
+                    "server_ref":{"type":"string"},
+                    "agent":{"type":"string"}
+                },"additionalProperties":true}
+            },"additionalProperties":false}},
+            "budgets":{"type":"object","properties":{
+                "max_steps":{"type":"integer"},
+                "timeout_seconds":{"type":"integer"},
+                "max_parallel_workers":{"type":"integer"},
+                "max_worker_retries":{"type":"integer"}
+            },"additionalProperties":false},
+            "policy":{"type":"object","properties":{
+                "read_only":{"type":"boolean"}
+            },"additionalProperties":false}
+        },
+        "additionalProperties":false
+    })JSON");
+}
+
+json compile_output_schema() {
+    return json::parse(R"JSON({
+        "type":"object","required":["ok","diagnostics","artifacts"],
+        "properties":{
+            "ok":{"type":"boolean"},
+            "artifact_id":{"type":"string"},
+            "diagnostics":{"type":"array"},
+            "artifacts":{"type":"object"}
+        },"additionalProperties":true
+    })JSON");
+}
+
+json run_snapshot_schema() {
+    return json::parse(R"JSON({
+        "type":"object","required":["run_id","status"],
+        "properties":{
+            "run_id":{"type":"string"},
+            "artifact_id":{"type":"string"},
+            "status":{"type":"string"},
+            "result":{"type":"object"},
+            "error":{"type":"string"}
+        },"additionalProperties":true
+    })JSON");
+}
+
+json worker_result_schema() {
+    return json::parse(R"JSON({
+        "type":"object","required":["worker_id","status","attempts"],
+        "properties":{
+            "worker_id":{"type":"string"},
+            "status":{"enum":["valid","failed"]},
+            "attempts":{"type":"integer"},
+            "output":{},
+            "failure_kind":{"enum":["empty_response","parse_error","schema_validation","tool_error","timeout"]},
+            "message":{"type":"string"}
+        },"additionalProperties":false
+    })JSON");
+}
+
+json make_diagnostic(std::string phase, std::string code,
+                     std::string severity, std::string path,
+                     std::string message, json witness = json::object(),
+                     std::string source = {}) {
+    if (source.empty()) source = path;
+    json value = {
+        {"phase", std::move(phase)},
+        {"code", std::move(code)},
+        {"severity", std::move(severity)},
+        {"path", std::move(path)},
+        {"message", std::move(message)},
+        {"witness", std::move(witness)},
+        {"source", std::move(source)},
+    };
+    return value;
+}
+
+bool diagnostics_have_errors(const json& diagnostics) {
+    for (const auto& diagnostic : diagnostics) {
+        if (diagnostic.value("severity", "") == "error") return true;
+    }
+    return false;
+}
+
+std::string diagnostic_pointer(std::string path) {
+    constexpr const char* definition_prefix = "$.harness.definition.";
+    if (path.rfind(definition_prefix, 0) == 0) {
+        path.erase(0, std::char_traits<char>::length(definition_prefix));
+    } else if (path.rfind("nodes.", 0) != 0
+               && path.rfind("channels.", 0) != 0
+               && path.rfind("edges", 0) != 0
+               && path.rfind("conditional_edges", 0) != 0) {
+        return {};
+    }
+    std::replace(path.begin(), path.end(), '.', '/');
+    return "/" + path;
+}
+
+void attach_elaborator_sources(json& diagnostics, const json& sourcemap) {
+    if (!sourcemap.is_array()) return;
+    for (std::size_t i = 0; i < diagnostics.size(); ++i) {
+        auto diagnostic = diagnostics[i];
+        const auto pointer = diagnostic_pointer(diagnostic.value("path", ""));
+        if (pointer.empty()) continue;
+        std::size_t longest = 0;
+        std::string source;
+        for (const auto& mapping : sourcemap) {
+            const auto target = mapping.value("target", "");
+            if (target.size() > longest && pointer.rfind(target, 0) == 0) {
+                longest = target.size();
+                source = mapping.value("source", "");
+            }
+        }
+        if (!source.empty()) {
+            diagnostic["source"] = std::move(source);
+            diagnostics[i] = std::move(diagnostic);
+        }
+    }
+}
+
+std::string response_kind_name(HarnessWorkerResponseKind kind) {
+    switch (kind) {
+    case HarnessWorkerResponseKind::VALUE: return "value";
+    case HarnessWorkerResponseKind::EMPTY: return "empty_response";
+    case HarnessWorkerResponseKind::PARSE_ERROR: return "parse_error";
+    case HarnessWorkerResponseKind::TOOL_ERROR: return "tool_error";
+    case HarnessWorkerResponseKind::TIMEOUT: return "timeout";
+    case HarnessWorkerResponseKind::CANCELLED: return "cancelled";
+    }
+    return "unknown";
+}
+
+class HarnessRuntimeProvider final : public Provider {
+public:
+    HarnessRuntimeProvider(json request, HarnessWorkerExecutor executor)
+        : request_(std::move(request)), executor_(std::move(executor)) {
+        for (const auto& worker : request_["workers"]) {
+            workers_[worker["id"].get<std::string>()] = worker;
+        }
+        for (const auto& tool : request_.value("tool_catalog", json::array())) {
+            tools_[tool["id"].get<std::string>()] = tool;
+        }
+        max_retries_ = request_.value("budgets", json::object())
+                           .value("max_worker_retries", 1);
+    }
+
+    std::string get_name() const override { return "harness-worker-executor"; }
+
+    json execute(const std::string& worker_id, const json& task,
+                 const std::shared_ptr<graph::CancelToken>& cancel) const {
+        const auto worker_it = workers_.find(worker_id);
+        if (worker_it == workers_.end()) {
+            throw std::runtime_error("unknown Harness worker: " + worker_id);
+        }
+
+        json selected_tools = json::array();
+        for (const auto& tool_id_json : worker_it->second.value("tools", json::array())) {
+            const auto tool_id = tool_id_json.get<std::string>();
+            auto tool_it = tools_.find(tool_id);
+            if (tool_it != tools_.end()) selected_tools.push_back(tool_it->second);
+        }
+
+        std::string feedback;
+        std::string failure_kind = "empty_response";
+        int attempts_made = 0;
+        for (int attempt = 0; attempt <= max_retries_; ++attempt) {
+            attempts_made = attempt + 1;
+            cancel->throw_if_cancelled("before Harness worker " + worker_id);
+            HarnessWorkerCall call;
+            call.task = task;
+            call.worker = worker_it->second;
+            call.tool_catalog = selected_tools;
+            call.attempt = static_cast<std::size_t>(attempt + 1);
+            call.repair_feedback = feedback;
+
+            HarnessWorkerResponse response;
+            if (!executor_) {
+                response = HarnessWorkerResponse::tool_error(
+                    "no Harness worker executor is configured");
+            } else {
+                response = executor_(call, cancel);
+            }
+
+            if (response.kind == HarnessWorkerResponseKind::CANCELLED) {
+                throw graph::CancelledException(response.message.empty()
+                    ? "Harness worker cancelled" : response.message);
+            }
+
+            if (response.kind == HarnessWorkerResponseKind::VALUE) {
+                if (response.value.is_null()
+                    || (response.value.is_string()
+                        && response.value.get<std::string>().empty())) {
+                    failure_kind = "empty_response";
+                    feedback = "worker returned an empty response";
+                } else {
+                    try {
+                        validate_json_value(response.value,
+                            worker_it->second["output_schema"],
+                            "Harness worker output", "$");
+                        return {
+                            {"worker_id", worker_id},
+                            {"status", "valid"},
+                            {"attempts", attempt + 1},
+                            {"output", response.value},
+                        };
+                    } catch (const std::exception& error) {
+                        failure_kind = "schema_validation";
+                        feedback = error.what();
+                    }
+                }
+            } else {
+                failure_kind = response_kind_name(response.kind);
+                feedback = response.message.empty() ? failure_kind : response.message;
+                if (response.kind == HarnessWorkerResponseKind::TIMEOUT
+                    || response.kind == HarnessWorkerResponseKind::TOOL_ERROR) {
+                    break;
+                }
+            }
+        }
+
+        return {
+            {"worker_id", worker_id},
+            {"status", "failed"},
+            {"failure_kind", failure_kind},
+            {"message", feedback},
+            {"attempts", attempts_made},
+        };
+    }
+
+private:
+    json request_;
+    HarnessWorkerExecutor executor_;
+    std::map<std::string, json> workers_;
+    std::map<std::string, json> tools_;
+    int max_retries_ = 1;
+};
+
+class HarnessWorkerNode final : public graph::GraphNode {
+public:
+    HarnessWorkerNode(std::string name, std::string worker_id,
+                      std::shared_ptr<HarnessRuntimeProvider> runtime)
+        : name_(std::move(name)), worker_id_(std::move(worker_id)),
+          runtime_(std::move(runtime)) {}
+
+    asio::awaitable<graph::NodeOutput> run(graph::NodeInput in) override {
+        auto cancel = in.ctx.cancel_token;
+        if (!cancel) cancel = std::make_shared<graph::CancelToken>();
+        auto result = runtime_->execute(worker_id_, in.state.get("task"), cancel);
+        graph::NodeOutput output;
+        output.writes.push_back({"worker_results", std::move(result)});
+        co_return output;
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+    std::string worker_id_;
+    std::shared_ptr<HarnessRuntimeProvider> runtime_;
+};
+
+class HarnessJudgeNode final : public graph::GraphNode {
+public:
+    explicit HarnessJudgeNode(std::string name) : name_(std::move(name)) {}
+
+    asio::awaitable<graph::NodeOutput> run(graph::NodeInput in) override {
+        std::vector<json> workers;
+        const auto results = in.state.get("worker_results");
+        for (const auto& result : results) workers.push_back(result);
+        std::sort(workers.begin(), workers.end(), [](const json& lhs, const json& rhs) {
+            return lhs.value("worker_id", "") < rhs.value("worker_id", "");
+        });
+
+        json normalized = json::array();
+        json findings = json::array();
+        int valid = 0;
+        int failed = 0;
+        bool partial = false;
+        bool findings_contract = !workers.empty();
+        for (const auto& worker : workers) {
+            normalized.push_back(worker);
+            if (worker.value("status", "") != "valid") {
+                ++failed;
+                findings_contract = false;
+                continue;
+            }
+            ++valid;
+            const auto output = worker["output"];
+            const auto worker_status = output.value("status", "ok");
+            if (worker_status == "partial") partial = true;
+            if (worker_status == "failed") {
+                ++failed;
+                --valid;
+            }
+            if (!output.contains("findings") || !output["findings"].is_array()) {
+                findings_contract = false;
+            } else {
+                for (const auto& finding : output["findings"]) {
+                    findings.push_back(finding);
+                }
+            }
+        }
+
+        std::string outcome = "ok";
+        if (valid == 0 && failed > 0) outcome = "failed";
+        else if (failed > 0 || partial) outcome = "partial";
+        else if (findings_contract && findings.empty()) outcome = "zero_findings";
+
+        json result = {
+            {"outcome", outcome},
+            {"workers", std::move(normalized)},
+            {"findings", std::move(findings)},
+            {"valid_workers", valid},
+            {"failed_workers", failed},
+        };
+        graph::NodeOutput output;
+        output.writes.push_back({"final_result", std::move(result)});
+        co_return output;
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+};
+
+void register_harness_node_types() {
+    static std::once_flag once;
+    std::call_once(once, [] {
+        graph::NodeFactory::instance().register_type(kWorkerNodeType,
+            [](const std::string& name, const json& config,
+               const graph::NodeContext& ctx) -> std::unique_ptr<graph::GraphNode> {
+                auto runtime = std::dynamic_pointer_cast<HarnessRuntimeProvider>(ctx.provider);
+                if (!runtime) {
+                    throw std::runtime_error(
+                        "Harness worker nodes require a Harness runtime context");
+                }
+                return std::make_unique<HarnessWorkerNode>(
+                    name, config.at("worker_id").get<std::string>(), std::move(runtime));
+            },
+            json::parse(R"JSON({"type":"object","required":["worker_id"],"properties":{"worker_id":{"type":"string"}},"additionalProperties":false})JSON"),
+            json::parse(R"JSON({"reads":["task"],"writes":["worker_results"]})JSON"));
+
+        graph::NodeFactory::instance().register_type(kJudgeNodeType,
+            [](const std::string& name, const json&,
+               const graph::NodeContext&) -> std::unique_ptr<graph::GraphNode> {
+                return std::make_unique<HarnessJudgeNode>(name);
+            },
+            json::parse(R"JSON({"type":"object","properties":{},"additionalProperties":false})JSON"),
+            json::parse(R"JSON({"reads":["worker_results"],"writes":["final_result"]})JSON"));
+    });
+}
+
+json preset_fanout_judge(const json& request) {
+    json core = {
+        {"schema_version", 1},
+        {"name", "harness_fanout_judge"},
+        {"channels", {
+            {"task", {{"reducer", "overwrite"}, {"initial", json::object()}}},
+            {"worker_results", {{"reducer", "append"}, {"initial", json::array()}}},
+            {"final_result", {{"reducer", "overwrite"}, {"initial", nullptr}}},
+        }},
+        {"nodes", json::object()},
+        {"edges", json::array()},
+    };
+
+    json wait_for = json::array();
+    std::size_t index = 0;
+    for (const auto& worker : request["workers"]) {
+        const auto node = "worker_" + std::to_string(index++);
+        core["nodes"][node] = {
+            {"type", kWorkerNodeType},
+            {"worker_id", worker["id"]},
+        };
+        core["edges"].push_back({{"from", graph::START_NODE}, {"to", node}});
+        core["edges"].push_back({{"from", node}, {"to", "judge"}});
+        wait_for.push_back(node);
+    }
+    core["nodes"]["judge"] = {
+        {"type", kJudgeNodeType},
+        {"barrier", {{"wait_for", wait_for}}},
+    };
+    core["edges"].push_back({{"from", "judge"}, {"to", graph::END_NODE}});
+    return core;
+}
+
+void validate_range(const json& budgets, const char* name, int minimum,
+                    int maximum, int default_value, json& diagnostics) {
+    const int value = budgets.value(name, default_value);
+    if (value < minimum || value > maximum) {
+        diagnostics.push_back(make_diagnostic("request", "H_REQUEST_BUDGET",
+            "error", std::string("$.budgets.") + name,
+            std::string(name) + " must be between " + std::to_string(minimum)
+                + " and " + std::to_string(maximum),
+            {{"value", value}, {"minimum", minimum}, {"maximum", maximum}}));
+    }
+}
+
+void validate_bindings(const json& request, const json& core,
+                       json& diagnostics) {
+    std::map<std::string, json> workers;
+    std::map<std::string, json> tools;
+    std::set<std::string> duplicates;
+
+    std::size_t index = 0;
+    for (const auto& worker : request["workers"]) {
+        const auto id = worker.value("id", "");
+        const auto path = "$.workers[" + std::to_string(index++) + "]";
+        if (id.empty()) {
+            diagnostics.push_back(make_diagnostic("binding", "H_WORKER_ID",
+                "error", path + ".id", "worker id must not be empty"));
+            continue;
+        }
+        if (!workers.emplace(id, worker).second) duplicates.insert(id);
+        try {
+            validate_json_schema(worker["output_schema"], path + ".output_schema");
+        } catch (const std::exception& error) {
+            diagnostics.push_back(make_diagnostic("binding", "H_WORKER_SCHEMA",
+                "error", path + ".output_schema", error.what()));
+        }
+    }
+    for (const auto& id : duplicates) {
+        diagnostics.push_back(make_diagnostic("binding", "H_DUPLICATE_WORKER",
+            "error", "$.workers", "duplicate worker id: " + id, {{"id", id}}));
+    }
+
+    index = 0;
+    for (const auto& tool : request.value("tool_catalog", json::array())) {
+        const auto id = tool.value("id", "");
+        const auto path = "$.tool_catalog[" + std::to_string(index++) + "]";
+        if (id.empty() || !tools.emplace(id, tool).second) {
+            diagnostics.push_back(make_diagnostic("binding", "H_DUPLICATE_TOOL",
+                "error", path + ".id", id.empty() ? "tool id must not be empty"
+                                                    : "duplicate tool id: " + id));
+        }
+        try {
+            validate_json_schema(tool["input_schema"], path + ".input_schema");
+            if (tool.contains("output_schema")) {
+                validate_json_schema(tool["output_schema"], path + ".output_schema");
+            }
+        } catch (const std::exception& error) {
+            diagnostics.push_back(make_diagnostic("binding", "H_TOOL_SCHEMA",
+                "error", path, error.what()));
+        }
+
+        const auto executor = tool.value("executor", json::object());
+        const auto kind = executor.value("kind", "");
+        if (kind == "mcp" && executor.value("server_ref", "").empty()) {
+            diagnostics.push_back(make_diagnostic("binding", "H_MCP_UNRESOLVED",
+                "error", path + ".executor.server_ref",
+                "mcp executor requires a resolvable server_ref"));
+        } else if (kind == "a2a" && executor.value("agent", "").empty()) {
+            diagnostics.push_back(make_diagnostic("binding", "H_A2A_UNRESOLVED",
+                "error", path + ".executor.agent",
+                "a2a executor requires an agent identifier"));
+        } else if (kind == "host_brokered") {
+            diagnostics.push_back(make_diagnostic("binding", "H_HOST_BROKER_UNAVAILABLE",
+                "error", path + ".executor.kind",
+                "host_brokered tools require neograph_resume, planned for M4"));
+        } else if (kind == "script") {
+            diagnostics.push_back(make_diagnostic("binding", "H_SCRIPT_DISABLED",
+                "error", path + ".executor.kind",
+                "script executors are disabled by default"));
+        }
+
+        const bool read_only = request.value("policy", json::object())
+                                   .value("read_only", false);
+        if (read_only && !tool.value("read_only", false)) {
+            diagnostics.push_back(make_diagnostic("binding", "H_WRITE_TOOL",
+                "error", path, "read-only harness contains a write-capable tool",
+                {{"tool_id", id}}));
+        }
+    }
+
+    for (const auto& [id, worker] : workers) {
+        for (const auto& tool_id_json : worker.value("tools", json::array())) {
+            const auto tool_id = tool_id_json.get<std::string>();
+            if (tools.find(tool_id) == tools.end()) {
+                diagnostics.push_back(make_diagnostic("binding", "H_UNKNOWN_TOOL",
+                    "error", "$.workers." + id + ".tools",
+                    "worker references unknown tool: " + tool_id,
+                    {{"worker_id", id}, {"tool_id", tool_id}}));
+            }
+        }
+    }
+
+    std::map<std::string, int> topology_workers;
+    int judges = 0;
+    if (core.contains("nodes") && core["nodes"].is_object()) {
+        for (const auto& [node_name, node] : core["nodes"].items()) {
+            const auto type = node.value("type", "");
+            if (type == kWorkerNodeType) {
+                const auto worker_id = node.value("worker_id", "");
+                ++topology_workers[worker_id];
+                if (workers.find(worker_id) == workers.end()) {
+                    diagnostics.push_back(make_diagnostic("binding", "H_UNKNOWN_WORKER",
+                        "error", "$.harness.definition.nodes." + node_name,
+                        "topology references unknown worker: " + worker_id,
+                        {{"node", node_name}, {"worker_id", worker_id}}));
+                }
+            } else if (type == kJudgeNodeType) {
+                ++judges;
+            } else {
+                diagnostics.push_back(make_diagnostic("binding", "H_NODE_TYPE",
+                    "error", "$.harness.definition.nodes." + node_name + ".type",
+                    "M2 Harness DSL only permits compiler-backed worker and judge nodes",
+                    {{"node", node_name}, {"type", type}}));
+            }
+        }
+    }
+    for (const auto& [id, worker] : workers) {
+        (void)worker;
+        if (topology_workers[id] != 1) {
+            diagnostics.push_back(make_diagnostic("binding", "H_WORKER_BINDING",
+                "error", "$.harness.definition.nodes",
+                "each declared worker must be bound exactly once",
+                {{"worker_id", id}, {"bindings", topology_workers[id]}}));
+        }
+    }
+    if (judges != 1) {
+        diagnostics.push_back(make_diagnostic("binding", "H_JUDGE_BINDING",
+            "error", "$.harness.definition.nodes",
+            "fanout_judge topology requires exactly one result-reading judge",
+            {{"judges", judges}}));
+    }
+}
+
+CallToolResult mcp_result(json structured, std::string text) {
+    CallToolResult result;
+    result.content = json::array({{{"type", "text"}, {"text", std::move(text)}}});
+    result.structured_content = std::move(structured);
+    return result;
+}
+
+ToolDefinition tool_definition(std::string name, std::string title,
+                               std::string description, json input, json output,
+                               bool read_only = false) {
+    ToolDefinition definition;
+    definition.name = std::move(name);
+    definition.title = std::move(title);
+    definition.description = std::move(description);
+    definition.input_schema = std::move(input);
+    definition.output_schema = std::move(output);
+    definition.annotations = {{"readOnlyHint", read_only}};
+    definition.execution = {{"taskSupport", "forbidden"}};
+    return definition;
+}
+
+} // namespace
+
+HarnessWorkerResponse HarnessWorkerResponse::success(json value) {
+    return {HarnessWorkerResponseKind::VALUE, std::move(value), {}};
+}
+HarnessWorkerResponse HarnessWorkerResponse::empty(std::string message) {
+    return {HarnessWorkerResponseKind::EMPTY, nullptr, std::move(message)};
+}
+HarnessWorkerResponse HarnessWorkerResponse::parse_error(std::string message) {
+    return {HarnessWorkerResponseKind::PARSE_ERROR, nullptr, std::move(message)};
+}
+HarnessWorkerResponse HarnessWorkerResponse::tool_error(std::string message) {
+    return {HarnessWorkerResponseKind::TOOL_ERROR, nullptr, std::move(message)};
+}
+HarnessWorkerResponse HarnessWorkerResponse::timeout(std::string message) {
+    return {HarnessWorkerResponseKind::TIMEOUT, nullptr, std::move(message)};
+}
+HarnessWorkerResponse HarnessWorkerResponse::cancelled(std::string message) {
+    return {HarnessWorkerResponseKind::CANCELLED, nullptr, std::move(message)};
+}
+
+struct HarnessService::Impl {
+    struct Artifact {
+        std::string id;
+        json request;
+        json core;
+        json sourcemap;
+        json diagnostics;
+    };
+
+    struct Run {
+        mutable std::mutex mutex;
+        std::string id;
+        std::string artifact_id;
+        std::string status = "queued";
+        json result;
+        std::string error;
+        std::shared_ptr<graph::CancelToken> cancel =
+            std::make_shared<graph::CancelToken>();
+    };
+
+    explicit Impl(HarnessServiceConfig value)
+        : config(std::move(value)), nonce(std::random_device{}()) {
+        register_harness_node_types();
+    }
+
+    ~Impl() {
+        std::vector<std::shared_ptr<Run>> active;
+        {
+            std::lock_guard lock(mutex);
+            for (const auto& [id, run] : runs) {
+                (void)id;
+                active.push_back(run);
+            }
+        }
+        for (const auto& run : active) run->cancel->cancel();
+        for (auto& thread : threads) {
+            if (thread.joinable()) thread.join();
+        }
+    }
+
+    std::string id(const char* prefix) {
+        const auto sequence = next_id.fetch_add(1, std::memory_order_relaxed);
+        std::ostringstream out;
+        out << prefix << '_' << std::hex << nonce << sequence;
+        return out.str();
+    }
+
+    json compile_request(const json& request, bool retain) {
+        json diagnostics = json::array();
+        json core;
+        json sourcemap = json::array();
+
+        try {
+            validate_json_value(request, harness_request_schema(),
+                                "Harness request", "$");
+        } catch (const std::exception& error) {
+            diagnostics.push_back(make_diagnostic("request", "H_REQUEST_SCHEMA",
+                "error", "$", error.what()));
+        }
+
+        if (!diagnostics_have_errors(diagnostics)) {
+            if (request["workers"].empty()) {
+                diagnostics.push_back(make_diagnostic("request", "H_WORKERS_EMPTY",
+                    "error", "$.workers", "at least one worker is required"));
+            }
+            const auto harness = request["harness"];
+            const auto mode = harness.value("mode", "");
+            if (mode == "preset") {
+                if (harness.value("preset", "") != "fanout_judge") {
+                    diagnostics.push_back(make_diagnostic("request", "H_PRESET",
+                        "error", "$.harness.preset",
+                        "M2 supports the fanout_judge preset"));
+                }
+            } else if (mode == "dsl" && !harness.contains("definition")) {
+                diagnostics.push_back(make_diagnostic("request", "H_DSL_DEFINITION",
+                    "error", "$.harness.definition",
+                    "dsl mode requires a definition"));
+            }
+            const auto budgets = request.value("budgets", json::object());
+            validate_range(budgets, "max_steps", 1, 1000, 40, diagnostics);
+            validate_range(budgets, "timeout_seconds", 1, 86400, 600, diagnostics);
+            validate_range(budgets, "max_parallel_workers", 1, 64, 4, diagnostics);
+            validate_range(budgets, "max_worker_retries", 0, 5, 1, diagnostics);
+        }
+
+        if (!diagnostics_have_errors(diagnostics)) {
+            try {
+                const auto harness = request["harness"];
+                json surface = harness.value("mode", "") == "preset"
+                    ? preset_fanout_judge(request)
+                    : harness["definition"];
+                auto elaborated = graph::Elaborator::elaborate(surface);
+                core = std::move(elaborated.core);
+                sourcemap = std::move(elaborated.sourcemap);
+                if (core.value("schema_version", 0) != 1) {
+                    diagnostics.push_back(make_diagnostic("elaboration", "H_STRICT_CORE",
+                        "error", "$.harness.definition.schema_version",
+                        "Harness core must declare schema_version: 1"));
+                }
+            } catch (const std::exception& error) {
+                diagnostics.push_back(make_diagnostic("elaboration", "H_ELABORATION",
+                    "error", "$.harness.definition", error.what()));
+            }
+        }
+
+        if (!diagnostics_have_errors(diagnostics)) {
+            try {
+                auto provider = std::make_shared<HarnessRuntimeProvider>(
+                    request, HarnessWorkerExecutor{});
+                graph::NodeContext context;
+                context.provider = provider;
+                auto compiled = graph::GraphCompiler::compile(core, context);
+                graph::GraphCompiler::verify_roundtrip(core, compiled);
+                auto report = graph::GraphValidator::validate(compiled);
+                for (const auto& diagnostic : report.diagnostics) {
+                    diagnostics.push_back(make_diagnostic("static", diagnostic.code,
+                        diagnostic.severity, diagnostic.path, diagnostic.message,
+                        diagnostic.witness));
+                }
+            } catch (const std::exception& error) {
+                diagnostics.push_back(make_diagnostic("compile", "H_COMPILE",
+                    "error", "$.harness.definition", error.what()));
+            }
+        }
+
+        if (!core.is_null()) validate_bindings(request, core, diagnostics);
+        attach_elaborator_sources(diagnostics, sourcemap);
+
+        json artifacts = {
+            {"core_lockfile", {{"uri", ""}, {"content", core}}},
+            {"source_map", {{"uri", ""}, {"content", sourcemap}}},
+            {"diagnostics", {{"uri", ""}, {"content", diagnostics}}},
+        };
+        const bool ok = !diagnostics_have_errors(diagnostics);
+        json result = {{"ok", ok}, {"diagnostics", diagnostics}, {"artifacts", artifacts}};
+        if (!ok || !retain) return result;
+
+        auto artifact = std::make_shared<Artifact>();
+        artifact->id = id("artifact");
+        artifact->request = request;
+        artifact->core = core;
+        artifact->sourcemap = sourcemap;
+        artifact->diagnostics = diagnostics;
+        const auto base_uri = "neograph://artifacts/" + artifact->id;
+        result["artifact_id"] = artifact->id;
+        result["artifacts"]["core_lockfile"]["uri"] = base_uri + "/core";
+        result["artifacts"]["source_map"]["uri"] = base_uri + "/sourcemap";
+        result["artifacts"]["diagnostics"]["uri"] = base_uri + "/diagnostics";
+
+        std::lock_guard lock(mutex);
+        if (artifacts_by_id.size() >= config.max_artifacts && !artifacts_by_id.empty()) {
+            artifacts_by_id.erase(artifacts_by_id.begin());
+        }
+        artifacts_by_id[artifact->id] = std::move(artifact);
+        return result;
+    }
+
+    void execute(std::shared_ptr<Run> run, std::shared_ptr<Artifact> artifact) {
+        {
+            std::lock_guard lock(run->mutex);
+            run->status = "running";
+        }
+
+        const auto budgets = artifact->request.value("budgets", json::object());
+        const int timeout_seconds = budgets.value("timeout_seconds", 600);
+        std::atomic<bool> timed_out{false};
+        std::mutex timer_mutex;
+        std::condition_variable timer_cv;
+        bool done = false;
+        std::thread timer([&] {
+            std::unique_lock lock(timer_mutex);
+            if (!timer_cv.wait_for(lock, std::chrono::seconds(timeout_seconds),
+                                   [&] { return done; })) {
+                timed_out.store(true, std::memory_order_release);
+                run->cancel->cancel();
+            }
+        });
+
+        try {
+            auto provider = std::make_shared<HarnessRuntimeProvider>(
+                artifact->request, config.worker_executor);
+            graph::NodeContext context;
+            context.provider = std::move(provider);
+            auto engine = graph::GraphEngine::compile(artifact->core, context);
+            engine->set_worker_count(static_cast<std::size_t>(
+                budgets.value("max_parallel_workers", 4)));
+
+            graph::RunConfig run_config;
+            run_config.thread_id = run->id;
+            run_config.input = {{"task", artifact->request["task"]}};
+            run_config.max_steps = budgets.value("max_steps", 40);
+            run_config.cancel_token = run->cancel;
+            auto graph_result = engine->run(run_config);
+
+            std::lock_guard lock(run->mutex);
+            if (graph_result.max_steps_exhausted()) {
+                run->status = "max_steps_exhausted";
+            } else {
+                run->status = "completed";
+                run->result = graph_result.channel_raw("final_result");
+                run->result["execution_trace"] = graph_result.execution_trace;
+            }
+        } catch (const graph::CancelledException& error) {
+            std::lock_guard lock(run->mutex);
+            run->status = timed_out.load(std::memory_order_acquire)
+                ? "timeout" : "cancelled";
+            run->error = error.what();
+        } catch (const std::exception& error) {
+            std::lock_guard lock(run->mutex);
+            run->status = "failed";
+            run->error = error.what();
+        } catch (...) {
+            std::lock_guard lock(run->mutex);
+            run->status = "failed";
+            run->error = "unknown Harness execution failure";
+        }
+
+        {
+            std::lock_guard lock(timer_mutex);
+            done = true;
+            timer_cv.notify_all();
+        }
+        timer.join();
+    }
+
+    HarnessServiceConfig config;
+    std::uint64_t nonce;
+    std::atomic<std::uint64_t> next_id{1};
+    mutable std::mutex mutex;
+    std::map<std::string, std::shared_ptr<Artifact>> artifacts_by_id;
+    std::map<std::string, std::shared_ptr<Run>> runs;
+    std::vector<std::thread> threads;
+};
+
+HarnessService::HarnessService(HarnessServiceConfig config)
+    : impl_(std::make_unique<Impl>(std::move(config))) {}
+
+HarnessService::~HarnessService() = default;
+
+json HarnessService::schema() const {
+    json executor_kinds = json::array({
+        {{"kind", "builtin"}, {"availability", "binding-only-in-m2"}},
+        {{"kind", "mcp"}, {"availability", "binding-only-in-m2"}},
+        {{"kind", "a2a"}, {"availability", "binding-only-in-m2"}},
+        {{"kind", "host_brokered"}, {"availability", "requires-neograph-resume-m4"}},
+        {{"kind", "script"}, {"availability", "disabled"}},
+    });
+    const auto request = harness_request_schema();
+    return {
+        {"protocol_version", MCP_PROTOCOL_VERSION},
+        {"service", "neograph-harness-m2"},
+        {"presets", json::array({"fanout_judge"})},
+        {"executor_kinds", std::move(executor_kinds)},
+        {"request_schema", request},
+        {"schemas", {
+            {"request", request},
+            {"worker", request["properties"]["workers"]["items"]},
+            {"tool_catalog_entry", request["properties"]["tool_catalog"]["items"]},
+            {"budgets", request["properties"]["budgets"]},
+            {"worker_result", worker_result_schema()},
+            {"run_snapshot", run_snapshot_schema()},
+        }},
+        {"node_palette", graph::NodeFactory::instance().export_schema()},
+        {"capabilities", {
+            {"strict_core", true},
+            {"translation_validation", true},
+            {"semantic_validation", true},
+            {"binding_validation", true},
+            {"bounded_worker_repair", true},
+            {"durable_runs", false},
+        }},
+    };
+}
+
+json HarnessService::compile(const json& request) {
+    return impl_->compile_request(request, true);
+}
+
+json HarnessService::start(const json& arguments) {
+    if (!arguments.is_object()) {
+        throw std::invalid_argument("neograph_start arguments must be an object");
+    }
+    std::string artifact_id;
+    if (arguments.contains("request")) {
+        if (arguments.contains("artifact_id")) {
+            throw std::invalid_argument(
+                "neograph_start accepts exactly one of artifact_id or request");
+        }
+        auto compiled = impl_->compile_request(arguments["request"], true);
+        if (!compiled.value("ok", false)) {
+            return {
+                {"started", false},
+                {"status", "compile_failed"},
+                {"diagnostics", compiled["diagnostics"]},
+                {"artifacts", compiled["artifacts"]},
+            };
+        }
+        artifact_id = compiled["artifact_id"].get<std::string>();
+    } else if (arguments.contains("artifact_id")
+               && arguments["artifact_id"].is_string()) {
+        artifact_id = arguments["artifact_id"].get<std::string>();
+    } else {
+        throw std::invalid_argument(
+            "neograph_start requires artifact_id or request");
+    }
+
+    std::shared_ptr<Impl::Artifact> artifact;
+    auto run = std::make_shared<Impl::Run>();
+    {
+        std::lock_guard lock(impl_->mutex);
+        auto artifact_it = impl_->artifacts_by_id.find(artifact_id);
+        if (artifact_it == impl_->artifacts_by_id.end()) {
+            throw std::invalid_argument("unknown Harness artifact_id: " + artifact_id);
+        }
+        if (impl_->runs.size() >= impl_->config.max_runs) {
+            throw std::runtime_error("Harness run capacity is exhausted");
+        }
+        artifact = artifact_it->second;
+        run->id = impl_->id("run");
+        run->artifact_id = artifact_id;
+        impl_->runs[run->id] = run;
+        try {
+            impl_->threads.emplace_back([impl = impl_.get(), run, artifact] {
+                impl->execute(run, artifact);
+            });
+        } catch (...) {
+            impl_->runs.erase(run->id);
+            throw;
+        }
+    }
+    return {
+        {"started", true},
+        {"run_id", run->id},
+        {"artifact_id", artifact_id},
+        {"status", "queued"},
+    };
+}
+
+json HarnessService::get(const std::string& run_id) const {
+    std::shared_ptr<Impl::Run> run;
+    {
+        std::lock_guard lock(impl_->mutex);
+        auto it = impl_->runs.find(run_id);
+        if (it == impl_->runs.end()) {
+            throw std::invalid_argument("unknown Harness run_id: " + run_id);
+        }
+        run = it->second;
+    }
+    std::lock_guard lock(run->mutex);
+    json snapshot = {
+        {"run_id", run->id},
+        {"artifact_id", run->artifact_id},
+        {"status", run->status},
+    };
+    if (!run->result.is_null()) snapshot["result"] = run->result;
+    if (!run->error.empty()) snapshot["error"] = run->error;
+    return snapshot;
+}
+
+bool HarnessService::cancel(const std::string& run_id) {
+    std::shared_ptr<Impl::Run> run;
+    {
+        std::lock_guard lock(impl_->mutex);
+        auto it = impl_->runs.find(run_id);
+        if (it == impl_->runs.end()) return false;
+        run = it->second;
+    }
+    {
+        std::lock_guard lock(run->mutex);
+        if (run->status != "queued" && run->status != "running") return false;
+    }
+    run->cancel->cancel();
+    return true;
+}
+
+void HarnessService::register_tools(MCPServer& server) {
+    server.register_tool(tool_definition(
+        "neograph_schema", "NeoGraph Harness schema",
+        "Return build-specific Harness request schemas, presets, executor kinds, and node palette.",
+        json::parse(R"JSON({"type":"object","properties":{},"additionalProperties":false})JSON"),
+        json::parse(R"JSON({"type":"object","required":["service","request_schema","node_palette"],"properties":{"service":{"type":"string"},"request_schema":{"type":"object"},"node_palette":{"type":"object"}},"additionalProperties":true})JSON"), true),
+        [this](const json&, const auto&) {
+            auto value = schema();
+            return mcp_result(std::move(value), "NeoGraph Harness M2 schema");
+        });
+
+    server.register_tool(tool_definition(
+        "neograph_compile", "Compile Harness",
+        "Elaborate, strict-compile, translation-validate, semantic-validate, and binding-validate a Harness request.",
+        harness_request_schema(), compile_output_schema()),
+        [this](const json& arguments, const auto&) {
+            auto value = compile(arguments);
+            const auto text = value.value("ok", false)
+                ? "Harness compiled: " + value.value("artifact_id", "")
+                : "Harness rejected by compiler diagnostics";
+            return mcp_result(std::move(value), text);
+        });
+
+    server.register_tool(tool_definition(
+        "neograph_start", "Start Harness",
+        "Start a retained artifact or compile-and-start an inline Harness request.",
+        json::parse(R"JSON({"type":"object","properties":{"artifact_id":{"type":"string"},"request":{"type":"object"}},"additionalProperties":false})JSON"),
+        json::parse(R"JSON({"type":"object","required":["started","status"],"properties":{"started":{"type":"boolean"},"run_id":{"type":"string"},"artifact_id":{"type":"string"},"status":{"type":"string"},"diagnostics":{"type":"array"},"artifacts":{"type":"object"}},"additionalProperties":true})JSON")),
+        [this](const json& arguments, const auto&) {
+            auto value = start(arguments);
+            const auto text = value.value("started", false)
+                ? "Harness started: " + value.value("run_id", "")
+                : "Harness did not start";
+            return mcp_result(std::move(value), text);
+        });
+
+    server.register_tool(tool_definition(
+        "neograph_get", "Get Harness run",
+        "Read compact run status, result, and failure classification.",
+        json::parse(R"JSON({"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string"}},"additionalProperties":false})JSON"),
+        run_snapshot_schema(), true),
+        [this](const json& arguments, const auto&) {
+            auto value = get(arguments["run_id"].get<std::string>());
+            const auto text = "Harness run " + value.value("run_id", "")
+                + ": " + value.value("status", "unknown");
+            return mcp_result(std::move(value), text);
+        });
+
+    server.register_tool(tool_definition(
+        "neograph_cancel", "Cancel Harness run",
+        "Cooperatively cancel a queued or running Harness run.",
+        json::parse(R"JSON({"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string"}},"additionalProperties":false})JSON"),
+        json::parse(R"JSON({"type":"object","required":["run_id","cancelled"],"properties":{"run_id":{"type":"string"},"cancelled":{"type":"boolean"}},"additionalProperties":false})JSON")),
+        [this](const json& arguments, const auto&) {
+            const auto run_id = arguments["run_id"].get<std::string>();
+            const bool accepted = cancel(run_id);
+            json value = {{"run_id", run_id}, {"cancelled", accepted}};
+            return mcp_result(std::move(value), accepted
+                ? "Harness cancellation requested" : "Harness run is unknown or terminal");
+        });
+}
+
+} // namespace neograph::mcp

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -1,20 +1,23 @@
-#include <neograph/mcp/harness.h>
-
 #include <neograph/graph/compiler.h>
 #include <neograph/graph/elaborator.h>
 #include <neograph/graph/engine.h>
 #include <neograph/graph/loader.h>
 #include <neograph/graph/node.h>
 #include <neograph/graph/validator.h>
+#include <neograph/mcp/harness.h>
 #include <neograph/mcp/json_schema.h>
 #include <neograph/mcp/server.h>
 #include <neograph/provider.h>
 
 #include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
 #include <iomanip>
 #include <map>
 #include <mutex>
@@ -28,11 +31,115 @@
 #include <utility>
 #include <vector>
 
+#ifdef _WIN32
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#endif
+
 namespace neograph::mcp {
 namespace {
 
 constexpr const char* kWorkerNodeType = "neograph_harness_worker";
 constexpr const char* kJudgeNodeType = "neograph_harness_judge";
+constexpr const char* kTasksExtension = "io.modelcontextprotocol/tasks";
+
+int64_t unix_millis() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+std::string iso8601(int64_t millis) {
+    const auto seconds = static_cast<std::time_t>(millis / 1000);
+    std::tm    utc{};
+#ifdef _WIN32
+    gmtime_s(&utc, &seconds);
+#else
+    gmtime_r(&seconds, &utc);
+#endif
+    std::ostringstream out;
+    out << std::put_time(&utc, "%Y-%m-%dT%H:%M:%S") << '.' << std::setfill('0') << std::setw(3)
+        << (millis % 1000) << 'Z';
+    return out.str();
+}
+
+bool tasks_requested(const json& meta) {
+    if (!meta.is_object()) return false;
+    const auto capabilities =
+        meta.value("io.modelcontextprotocol/clientCapabilities", json::object());
+    return capabilities.is_object() &&
+           capabilities.value("extensions", json::object()).contains(kTasksExtension);
+}
+
+void require_tasks_negotiated(const json& context) {
+    if (!context.is_object() ||
+        !context.value("extensions", json::object()).contains(kTasksExtension)) {
+        throw std::invalid_argument("MCP Tasks extension was not negotiated during initialize");
+    }
+}
+
+json task_from_snapshot(const json& snapshot, bool creation = false) {
+    const auto  harness_status = snapshot.value("status", "failed");
+    std::string status         = "working";
+    if (harness_status == "awaiting_tool_results" || harness_status == "input_required")
+        status = "input_required";
+    else if (harness_status == "completed")
+        status = "completed";
+    else if (harness_status == "cancelled")
+        status = "cancelled";
+    else if (harness_status != "queued" && harness_status != "running") {
+        status = "failed";
+    }
+    const auto created = snapshot.value("created_at", int64_t{0});
+    const auto updated = snapshot.value("updated_at", created);
+    const auto expires = snapshot.value("expires_at", int64_t{0});
+    json       task    = {
+        {"resultType", creation ? "task" : "complete"},
+        {"taskId", snapshot.at("run_id")},
+        {"status", status},
+        {"createdAt", iso8601(created)},
+        {"lastUpdatedAt", iso8601(updated)},
+        {"ttlMs", expires > 0 ? json(expires - created) : json(nullptr)},
+        {"pollIntervalMs", snapshot.value("poll_after_ms", int64_t{1000})},
+    };
+    if (status == "input_required") {
+        const auto pending    = snapshot.at("pending");
+        task["statusMessage"] = harness_status == "input_required"
+                                    ? "Harness worker requires host input"
+                                    : "Harness worker awaits a host-brokered tool result";
+        task["inputRequests"] = {
+            {pending.at("call_id").get<std::string>(),
+             {
+                 {"method", "elicitation/create"},
+                 {"params",
+                  {
+                      {"message",
+                       "Provide result for " + pending.value("tool_id", "host capability")},
+                      {"requestedSchema", pending.value("result_schema", json::object())},
+                      {"_meta",
+                       {
+                           {"toolId", pending.value("tool_id", "")},
+                           {"arguments", pending.value("arguments", json::object())},
+                       }},
+                  }},
+             }},
+        };
+    } else if (status == "completed") {
+        CallToolResult result;
+        result.content = json::array({{{"type", "text"}, {"text", "Harness run completed"}}});
+        result.structured_content = snapshot;
+        task["result"]            = result.to_json();
+    } else if (status == "failed") {
+        task["statusMessage"] = snapshot.value("error", "Harness run did not complete");
+        task["error"]         = {
+            {"code", -32000},
+            {"message", task["statusMessage"]},
+        };
+    }
+    return task;
+}
 
 json harness_request_schema() {
     return json::parse(R"JSON({
@@ -65,7 +172,8 @@ json harness_request_schema() {
                     "kind":{"enum":["builtin","mcp","a2a","host_brokered","script"]},
                     "tool":{"type":"string"},
                     "server_ref":{"type":"string"},
-                    "agent":{"type":"string"}
+                    "agent":{"type":"string"},
+                    "interaction":{"enum":["tool_result","input"]}
                 },"additionalProperties":true}
             },"additionalProperties":false}},
             "budgets":{"type":"object","properties":{
@@ -123,18 +231,18 @@ json worker_result_schema() {
     })JSON");
 }
 
-json make_diagnostic(std::string phase, std::string code,
-                     std::string severity, std::string path,
-                     std::string message, json witness = json::object(),
-                     std::string source = {}) {
+json make_diagnostic(std::string phase,
+                     std::string code,
+                     std::string severity,
+                     std::string path,
+                     std::string message,
+                     json        witness = json::object(),
+                     std::string source  = {}) {
     if (source.empty()) source = path;
     json value = {
-        {"phase", std::move(phase)},
-        {"code", std::move(code)},
-        {"severity", std::move(severity)},
-        {"path", std::move(path)},
-        {"message", std::move(message)},
-        {"witness", std::move(witness)},
+        {"phase", std::move(phase)},       {"code", std::move(code)},
+        {"severity", std::move(severity)}, {"path", std::move(path)},
+        {"message", std::move(message)},   {"witness", std::move(witness)},
         {"source", std::move(source)},
     };
     return value;
@@ -151,10 +259,8 @@ std::string diagnostic_pointer(std::string path) {
     constexpr const char* definition_prefix = "$.harness.definition.";
     if (path.rfind(definition_prefix, 0) == 0) {
         path.erase(0, std::char_traits<char>::length(definition_prefix));
-    } else if (path.rfind("nodes.", 0) != 0
-               && path.rfind("channels.", 0) != 0
-               && path.rfind("edges", 0) != 0
-               && path.rfind("conditional_edges", 0) != 0) {
+    } else if (path.rfind("nodes.", 0) != 0 && path.rfind("channels.", 0) != 0 &&
+               path.rfind("edges", 0) != 0 && path.rfind("conditional_edges", 0) != 0) {
         return {};
     }
     std::replace(path.begin(), path.end(), '.', '/');
@@ -185,12 +291,22 @@ void attach_elaborator_sources(json& diagnostics, const json& sourcemap) {
 
 std::string response_kind_name(HarnessWorkerResponseKind kind) {
     switch (kind) {
-    case HarnessWorkerResponseKind::VALUE: return "value";
-    case HarnessWorkerResponseKind::EMPTY: return "empty_response";
-    case HarnessWorkerResponseKind::PARSE_ERROR: return "parse_error";
-    case HarnessWorkerResponseKind::TOOL_ERROR: return "tool_error";
-    case HarnessWorkerResponseKind::TIMEOUT: return "timeout";
-    case HarnessWorkerResponseKind::CANCELLED: return "cancelled";
+        case HarnessWorkerResponseKind::VALUE:
+            return "value";
+        case HarnessWorkerResponseKind::EMPTY:
+            return "empty_response";
+        case HarnessWorkerResponseKind::PARSE_ERROR:
+            return "parse_error";
+        case HarnessWorkerResponseKind::TOOL_ERROR:
+            return "tool_error";
+        case HarnessWorkerResponseKind::TIMEOUT:
+            return "timeout";
+        case HarnessWorkerResponseKind::CANCELLED:
+            return "cancelled";
+        case HarnessWorkerResponseKind::AWAITING_TOOL_RESULTS:
+            return "awaiting_tool_results";
+        case HarnessWorkerResponseKind::INPUT_REQUIRED:
+            return "input_required";
     }
     return "unknown";
 }
@@ -205,13 +321,14 @@ public:
         for (const auto& tool : request_.value("tool_catalog", json::array())) {
             tools_[tool["id"].get<std::string>()] = tool;
         }
-        max_retries_ = request_.value("budgets", json::object())
-                           .value("max_worker_retries", 1);
+        max_retries_ = request_.value("budgets", json::object()).value("max_worker_retries", 1);
     }
 
     std::string get_name() const override { return "harness-worker-executor"; }
 
-    json execute(const std::string& worker_id, const json& task,
+    json execute(const std::string&                         worker_id,
+                 const json&                                task,
+                 const std::optional<json>&                 resume_value,
                  const std::shared_ptr<graph::CancelToken>& cancel) const {
         const auto worker_it = workers_.find(worker_id);
         if (worker_it == workers_.end()) {
@@ -238,31 +355,41 @@ public:
             call.policy = request_.value("policy", json::object());
             call.attempt = static_cast<std::size_t>(attempt + 1);
             call.repair_feedback = feedback;
+            call.resume_value    = resume_value;
 
             HarnessWorkerResponse response;
             if (!executor_) {
-                response = HarnessWorkerResponse::tool_error(
-                    "no Harness worker executor is configured");
+                response =
+                    HarnessWorkerResponse::tool_error("no Harness worker executor is configured");
             } else {
                 response = executor_(call, cancel);
             }
 
             if (response.kind == HarnessWorkerResponseKind::CANCELLED) {
-                throw graph::CancelledException(response.message.empty()
-                    ? "Harness worker cancelled" : response.message);
+                throw graph::CancelledException(
+                    response.message.empty() ? "Harness worker cancelled" : response.message);
+            }
+
+            if (response.kind == HarnessWorkerResponseKind::AWAITING_TOOL_RESULTS ||
+                response.kind == HarnessWorkerResponseKind::INPUT_REQUIRED) {
+                auto pending     = response.value;
+                pending["state"] = response_kind_name(response.kind);
+                throw graph::NodeInterrupt(
+                    response.kind == HarnessWorkerResponseKind::INPUT_REQUIRED
+                        ? "Harness worker requires host input"
+                        : "Harness worker awaits host-brokered tool results",
+                    std::move(pending));
             }
 
             if (response.kind == HarnessWorkerResponseKind::VALUE) {
-                if (response.value.is_null()
-                    || (response.value.is_string()
-                        && response.value.get<std::string>().empty())) {
+                if (response.value.is_null() ||
+                    (response.value.is_string() && response.value.get<std::string>().empty())) {
                     failure_kind = "empty_response";
                     feedback = "worker returned an empty response";
                 } else {
                     try {
-                        validate_json_value(response.value,
-                            worker_it->second["output_schema"],
-                            "Harness worker output", "$");
+                        validate_json_value(response.value, worker_it->second["output_schema"],
+                                            "Harness worker output", "$");
                         return {
                             {"worker_id", worker_id},
                             {"status", "valid"},
@@ -277,19 +404,16 @@ public:
             } else {
                 failure_kind = response_kind_name(response.kind);
                 feedback = response.message.empty() ? failure_kind : response.message;
-                if (response.kind == HarnessWorkerResponseKind::TIMEOUT
-                    || response.kind == HarnessWorkerResponseKind::TOOL_ERROR) {
+                if (response.kind == HarnessWorkerResponseKind::TIMEOUT ||
+                    response.kind == HarnessWorkerResponseKind::TOOL_ERROR) {
                     break;
                 }
             }
         }
 
         return {
-            {"worker_id", worker_id},
-            {"status", "failed"},
-            {"failure_kind", failure_kind},
-            {"message", feedback},
-            {"attempts", attempts_made},
+            {"worker_id", worker_id}, {"status", "failed"},        {"failure_kind", failure_kind},
+            {"message", feedback},    {"attempts", attempts_made},
         };
     }
 
@@ -303,15 +427,16 @@ private:
 
 class HarnessWorkerNode final : public graph::GraphNode {
 public:
-    HarnessWorkerNode(std::string name, std::string worker_id,
+    HarnessWorkerNode(std::string                             name,
+                      std::string                             worker_id,
                       std::shared_ptr<HarnessRuntimeProvider> runtime)
-        : name_(std::move(name)), worker_id_(std::move(worker_id)),
-          runtime_(std::move(runtime)) {}
+        : name_(std::move(name)), worker_id_(std::move(worker_id)), runtime_(std::move(runtime)) {}
 
     asio::awaitable<graph::NodeOutput> run(graph::NodeInput in) override {
         auto cancel = in.ctx.cancel_token;
         if (!cancel) cancel = std::make_shared<graph::CancelToken>();
-        auto result = runtime_->execute(worker_id_, in.state.get("task"), cancel);
+        auto result =
+            runtime_->execute(worker_id_, in.state.get("task"), in.ctx.resume_value, cancel);
         graph::NodeOutput output;
         output.writes.push_back({"worker_results", std::move(result)});
         co_return output;
@@ -332,7 +457,8 @@ public:
     asio::awaitable<graph::NodeOutput> run(graph::NodeInput in) override {
         std::vector<json> workers;
         const auto results = in.state.get("worker_results");
-        for (const auto& result : results) workers.push_back(result);
+        for (const auto& result : results)
+            workers.push_back(result);
         std::sort(workers.begin(), workers.end(), [](const json& lhs, const json& rhs) {
             return lhs.value("worker_id", "") < rhs.value("worker_id", "");
         });
@@ -368,9 +494,12 @@ public:
         }
 
         std::string outcome = "ok";
-        if (valid == 0 && failed > 0) outcome = "failed";
-        else if (failed > 0 || partial) outcome = "partial";
-        else if (findings_contract && findings.empty()) outcome = "zero_findings";
+        if (valid == 0 && failed > 0)
+            outcome = "failed";
+        else if (failed > 0 || partial)
+            outcome = "partial";
+        else if (findings_contract && findings.empty())
+            outcome = "zero_findings";
 
         json result = {
             {"outcome", outcome},
@@ -393,7 +522,8 @@ private:
 void register_harness_node_types() {
     static std::once_flag once;
     std::call_once(once, [] {
-        graph::NodeFactory::instance().register_type(kWorkerNodeType,
+        graph::NodeFactory::instance().register_type(
+            kWorkerNodeType,
             [](const std::string& name, const json& config,
                const graph::NodeContext& ctx) -> std::unique_ptr<graph::GraphNode> {
                 auto runtime = std::dynamic_pointer_cast<HarnessRuntimeProvider>(ctx.provider);
@@ -404,15 +534,18 @@ void register_harness_node_types() {
                 return std::make_unique<HarnessWorkerNode>(
                     name, config.at("worker_id").get<std::string>(), std::move(runtime));
             },
-            json::parse(R"JSON({"type":"object","required":["worker_id"],"properties":{"worker_id":{"type":"string"}},"additionalProperties":false})JSON"),
+            json::parse(
+                R"JSON({"type":"object","required":["worker_id"],"properties":{"worker_id":{"type":"string"}},"additionalProperties":false})JSON"),
             json::parse(R"JSON({"reads":["task"],"writes":["worker_results"]})JSON"));
 
-        graph::NodeFactory::instance().register_type(kJudgeNodeType,
+        graph::NodeFactory::instance().register_type(
+            kJudgeNodeType,
             [](const std::string& name, const json&,
                const graph::NodeContext&) -> std::unique_ptr<graph::GraphNode> {
                 return std::make_unique<HarnessJudgeNode>(name);
             },
-            json::parse(R"JSON({"type":"object","properties":{},"additionalProperties":false})JSON"),
+            json::parse(
+                R"JSON({"type":"object","properties":{},"additionalProperties":false})JSON"),
             json::parse(R"JSON({"reads":["worker_results"],"writes":["final_result"]})JSON"));
     });
 }
@@ -421,11 +554,12 @@ json preset_fanout_judge(const json& request, const std::string& preset) {
     json core = {
         {"schema_version", 1},
         {"name", "harness_" + preset},
-        {"channels", {
-            {"task", {{"reducer", "overwrite"}, {"initial", json::object()}}},
-            {"worker_results", {{"reducer", "append"}, {"initial", json::array()}}},
-            {"final_result", {{"reducer", "overwrite"}, {"initial", nullptr}}},
-        }},
+        {"channels",
+         {
+             {"task", {{"reducer", "overwrite"}, {"initial", json::object()}}},
+             {"worker_results", {{"reducer", "append"}, {"initial", json::array()}}},
+             {"final_result", {{"reducer", "overwrite"}, {"initial", nullptr}}},
+         }},
         {"nodes", json::object()},
         {"edges", json::array()},
     };
@@ -450,31 +584,36 @@ json preset_fanout_judge(const json& request, const std::string& preset) {
     return core;
 }
 
-void validate_range(const json& budgets, const char* name, int minimum,
-                    int maximum, int default_value, json& diagnostics) {
+void validate_range(const json& budgets,
+                    const char* name,
+                    int         minimum,
+                    int         maximum,
+                    int         default_value,
+                    json&       diagnostics) {
     const int value = budgets.value(name, default_value);
     if (value < minimum || value > maximum) {
-        diagnostics.push_back(make_diagnostic("request", "H_REQUEST_BUDGET",
-            "error", std::string("$.budgets.") + name,
-            std::string(name) + " must be between " + std::to_string(minimum)
-                + " and " + std::to_string(maximum),
+        diagnostics.push_back(make_diagnostic(
+            "request", "H_REQUEST_BUDGET", "error", std::string("$.budgets.") + name,
+            std::string(name) + " must be between " + std::to_string(minimum) + " and " +
+                std::to_string(maximum),
             {{"value", value}, {"minimum", minimum}, {"maximum", maximum}}));
     }
 }
 
-void validate_bindings(const json& request, const json& core,
-                       json& diagnostics) {
+void validate_bindings(const json& request,
+                       const json& core,
+                       bool        durable_resume_available,
+                       json&       diagnostics) {
     std::map<std::string, json> workers;
     std::map<std::string, json> tools;
     std::set<std::string> duplicates;
 
-    for (const auto& root : request.value("policy", json::object())
-                                .value("workspace_roots", json::array())) {
+    for (const auto& root :
+         request.value("policy", json::object()).value("workspace_roots", json::array())) {
         if (root.get<std::string>().empty()) {
-            diagnostics.push_back(make_diagnostic(
-                "binding", "H_WORKSPACE_ROOT", "error",
-                "$.policy.workspace_roots",
-                "workspace roots must not contain empty paths"));
+            diagnostics.push_back(make_diagnostic("binding", "H_WORKSPACE_ROOT", "error",
+                                                  "$.policy.workspace_roots",
+                                                  "workspace roots must not contain empty paths"));
         }
     }
 
@@ -483,29 +622,28 @@ void validate_bindings(const json& request, const json& core,
         const auto id = worker.value("id", "");
         const auto path = "$.workers[" + std::to_string(index++) + "]";
         if (id.empty()) {
-            diagnostics.push_back(make_diagnostic("binding", "H_WORKER_ID",
-                "error", path + ".id", "worker id must not be empty"));
+            diagnostics.push_back(make_diagnostic("binding", "H_WORKER_ID", "error", path + ".id",
+                                                  "worker id must not be empty"));
             continue;
         }
         if (!workers.emplace(id, worker).second) duplicates.insert(id);
         try {
             validate_json_schema(worker["output_schema"], path + ".output_schema");
         } catch (const std::exception& error) {
-            diagnostics.push_back(make_diagnostic("binding", "H_WORKER_SCHEMA",
-                "error", path + ".output_schema", error.what()));
+            diagnostics.push_back(make_diagnostic("binding", "H_WORKER_SCHEMA", "error",
+                                                  path + ".output_schema", error.what()));
         }
     }
     for (const auto& id : duplicates) {
-        diagnostics.push_back(make_diagnostic("binding", "H_DUPLICATE_WORKER",
-            "error", "$.workers", "duplicate worker id: " + id, {{"id", id}}));
+        diagnostics.push_back(make_diagnostic("binding", "H_DUPLICATE_WORKER", "error", "$.workers",
+                                              "duplicate worker id: " + id, {{"id", id}}));
     }
 
-    const auto evidence_required = request.value("policy", json::object())
-                                       .value("evidence_required", json::array());
+    const auto evidence_required =
+        request.value("policy", json::object()).value("evidence_required", json::array());
     if (!evidence_required.empty()) {
         for (const auto& [id, worker] : workers) {
-            const auto properties = worker["output_schema"].value(
-                "properties", json::object());
+            const auto properties = worker["output_schema"].value("properties", json::object());
             const auto findings = properties.value("findings", json::object());
             const auto item = findings.value("items", json::object());
             const auto item_properties = item.value("properties", json::object());
@@ -535,9 +673,9 @@ void validate_bindings(const json& request, const json& core,
         const auto id = tool.value("id", "");
         const auto path = "$.tool_catalog[" + std::to_string(index++) + "]";
         if (id.empty() || !tools.emplace(id, tool).second) {
-            diagnostics.push_back(make_diagnostic("binding", "H_DUPLICATE_TOOL",
-                "error", path + ".id", id.empty() ? "tool id must not be empty"
-                                                    : "duplicate tool id: " + id));
+            diagnostics.push_back(make_diagnostic(
+                "binding", "H_DUPLICATE_TOOL", "error", path + ".id",
+                id.empty() ? "tool id must not be empty" : "duplicate tool id: " + id));
         }
         try {
             validate_json_schema(tool["input_schema"], path + ".input_schema");
@@ -545,58 +683,55 @@ void validate_bindings(const json& request, const json& core,
                 validate_json_schema(tool["output_schema"], path + ".output_schema");
             }
         } catch (const std::exception& error) {
-            diagnostics.push_back(make_diagnostic("binding", "H_TOOL_SCHEMA",
-                "error", path, error.what()));
+            diagnostics.push_back(
+                make_diagnostic("binding", "H_TOOL_SCHEMA", "error", path, error.what()));
         }
 
         for (const auto& argument_json : tool.value("path_arguments", json::array())) {
             const auto argument = argument_json.get<std::string>();
-            const auto properties = tool["input_schema"].value(
-                "properties", json::object());
-            if (!properties.contains(argument)
-                || properties[argument].value("type", "") != "string") {
-                diagnostics.push_back(make_diagnostic(
-                    "binding", "H_PATH_ARGUMENT", "error",
-                    path + ".path_arguments",
-                    "path_arguments must name string properties in input_schema",
-                    {{"tool_id", id}, {"argument", argument}}));
+            const auto properties = tool["input_schema"].value("properties", json::object());
+            if (!properties.contains(argument) ||
+                properties[argument].value("type", "") != "string") {
+                diagnostics.push_back(
+                    make_diagnostic("binding", "H_PATH_ARGUMENT", "error", path + ".path_arguments",
+                                    "path_arguments must name string properties in input_schema",
+                                    {{"tool_id", id}, {"argument", argument}}));
             }
         }
 
         const auto executor = tool.value("executor", json::object());
         const auto kind = executor.value("kind", "");
         if (kind == "mcp" && executor.value("server_ref", "").empty()) {
-            diagnostics.push_back(make_diagnostic("binding", "H_MCP_UNRESOLVED",
-                "error", path + ".executor.server_ref",
-                "mcp executor requires a resolvable server_ref"));
+            diagnostics.push_back(make_diagnostic("binding", "H_MCP_UNRESOLVED", "error",
+                                                  path + ".executor.server_ref",
+                                                  "mcp executor requires a resolvable server_ref"));
         } else if (kind == "a2a" && executor.value("agent", "").empty()) {
-            diagnostics.push_back(make_diagnostic("binding", "H_A2A_UNRESOLVED",
-                "error", path + ".executor.agent",
-                "a2a executor requires an agent identifier"));
-        } else if (kind == "host_brokered") {
-            diagnostics.push_back(make_diagnostic("binding", "H_HOST_BROKER_UNAVAILABLE",
-                "error", path + ".executor.kind",
-                "host_brokered tools require neograph_resume, planned for M4"));
+            diagnostics.push_back(make_diagnostic("binding", "H_A2A_UNRESOLVED", "error",
+                                                  path + ".executor.agent",
+                                                  "a2a executor requires an agent identifier"));
+        } else if (kind == "host_brokered" && !durable_resume_available) {
+            diagnostics.push_back(make_diagnostic(
+                "binding", "H_HOST_BROKER_UNAVAILABLE", "error", path + ".executor.kind",
+                "host_brokered tools require both checkpoint_store and record_store"));
         } else if (kind == "script") {
-            diagnostics.push_back(make_diagnostic("binding", "H_SCRIPT_DISABLED",
-                "error", path + ".executor.kind",
-                "script executors are disabled by default"));
+            diagnostics.push_back(make_diagnostic("binding", "H_SCRIPT_DISABLED", "error",
+                                                  path + ".executor.kind",
+                                                  "script executors are disabled by default"));
         }
 
-        const bool read_only = request.value("policy", json::object())
-                                   .value("read_only", false);
+        const bool read_only = request.value("policy", json::object()).value("read_only", false);
         if (read_only && !tool.value("read_only", false)) {
-            diagnostics.push_back(make_diagnostic("binding", "H_WRITE_TOOL",
-                "error", path, "read-only harness contains a write-capable tool",
-                {{"tool_id", id}}));
+            diagnostics.push_back(make_diagnostic("binding", "H_WRITE_TOOL", "error", path,
+                                                  "read-only harness contains a write-capable tool",
+                                                  {{"tool_id", id}}));
         }
-        if (!tool.value("path_arguments", json::array()).empty()
-            && request.value("policy", json::object())
-                   .value("workspace_roots", json::array()).empty()) {
+        if (!tool.value("path_arguments", json::array()).empty() &&
+            request.value("policy", json::object())
+                .value("workspace_roots", json::array())
+                .empty()) {
             diagnostics.push_back(make_diagnostic(
                 "binding", "H_WORKSPACE_ROOT", "error", path,
-                "path-bearing tools require policy.workspace_roots",
-                {{"tool_id", id}}));
+                "path-bearing tools require policy.workspace_roots", {{"tool_id", id}}));
         }
     }
 
@@ -604,10 +739,10 @@ void validate_bindings(const json& request, const json& core,
         for (const auto& tool_id_json : worker.value("tools", json::array())) {
             const auto tool_id = tool_id_json.get<std::string>();
             if (tools.find(tool_id) == tools.end()) {
-                diagnostics.push_back(make_diagnostic("binding", "H_UNKNOWN_TOOL",
-                    "error", "$.workers." + id + ".tools",
-                    "worker references unknown tool: " + tool_id,
-                    {{"worker_id", id}, {"tool_id", tool_id}}));
+                diagnostics.push_back(make_diagnostic("binding", "H_UNKNOWN_TOOL", "error",
+                                                      "$.workers." + id + ".tools",
+                                                      "worker references unknown tool: " + tool_id,
+                                                      {{"worker_id", id}, {"tool_id", tool_id}}));
             }
         }
     }
@@ -621,16 +756,18 @@ void validate_bindings(const json& request, const json& core,
                 const auto worker_id = node.value("worker_id", "");
                 ++topology_workers[worker_id];
                 if (workers.find(worker_id) == workers.end()) {
-                    diagnostics.push_back(make_diagnostic("binding", "H_UNKNOWN_WORKER",
-                        "error", "$.harness.definition.nodes." + node_name,
-                        "topology references unknown worker: " + worker_id,
-                        {{"node", node_name}, {"worker_id", worker_id}}));
+                    diagnostics.push_back(
+                        make_diagnostic("binding", "H_UNKNOWN_WORKER", "error",
+                                        "$.harness.definition.nodes." + node_name,
+                                        "topology references unknown worker: " + worker_id,
+                                        {{"node", node_name}, {"worker_id", worker_id}}));
                 }
             } else if (type == kJudgeNodeType) {
                 ++judges;
             } else {
-                diagnostics.push_back(make_diagnostic("binding", "H_NODE_TYPE",
-                    "error", "$.harness.definition.nodes." + node_name + ".type",
+                diagnostics.push_back(make_diagnostic(
+                    "binding", "H_NODE_TYPE", "error",
+                    "$.harness.definition.nodes." + node_name + ".type",
                     "Harness DSL only permits compiler-backed worker and judge nodes",
                     {{"node", node_name}, {"type", type}}));
             }
@@ -639,17 +776,17 @@ void validate_bindings(const json& request, const json& core,
     for (const auto& [id, worker] : workers) {
         (void)worker;
         if (topology_workers[id] != 1) {
-            diagnostics.push_back(make_diagnostic("binding", "H_WORKER_BINDING",
-                "error", "$.harness.definition.nodes",
+            diagnostics.push_back(make_diagnostic(
+                "binding", "H_WORKER_BINDING", "error", "$.harness.definition.nodes",
                 "each declared worker must be bound exactly once",
                 {{"worker_id", id}, {"bindings", topology_workers[id]}}));
         }
     }
     if (judges != 1) {
-        diagnostics.push_back(make_diagnostic("binding", "H_JUDGE_BINDING",
-            "error", "$.harness.definition.nodes",
-            "fanout_judge topology requires exactly one result-reading judge",
-            {{"judges", judges}}));
+        diagnostics.push_back(
+            make_diagnostic("binding", "H_JUDGE_BINDING", "error", "$.harness.definition.nodes",
+                            "fanout_judge topology requires exactly one result-reading judge",
+                            {{"judges", judges}}));
     }
 }
 
@@ -660,9 +797,12 @@ CallToolResult mcp_result(json structured, std::string text) {
     return result;
 }
 
-ToolDefinition tool_definition(std::string name, std::string title,
-                               std::string description, json input, json output,
-                               bool read_only = false) {
+ToolDefinition tool_definition(std::string name,
+                               std::string title,
+                               std::string description,
+                               json        input,
+                               json        output,
+                               bool        read_only = false) {
     ToolDefinition definition;
     definition.name = std::move(name);
     definition.title = std::move(title);
@@ -694,6 +834,110 @@ HarnessWorkerResponse HarnessWorkerResponse::timeout(std::string message) {
 HarnessWorkerResponse HarnessWorkerResponse::cancelled(std::string message) {
     return {HarnessWorkerResponseKind::CANCELLED, nullptr, std::move(message)};
 }
+HarnessWorkerResponse HarnessWorkerResponse::awaiting_tool_results(json pending) {
+    return {HarnessWorkerResponseKind::AWAITING_TOOL_RESULTS, std::move(pending), {}};
+}
+HarnessWorkerResponse HarnessWorkerResponse::input_required(json pending) {
+    return {HarnessWorkerResponseKind::INPUT_REQUIRED, std::move(pending), {}};
+}
+
+struct FileHarnessRecordStore::Impl {
+    explicit Impl(std::string directory) : root(std::move(directory)) {
+        if (root.empty()) {
+            throw std::invalid_argument("FileHarnessRecordStore root directory must not be empty");
+        }
+        std::filesystem::create_directories(root / "artifacts");
+        std::filesystem::create_directories(root / "runs");
+    }
+
+    static void validate_id(const std::string& id) {
+        if (id.empty() || !std::all_of(id.begin(), id.end(), [](unsigned char c) {
+                return std::isalnum(c) || c == '-' || c == '_';
+            })) {
+            throw std::invalid_argument("invalid Harness record identifier");
+        }
+    }
+
+    std::filesystem::path path(const char* collection, const std::string& id) const {
+        validate_id(id);
+        return root / collection / (id + ".json");
+    }
+
+    void save(const char* collection, const std::string& id, const json& record) {
+        const auto                  target = path(collection, id);
+        std::lock_guard             lock(mutex);
+        const std::filesystem::path temporary =
+            target.string() + ".tmp." +
+            std::to_string(next_temp.fetch_add(1, std::memory_order_relaxed));
+        {
+            std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
+            if (!output) {
+                throw std::runtime_error("cannot open temporary Harness record: " +
+                                         temporary.string());
+            }
+            output << record.dump();
+            output.flush();
+            if (!output) {
+                throw std::runtime_error("cannot write temporary Harness record: " +
+                                         temporary.string());
+            }
+        }
+#ifdef _WIN32
+        if (!MoveFileExW(temporary.c_str(), target.c_str(),
+                         MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
+            const auto code = GetLastError();
+            std::filesystem::remove(temporary);
+            throw std::runtime_error("cannot commit Harness record (Windows error " +
+                                     std::to_string(code) + ")");
+        }
+#else
+        std::error_code error;
+        std::filesystem::rename(temporary, target, error);
+        if (error) {
+            std::filesystem::remove(temporary);
+            throw std::runtime_error("cannot commit Harness record: " + error.message());
+        }
+#endif
+    }
+
+    std::optional<json> load(const char* collection, const std::string& id) {
+        const auto      target = path(collection, id);
+        std::lock_guard lock(mutex);
+        std::ifstream   input(target, std::ios::binary);
+        if (!input) {
+            if (!std::filesystem::exists(target)) return std::nullopt;
+            throw std::runtime_error("cannot read Harness record: " + target.string());
+        }
+        std::ostringstream content;
+        content << input.rdbuf();
+        return json::parse(content.str());
+    }
+
+    std::filesystem::path      root;
+    std::mutex                 mutex;
+    std::atomic<std::uint64_t> next_temp{1};
+};
+
+FileHarnessRecordStore::FileHarnessRecordStore(std::string root_directory)
+    : impl_(std::make_unique<Impl>(std::move(root_directory))) {}
+
+FileHarnessRecordStore::~FileHarnessRecordStore() = default;
+
+void FileHarnessRecordStore::save_artifact(const std::string& artifact_id, const json& record) {
+    impl_->save("artifacts", artifact_id, record);
+}
+
+std::optional<json> FileHarnessRecordStore::load_artifact(const std::string& artifact_id) {
+    return impl_->load("artifacts", artifact_id);
+}
+
+void FileHarnessRecordStore::save_run(const std::string& run_id, const json& record) {
+    impl_->save("runs", run_id, record);
+}
+
+std::optional<json> FileHarnessRecordStore::load_run(const std::string& run_id) {
+    return impl_->load("runs", run_id);
+}
 
 struct HarnessService::Impl {
     struct Artifact {
@@ -711,13 +955,26 @@ struct HarnessService::Impl {
         std::string status = "queued";
         json result;
         json details;
+        json                                pending;
+        json                                consumed = json::object();
+        json                                resume_value;
+        bool                                resume_scheduled = false;
         std::string error;
-        std::shared_ptr<graph::CancelToken> cancel =
-            std::make_shared<graph::CancelToken>();
+        int64_t                             created_at = unix_millis();
+        int64_t                             updated_at = created_at;
+        int64_t                             expires_at = 0;
+        std::shared_ptr<graph::CancelToken> cancel     = std::make_shared<graph::CancelToken>();
     };
 
     explicit Impl(HarnessServiceConfig value)
         : config(std::move(value)), nonce(std::random_device{}()) {
+        if (config.poll_interval.count() <= 0 || config.run_ttl.count() <= 0) {
+            throw std::invalid_argument("Harness poll_interval and run_ttl must be positive");
+        }
+        if (config.enable_experimental_tasks && !config.record_store) {
+            throw std::invalid_argument(
+                "experimental Tasks profile requires a durable record_store");
+        }
         register_harness_node_types();
     }
 
@@ -730,7 +987,12 @@ struct HarnessService::Impl {
                 active.push_back(run);
             }
         }
-        for (const auto& run : active) run->cancel->cancel();
+        for (const auto& run : active) {
+            std::lock_guard lock(run->mutex);
+            if (run->status == "queued" || run->status == "running") {
+                run->cancel->cancel();
+            }
+        }
         for (auto& thread : threads) {
             if (thread.joinable()) thread.join();
         }
@@ -743,39 +1005,131 @@ struct HarnessService::Impl {
         return out.str();
     }
 
+    json artifact_record(const Artifact& artifact) const {
+        return {
+            {"artifact_id", artifact.id},
+            {"request", artifact.request},
+            {"core", artifact.core},
+            {"sourcemap", artifact.sourcemap},
+            {"diagnostics", artifact.diagnostics},
+        };
+    }
+
+    json run_record_locked(const Run& run) const {
+        return {
+            {"run_id", run.id},
+            {"artifact_id", run.artifact_id},
+            {"status", run.status},
+            {"result", run.result},
+            {"details", run.details},
+            {"pending", run.pending},
+            {"consumed", run.consumed},
+            {"resume_value", run.resume_value},
+            {"error", run.error},
+            {"created_at", run.created_at},
+            {"updated_at", run.updated_at},
+            {"expires_at", run.expires_at},
+        };
+    }
+
+    void persist_run(const std::shared_ptr<Run>& run) const {
+        if (!config.record_store) return;
+        json record;
+        {
+            std::lock_guard lock(run->mutex);
+            record = run_record_locked(*run);
+        }
+        config.record_store->save_run(run->id, record);
+    }
+
+    std::shared_ptr<Artifact> find_artifact(const std::string& artifact_id) {
+        {
+            std::lock_guard lock(mutex);
+            auto            it = artifacts_by_id.find(artifact_id);
+            if (it != artifacts_by_id.end()) return it->second;
+        }
+        if (!config.record_store) return nullptr;
+        auto record = config.record_store->load_artifact(artifact_id);
+        if (!record) return nullptr;
+        if (record->value("artifact_id", "") != artifact_id) {
+            throw std::runtime_error("Harness artifact record id mismatch");
+        }
+        auto artifact         = std::make_shared<Artifact>();
+        artifact->id          = artifact_id;
+        artifact->request     = record->at("request");
+        artifact->core        = record->at("core");
+        artifact->sourcemap   = record->value("sourcemap", json::array());
+        artifact->diagnostics = record->value("diagnostics", json::array());
+        std::lock_guard lock(mutex);
+        auto [it, inserted] = artifacts_by_id.emplace(artifact_id, artifact);
+        return inserted ? artifact : it->second;
+    }
+
+    std::shared_ptr<Run> find_run(const std::string& run_id) {
+        {
+            std::lock_guard lock(mutex);
+            auto            it = runs.find(run_id);
+            if (it != runs.end()) return it->second;
+        }
+        if (!config.record_store) return nullptr;
+        auto record = config.record_store->load_run(run_id);
+        if (!record) return nullptr;
+        if (record->value("run_id", "") != run_id) {
+            throw std::runtime_error("Harness run record id mismatch");
+        }
+        auto run          = std::make_shared<Run>();
+        run->id           = run_id;
+        run->artifact_id  = record->at("artifact_id").get<std::string>();
+        run->status       = record->at("status").get<std::string>();
+        run->result       = record->value("result", json());
+        run->details      = record->value("details", json());
+        run->pending      = record->value("pending", json());
+        run->consumed     = record->value("consumed", json::object());
+        run->resume_value = record->value("resume_value", json());
+        run->error        = record->value("error", "");
+        run->created_at   = record->value("created_at", unix_millis());
+        run->updated_at   = record->value("updated_at", run->created_at);
+        run->expires_at   = record->value("expires_at", int64_t{0});
+        if (run->status == "running" && !run->resume_value.is_null()) {
+            run->status = "queued";
+        }
+        std::lock_guard lock(mutex);
+        auto [it, inserted] = runs.emplace(run_id, run);
+        return inserted ? run : it->second;
+    }
+
     json compile_request(const json& request, bool retain) {
         json diagnostics = json::array();
         json core;
         json sourcemap = json::array();
 
         try {
-            validate_json_value(request, harness_request_schema(),
-                                "Harness request", "$");
+            validate_json_value(request, harness_request_schema(), "Harness request", "$");
         } catch (const std::exception& error) {
-            diagnostics.push_back(make_diagnostic("request", "H_REQUEST_SCHEMA",
-                "error", "$", error.what()));
+            diagnostics.push_back(
+                make_diagnostic("request", "H_REQUEST_SCHEMA", "error", "$", error.what()));
         }
 
         if (!diagnostics_have_errors(diagnostics)) {
             if (request["workers"].empty()) {
-                diagnostics.push_back(make_diagnostic("request", "H_WORKERS_EMPTY",
-                    "error", "$.workers", "at least one worker is required"));
+                diagnostics.push_back(make_diagnostic("request", "H_WORKERS_EMPTY", "error",
+                                                      "$.workers",
+                                                      "at least one worker is required"));
             }
             const auto harness = request["harness"];
             const auto mode = harness.value("mode", "");
             if (mode == "preset") {
-                static const std::set<std::string> presets = {
-                    "fanout_judge", "pr_review_panel", "bug_triage",
-                    "research_synthesis"};
+                static const std::set<std::string> presets = {"fanout_judge", "pr_review_panel",
+                                                              "bug_triage", "research_synthesis"};
                 if (presets.find(harness.value("preset", "")) == presets.end()) {
-                    diagnostics.push_back(make_diagnostic("request", "H_PRESET",
-                        "error", "$.harness.preset",
-                        "unknown Harness preset"));
+                    diagnostics.push_back(make_diagnostic("request", "H_PRESET", "error",
+                                                          "$.harness.preset",
+                                                          "unknown Harness preset"));
                 }
             } else if (mode == "dsl" && !harness.contains("definition")) {
-                diagnostics.push_back(make_diagnostic("request", "H_DSL_DEFINITION",
-                    "error", "$.harness.definition",
-                    "dsl mode requires a definition"));
+                diagnostics.push_back(make_diagnostic("request", "H_DSL_DEFINITION", "error",
+                                                      "$.harness.definition",
+                                                      "dsl mode requires a definition"));
             }
             const auto budgets = request.value("budgets", json::object());
             validate_range(budgets, "max_steps", 1, 1000, 40, diagnostics);
@@ -794,20 +1148,21 @@ struct HarnessService::Impl {
                 core = std::move(elaborated.core);
                 sourcemap = std::move(elaborated.sourcemap);
                 if (core.value("schema_version", 0) != 1) {
-                    diagnostics.push_back(make_diagnostic("elaboration", "H_STRICT_CORE",
-                        "error", "$.harness.definition.schema_version",
-                        "Harness core must declare schema_version: 1"));
+                    diagnostics.push_back(
+                        make_diagnostic("elaboration", "H_STRICT_CORE", "error",
+                                        "$.harness.definition.schema_version",
+                                        "Harness core must declare schema_version: 1"));
                 }
             } catch (const std::exception& error) {
-                diagnostics.push_back(make_diagnostic("elaboration", "H_ELABORATION",
-                    "error", "$.harness.definition", error.what()));
+                diagnostics.push_back(make_diagnostic("elaboration", "H_ELABORATION", "error",
+                                                      "$.harness.definition", error.what()));
             }
         }
 
         if (!diagnostics_have_errors(diagnostics)) {
             try {
-                auto provider = std::make_shared<HarnessRuntimeProvider>(
-                    request, HarnessWorkerExecutor{});
+                auto provider =
+                    std::make_shared<HarnessRuntimeProvider>(request, HarnessWorkerExecutor{});
                 graph::NodeContext context;
                 context.provider = provider;
                 auto compiled = graph::GraphCompiler::compile(core, context);
@@ -815,16 +1170,19 @@ struct HarnessService::Impl {
                 auto report = graph::GraphValidator::validate(compiled);
                 for (const auto& diagnostic : report.diagnostics) {
                     diagnostics.push_back(make_diagnostic("static", diagnostic.code,
-                        diagnostic.severity, diagnostic.path, diagnostic.message,
-                        diagnostic.witness));
+                                                          diagnostic.severity, diagnostic.path,
+                                                          diagnostic.message, diagnostic.witness));
                 }
             } catch (const std::exception& error) {
-                diagnostics.push_back(make_diagnostic("compile", "H_COMPILE",
-                    "error", "$.harness.definition", error.what()));
+                diagnostics.push_back(make_diagnostic("compile", "H_COMPILE", "error",
+                                                      "$.harness.definition", error.what()));
             }
         }
 
-        if (!core.is_null()) validate_bindings(request, core, diagnostics);
+        if (!core.is_null()) {
+            validate_bindings(request, core, config.checkpoint_store && config.record_store,
+                              diagnostics);
+        }
         attach_elaborator_sources(diagnostics, sourcemap);
 
         json artifacts = {
@@ -853,13 +1211,30 @@ struct HarnessService::Impl {
             artifacts_by_id.erase(artifacts_by_id.begin());
         }
         artifacts_by_id[artifact->id] = std::move(artifact);
+        if (config.record_store) {
+            const auto& retained = artifacts_by_id.at(result["artifact_id"].get<std::string>());
+            config.record_store->save_artifact(retained->id, artifact_record(*retained));
+        }
         return result;
     }
 
-    void execute(std::shared_ptr<Run> run, std::shared_ptr<Artifact> artifact) {
+    void execute(std::shared_ptr<Run>      run,
+                 std::shared_ptr<Artifact> artifact,
+                 std::optional<json>       resume_value = std::nullopt) {
         {
             std::lock_guard lock(run->mutex);
             run->status = "running";
+            run->resume_scheduled = resume_value.has_value();
+            run->updated_at       = unix_millis();
+        }
+        try {
+            persist_run(run);
+        } catch (const std::exception& error) {
+            std::lock_guard lock(run->mutex);
+            run->status           = "failed";
+            run->error            = std::string("cannot persist Harness run: ") + error.what();
+            run->resume_scheduled = false;
+            return;
         }
 
         const auto budgets = artifact->request.value("budgets", json::object());
@@ -873,59 +1248,97 @@ struct HarnessService::Impl {
             if (!timer_cv.wait_for(lock, std::chrono::seconds(timeout_seconds),
                                    [&] { return done; })) {
                 timed_out.store(true, std::memory_order_release);
-                run->cancel->cancel();
+                std::lock_guard run_lock(run->mutex);
+                if (run->status == "running") run->cancel->cancel();
             }
         });
 
+        std::unique_ptr<graph::GraphEngine> engine;
         try {
-            auto provider = std::make_shared<HarnessRuntimeProvider>(
-                artifact->request, config.worker_executor);
+            auto provider =
+                std::make_shared<HarnessRuntimeProvider>(artifact->request, config.worker_executor);
             graph::NodeContext context;
             context.provider = std::move(provider);
-            auto engine = graph::GraphEngine::compile(artifact->core, context);
-            engine->set_worker_count(static_cast<std::size_t>(
-                budgets.value("max_parallel_workers", 4)));
+            engine = graph::GraphEngine::compile(artifact->core, context, config.checkpoint_store);
+            engine->set_worker_count(
+                static_cast<std::size_t>(budgets.value("max_parallel_workers", 4)));
 
             graph::RunConfig run_config;
             run_config.thread_id = run->id;
             run_config.input = {{"task", artifact->request["task"]}};
             run_config.max_steps = budgets.value("max_steps", 40);
             run_config.cancel_token = run->cancel;
-            auto graph_result = engine->run(run_config);
+            auto graph_result =
+                resume_value ? engine->resume(run_config, *resume_value) : engine->run(run_config);
 
             std::lock_guard lock(run->mutex);
-            if (graph_result.max_steps_exhausted()) {
+            // CancelToken callbacks are bound to the engine's executor. Drain
+            // that executor while holding the same lock used by cancel().
+            engine.reset();
+            run->cancel     = std::make_shared<graph::CancelToken>();
+            run->updated_at = unix_millis();
+            if (graph_result.interrupted) {
+                if (!graph_result.interrupt_value.contains("value") ||
+                    !graph_result.interrupt_value["value"].is_object()) {
+                    throw std::runtime_error("Harness interrupt omitted its pending-call payload");
+                }
+                auto       pending = graph_result.interrupt_value["value"];
+                const auto state   = pending.value("state", "");
+                if (state != "awaiting_tool_results" && state != "input_required") {
+                    throw std::runtime_error(
+                        "Harness interrupt returned an unsupported pending state");
+                }
+                run->pending = std::move(pending);
+                run->status  = state;
+            } else if (graph_result.max_steps_exhausted()) {
                 run->status = "max_steps_exhausted";
             } else {
                 run->status = "completed";
+                run->pending                    = nullptr;
                 run->details = graph_result.channel_raw("final_result");
                 run->details["execution_trace"] = graph_result.execution_trace;
                 const auto base_uri = "neograph://runs/" + run->id;
-                run->result = {
+                run->result                     = {
                     {"outcome", run->details.value("outcome", "unknown")},
                     {"valid_workers", run->details.value("valid_workers", 0)},
                     {"failed_workers", run->details.value("failed_workers", 0)},
-                    {"finding_count",
-                     run->details.value("findings", json::array()).size()},
-                    {"artifacts", {
-                        {"details", {{"uri", base_uri + "/details"}}},
-                        {"trace", {{"uri", base_uri + "/trace"}}},
-                    }},
+                    {"finding_count", run->details.value("findings", json::array()).size()},
+                    {"artifacts",
+                                         {
+                         {"details", {{"uri", base_uri + "/details"}}},
+                         {"trace", {{"uri", base_uri + "/trace"}}},
+                     }},
                 };
             }
+            run->resume_value     = nullptr;
+            run->resume_scheduled = false;
         } catch (const graph::CancelledException& error) {
             std::lock_guard lock(run->mutex);
-            run->status = timed_out.load(std::memory_order_acquire)
-                ? "timeout" : "cancelled";
+            engine.reset();
+            run->cancel       = std::make_shared<graph::CancelToken>();
+            run->status       = timed_out.load(std::memory_order_acquire) ? "timeout" : "cancelled";
             run->error = error.what();
+            run->resume_value = nullptr;
+            run->resume_scheduled = false;
+            run->updated_at       = unix_millis();
         } catch (const std::exception& error) {
             std::lock_guard lock(run->mutex);
+            engine.reset();
+            run->cancel           = std::make_shared<graph::CancelToken>();
             run->status = "failed";
             run->error = error.what();
+            run->resume_value     = nullptr;
+            run->resume_scheduled = false;
+            run->updated_at       = unix_millis();
         } catch (...) {
             std::lock_guard lock(run->mutex);
+            engine.reset();
+            run->cancel           = std::make_shared<graph::CancelToken>();
             run->status = "failed";
             run->error = "unknown Harness execution failure";
+            run->resume_value     = nullptr;
+            run->resume_scheduled = false;
+            run->updated_at       = unix_millis();
         }
 
         {
@@ -934,6 +1347,54 @@ struct HarnessService::Impl {
             timer_cv.notify_all();
         }
         timer.join();
+        try {
+            persist_run(run);
+        } catch (const std::exception& error) {
+            std::lock_guard lock(run->mutex);
+            run->status = "failed";
+            run->error  = std::string("cannot persist Harness run: ") + error.what();
+        }
+    }
+
+    void ensure_resume_scheduled(const std::shared_ptr<Run>& run) {
+        json        value;
+        std::string artifact_id;
+        {
+            std::lock_guard lock(run->mutex);
+            if (run->status != "queued" || run->resume_value.is_null() || run->resume_scheduled)
+                return;
+            run->resume_scheduled = true;
+            value                 = run->resume_value;
+            artifact_id           = run->artifact_id;
+        }
+        auto artifact = find_artifact(artifact_id);
+        if (!artifact) {
+            {
+                std::lock_guard lock(run->mutex);
+                run->resume_scheduled = false;
+                run->status           = "failed";
+                run->error            = "Harness resume artifact is unavailable";
+                run->updated_at       = unix_millis();
+            }
+            persist_run(run);
+            return;
+        }
+        try {
+            std::lock_guard lock(mutex);
+            threads.emplace_back([this, run, artifact, value = std::move(value)]() mutable {
+                execute(run, artifact, std::move(value));
+            });
+        } catch (...) {
+            {
+                std::lock_guard lock(run->mutex);
+                run->resume_scheduled = false;
+                run->status           = "failed";
+                run->error            = "failed to schedule Harness resume";
+                run->updated_at       = unix_millis();
+            }
+            persist_run(run);
+            throw;
+        }
     }
 
     HarnessServiceConfig config;
@@ -951,68 +1412,78 @@ HarnessService::HarnessService(HarnessServiceConfig config)
 HarnessService::~HarnessService() = default;
 
 json HarnessService::schema() const {
-    json executor_kinds = json::array({
+    json       executor_kinds = json::array({
         {{"kind", "builtin"}, {"availability", "provider-capability-adapter"}},
         {{"kind", "mcp"}, {"availability", "downstream-client-adapter"}},
         {{"kind", "a2a"}, {"availability", "downstream-client-adapter"}},
-        {{"kind", "host_brokered"}, {"availability", "requires-neograph-resume-m4"}},
+        {{"kind", "host_brokered"},
+               {"availability", impl_->config.checkpoint_store && impl_->config.record_store
+                                    ? "durable-resume"
+                                    : "requires-checkpoint-and-record-stores"}},
         {{"kind", "script"}, {"availability", "disabled"}},
     });
     const auto request = harness_request_schema();
     return {
         {"protocol_version", MCP_PROTOCOL_VERSION},
-        {"service", "neograph-harness-m3"},
-        {"presets", json::array({"fanout_judge", "pr_review_panel",
-                                  "bug_triage", "research_synthesis"})},
-        {"preset_contracts", {
-            {"fanout_judge", {
-                {"topology", "parallel workers, barrier, normalized judge"},
-            }},
-            {"pr_review_panel", {
-                {"topology", "parallel review specialists, evidence judge"},
-                {"recommended_roles", json::array(
-                    {"correctness", "security", "regression"})},
-                {"recommended_policy", {
-                    {"read_only", true},
-                    {"evidence_required", json::array(
-                        {"file", "line", "evidence"})},
-                }},
-            }},
-            {"bug_triage", {
-                {"topology", "parallel hypotheses, reproduction judge"},
-                {"recommended_roles", json::array(
-                    {"reproducer", "root_cause", "fix_validator"})},
-            }},
-            {"research_synthesis", {
-                {"topology", "parallel sources, contradiction-aware judge"},
-                {"recommended_roles", json::array(
-                    {"researcher", "skeptic", "synthesizer"})},
-            }},
-        }},
+        {"service", "neograph-harness-m4"},
+        {"presets",
+         json::array({"fanout_judge", "pr_review_panel", "bug_triage", "research_synthesis"})},
+        {"preset_contracts",
+         {
+             {"fanout_judge",
+              {
+                  {"topology", "parallel workers, barrier, normalized judge"},
+              }},
+             {"pr_review_panel",
+              {
+                  {"topology", "parallel review specialists, evidence judge"},
+                  {"recommended_roles", json::array({"correctness", "security", "regression"})},
+                  {"recommended_policy",
+                   {
+                       {"read_only", true},
+                       {"evidence_required", json::array({"file", "line", "evidence"})},
+                   }},
+              }},
+             {"bug_triage",
+              {
+                  {"topology", "parallel hypotheses, reproduction judge"},
+                  {"recommended_roles", json::array({"reproducer", "root_cause", "fix_validator"})},
+              }},
+             {"research_synthesis",
+              {
+                  {"topology", "parallel sources, contradiction-aware judge"},
+                  {"recommended_roles", json::array({"researcher", "skeptic", "synthesizer"})},
+              }},
+         }},
         {"executor_kinds", std::move(executor_kinds)},
         {"request_schema", request},
-        {"schemas", {
-            {"request", request},
-            {"worker", request["properties"]["workers"]["items"]},
-            {"tool_catalog_entry", request["properties"]["tool_catalog"]["items"]},
-            {"budgets", request["properties"]["budgets"]},
-            {"worker_result", worker_result_schema()},
-            {"run_snapshot", run_snapshot_schema()},
-        }},
+        {"schemas",
+         {
+             {"request", request},
+             {"worker", request["properties"]["workers"]["items"]},
+             {"tool_catalog_entry", request["properties"]["tool_catalog"]["items"]},
+             {"budgets", request["properties"]["budgets"]},
+             {"worker_result", worker_result_schema()},
+             {"run_snapshot", run_snapshot_schema()},
+         }},
         {"node_palette", graph::NodeFactory::instance().export_schema()},
-        {"capabilities", {
-            {"strict_core", true},
-            {"translation_validation", true},
-            {"semantic_validation", true},
-            {"binding_validation", true},
-            {"bounded_worker_repair", true},
-            {"direct_provider_workers", true},
-            {"downstream_mcp_tools", true},
-            {"downstream_a2a_tools", true},
-            {"read_only_workspace_policy", true},
-            {"compact_results", true},
-            {"durable_runs", false},
-        }},
+        {"capabilities",
+         {
+             {"strict_core", true},
+             {"translation_validation", true},
+             {"semantic_validation", true},
+             {"binding_validation", true},
+             {"bounded_worker_repair", true},
+             {"direct_provider_workers", true},
+             {"downstream_mcp_tools", true},
+             {"downstream_a2a_tools", true},
+             {"read_only_workspace_policy", true},
+             {"compact_results", true},
+             {"durable_runs", static_cast<bool>(impl_->config.record_store)},
+             {"host_brokered_resume",
+              static_cast<bool>(impl_->config.checkpoint_store && impl_->config.record_store)},
+             {"experimental_tasks", impl_->config.enable_experimental_tasks},
+         }},
     };
 }
 
@@ -1040,33 +1511,30 @@ json HarnessService::start(const json& arguments) {
             };
         }
         artifact_id = compiled["artifact_id"].get<std::string>();
-    } else if (arguments.contains("artifact_id")
-               && arguments["artifact_id"].is_string()) {
+    } else if (arguments.contains("artifact_id") && arguments["artifact_id"].is_string()) {
         artifact_id = arguments["artifact_id"].get<std::string>();
     } else {
-        throw std::invalid_argument(
-            "neograph_start requires artifact_id or request");
+        throw std::invalid_argument("neograph_start requires artifact_id or request");
     }
 
-    std::shared_ptr<Impl::Artifact> artifact;
+    auto artifact = impl_->find_artifact(artifact_id);
+    if (!artifact) {
+        throw std::invalid_argument("unknown Harness artifact_id: " + artifact_id);
+    }
     auto run = std::make_shared<Impl::Run>();
     {
         std::lock_guard lock(impl_->mutex);
-        auto artifact_it = impl_->artifacts_by_id.find(artifact_id);
-        if (artifact_it == impl_->artifacts_by_id.end()) {
-            throw std::invalid_argument("unknown Harness artifact_id: " + artifact_id);
-        }
         if (impl_->runs.size() >= impl_->config.max_runs) {
             throw std::runtime_error("Harness run capacity is exhausted");
         }
-        artifact = artifact_it->second;
         run->id = impl_->id("run");
         run->artifact_id = artifact_id;
+        run->expires_at      = run->created_at + impl_->config.run_ttl.count();
         impl_->runs[run->id] = run;
         try {
-            impl_->threads.emplace_back([impl = impl_.get(), run, artifact] {
-                impl->execute(run, artifact);
-            });
+            impl_->persist_run(run);
+            impl_->threads.emplace_back(
+                [impl = impl_.get(), run, artifact] { impl->execute(run, artifact); });
         } catch (...) {
             impl_->runs.erase(run->id);
             throw;
@@ -1080,23 +1548,105 @@ json HarnessService::start(const json& arguments) {
     };
 }
 
-json HarnessService::get(const std::string& run_id,
-                         const std::string& view) const {
-    std::shared_ptr<Impl::Run> run;
-    {
-        std::lock_guard lock(impl_->mutex);
-        auto it = impl_->runs.find(run_id);
-        if (it == impl_->runs.end()) {
-            throw std::invalid_argument("unknown Harness run_id: " + run_id);
-        }
-        run = it->second;
+json HarnessService::resume(const json& arguments) {
+    if (!arguments.is_object() || !arguments.contains("run_id") ||
+        !arguments["run_id"].is_string() || !arguments.contains("call_id") ||
+        !arguments["call_id"].is_string() || !arguments.contains("result")) {
+        throw std::invalid_argument(
+            "neograph_resume requires string run_id, string call_id, and result");
     }
+    const auto run_id  = arguments["run_id"].get<std::string>();
+    const auto call_id = arguments["call_id"].get<std::string>();
+    auto       run     = impl_->find_run(run_id);
+    if (!run) throw std::invalid_argument("unknown Harness run_id: " + run_id);
+    auto artifact = impl_->find_artifact(run->artifact_id);
+    if (!artifact) {
+        throw std::runtime_error("Harness run references an unavailable artifact: " +
+                                 run->artifact_id);
+    }
+
+    bool expired   = false;
+    bool duplicate = false;
+    {
+        std::lock_guard lock(run->mutex);
+        if (run->consumed.contains(call_id)) {
+            if (run->consumed[call_id] != arguments["result"]) {
+                throw std::invalid_argument(
+                    "conflicting duplicate result for consumed Harness call_id");
+            }
+            duplicate = true;
+        }
+        if (!duplicate && run->expires_at > 0 && unix_millis() >= run->expires_at) {
+            run->status     = "expired";
+            run->pending    = nullptr;
+            run->updated_at = unix_millis();
+            expired         = true;
+        }
+        if (duplicate || expired) {
+            // Persist after releasing the run lock below.
+        } else {
+            if (run->status != "awaiting_tool_results" && run->status != "input_required") {
+                throw std::invalid_argument(
+                    "late result rejected: Harness run is not awaiting input");
+            }
+            if (!run->pending.is_object() || run->pending.value("call_id", "") != call_id) {
+                throw std::invalid_argument("Harness call_id does not match the pending call");
+            }
+            if (run->pending.contains("result_schema")) {
+                validate_json_value(arguments["result"], run->pending["result_schema"],
+                                    "Harness resume result", "$");
+            }
+            run->consumed[call_id] = arguments["result"];
+            run->pending           = nullptr;
+            run->status            = "queued";
+            run->resume_value      = {
+                {"call_id", call_id},
+                {"result", arguments["result"]},
+            };
+            run->updated_at = unix_millis();
+        }
+    }
+    if (!duplicate) impl_->persist_run(run);
+    if (expired) throw std::invalid_argument("Harness run has expired");
+    impl_->ensure_resume_scheduled(run);
+    std::string status;
+    {
+        std::lock_guard lock(run->mutex);
+        status = run->status;
+    }
+    return {
+        {"accepted", !duplicate}, {"duplicate", duplicate}, {"run_id", run_id},
+        {"call_id", call_id},     {"status", status},
+    };
+}
+
+json HarnessService::get(const std::string& run_id, const std::string& view) const {
+    auto run = impl_->find_run(run_id);
+    if (!run) throw std::invalid_argument("unknown Harness run_id: " + run_id);
+    bool expired = false;
+    {
+        std::lock_guard lock(run->mutex);
+        if ((run->status == "awaiting_tool_results" || run->status == "input_required") &&
+            run->expires_at > 0 && unix_millis() >= run->expires_at) {
+            run->status     = "expired";
+            run->pending    = nullptr;
+            run->updated_at = unix_millis();
+            expired         = true;
+        }
+    }
+    if (expired) impl_->persist_run(run);
+    impl_->ensure_resume_scheduled(run);
     std::lock_guard lock(run->mutex);
-    json snapshot = {
+    json            snapshot = {
         {"run_id", run->id},
         {"artifact_id", run->artifact_id},
         {"status", run->status},
+        {"created_at", run->created_at},
+        {"updated_at", run->updated_at},
+        {"expires_at", run->expires_at},
+        {"poll_after_ms", impl_->config.poll_interval.count()},
     };
+    if (!run->pending.is_null()) snapshot["pending"] = run->pending;
     if (view == "status") {
         if (!run->result.is_null()) snapshot["result"] = run->result;
     } else if (view == "details") {
@@ -1104,8 +1654,7 @@ json HarnessService::get(const std::string& run_id,
     } else if (view == "trace") {
         if (!run->details.is_null()) {
             snapshot["result"] = {
-                {"execution_trace", run->details.value(
-                    "execution_trace", json::array())},
+                {"execution_trace", run->details.value("execution_trace", json::array())},
             };
         }
     } else if (view == "artifacts") {
@@ -1113,8 +1662,7 @@ json HarnessService::get(const std::string& run_id,
             snapshot["result"] = run->result.value("artifacts", json::object());
         }
     } else {
-        throw std::invalid_argument(
-            "Harness view must be status, details, trace, or artifacts");
+        throw std::invalid_argument("Harness view must be status, details, trace, or artifacts");
     }
     if (!run->error.empty()) snapshot["error"] = run->error;
     return snapshot;
@@ -1127,45 +1675,52 @@ json HarnessService::read(const std::string& uri) const {
     }
     const auto remainder = uri.substr(prefix.size());
     const auto separator = remainder.rfind('/');
-    if (separator == std::string::npos || separator == 0
-        || separator + 1 == remainder.size()) {
+    if (separator == std::string::npos || separator == 0 || separator + 1 == remainder.size()) {
         throw std::invalid_argument("malformed Harness artifact URI: " + uri);
     }
-    return get(remainder.substr(0, separator),
-               remainder.substr(separator + 1));
+    return get(remainder.substr(0, separator), remainder.substr(separator + 1));
 }
 
 bool HarnessService::cancel(const std::string& run_id) {
-    std::shared_ptr<Impl::Run> run;
-    {
-        std::lock_guard lock(impl_->mutex);
-        auto it = impl_->runs.find(run_id);
-        if (it == impl_->runs.end()) return false;
-        run = it->second;
-    }
+    auto run = impl_->find_run(run_id);
+    if (!run) return false;
     {
         std::lock_guard lock(run->mutex);
-        if (run->status != "queued" && run->status != "running") return false;
-    }
+        if (run->status != "queued" && run->status != "running" &&
+            run->status != "awaiting_tool_results" && run->status != "input_required")
+            return false;
+        if (run->status == "awaiting_tool_results" || run->status == "input_required") {
+            run->status     = "cancelled";
+            run->pending    = nullptr;
+            run->updated_at = unix_millis();
+        }
     run->cancel->cancel();
+    }
+    impl_->persist_run(run);
     return true;
 }
 
 void HarnessService::register_tools(MCPServer& server) {
-    server.register_tool(tool_definition(
-        "neograph_schema", "NeoGraph Harness schema",
-        "Return build-specific Harness request schemas, presets, executor kinds, and node palette.",
-        json::parse(R"JSON({"type":"object","properties":{},"additionalProperties":false})JSON"),
-        json::parse(R"JSON({"type":"object","required":["service","request_schema","node_palette"],"properties":{"service":{"type":"string"},"request_schema":{"type":"object"},"node_palette":{"type":"object"}},"additionalProperties":true})JSON"), true),
+    server.register_tool(
+        tool_definition(
+            "neograph_schema", "NeoGraph Harness schema",
+            "Return build-specific Harness request schemas, presets, executor kinds, and node "
+            "palette.",
+            json::parse(
+                R"JSON({"type":"object","properties":{},"additionalProperties":false})JSON"),
+            json::parse(
+                R"JSON({"type":"object","required":["service","request_schema","node_palette"],"properties":{"service":{"type":"string"},"request_schema":{"type":"object"},"node_palette":{"type":"object"}},"additionalProperties":true})JSON"),
+            true),
         [this](const json&, const auto&) {
             auto value = schema();
-            return mcp_result(std::move(value), "NeoGraph Harness M3 schema");
+            return mcp_result(std::move(value), "NeoGraph Harness M4 schema");
         });
 
-    server.register_tool(tool_definition(
-        "neograph_compile", "Compile Harness",
-        "Elaborate, strict-compile, translation-validate, semantic-validate, and binding-validate a Harness request.",
-        harness_request_schema(), compile_output_schema()),
+    server.register_tool(
+        tool_definition("neograph_compile", "Compile Harness",
+                        "Elaborate, strict-compile, translation-validate, semantic-validate, and "
+                        "binding-validate a Harness request.",
+                        harness_request_schema(), compile_output_schema()),
         [this](const json& arguments, const auto&) {
             auto value = compile(arguments);
             const auto text = value.value("ok", false)
@@ -1174,51 +1729,132 @@ void HarnessService::register_tools(MCPServer& server) {
             return mcp_result(std::move(value), text);
         });
 
-    server.register_tool(tool_definition(
+    auto start_definition = tool_definition(
         "neograph_start", "Start Harness",
         "Start a retained artifact or compile-and-start an inline Harness request.",
-        json::parse(R"JSON({"type":"object","description":"Provide exactly one of artifact_id or request.","properties":{"artifact_id":{"type":"string","description":"Artifact returned by neograph_compile."},"request":{"type":"object","description":"Inline Harness request; do not also provide artifact_id."}},"additionalProperties":false})JSON"),
-        json::parse(R"JSON({"type":"object","required":["started","status"],"properties":{"started":{"type":"boolean"},"run_id":{"type":"string"},"artifact_id":{"type":"string"},"status":{"type":"string"},"diagnostics":{"type":"array"},"artifacts":{"type":"object"}},"additionalProperties":true})JSON")),
-        [this](const json& arguments, const auto&) {
+        json::parse(
+            R"JSON({"type":"object","description":"Provide exactly one of artifact_id or request.","properties":{"artifact_id":{"type":"string","description":"Artifact returned by neograph_compile."},"request":{"type":"object","description":"Inline Harness request; do not also provide artifact_id."}},"additionalProperties":false})JSON"),
+        json::parse(
+            R"JSON({"type":"object","required":["started","status"],"properties":{"started":{"type":"boolean"},"run_id":{"type":"string"},"artifact_id":{"type":"string"},"status":{"type":"string"},"diagnostics":{"type":"array"},"artifacts":{"type":"object"}},"additionalProperties":true})JSON"));
+    if (impl_->config.enable_experimental_tasks) {
+        start_definition.execution = {{"taskSupport", "optional"}};
+        server.register_raw_tool(
+            std::move(start_definition),
+            [this](const json& arguments, const auto&, const json& meta) {
+                auto value = start(arguments);
+                if (value.value("started", false) && tasks_requested(meta)) {
+                    return task_from_snapshot(get(value["run_id"].get<std::string>()), true);
+                }
+                const auto text = value.value("started", false)
+                                      ? "Harness started: " + value.value("run_id", "")
+                                      : "Harness did not start";
+                return mcp_result(std::move(value), text).to_json();
+            });
+    } else {
+        server.register_tool(std::move(start_definition), [this](const json& arguments,
+                                                                 const auto&) {
             auto value = start(arguments);
             const auto text = value.value("started", false)
                 ? "Harness started: " + value.value("run_id", "")
                 : "Harness did not start";
             return mcp_result(std::move(value), text);
         });
+    }
 
-    server.register_tool(tool_definition(
-        "neograph_get", "Get Harness run",
-        "Read compact run status or dereference a detailed neograph:// run artifact URI.",
-        json::parse(R"JSON({"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string"},"view":{"enum":["status","details","trace","artifacts"],"description":"Named view used when uri is absent."},"uri":{"type":"string","description":"Returned artifact URI. When present, its embedded view is authoritative."}},"additionalProperties":false})JSON"),
-        run_snapshot_schema(), true),
+    server.register_tool(
+        tool_definition(
+            "neograph_get", "Get Harness run",
+            "Read compact run status or dereference a detailed neograph:// run artifact URI.",
+            json::parse(
+                R"JSON({"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string"},"view":{"enum":["status","details","trace","artifacts"],"description":"Named view used when uri is absent."},"uri":{"type":"string","description":"Returned artifact URI. When present, its embedded view is authoritative."}},"additionalProperties":false})JSON"),
+            run_snapshot_schema(), true),
         [this](const json& arguments, const auto&) {
             const bool has_uri = arguments.contains("uri");
             const auto run_id = arguments["run_id"].get<std::string>();
-            auto value = has_uri
-                ? read(arguments["uri"].get<std::string>())
-                : get(run_id, arguments.value("view", "status"));
+            auto       value   = has_uri ? read(arguments["uri"].get<std::string>())
+                                         : get(run_id, arguments.value("view", "status"));
             if (value.value("run_id", "") != run_id) {
-                throw std::invalid_argument(
-                    "Harness artifact URI does not belong to run_id");
+                throw std::invalid_argument("Harness artifact URI does not belong to run_id");
             }
-            const auto text = "Harness run " + value.value("run_id", "")
-                + ": " + value.value("status", "unknown");
+            const auto text = "Harness run " + value.value("run_id", "") + ": " +
+                              value.value("status", "unknown");
             return mcp_result(std::move(value), text);
         });
 
-    server.register_tool(tool_definition(
-        "neograph_cancel", "Cancel Harness run",
-        "Cooperatively cancel a queued or running Harness run.",
-        json::parse(R"JSON({"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string"}},"additionalProperties":false})JSON"),
-        json::parse(R"JSON({"type":"object","required":["run_id","cancelled"],"properties":{"run_id":{"type":"string"},"cancelled":{"type":"boolean"}},"additionalProperties":false})JSON")),
+    server.register_tool(
+        tool_definition(
+            "neograph_resume", "Resume Harness run",
+            "Submit the exact pending host result and resume from the durable checkpoint.",
+            json::parse(
+                R"JSON({"type":"object","required":["run_id","call_id","result"],"properties":{"run_id":{"type":"string"},"call_id":{"type":"string"},"result":{}} ,"additionalProperties":false})JSON"),
+            json::parse(
+                R"JSON({"type":"object","required":["accepted","duplicate","run_id","call_id","status"],"properties":{"accepted":{"type":"boolean"},"duplicate":{"type":"boolean"},"run_id":{"type":"string"},"call_id":{"type":"string"},"status":{"type":"string"}},"additionalProperties":false})JSON")),
+        [this](const json& arguments, const auto&) {
+            auto       value = resume(arguments);
+            const auto text  = value.value("duplicate", false)
+                                   ? "Harness result was already consumed"
+                                   : "Harness resume accepted";
+            return mcp_result(std::move(value), text);
+        });
+
+    server.register_tool(
+        tool_definition(
+            "neograph_cancel", "Cancel Harness run",
+            "Cooperatively cancel a queued, running, or input-waiting Harness run.",
+            json::parse(
+                R"JSON({"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string"}},"additionalProperties":false})JSON"),
+            json::parse(
+                R"JSON({"type":"object","required":["run_id","cancelled"],"properties":{"run_id":{"type":"string"},"cancelled":{"type":"boolean"}},"additionalProperties":false})JSON")),
         [this](const json& arguments, const auto&) {
             const auto run_id = arguments["run_id"].get<std::string>();
             const bool accepted = cancel(run_id);
             json value = {{"run_id", run_id}, {"cancelled", accepted}};
-            return mcp_result(std::move(value), accepted
-                ? "Harness cancellation requested" : "Harness run is unknown or terminal");
+            return mcp_result(std::move(value), accepted ? "Harness cancellation requested"
+                                                         : "Harness run is unknown or terminal");
         });
+
+    if (!impl_->config.enable_experimental_tasks) return;
+    server.register_extension(kTasksExtension);
+    server.register_method("tasks/get", [this](const json& params, const json& context) {
+        require_tasks_negotiated(context);
+        if (!params.is_object() || params.size() != 1 || !params.contains("taskId") ||
+            !params["taskId"].is_string()) {
+            throw std::invalid_argument("tasks/get requires only string taskId");
+        }
+        return task_from_snapshot(get(params["taskId"].get<std::string>()));
+    });
+    server.register_method("tasks/update", [this](const json& params, const json& context) {
+        require_tasks_negotiated(context);
+        if (!params.is_object() || params.size() != 2 || !params.contains("taskId") ||
+            !params["taskId"].is_string() || !params.contains("inputResponses") ||
+            !params["inputResponses"].is_object() || params["inputResponses"].size() != 1) {
+            throw std::invalid_argument(
+                "tasks/update requires taskId and exactly one input response");
+        }
+        const auto& responses = params["inputResponses"];
+        const auto  response  = responses.begin();
+        auto        supplied  = response.value();
+        if (supplied.is_object() && supplied.contains("content")) {
+            supplied = supplied["content"];
+        }
+        (void)resume({
+            {"run_id", params["taskId"]},
+            {"call_id", response.key()},
+            {"result", std::move(supplied)},
+        });
+        return json{{"resultType", "complete"}};
+    });
+    server.register_method("tasks/cancel", [this](const json& params, const json& context) {
+        require_tasks_negotiated(context);
+        if (!params.is_object() || params.size() != 1 || !params.contains("taskId") ||
+            !params["taskId"].is_string()) {
+            throw std::invalid_argument("tasks/cancel requires only string taskId");
+        }
+        if (!cancel(params["taskId"].get<std::string>())) {
+            throw std::invalid_argument("task is unknown or terminal");
+        }
+        return json{{"resultType", "complete"}};
+    });
 }
 
 } // namespace neograph::mcp

--- a/src/mcp/harness_mcp_backend.cpp
+++ b/src/mcp/harness_mcp_backend.cpp
@@ -1,0 +1,34 @@
+#include <neograph/mcp/harness_mcp_backend.h>
+
+#include <neograph/mcp/client.h>
+
+#include <stdexcept>
+#include <utility>
+
+namespace neograph::mcp {
+
+HarnessCapabilityExecutor make_mcp_harness_capability_executor(
+    std::map<std::string, std::shared_ptr<MCPClient>> clients) {
+    return [clients = std::move(clients)](
+               const json& tool, const json& arguments,
+               const std::shared_ptr<graph::CancelToken>& cancel) {
+        cancel->throw_if_cancelled("before downstream MCP call");
+        const auto executor = tool["executor"];
+        const auto server_ref = executor["server_ref"].get<std::string>();
+        auto it = clients.find(server_ref);
+        if (it == clients.end() || !it->second) {
+            throw std::runtime_error("unresolved MCP server_ref: " + server_ref);
+        }
+        const auto tool_name = executor.value("tool", tool["id"].get<std::string>());
+        auto result = it->second->call_tool_result(tool_name, arguments);
+        if (result.is_error) {
+            throw std::runtime_error("downstream MCP tool returned isError: "
+                                     + result.to_json().dump());
+        }
+        cancel->throw_if_cancelled("after downstream MCP call");
+        if (!result.structured_content.is_null()) return result.structured_content;
+        return result.to_json();
+    };
+}
+
+} // namespace neograph::mcp

--- a/src/mcp/harness_provider.cpp
+++ b/src/mcp/harness_provider.cpp
@@ -1,0 +1,201 @@
+#include <neograph/mcp/harness.h>
+
+#include <neograph/mcp/json_schema.h>
+#include <neograph/provider.h>
+
+#include <filesystem>
+#include <map>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace neograph::mcp {
+namespace {
+
+bool is_within(const std::filesystem::path& child,
+               const std::filesystem::path& root) {
+    auto child_it = child.begin();
+    auto root_it = root.begin();
+    for (; root_it != root.end(); ++root_it, ++child_it) {
+        if (child_it == child.end() || *child_it != *root_it) return false;
+    }
+    return true;
+}
+
+std::filesystem::path resolved_path(const std::filesystem::path& value) {
+    std::error_code error;
+    auto absolute = std::filesystem::absolute(value, error);
+    if (error) {
+        throw std::runtime_error("cannot resolve Harness path: "
+                                 + value.string());
+    }
+    auto resolved = std::filesystem::weakly_canonical(absolute, error);
+    if (error) {
+        throw std::runtime_error("cannot canonicalize Harness path: "
+                                 + absolute.string());
+    }
+    return resolved;
+}
+
+json enforce_path_policy(const HarnessWorkerCall& call, const json& tool,
+                         const json& arguments) {
+    const auto path_arguments = tool.value("path_arguments", json::array());
+    if (path_arguments.empty()) return arguments;
+
+    const auto roots = call.policy.value("workspace_roots", json::array());
+    if (roots.empty()) {
+        throw std::runtime_error(
+            "path-bearing tool requires policy.workspace_roots");
+    }
+
+    std::vector<std::filesystem::path> normalized_roots;
+    for (const auto& root_json : roots) {
+        const auto root = root_json.get<std::string>();
+        if (root.empty()) {
+            throw std::runtime_error("policy.workspace_roots must not contain empty paths");
+        }
+        normalized_roots.push_back(resolved_path(root));
+    }
+    auto normalized_arguments = arguments;
+    for (const auto& key_json : path_arguments) {
+        const auto key = key_json.get<std::string>();
+        if (!arguments.contains(key) || !arguments[key].is_string()) continue;
+        auto candidate = std::filesystem::path(arguments[key].get<std::string>());
+        if (candidate.is_relative()) candidate = normalized_roots.front() / candidate;
+        candidate = resolved_path(candidate);
+        bool allowed = false;
+        for (const auto& root : normalized_roots) {
+            if (is_within(candidate, root)) {
+                allowed = true;
+                break;
+            }
+        }
+        if (!allowed) {
+            throw std::runtime_error("tool path escapes configured workspace roots: "
+                                     + candidate.string());
+        }
+        normalized_arguments[key] = candidate.string();
+    }
+    return normalized_arguments;
+}
+
+std::vector<ChatTool> chat_tools(const json& catalog) {
+    std::vector<ChatTool> tools;
+    for (const auto& entry : catalog) {
+        ChatTool tool;
+        tool.name = entry["id"].get<std::string>();
+        tool.description = entry.value("description", "");
+        tool.parameters = entry["input_schema"];
+        tools.push_back(std::move(tool));
+    }
+    return tools;
+}
+
+std::string worker_prompt(const HarnessWorkerCall& call) {
+    json contract = {
+        {"objective", call.task.value("objective", "")},
+        {"acceptance", call.task.value("acceptance", json::array())},
+        {"instructions", call.worker.value("instructions", "")},
+        {"output_schema", call.worker["output_schema"]},
+    };
+    if (!call.repair_feedback.empty()) {
+        contract["repair_feedback"] = call.repair_feedback;
+    }
+    return "Execute this worker contract. Use only the supplied tools. Return only "
+           "one JSON value conforming to output_schema, without Markdown fences.\n"
+           + contract.dump(2);
+}
+
+} // namespace
+
+HarnessWorkerExecutor make_provider_harness_executor(
+    HarnessProviderExecutorConfig config) {
+    if (!config.provider) {
+        throw std::invalid_argument("Harness provider executor requires a provider");
+    }
+    if (config.max_tool_rounds == 0 || config.max_tool_rounds > 64) {
+        throw std::invalid_argument("max_tool_rounds must be between 1 and 64");
+    }
+
+    return [config = std::move(config)](
+               const HarnessWorkerCall& call,
+               const std::shared_ptr<graph::CancelToken>& cancel) {
+        std::map<std::string, json> catalog;
+        for (const auto& tool : call.tool_catalog) {
+            catalog[tool["id"].get<std::string>()] = tool;
+        }
+
+        CompletionParams params;
+        params.model = config.model;
+        params.temperature = 0.0f;
+        params.cancel_token = cancel;
+        params.tools = chat_tools(call.tool_catalog);
+        ChatMessage initial;
+        initial.role = "user";
+        initial.content = worker_prompt(call);
+        params.messages.push_back(std::move(initial));
+
+        for (std::size_t round = 0; round < config.max_tool_rounds; ++round) {
+            cancel->throw_if_cancelled("before provider Harness completion");
+            ChatCompletion completion;
+            try {
+                completion = config.provider->complete(params);
+            } catch (const graph::CancelledException&) {
+                return HarnessWorkerResponse::cancelled();
+            } catch (const std::exception& error) {
+                return HarnessWorkerResponse::tool_error(error.what());
+            }
+
+            if (completion.message.tool_calls.empty()) {
+                if (completion.message.content.empty()) {
+                    return HarnessWorkerResponse::empty(
+                        "provider returned empty content");
+                }
+                try {
+                    return HarnessWorkerResponse::success(
+                        json::parse(completion.message.content));
+                } catch (const std::exception& error) {
+                    return HarnessWorkerResponse::parse_error(error.what());
+                }
+            }
+
+            params.messages.push_back(completion.message);
+            for (const auto& tool_call : completion.message.tool_calls) {
+                auto tool_it = catalog.find(tool_call.name);
+                if (tool_it == catalog.end()) {
+                    return HarnessWorkerResponse::tool_error(
+                        "provider requested undeclared tool: " + tool_call.name);
+                }
+                if (!config.capability_executor) {
+                    return HarnessWorkerResponse::tool_error(
+                        "provider requested a tool but no capability executor is configured");
+                }
+                try {
+                    auto arguments = json::parse(tool_call.arguments);
+                    validate_json_value(arguments, tool_it->second["input_schema"],
+                                        "Harness tool arguments", "$");
+                    arguments = enforce_path_policy(
+                        call, tool_it->second, arguments);
+                    auto result = config.capability_executor(
+                        tool_it->second, arguments, cancel);
+                    if (tool_it->second.contains("output_schema")) {
+                        validate_json_value(result, tool_it->second["output_schema"],
+                                            "Harness tool result", "$");
+                    }
+                    ChatMessage message;
+                    message.role = "tool";
+                    message.tool_call_id = tool_call.id;
+                    message.tool_name = tool_call.name;
+                    message.content = result.dump();
+                    params.messages.push_back(std::move(message));
+                } catch (const std::exception& error) {
+                    return HarnessWorkerResponse::tool_error(error.what());
+                }
+            }
+        }
+        return HarnessWorkerResponse::tool_error(
+            "provider exhausted max_tool_rounds without a final result");
+    };
+}
+
+} // namespace neograph::mcp

--- a/src/mcp/harness_provider.cpp
+++ b/src/mcp/harness_provider.cpp
@@ -1,10 +1,12 @@
 #include <neograph/mcp/harness.h>
-
 #include <neograph/mcp/json_schema.h>
 #include <neograph/provider.h>
 
+#include <atomic>
 #include <filesystem>
 #include <map>
+#include <random>
+#include <sstream>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -12,8 +14,7 @@
 namespace neograph::mcp {
 namespace {
 
-bool is_within(const std::filesystem::path& child,
-               const std::filesystem::path& root) {
+bool is_within(const std::filesystem::path& child, const std::filesystem::path& root) {
     auto child_it = child.begin();
     auto root_it = root.begin();
     for (; root_it != root.end(); ++root_it, ++child_it) {
@@ -26,26 +27,22 @@ std::filesystem::path resolved_path(const std::filesystem::path& value) {
     std::error_code error;
     auto absolute = std::filesystem::absolute(value, error);
     if (error) {
-        throw std::runtime_error("cannot resolve Harness path: "
-                                 + value.string());
+        throw std::runtime_error("cannot resolve Harness path: " + value.string());
     }
     auto resolved = std::filesystem::weakly_canonical(absolute, error);
     if (error) {
-        throw std::runtime_error("cannot canonicalize Harness path: "
-                                 + absolute.string());
+        throw std::runtime_error("cannot canonicalize Harness path: " + absolute.string());
     }
     return resolved;
 }
 
-json enforce_path_policy(const HarnessWorkerCall& call, const json& tool,
-                         const json& arguments) {
+json enforce_path_policy(const HarnessWorkerCall& call, const json& tool, const json& arguments) {
     const auto path_arguments = tool.value("path_arguments", json::array());
     if (path_arguments.empty()) return arguments;
 
     const auto roots = call.policy.value("workspace_roots", json::array());
     if (roots.empty()) {
-        throw std::runtime_error(
-            "path-bearing tool requires policy.workspace_roots");
+        throw std::runtime_error("path-bearing tool requires policy.workspace_roots");
     }
 
     std::vector<std::filesystem::path> normalized_roots;
@@ -71,8 +68,8 @@ json enforce_path_policy(const HarnessWorkerCall& call, const json& tool,
             }
         }
         if (!allowed) {
-            throw std::runtime_error("tool path escapes configured workspace roots: "
-                                     + candidate.string());
+            throw std::runtime_error("tool path escapes configured workspace roots: " +
+                                     candidate.string());
         }
         normalized_arguments[key] = candidate.string();
     }
@@ -101,15 +98,25 @@ std::string worker_prompt(const HarnessWorkerCall& call) {
     if (!call.repair_feedback.empty()) {
         contract["repair_feedback"] = call.repair_feedback;
     }
+    if (call.resume_value) {
+        contract["host_resume"] = *call.resume_value;
+    }
     return "Execute this worker contract. Use only the supplied tools. Return only "
-           "one JSON value conforming to output_schema, without Markdown fences.\n"
-           + contract.dump(2);
+           "one JSON value conforming to output_schema, without Markdown fences.\n" +
+           contract.dump(2);
+}
+
+std::string host_call_id() {
+    static const std::uint64_t        nonce = std::random_device{}();
+    static std::atomic<std::uint64_t> sequence{1};
+    std::ostringstream                out;
+    out << "hcall_" << std::hex << nonce << '_' << sequence.fetch_add(1, std::memory_order_relaxed);
+    return out.str();
 }
 
 } // namespace
 
-HarnessWorkerExecutor make_provider_harness_executor(
-    HarnessProviderExecutorConfig config) {
+HarnessWorkerExecutor make_provider_harness_executor(HarnessProviderExecutorConfig config) {
     if (!config.provider) {
         throw std::invalid_argument("Harness provider executor requires a provider");
     }
@@ -117,9 +124,8 @@ HarnessWorkerExecutor make_provider_harness_executor(
         throw std::invalid_argument("max_tool_rounds must be between 1 and 64");
     }
 
-    return [config = std::move(config)](
-               const HarnessWorkerCall& call,
-               const std::shared_ptr<graph::CancelToken>& cancel) {
+    return [config = std::move(config)](const HarnessWorkerCall&                   call,
+                                        const std::shared_ptr<graph::CancelToken>& cancel) {
         std::map<std::string, json> catalog;
         for (const auto& tool : call.tool_catalog) {
             catalog[tool["id"].get<std::string>()] = tool;
@@ -148,12 +154,10 @@ HarnessWorkerExecutor make_provider_harness_executor(
 
             if (completion.message.tool_calls.empty()) {
                 if (completion.message.content.empty()) {
-                    return HarnessWorkerResponse::empty(
-                        "provider returned empty content");
+                    return HarnessWorkerResponse::empty("provider returned empty content");
                 }
                 try {
-                    return HarnessWorkerResponse::success(
-                        json::parse(completion.message.content));
+                    return HarnessWorkerResponse::success(json::parse(completion.message.content));
                 } catch (const std::exception& error) {
                     return HarnessWorkerResponse::parse_error(error.what());
                 }
@@ -166,18 +170,31 @@ HarnessWorkerExecutor make_provider_harness_executor(
                     return HarnessWorkerResponse::tool_error(
                         "provider requested undeclared tool: " + tool_call.name);
                 }
-                if (!config.capability_executor) {
-                    return HarnessWorkerResponse::tool_error(
-                        "provider requested a tool but no capability executor is configured");
-                }
                 try {
                     auto arguments = json::parse(tool_call.arguments);
                     validate_json_value(arguments, tool_it->second["input_schema"],
                                         "Harness tool arguments", "$");
-                    arguments = enforce_path_policy(
-                        call, tool_it->second, arguments);
-                    auto result = config.capability_executor(
-                        tool_it->second, arguments, cancel);
+                    arguments           = enforce_path_policy(call, tool_it->second, arguments);
+                    const auto executor = tool_it->second.value("executor", json::object());
+                    if (executor.value("kind", "") == "host_brokered") {
+                        json pending = {
+                            {"call_id", host_call_id()},
+                            {"provider_call_id", tool_call.id},
+                            {"tool_id", tool_call.name},
+                            {"arguments", std::move(arguments)},
+                            {"result_schema",
+                             tool_it->second.value("output_schema", json::object())},
+                        };
+                        if (executor.value("interaction", "tool_result") == "input") {
+                            return HarnessWorkerResponse::input_required(std::move(pending));
+                        }
+                        return HarnessWorkerResponse::awaiting_tool_results(std::move(pending));
+                    }
+                    if (!config.capability_executor) {
+                        return HarnessWorkerResponse::tool_error(
+                            "provider requested a tool but no capability executor is configured");
+                    }
+                    auto result = config.capability_executor(tool_it->second, arguments, cancel);
                     if (tool_it->second.contains("output_schema")) {
                         validate_json_value(result, tool_it->second["output_schema"],
                                             "Harness tool result", "$");

--- a/src/mcp/http_server.cpp
+++ b/src/mcp/http_server.cpp
@@ -1,0 +1,494 @@
+#include <neograph/mcp/http_server.h>
+
+// cpp-httplib v0.41.0 uses blocking Server handlers, bounded below with its
+// runtime ThreadPool. Keep the TLS macro consistent with every NeoGraph TU that
+// instantiates httplib types to avoid the macro-gated layout ODR trap.
+// Source: https://github.com/yhirose/cpp-httplib/blob/v0.41.0/README.md
+// Verified against the vendored header on 2026-07-21.
+#ifndef CPPHTTPLIB_OPENSSL_SUPPORT
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#endif
+#include <httplib.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <cstdint>
+#include <future>
+#include <iomanip>
+#include <map>
+#include <mutex>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+
+namespace neograph::mcp {
+namespace {
+
+json rpc_error(int code, std::string message, json id = nullptr) {
+    return {
+        {"jsonrpc", "2.0"},
+        {"id", std::move(id)},
+        {"error", {{"code", code}, {"message", std::move(message)}}},
+    };
+}
+
+bool is_loopback_bind(const std::string& host) {
+    return host == "127.0.0.1" || host == "::1" || host == "localhost";
+}
+
+std::string lower(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+bool media_type_contains(const std::string& header, const std::string& expected) {
+    std::size_t start = 0;
+    while (start < header.size()) {
+        auto end = header.find(',', start);
+        if (end == std::string::npos) end = header.size();
+        auto token = header.substr(start, end - start);
+        if (const auto parameters = token.find(';'); parameters != std::string::npos) {
+            token.erase(parameters);
+        }
+        const auto first = token.find_first_not_of(" \t");
+        const auto last  = token.find_last_not_of(" \t");
+        if (first != std::string::npos &&
+            lower(token.substr(first, last - first + 1)) == lower(expected)) {
+            return true;
+        }
+        start = end + 1;
+    }
+    return false;
+}
+
+std::string request_key(const json& id) {
+    if (id.is_string()) return "s:" + id.get<std::string>();
+    return "n:" + id.dump();
+}
+
+std::string fresh_session_id() {
+    std::random_device random;
+    std::ostringstream out;
+    out << "ng_" << std::hex << std::setfill('0');
+    for (int i = 0; i < 8; ++i) {
+        out << std::setw(8) << static_cast<std::uint32_t>(random());
+    }
+    return out.str();
+}
+
+void http_error(
+    httplib::Response& response, int status, int rpc_code, std::string message, json id = nullptr) {
+    response.status = status;
+    response.set_content(rpc_error(rpc_code, std::move(message), std::move(id)).dump(),
+                         "application/json");
+}
+
+}  // namespace
+
+struct MCPHttpServer::Impl {
+    struct Session {
+        std::string                                                          scope;
+        std::shared_ptr<void>                                                owner;
+        std::unique_ptr<MCPServer>                                           server;
+        std::mutex                                                           dispatch_mutex;
+        std::mutex                                                           pending_mutex;
+        std::unordered_map<std::string, std::shared_ptr<std::promise<json>>> pending;
+
+        ~Session() {
+            if (server) server->stop();
+        }
+    };
+
+    Impl(ServerFactory value_factory, MCPHttpServerConfig value_config)
+        : factory(std::move(value_factory)), config(std::move(value_config)) {
+        if (!factory) throw std::invalid_argument("MCPHttpServer factory is required");
+        if (config.endpoint.empty() || config.endpoint.front() != '/' ||
+            config.endpoint.find_first_of("\r\n?#") != std::string::npos) {
+            throw std::invalid_argument("MCP HTTP endpoint must be an absolute path");
+        }
+        if (config.port < 0 || config.port > 65535 || config.max_sessions == 0 ||
+            config.max_payload_bytes == 0 || config.http_threads == 0 ||
+            config.max_queued_requests == 0 || config.response_timeout.count() <= 0) {
+            throw std::invalid_argument("MCP HTTP limits and port must be valid");
+        }
+        if (!is_loopback_bind(config.host) && !config.bearer_authorizer) {
+            throw std::invalid_argument("remote MCP HTTP binds require a bearer authorizer");
+        }
+
+        http.set_payload_max_length(config.max_payload_bytes);
+        http.new_task_queue = [threads = config.http_threads, queued = config.max_queued_requests] {
+            return new httplib::ThreadPool(threads, threads, queued);
+        };
+        register_routes();
+    }
+
+    ServerFactory       factory;
+    MCPHttpServerConfig config;
+    httplib::Server     http;
+    std::thread         listener;
+    std::atomic<bool>   running{false};
+    int                 bound_port = 0;
+
+    std::mutex                                      sessions_mutex;
+    std::map<std::string, std::shared_ptr<Session>> sessions;
+    std::size_t                                     creating_sessions = 0;
+
+    std::optional<std::string> authorize(const httplib::Request& request,
+                                         httplib::Response&      response) const {
+        if (!validate_origin(request, response)) return std::nullopt;
+
+        if (!config.bearer_authorizer) return std::string{};
+        const auto                 authorization = request.get_header_value("Authorization");
+        constexpr std::string_view prefix        = "Bearer ";
+        if (authorization.size() <= prefix.size() ||
+            authorization.compare(0, prefix.size(), prefix) != 0) {
+            response.set_header("WWW-Authenticate", "Bearer");
+            http_error(response, 401, -32001, "Bearer authentication is required");
+            return std::nullopt;
+        }
+        std::optional<std::string> scope;
+        try {
+            scope = config.bearer_authorizer(std::string_view(authorization).substr(prefix.size()));
+        } catch (...) {
+            http_error(response, 503, -32000, "Bearer authorization is unavailable");
+            return std::nullopt;
+        }
+        if (!scope || scope->empty()) {
+            response.set_header("WWW-Authenticate", "Bearer error=\"invalid_token\"");
+            http_error(response, 401, -32001, "Bearer token is invalid");
+            return std::nullopt;
+        }
+        return scope;
+    }
+
+    bool validate_origin(const httplib::Request& request, httplib::Response& response) const {
+        if (request.has_header("Origin")) {
+            const auto origin = request.get_header_value("Origin");
+            if (std::find(config.allowed_origins.begin(), config.allowed_origins.end(), origin) ==
+                config.allowed_origins.end()) {
+                http_error(response, 403, -32003, "Origin is not allowed");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    std::shared_ptr<Session> find_session(const std::string& id) {
+        std::lock_guard lock(sessions_mutex);
+        auto            it = sessions.find(id);
+        return it == sessions.end() ? nullptr : it->second;
+    }
+
+    std::pair<std::string, std::shared_ptr<Session>> create_session(std::string scope) {
+        {
+            std::lock_guard lock(sessions_mutex);
+            if (sessions.size() + creating_sessions >= config.max_sessions) {
+                throw std::runtime_error("MCP HTTP session capacity is exhausted");
+            }
+            ++creating_sessions;
+        }
+
+        bool reserved = true;
+        try {
+            auto built      = factory(scope);
+            auto session    = std::make_shared<Session>();
+            session->scope  = std::move(scope);
+            session->server = std::move(built.server);
+            session->owner  = std::move(built.owner);
+            if (!session->server) {
+                throw std::runtime_error("MCP HTTP server factory returned null");
+            }
+
+            std::weak_ptr<Session> weak = session;
+            session->server->set_response_sink([weak](const json& envelope) {
+                auto current = weak.lock();
+                if (!current || !envelope.contains("id")) return;
+                std::shared_ptr<std::promise<json>> promise;
+                {
+                    std::lock_guard lock(current->pending_mutex);
+                    auto            it = current->pending.find(request_key(envelope["id"]));
+                    if (it == current->pending.end()) return;
+                    promise = std::move(it->second);
+                    current->pending.erase(it);
+                }
+                promise->set_value(envelope);
+            });
+
+            std::lock_guard lock(sessions_mutex);
+            std::string     id;
+            do {
+                id = fresh_session_id();
+            } while (sessions.find(id) != sessions.end());
+            sessions.emplace(id, session);
+            --creating_sessions;
+            reserved = false;
+            return {std::move(id), std::move(session)};
+        } catch (...) {
+            if (reserved) {
+                std::lock_guard lock(sessions_mutex);
+                --creating_sessions;
+            }
+            throw;
+        }
+    }
+
+    bool erase_session(const std::string& id) {
+        std::shared_ptr<Session> removed;
+        {
+            std::lock_guard lock(sessions_mutex);
+            auto            it = sessions.find(id);
+            if (it == sessions.end()) return false;
+            removed = std::move(it->second);
+            sessions.erase(it);
+        }
+        removed->server->stop();
+        return true;
+    }
+
+    bool validate_protocol_header(const httplib::Request& request,
+                                  httplib::Response&      response) const {
+        if (request.get_header_value("MCP-Protocol-Version") != MCP_PROTOCOL_VERSION) {
+            http_error(response, 400, -32600,
+                       "MCP-Protocol-Version must be " + std::string(MCP_PROTOCOL_VERSION));
+            return false;
+        }
+        return true;
+    }
+
+    void handle_post(const httplib::Request& request, httplib::Response& response) {
+        auto scope = authorize(request, response);
+        if (!scope) return;
+        if (!media_type_contains(request.get_header_value("Content-Type"), "application/json")) {
+            http_error(response, 415, -32600, "Content-Type must be application/json");
+            return;
+        }
+        const auto accept = request.get_header_value("Accept");
+        if (!media_type_contains(accept, "application/json") ||
+            !media_type_contains(accept, "text/event-stream")) {
+            http_error(response, 406, -32600,
+                       "Accept must include application/json and text/event-stream");
+            return;
+        }
+
+        json envelope;
+        try {
+            envelope = json::parse(request.body);
+        } catch (const std::exception&) {
+            http_error(response, 400, -32700, "Parse error");
+            return;
+        }
+        if (!envelope.is_object()) {
+            http_error(response, 400, -32600, "JSON-RPC body must be an object");
+            return;
+        }
+
+        const bool has_method = envelope.contains("method") && envelope["method"].is_string();
+        const bool initialize = has_method && envelope["method"] == "initialize";
+        const auto session_id = request.get_header_value("Mcp-Session-Id");
+        std::shared_ptr<Session> session;
+        std::string              response_session_id;
+
+        if (initialize && !session_id.empty()) {
+            http_error(response, 400, -32600, "initialize must not include Mcp-Session-Id",
+                       envelope.contains("id") ? envelope["id"] : json(nullptr));
+            return;
+        }
+        if (session_id.empty()) {
+            if (!initialize) {
+                http_error(response, 400, -32600,
+                           "Mcp-Session-Id is required after initialization");
+                return;
+            }
+            try {
+                auto created        = create_session(*scope);
+                response_session_id = std::move(created.first);
+                session             = std::move(created.second);
+            } catch (const std::exception& error) {
+                http_error(response, 503, -32000, error.what());
+                return;
+            }
+        } else {
+            if (!validate_protocol_header(request, response)) return;
+            session = find_session(session_id);
+            if (!session) {
+                http_error(response, 404, -32004, "MCP session was not found");
+                return;
+            }
+            if (session->scope != *scope) {
+                http_error(response, 403, -32003,
+                           "MCP session belongs to a different authorization scope");
+                return;
+            }
+        }
+
+        if (!has_method) {
+            response.status = 202;
+            return;
+        }
+
+        const bool                          has_id = envelope.contains("id");
+        std::shared_ptr<std::promise<json>> promise;
+        std::future<json>                   future;
+        std::string                         key;
+        bool                                owns_waiter = false;
+        if (has_id) {
+            key     = request_key(envelope["id"]);
+            promise = std::make_shared<std::promise<json>>();
+            future  = promise->get_future();
+            std::lock_guard lock(session->pending_mutex);
+            owns_waiter = session->pending.emplace(key, promise).second;
+        }
+        if (has_id && !owns_waiter) {
+            response.status = 200;
+            response.set_content(
+                rpc_error(-32600, "MCP request ID is already in flight", envelope["id"]).dump(),
+                "application/json");
+            return;
+        }
+
+        json immediate;
+        {
+            std::lock_guard lock(session->dispatch_mutex);
+            immediate = session->server->handle_message(envelope);
+        }
+        if (!response_session_id.empty()) {
+            if (!immediate.contains("result")) {
+                erase_session(response_session_id);
+            } else {
+                response.set_header("Mcp-Session-Id", response_session_id);
+            }
+        }
+
+        if (!immediate.is_null()) {
+            if (owns_waiter) {
+                std::lock_guard lock(session->pending_mutex);
+                session->pending.erase(key);
+            }
+            response.status = 200;
+            response.set_content(immediate.dump(), "application/json");
+            return;
+        }
+        if (!has_id) {
+            response.status = 202;
+            return;
+        }
+        if (future.wait_for(config.response_timeout) != std::future_status::ready) {
+            {
+                std::lock_guard lock(session->pending_mutex);
+                session->pending.erase(key);
+            }
+            http_error(response, 504, -32001, "MCP tool response timed out", envelope["id"]);
+            return;
+        }
+        response.status = 200;
+        response.set_content(future.get().dump(), "application/json");
+    }
+
+    void handle_get(const httplib::Request& request, httplib::Response& response) const {
+        if (!validate_origin(request, response)) return;
+        response.status = 405;
+        response.set_header("Allow", "POST, DELETE");
+    }
+
+    void handle_delete(const httplib::Request& request, httplib::Response& response) {
+        auto scope = authorize(request, response);
+        if (!scope) return;
+        if (!validate_protocol_header(request, response)) return;
+        const auto session_id = request.get_header_value("Mcp-Session-Id");
+        auto       session    = find_session(session_id);
+        if (!session) {
+            http_error(response, 404, -32004, "MCP session was not found");
+            return;
+        }
+        if (session->scope != *scope) {
+            http_error(response, 403, -32003,
+                       "MCP session belongs to a different authorization scope");
+            return;
+        }
+        erase_session(session_id);
+        response.status = 204;
+    }
+
+    void register_routes() {
+        http.Post(config.endpoint,
+                  [this](const auto& request, auto& response) { handle_post(request, response); });
+        http.Get(config.endpoint,
+                 [this](const auto& request, auto& response) { handle_get(request, response); });
+        http.Delete(config.endpoint, [this](const auto& request, auto& response) {
+            handle_delete(request, response);
+        });
+    }
+
+    bool bind() {
+        if (config.port == 0) {
+            bound_port = http.bind_to_any_port(config.host);
+            return bound_port >= 0;
+        }
+        if (!http.bind_to_port(config.host, config.port)) return false;
+        bound_port = config.port;
+        return true;
+    }
+
+    void stop_sessions() {
+        std::vector<std::shared_ptr<Session>> active;
+        {
+            std::lock_guard lock(sessions_mutex);
+            for (auto& [id, session] : sessions) {
+                (void)id;
+                active.push_back(std::move(session));
+            }
+            sessions.clear();
+        }
+        for (const auto& session : active)
+            session->server->stop();
+    }
+};
+
+MCPHttpServer::MCPHttpServer(ServerFactory factory, MCPHttpServerConfig config)
+    : impl_(std::make_unique<Impl>(std::move(factory), std::move(config))) {}
+
+MCPHttpServer::~MCPHttpServer() {
+    stop();
+}
+
+bool MCPHttpServer::start() {
+    if (!impl_->bind()) return false;
+    impl_->running.store(true, std::memory_order_release);
+    const bool ok = impl_->http.listen_after_bind();
+    impl_->running.store(false, std::memory_order_release);
+    impl_->stop_sessions();
+    return ok;
+}
+
+bool MCPHttpServer::start_async() {
+    if (!impl_->bind()) return false;
+    impl_->running.store(true, std::memory_order_release);
+    impl_->listener = std::thread([this] {
+        impl_->http.listen_after_bind();
+        impl_->running.store(false, std::memory_order_release);
+    });
+    impl_->http.wait_until_ready();
+    return impl_->http.is_running();
+}
+
+void MCPHttpServer::stop() {
+    if (impl_->http.is_running()) impl_->http.stop();
+    if (impl_->listener.joinable()) impl_->listener.join();
+    impl_->running.store(false, std::memory_order_release);
+    impl_->stop_sessions();
+}
+
+bool MCPHttpServer::is_running() const {
+    return impl_->running.load(std::memory_order_acquire);
+}
+
+int MCPHttpServer::port() const {
+    return impl_->bound_port;
+}
+
+}  // namespace neograph::mcp

--- a/src/mcp/json_schema.cpp
+++ b/src/mcp/json_schema.cpp
@@ -1,0 +1,196 @@
+#include <neograph/mcp/json_schema.h>
+
+#include <algorithm>
+#include <stdexcept>
+#include <vector>
+
+namespace neograph::mcp {
+namespace {
+
+constexpr std::size_t kMaxSchemaDepth = 64;
+
+void check_depth(std::size_t depth, const std::string& path) {
+    if (depth > kMaxSchemaDepth) {
+        throw std::invalid_argument("JSON Schema nesting exceeds 64 levels at "
+                                    + path);
+    }
+}
+
+bool schema_type_matches(const json& value, const std::string& type) {
+    if (type == "null") return value.is_null();
+    if (type == "boolean") return value.is_boolean();
+    if (type == "object") return value.is_object();
+    if (type == "array") return value.is_array();
+    if (type == "number") return value.is_number();
+    if (type == "integer") return value.is_number_integer();
+    if (type == "string") return value.is_string();
+    throw std::invalid_argument("unsupported JSON Schema type: " + type);
+}
+
+void validate_type_name(const json& type, const std::string& path) {
+    if (!type.is_string()) {
+        throw std::invalid_argument("JSON Schema type at " + path
+                                    + " must contain strings");
+    }
+    static const std::vector<std::string> supported = {
+        "null", "boolean", "object", "array", "number", "integer", "string"
+    };
+    const auto name = type.get<std::string>();
+    if (std::find(supported.begin(), supported.end(), name) == supported.end()) {
+        throw std::invalid_argument("unsupported JSON Schema type: " + name);
+    }
+}
+
+void validate_schema_impl(const json& schema, const std::string& path,
+                          std::size_t depth) {
+    check_depth(depth, path);
+    if (!schema.is_object()) {
+        throw std::invalid_argument("JSON Schema at " + path + " must be an object");
+    }
+    if (schema.contains("type")) {
+        if (schema["type"].is_string()) {
+            validate_type_name(schema["type"], path);
+        } else if (schema["type"].is_array()) {
+            for (const auto& type : schema["type"]) validate_type_name(type, path);
+        } else {
+            throw std::invalid_argument("JSON Schema type at " + path
+                                        + " must be a string or array");
+        }
+    }
+    if (schema.contains("enum") && !schema["enum"].is_array()) {
+        throw std::invalid_argument("JSON Schema enum at " + path
+                                    + " must be an array");
+    }
+    if (schema.contains("required")) {
+        if (!schema["required"].is_array()) {
+            throw std::invalid_argument("JSON Schema required at " + path
+                                        + " must be an array");
+        }
+        for (const auto& name : schema["required"]) {
+            if (!name.is_string()) {
+                throw std::invalid_argument("JSON Schema required at " + path
+                                            + " must contain strings");
+            }
+        }
+    }
+    if (schema.contains("properties")) {
+        if (!schema["properties"].is_object()) {
+            throw std::invalid_argument("JSON Schema properties at " + path
+                                        + " must be an object");
+        }
+        for (auto it = schema["properties"].begin();
+             it != schema["properties"].end(); ++it) {
+            validate_schema_impl(it.value(), path + "/properties/" + it.key(),
+                                 depth + 1);
+        }
+    }
+    if (schema.contains("items")) {
+        validate_schema_impl(schema["items"], path + "/items", depth + 1);
+    }
+    if (schema.contains("additionalProperties")
+        && !schema["additionalProperties"].is_boolean()
+        && !schema["additionalProperties"].is_object()) {
+        throw std::invalid_argument("JSON Schema additionalProperties at " + path
+                                    + " must be a boolean or object");
+    }
+    if (schema.contains("additionalProperties")
+        && schema["additionalProperties"].is_object()) {
+        validate_schema_impl(schema["additionalProperties"],
+                             path + "/additionalProperties", depth + 1);
+    }
+}
+
+void validate_value_impl(const json& value, const json& schema,
+                         const std::string& subject, const std::string& path,
+                         std::size_t depth) {
+    check_depth(depth, path);
+    if (schema.contains("const") && value != schema["const"]) {
+        throw std::invalid_argument(subject + " at " + path
+                                    + " does not match const");
+    }
+    if (schema.contains("enum")) {
+        bool matched = false;
+        for (const auto& candidate : schema["enum"]) {
+            if (candidate == value) {
+                matched = true;
+                break;
+            }
+        }
+        if (!matched) {
+            throw std::invalid_argument(subject + " at " + path
+                                        + " is not in enum");
+        }
+    }
+    if (schema.contains("type")) {
+        bool matched = false;
+        const auto& types = schema["type"];
+        if (types.is_string()) {
+            matched = schema_type_matches(value, types.get<std::string>());
+        } else {
+            for (const auto& type : types) {
+                if (schema_type_matches(value, type.get<std::string>())) {
+                    matched = true;
+                    break;
+                }
+            }
+        }
+        if (!matched) {
+            throw std::invalid_argument(subject + " at " + path
+                                        + " has the wrong JSON type");
+        }
+    }
+    if (value.is_object()) {
+        if (schema.contains("required")) {
+            for (const auto& name : schema["required"]) {
+                const auto property = name.get<std::string>();
+                if (!value.contains(property)) {
+                    throw std::invalid_argument(subject + " at " + path
+                                                + " is missing required property "
+                                                + property);
+                }
+            }
+        }
+        const json properties = schema.value("properties", json::object());
+        for (auto it = properties.begin(); it != properties.end(); ++it) {
+            if (value.contains(it.key())) {
+                validate_value_impl(value[it.key()], it.value(), subject,
+                                    path + "/" + it.key(), depth + 1);
+            }
+        }
+        if (schema.contains("additionalProperties")) {
+            const auto& additional = schema["additionalProperties"];
+            for (auto it = value.begin(); it != value.end(); ++it) {
+                if (properties.contains(it.key())) continue;
+                if (additional.is_boolean() && !additional.get<bool>()) {
+                    throw std::invalid_argument(subject + " at " + path
+                                                + " has unexpected property "
+                                                + it.key());
+                }
+                if (additional.is_object()) {
+                    validate_value_impl(it.value(), additional, subject,
+                                        path + "/" + it.key(), depth + 1);
+                }
+            }
+        }
+    }
+    if (value.is_array() && schema.contains("items")) {
+        for (std::size_t i = 0; i < value.size(); ++i) {
+            validate_value_impl(value[i], schema["items"], subject,
+                                path + "/" + std::to_string(i), depth + 1);
+        }
+    }
+}
+
+} // namespace
+
+void validate_json_schema(const json& schema, const std::string& path) {
+    validate_schema_impl(schema, path, 0);
+}
+
+void validate_json_value(const json& value, const json& schema,
+                         const std::string& subject, const std::string& path) {
+    validate_schema_impl(schema, path, 0);
+    validate_value_impl(value, schema, subject, path, 0);
+}
+
+} // namespace neograph::mcp

--- a/src/mcp/server.cpp
+++ b/src/mcp/server.cpp
@@ -1,6 +1,6 @@
 #include <neograph/mcp/server.h>
+#include <neograph/mcp/json_schema.h>
 
-#include <algorithm>
 #include <atomic>
 #include <condition_variable>
 #include <deque>
@@ -44,180 +44,11 @@ std::string request_key(const json& id) {
     return "n:" + id.dump();
 }
 
-bool schema_type_matches(const json& value, const std::string& type) {
-    if (type == "null") return value.is_null();
-    if (type == "boolean") return value.is_boolean();
-    if (type == "object") return value.is_object();
-    if (type == "array") return value.is_array();
-    if (type == "number") return value.is_number();
-    if (type == "integer") return value.is_number_integer();
-    if (type == "string") return value.is_string();
-    throw std::invalid_argument("unsupported JSON Schema type: " + type);
-}
-
-void validate_schema_shape(const json& schema, const std::string& path) {
-    if (!schema.is_object()) {
-        throw std::invalid_argument("JSON Schema at " + path + " must be an object");
-    }
-    if (schema.contains("type")) {
-        const auto validate_type = [&path](const json& type) {
-            if (!type.is_string()) {
-                throw std::invalid_argument("JSON Schema type at " + path
-                                            + " must contain strings");
-            }
-            static const std::vector<std::string> supported = {
-                "null", "boolean", "object", "array", "number", "integer", "string"
-            };
-            const auto name = type.get<std::string>();
-            if (std::find(supported.begin(), supported.end(), name) == supported.end()) {
-                throw std::invalid_argument("unsupported JSON Schema type: " + name);
-            }
-        };
-        if (schema["type"].is_string()) {
-            validate_type(schema["type"]);
-        } else if (schema["type"].is_array()) {
-            for (const auto& type : schema["type"]) validate_type(type);
-        } else {
-            throw std::invalid_argument("JSON Schema type at " + path
-                                        + " must be a string or array");
-        }
-    }
-    if (schema.contains("enum") && !schema["enum"].is_array()) {
-        throw std::invalid_argument("JSON Schema enum at " + path
-                                    + " must be an array");
-    }
-    if (schema.contains("required")) {
-        if (!schema["required"].is_array()) {
-            throw std::invalid_argument("JSON Schema required at " + path
-                                        + " must be an array");
-        }
-        for (const auto& name : schema["required"]) {
-            if (!name.is_string()) {
-                throw std::invalid_argument("JSON Schema required at " + path
-                                            + " must contain strings");
-            }
-        }
-    }
-    if (schema.contains("properties")) {
-        if (!schema["properties"].is_object()) {
-            throw std::invalid_argument("JSON Schema properties at " + path
-                                        + " must be an object");
-        }
-        for (auto it = schema["properties"].begin();
-             it != schema["properties"].end(); ++it) {
-            validate_schema_shape(it.value(), path + "/properties/" + it.key());
-        }
-    }
-    if (schema.contains("items")) {
-        validate_schema_shape(schema["items"], path + "/items");
-    }
-}
-
-void validate_value(const json& value, const json& schema,
-                    const std::string& subject, const std::string& path) {
-    if (!schema.is_object()) {
-        throw std::invalid_argument(subject + " schema at " + path
-                                    + " must be an object");
-    }
-    if (schema.contains("const") && value != schema["const"]) {
-        throw std::invalid_argument(subject + " at " + path
-                                    + " does not match const");
-    }
-    if (schema.contains("enum")) {
-        if (!schema["enum"].is_array()) {
-            throw std::invalid_argument(subject + " schema enum at " + path
-                                        + " must be an array");
-        }
-        bool matched = false;
-        for (const auto& candidate : schema["enum"]) {
-            if (candidate == value) {
-                matched = true;
-                break;
-            }
-        }
-        if (!matched) {
-            throw std::invalid_argument(subject + " at " + path
-                                        + " is not in enum");
-        }
-    }
-    if (schema.contains("type")) {
-        bool matched = false;
-        const auto& types = schema["type"];
-        if (types.is_string()) {
-            matched = schema_type_matches(value, types.get<std::string>());
-        } else if (types.is_array()) {
-            for (const auto& type : types) {
-                if (!type.is_string()) {
-                    throw std::invalid_argument(subject + " schema type at "
-                                                + path + " must contain strings");
-                }
-                if (schema_type_matches(value, type.get<std::string>())) {
-                    matched = true;
-                    break;
-                }
-            }
-        } else {
-            throw std::invalid_argument(subject + " schema type at " + path
-                                        + " must be a string or array");
-        }
-        if (!matched) {
-            throw std::invalid_argument(subject + " at " + path
-                                        + " has the wrong JSON type");
-        }
-    }
-    if (value.is_object()) {
-        if (schema.contains("required")) {
-            if (!schema["required"].is_array()) {
-                throw std::invalid_argument(subject + " schema required at "
-                                            + path + " must be an array");
-            }
-            for (const auto& name : schema["required"]) {
-                if (!name.is_string()) {
-                    throw std::invalid_argument(subject
-                        + " schema required entries must be strings");
-                }
-                const auto property = name.get<std::string>();
-                if (!value.contains(property)) {
-                    throw std::invalid_argument(subject + " at " + path
-                                                + " is missing required property "
-                                                + property);
-                }
-            }
-        }
-        const json properties = schema.value("properties", json::object());
-        if (!properties.is_object()) {
-            throw std::invalid_argument(subject + " schema properties at "
-                                        + path + " must be an object");
-        }
-        for (auto it = properties.begin(); it != properties.end(); ++it) {
-            if (value.contains(it.key())) {
-                validate_value(value[it.key()], it.value(), subject,
-                               path + "/" + it.key());
-            }
-        }
-        if (schema.value("additionalProperties", true) == false) {
-            for (auto it = value.begin(); it != value.end(); ++it) {
-                if (!properties.contains(it.key())) {
-                    throw std::invalid_argument(subject + " at " + path
-                                                + " has unexpected property "
-                                                + it.key());
-                }
-            }
-        }
-    }
-    if (value.is_array() && schema.contains("items")) {
-        for (std::size_t i = 0; i < value.size(); ++i) {
-            validate_value(value[i], schema["items"], subject,
-                           path + "/" + std::to_string(i));
-        }
-    }
-}
-
 void validate_definition(const ToolDefinition& definition) {
     ToolDefinition::from_json(definition.to_json());
-    validate_schema_shape(definition.input_schema, "inputSchema");
+    validate_json_schema(definition.input_schema, "inputSchema");
     if (!definition.output_schema.is_null()) {
-        validate_schema_shape(definition.output_schema, "outputSchema");
+        validate_json_schema(definition.output_schema, "outputSchema");
     }
 }
 
@@ -307,9 +138,9 @@ struct MCPServer::Impl {
                         throw std::invalid_argument(
                             "tool advertised outputSchema but returned no structuredContent");
                     }
-                    validate_value(result.structured_content,
-                                   task->tool.definition.output_schema,
-                                   "MCP tool structuredContent", "$");
+                    validate_json_value(result.structured_content,
+                                        task->tool.definition.output_schema,
+                                        "MCP tool structuredContent", "$");
                 }
                 task->cancel->throw_if_cancelled("after tool execution");
             } catch (const graph::CancelledException& e) {
@@ -399,8 +230,8 @@ struct MCPServer::Impl {
             tool = it->second;
         }
         try {
-            validate_value(arguments, tool.definition.input_schema,
-                           "MCP tool arguments", "$");
+            validate_json_value(arguments, tool.definition.input_schema,
+                                "MCP tool arguments", "$");
         } catch (const std::exception& e) {
             return rpc_result(tool_error(e.what()).to_json(), id);
         }

--- a/src/mcp/server.cpp
+++ b/src/mcp/server.cpp
@@ -1,5 +1,5 @@
-#include <neograph/mcp/server.h>
 #include <neograph/mcp/json_schema.h>
+#include <neograph/mcp/server.h>
 
 #include <atomic>
 #include <condition_variable>
@@ -21,8 +21,7 @@ json rpc_result(json result, const json& id) {
     return {{"jsonrpc", "2.0"}, {"id", id}, {"result", std::move(result)}};
 }
 
-json rpc_error(int code, std::string message, const json& id,
-               json data = nullptr) {
+json rpc_error(int code, std::string message, const json& id, json data = nullptr) {
     json error = {{"code", code}, {"message", std::move(message)}};
     if (!data.is_null()) error["data"] = std::move(data);
     return {{"jsonrpc", "2.0"}, {"id", id}, {"error", std::move(error)}};
@@ -58,12 +57,14 @@ struct MCPServer::Impl {
     struct RegisteredTool {
         ToolDefinition definition;
         ToolHandler handler;
+        RawToolHandler raw_handler;
     };
 
     struct CallTask {
         json id;
         std::string key;
         json arguments;
+        json                                meta;
         RegisteredTool tool;
         std::shared_ptr<graph::CancelToken> cancel;
     };
@@ -78,6 +79,9 @@ struct MCPServer::Impl {
 
     std::mutex tools_mu;
     std::map<std::string, RegisteredTool> tools;
+    std::map<std::string, MethodHandler>  methods;
+    json                                  extensions        = json::object();
+    json                                  client_extensions = json::object();
 
     std::shared_ptr<ResponseSink> sink;
 
@@ -89,8 +93,7 @@ struct MCPServer::Impl {
 
     void emit(const json& envelope) noexcept {
         try {
-            auto current = std::atomic_load_explicit(&sink,
-                                                     std::memory_order_acquire);
+            auto current = std::atomic_load_explicit(&sink, std::memory_order_acquire);
             if (current && *current) (*current)(envelope);
         } catch (...) {
             // A transport failure cannot safely be reported through itself.
@@ -120,42 +123,50 @@ struct MCPServer::Impl {
             {
                 std::unique_lock lk(calls_mu);
                 calls_cv.wait(lk, [this] {
-                    return stopping.load(std::memory_order_acquire)
-                        || !queue.empty();
+                    return stopping.load(std::memory_order_acquire) || !queue.empty();
                 });
                 if (queue.empty()) return;
                 task = std::move(queue.front());
                 queue.pop_front();
             }
 
-            CallToolResult result;
+            json result_json;
             try {
                 task->cancel->throw_if_cancelled("before tool execution");
-                result = task->tool.handler(task->arguments, task->cancel);
-                result = CallToolResult::from_json(result.to_json());
-                if (!result.is_error && !task->tool.definition.output_schema.is_null()) {
-                    if (result.structured_content.is_null()) {
-                        throw std::invalid_argument(
-                            "tool advertised outputSchema but returned no structuredContent");
+                if (task->tool.raw_handler) {
+                    result_json = task->tool.raw_handler(task->arguments, task->cancel, task->meta);
+                    if (!result_json.is_object()) {
+                        throw std::invalid_argument("raw MCP tool handler must return an object");
                     }
-                    validate_json_value(result.structured_content,
-                                        task->tool.definition.output_schema,
-                                        "MCP tool structuredContent", "$");
+                } else {
+                    auto result = task->tool.handler(task->arguments, task->cancel);
+                    result      = CallToolResult::from_json(result.to_json());
+                    if (!result.is_error && !task->tool.definition.output_schema.is_null()) {
+                        if (result.structured_content.is_null()) {
+                            throw std::invalid_argument(
+                                "tool advertised outputSchema but returned no structuredContent");
+                        }
+                        validate_json_value(result.structured_content,
+                                            task->tool.definition.output_schema,
+                                            "MCP tool structuredContent", "$");
+                    }
+                    result_json = result.to_json();
                 }
                 task->cancel->throw_if_cancelled("after tool execution");
             } catch (const graph::CancelledException& e) {
-                result = tool_error(e.what());
+                result_json = tool_error(e.what()).to_json();
             } catch (const std::exception& e) {
-                result = tool_error(std::string("Tool execution failed: ") + e.what());
+                result_json =
+                    tool_error(std::string("Tool execution failed: ") + e.what()).to_json();
             } catch (...) {
-                result = tool_error("Tool execution failed: unknown exception");
+                result_json = tool_error("Tool execution failed: unknown exception").to_json();
             }
 
             {
                 std::lock_guard lk(calls_mu);
                 active.erase(task->key);
             }
-            emit(rpc_result(result.to_json(), task->id));
+            emit(rpc_result(std::move(result_json), task->id));
         }
     }
 
@@ -163,17 +174,13 @@ struct MCPServer::Impl {
         if (initialize_seen.exchange(true, std::memory_order_acq_rel)) {
             return rpc_error(-32600, "MCP initialize may only be sent once", id);
         }
-        if (!params.is_object()
-            || !params.contains("protocolVersion")
-            || !params["protocolVersion"].is_string()
-            || !params.contains("capabilities")
-            || !params["capabilities"].is_object()
-            || !params.contains("clientInfo")
-            || !params["clientInfo"].is_object()) {
+        if (!params.is_object() || !params.contains("protocolVersion") ||
+            !params["protocolVersion"].is_string() || !params.contains("capabilities") ||
+            !params["capabilities"].is_object() || !params.contains("clientInfo") ||
+            !params["clientInfo"].is_object()) {
             initialize_seen.store(false, std::memory_order_release);
-            return rpc_error(-32602,
-                "initialize requires protocolVersion, capabilities, and clientInfo",
-                id);
+            return rpc_error(
+                -32602, "initialize requires protocolVersion, capabilities, and clientInfo", id);
         }
 
         json result = {
@@ -181,6 +188,11 @@ struct MCPServer::Impl {
             {"capabilities", {{"tools", {{"listChanged", false}}}}},
             {"serverInfo", config.server_info},
         };
+        const auto client_capabilities = params.value("capabilities", json::object());
+        client_extensions              = client_capabilities.value("extensions", json::object());
+        if (!extensions.empty()) {
+            result["capabilities"]["extensions"] = extensions;
+        }
         if (!config.instructions.empty()) {
             result["instructions"] = config.instructions;
         }
@@ -192,9 +204,7 @@ struct MCPServer::Impl {
             return rpc_error(-32602, "tools/list params must be an object", id);
         }
         if (params.is_object() && params.contains("cursor")) {
-            return rpc_error(-32602,
-                             "tools/list cursor is invalid: this catalogue is unpaged",
-                             id);
+            return rpc_error(-32602, "tools/list cursor is invalid: this catalogue is unpaged", id);
         }
 
         json listed = json::array();
@@ -209,14 +219,17 @@ struct MCPServer::Impl {
     }
 
     json handle_tools_call(const json& params, const json& id) {
-        if (!params.is_object() || !params.contains("name")
-            || !params["name"].is_string()
-            || params["name"].get<std::string>().empty()) {
+        if (!params.is_object() || !params.contains("name") || !params["name"].is_string() ||
+            params["name"].get<std::string>().empty()) {
             return rpc_error(-32602, "tools/call requires a non-empty name", id);
         }
         json arguments = params.value("arguments", json::object());
         if (!arguments.is_object()) {
             return rpc_error(-32602, "tools/call arguments must be an object", id);
+        }
+        json meta = params.value("_meta", json::object());
+        if (!meta.is_object()) {
+            return rpc_error(-32602, "tools/call _meta must be an object", id);
         }
 
         RegisteredTool tool;
@@ -230,8 +243,7 @@ struct MCPServer::Impl {
             tool = it->second;
         }
         try {
-            validate_json_value(arguments, tool.definition.input_schema,
-                                "MCP tool arguments", "$");
+            validate_json_value(arguments, tool.definition.input_schema, "MCP tool arguments", "$");
         } catch (const std::exception& e) {
             return rpc_result(tool_error(e.what()).to_json(), id);
         }
@@ -240,6 +252,8 @@ struct MCPServer::Impl {
         task->id = id;
         task->key = request_key(id);
         task->arguments = std::move(arguments);
+        task->meta                                     = std::move(meta);
+        task->meta["io.neograph/negotiatedExtensions"] = client_extensions;
         task->tool = std::move(tool);
         task->cancel = std::make_shared<graph::CancelToken>();
 
@@ -251,11 +265,9 @@ struct MCPServer::Impl {
             if (active.contains(task->key)) {
                 return rpc_error(-32600, "duplicate in-flight request id", id);
             }
-            const auto capacity = config.max_concurrent_calls
-                                + config.max_pending_calls;
+            const auto capacity = config.max_concurrent_calls + config.max_pending_calls;
             if (active.size() >= capacity) {
-                return rpc_error(-32000, "MCP tool queue is full", id,
-                                 {{"capacity", capacity}});
+                return rpc_error(-32000, "MCP tool queue is full", id, {{"capacity", capacity}});
             }
             active.emplace(task->key, task);
             queue.push_back(task);
@@ -265,8 +277,8 @@ struct MCPServer::Impl {
     }
 
     void handle_cancel(const json& params) {
-        if (!params.is_object() || !params.contains("requestId")
-            || !valid_request_id(params["requestId"])) {
+        if (!params.is_object() || !params.contains("requestId") ||
+            !valid_request_id(params["requestId"])) {
             return;
         }
         std::shared_ptr<CallTask> task;
@@ -279,15 +291,12 @@ struct MCPServer::Impl {
     }
 };
 
-MCPServer::MCPServer(MCPServerConfig config)
-    : impl_(std::make_unique<Impl>(std::move(config))) {
-    if (!impl_->config.server_info.is_object()
-        || !impl_->config.server_info.contains("name")
-        || !impl_->config.server_info["name"].is_string()
-        || !impl_->config.server_info.contains("version")
-        || !impl_->config.server_info["version"].is_string()) {
-        throw std::invalid_argument(
-            "MCP server_info requires string name and version fields");
+MCPServer::MCPServer(MCPServerConfig config) : impl_(std::make_unique<Impl>(std::move(config))) {
+    if (!impl_->config.server_info.is_object() || !impl_->config.server_info.contains("name") ||
+        !impl_->config.server_info["name"].is_string() ||
+        !impl_->config.server_info.contains("version") ||
+        !impl_->config.server_info["version"].is_string()) {
+        throw std::invalid_argument("MCP server_info requires string name and version fields");
     }
     if (impl_->config.max_concurrent_calls == 0) {
         throw std::invalid_argument("MCP max_concurrent_calls must be positive");
@@ -308,10 +317,53 @@ void MCPServer::register_tool(ToolDefinition definition, ToolHandler handler) {
     const auto name = definition.name;
     std::lock_guard lk(impl_->tools_mu);
     auto [it, inserted] = impl_->tools.emplace(
-        name, Impl::RegisteredTool{std::move(definition), std::move(handler)});
+        name, Impl::RegisteredTool{std::move(definition), std::move(handler), {}});
     if (!inserted) {
         throw std::invalid_argument("duplicate MCP tool name: " + it->first);
     }
+}
+
+void MCPServer::register_raw_tool(ToolDefinition definition, RawToolHandler handler) {
+    if (!handler) throw std::invalid_argument("MCP raw tool handler must be callable");
+    if (impl_->initialize_seen.load(std::memory_order_acquire)) {
+        throw std::logic_error("MCP tools must be registered before initialize");
+    }
+    validate_definition(definition);
+    const auto      name = definition.name;
+    std::lock_guard lk(impl_->tools_mu);
+    auto [it, inserted] = impl_->tools.emplace(
+        name, Impl::RegisteredTool{std::move(definition), {}, std::move(handler)});
+    if (!inserted) {
+        throw std::invalid_argument("duplicate MCP tool name: " + it->first);
+    }
+}
+
+void MCPServer::register_method(std::string method, MethodHandler handler) {
+    if (method.empty() || !handler) {
+        throw std::invalid_argument("MCP extension method requires a name and callable handler");
+    }
+    if (impl_->initialize_seen.load(std::memory_order_acquire)) {
+        throw std::logic_error("MCP methods must be registered before initialize");
+    }
+    std::lock_guard lk(impl_->tools_mu);
+    auto [it, inserted] = impl_->methods.emplace(std::move(method), std::move(handler));
+    if (!inserted) {
+        throw std::invalid_argument("duplicate MCP method name: " + it->first);
+    }
+}
+
+void MCPServer::register_extension(std::string identifier, json settings) {
+    if (identifier.empty() || !settings.is_object()) {
+        throw std::invalid_argument("MCP extension requires an identifier and object settings");
+    }
+    if (impl_->initialize_seen.load(std::memory_order_acquire)) {
+        throw std::logic_error("MCP extensions must be registered before initialize");
+    }
+    std::lock_guard lk(impl_->tools_mu);
+    if (impl_->extensions.contains(identifier)) {
+        throw std::invalid_argument("duplicate MCP extension: " + identifier);
+    }
+    impl_->extensions[identifier] = std::move(settings);
 }
 
 json MCPServer::handle_message(const json& envelope) {
@@ -321,8 +373,8 @@ json MCPServer::handle_message(const json& envelope) {
     if (!envelope.contains("method")) {
         // The server currently sends no requests, so inbound responses have no
         // waiter. Valid response envelopes are ignored rather than answered.
-        if (envelope.contains("id")
-            && (envelope.contains("result") || envelope.contains("error"))) {
+        if (envelope.contains("id") &&
+            (envelope.contains("result") || envelope.contains("error"))) {
             return nullptr;
         }
         return rpc_error(-32600, "JSON-RPC request is missing method", nullptr);
@@ -357,6 +409,22 @@ json MCPServer::handle_message(const json& envelope) {
     }
     if (method == "tools/list") return impl_->handle_tools_list(params, id);
     if (method == "tools/call") return impl_->handle_tools_call(params, id);
+    MCPServer::MethodHandler extension_handler;
+    {
+        std::lock_guard lk(impl_->tools_mu);
+        auto            it = impl_->methods.find(method);
+        if (it != impl_->methods.end()) extension_handler = it->second;
+    }
+    if (extension_handler) {
+        try {
+            json context = {{"extensions", impl_->client_extensions}};
+            return rpc_result(extension_handler(params, context), id);
+        } catch (const std::invalid_argument& error) {
+            return rpc_error(-32602, error.what(), id);
+        } catch (const std::exception& error) {
+            return rpc_error(-32603, error.what(), id);
+        }
+    }
     return rpc_error(-32601, "Method not found: " + method, id);
 }
 
@@ -372,8 +440,7 @@ void MCPServer::run(std::istream& in, std::ostream& out) {
     });
 
     std::string line;
-    while (!impl_->stopping.load(std::memory_order_acquire)
-           && std::getline(in, line)) {
+    while (!impl_->stopping.load(std::memory_order_acquire) && std::getline(in, line)) {
         if (line.empty()) continue;
         json response;
         try {
@@ -400,10 +467,8 @@ void MCPServer::run() {
 }
 
 void MCPServer::set_response_sink(ResponseSink sink) {
-    std::atomic_store_explicit(
-        &impl_->sink,
-        std::make_shared<ResponseSink>(std::move(sink)),
-        std::memory_order_release);
+    std::atomic_store_explicit(&impl_->sink, std::make_shared<ResponseSink>(std::move(sink)),
+                               std::memory_order_release);
 }
 
 void MCPServer::stop() {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,10 @@ if(NEOGRAPH_BUILD_MCP_SERVER)
     )
 endif()
 
+if(NEOGRAPH_BUILD_MCP_CLIENT AND NEOGRAPH_BUILD_MCP_SERVER)
+    target_sources(neograph_tests PRIVATE test_harness_mcp_backend.cpp)
+endif()
+
 if(NEOGRAPH_BUILD_A2A)
     target_sources(neograph_tests PRIVATE
         test_a2a_types.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,7 +85,10 @@ if(NEOGRAPH_BUILD_MCP_CLIENT)
 endif()
 
 if(NEOGRAPH_BUILD_MCP_SERVER)
-    target_sources(neograph_tests PRIVATE test_mcp_server.cpp)
+    target_sources(neograph_tests PRIVATE
+        test_mcp_server.cpp
+        test_harness_service.cpp
+    )
 endif()
 
 if(NEOGRAPH_BUILD_A2A)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ if(NEOGRAPH_BUILD_MCP_CLIENT)
         test_mcp_client_async.cpp
         test_mcp_stdio_async.cpp
     )
+    target_compile_definitions(neograph_tests PRIVATE NEOGRAPH_TESTS_HAVE_MCP_CLIENT)
 endif()
 
 if(NEOGRAPH_BUILD_MCP_SERVER)
@@ -89,6 +90,10 @@ if(NEOGRAPH_BUILD_MCP_SERVER)
         test_mcp_server.cpp
         test_harness_service.cpp
     )
+endif()
+
+if(NEOGRAPH_BUILD_MCP_HTTP_SERVER)
+    target_sources(neograph_tests PRIVATE test_mcp_http_server.cpp)
 endif()
 
 if(NEOGRAPH_BUILD_MCP_CLIENT AND NEOGRAPH_BUILD_MCP_SERVER)
@@ -158,6 +163,10 @@ endif()
 
 if(NEOGRAPH_BUILD_MCP_SERVER)
     target_link_libraries(neograph_tests PRIVATE neograph::mcp_server)
+endif()
+
+if(NEOGRAPH_BUILD_MCP_HTTP_SERVER)
+    target_link_libraries(neograph_tests PRIVATE neograph::mcp_http_server)
 endif()
 
 if(NEOGRAPH_BUILD_A2A)

--- a/tests/test_a2a_client.cpp
+++ b/tests/test_a2a_client.cpp
@@ -10,6 +10,7 @@
 
 #include <gtest/gtest.h>
 #include <neograph/a2a/client.h>
+#include <neograph/a2a/harness_backend.h>
 
 #define CPPHTTPLIB_OPENSSL_SUPPORT
 #include <httplib.h>
@@ -130,6 +131,23 @@ TEST(A2AClient, FetchAgentCardReadsWellKnownPath) {
     EXPECT_EQ(card.name,             "mock-agent");
     EXPECT_EQ(card.protocol_version, "0.3.0");
     EXPECT_EQ(card.preferred_transport, "JSONRPC");
+}
+
+TEST(A2AClient, HarnessAdapterCallsConfiguredAgent) {
+    MockA2AServer srv;
+    auto client = std::make_shared<A2AClient>(srv.url());
+    auto executor = make_harness_capability_executor({{"research", client}});
+    json tool = {
+        {"id", "research.ask"},
+        {"executor", {{"kind", "a2a"}, {"agent", "research"}}},
+    };
+
+    auto result = executor(tool, {{"question", "What changed?"}},
+        std::make_shared<neograph::graph::CancelToken>());
+
+    EXPECT_EQ(srv.last_method, "message/send");
+    EXPECT_EQ(result["id"], "task-1");
+    EXPECT_EQ(result["status"]["state"], "completed");
 }
 
 TEST(A2AClient, FetchAgentCardCachesByDefault) {

--- a/tests/test_harness_mcp_backend.cpp
+++ b/tests/test_harness_mcp_backend.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+
+#include <neograph/mcp/client.h>
+#include <neograph/mcp/harness_mcp_backend.h>
+
+#include <filesystem>
+#include <memory>
+
+namespace {
+
+const char* python_cmd() {
+#ifdef _WIN32
+    return "python";
+#else
+    return "python3";
+#endif
+}
+
+TEST(HarnessMcpBackendTest, CallsConfiguredDownstreamServer) {
+    auto fixture = std::filesystem::path(__FILE__).parent_path()
+        / "fixtures" / "mcp_stdio_echo.py";
+    auto client = std::make_shared<neograph::mcp::MCPClient>(
+        std::vector<std::string>{python_cmd(), fixture.string()});
+    ASSERT_TRUE(client->initialize("harness-mcp-backend-test"));
+    auto executor = neograph::mcp::make_mcp_harness_capability_executor(
+        {{"repo", client}});
+
+    neograph::json tool = {
+        {"id", "repo.echo"},
+        {"executor", {{"kind", "mcp"}, {"server_ref", "repo"},
+                       {"tool", "echo"}}},
+    };
+    auto result = executor(tool, {{"msg", "hello"}},
+        std::make_shared<neograph::graph::CancelToken>());
+
+    ASSERT_TRUE(result.contains("content"));
+    ASSERT_EQ(result["content"].size(), 1u);
+    EXPECT_NE(result["content"][0]["text"].get<std::string>().find("hello"),
+              std::string::npos);
+}
+
+TEST(HarnessMcpBackendTest, RejectsUnknownServerReference) {
+    auto executor = neograph::mcp::make_mcp_harness_capability_executor({});
+    neograph::json tool = {
+        {"id", "repo.echo"},
+        {"executor", {{"kind", "mcp"}, {"server_ref", "missing"}}},
+    };
+    EXPECT_THROW(executor(tool, neograph::json::object(),
+                         std::make_shared<neograph::graph::CancelToken>()),
+                 std::runtime_error);
+}
+
+} // namespace

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -1,0 +1,367 @@
+#include <gtest/gtest.h>
+
+#include <neograph/graph/compiler.h>
+#include <neograph/mcp/harness.h>
+#include <neograph/mcp/server.h>
+
+#include <atomic>
+#include <chrono>
+#include <string>
+#include <thread>
+
+using namespace std::chrono_literals;
+
+namespace {
+
+using neograph::json;
+using neograph::mcp::HarnessService;
+using neograph::mcp::HarnessServiceConfig;
+using neograph::mcp::HarnessWorkerCall;
+using neograph::mcp::HarnessWorkerResponse;
+
+json output_schema() {
+    return json::parse(R"JSON({
+        "type":"object",
+        "required":["status","findings"],
+        "properties":{
+            "status":{"enum":["ok","partial","failed"]},
+            "findings":{"type":"array"}
+        },
+        "additionalProperties":false
+    })JSON");
+}
+
+json worker(std::string id, json tools = json::array()) {
+    return {
+        {"id", std::move(id)},
+        {"instructions", "Return structured findings"},
+        {"tools", std::move(tools)},
+        {"output_schema", output_schema()},
+    };
+}
+
+json request(json workers = json::array({worker("reviewer")})) {
+    return {
+        {"task", {
+            {"objective", "Review the change"},
+            {"acceptance", json::array({"Use structured output"})},
+        }},
+        {"harness", {{"mode", "preset"}, {"preset", "fanout_judge"}}},
+        {"workers", std::move(workers)},
+        {"tool_catalog", json::array()},
+        {"budgets", {
+            {"max_steps", 10},
+            {"timeout_seconds", 5},
+            {"max_parallel_workers", 2},
+            {"max_worker_retries", 1},
+        }},
+    };
+}
+
+json wait_terminal(HarnessService& service, const std::string& run_id,
+                   std::chrono::milliseconds timeout = 3s) {
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto snapshot = service.get(run_id);
+        const auto status = snapshot["status"].get<std::string>();
+        if (status != "queued" && status != "running") return snapshot;
+        std::this_thread::sleep_for(2ms);
+    }
+    return service.get(run_id);
+}
+
+TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
+    HarnessService service;
+    neograph::mcp::MCPServerConfig server_config;
+    server_config.server_info = {{"name", "harness-test"}, {"version", "1"}};
+    neograph::mcp::MCPServer server(server_config);
+    service.register_tools(server);
+
+    auto initialize = server.handle_message({
+        {"jsonrpc", "2.0"}, {"id", 1}, {"method", "initialize"},
+        {"params", {
+            {"protocolVersion", "2025-11-25"},
+            {"capabilities", json::object()},
+            {"clientInfo", {{"name", "test"}, {"version", "1"}}},
+        }},
+    });
+    ASSERT_TRUE(initialize.contains("result"));
+    server.handle_message({
+        {"jsonrpc", "2.0"}, {"method", "notifications/initialized"},
+        {"params", json::object()},
+    });
+    auto listed = server.handle_message({
+        {"jsonrpc", "2.0"}, {"id", 2}, {"method", "tools/list"},
+        {"params", json::object()},
+    });
+    ASSERT_TRUE(listed.contains("result"));
+    ASSERT_EQ(listed["result"]["tools"].size(), 5u);
+    EXPECT_EQ(listed["result"]["tools"][0]["name"], "neograph_cancel");
+    EXPECT_EQ(listed["result"]["tools"][4]["name"], "neograph_start");
+    for (const auto& tool : listed["result"]["tools"]) {
+        EXPECT_TRUE(tool.contains("outputSchema"));
+    }
+}
+
+TEST(HarnessServiceTest, MalformedHarnessCannotProduceExecutableArtifact) {
+    HarnessService service;
+    auto malformed = request();
+    malformed["workers"][0]["tools"] = json::array({"missing.tool"});
+
+    auto compiled = service.compile(malformed);
+    EXPECT_FALSE(compiled["ok"].get<bool>());
+    EXPECT_FALSE(compiled.contains("artifact_id"));
+    bool saw_binding_error = false;
+    for (const auto& diagnostic : compiled["diagnostics"]) {
+        EXPECT_TRUE(diagnostic.contains("phase"));
+        EXPECT_TRUE(diagnostic.contains("severity"));
+        EXPECT_TRUE(diagnostic.contains("path"));
+        EXPECT_TRUE(diagnostic.contains("message"));
+        EXPECT_TRUE(diagnostic.contains("witness"));
+        EXPECT_TRUE(diagnostic.contains("source"));
+        if (diagnostic["code"] == "H_UNKNOWN_TOOL") saw_binding_error = true;
+    }
+    EXPECT_TRUE(saw_binding_error);
+
+    auto started = service.start({{"request", malformed}});
+    EXPECT_FALSE(started["started"].get<bool>());
+    EXPECT_EQ(started["status"], "compile_failed");
+}
+
+TEST(HarnessServiceTest, PresetAndEquivalentDslCompileToCanonicalCore) {
+    HarnessService service;
+    auto preset_request = request(json::array({worker("a"), worker("b")}));
+    auto preset = service.compile(preset_request);
+    ASSERT_TRUE(preset["ok"].get<bool>()) << preset.dump();
+
+    auto dsl_request = preset_request;
+    dsl_request["harness"] = {
+        {"mode", "dsl"},
+        {"definition", preset["artifacts"]["core_lockfile"]["content"]},
+    };
+    auto dsl = service.compile(dsl_request);
+    ASSERT_TRUE(dsl["ok"].get<bool>()) << dsl.dump();
+
+    EXPECT_EQ(neograph::graph::GraphCompiler::canon(
+                  preset["artifacts"]["core_lockfile"]["content"]),
+              neograph::graph::GraphCompiler::canon(
+                  dsl["artifacts"]["core_lockfile"]["content"]));
+}
+
+TEST(HarnessServiceTest, BindingDiagnosticCarriesElaboratorSourceCoordinate) {
+    HarnessService service;
+    auto authored = request();
+    authored["harness"] = {
+        {"mode", "dsl"},
+        {"definition", {
+            {"schema_version", 1},
+            {"channels", {
+                {"task", {{"reducer", "overwrite"}, {"initial", json::object()}}},
+                {"worker_results", {{"reducer", "append"}, {"initial", json::array()}}},
+                {"final_result", {{"reducer", "overwrite"}, {"initial", nullptr}}},
+            }},
+            {"nodes", {
+                {"judge", {
+                    {"type", "neograph_harness_judge"},
+                    {"barrier", {{"wait_for", json::array({"panel_worker"})}}},
+                }},
+            }},
+            {"edges", json::array({
+                {{"from", "__start__"}, {"to", "panel_worker"}},
+                {{"from", "panel_worker"}, {"to", "judge"}},
+                {{"from", "judge"}, {"to", "__end__"}},
+            })},
+            {"templates", {
+                {"worker", {
+                    {"params", json::array()},
+                    {"nodes", {
+                        {"worker", {
+                            {"type", "neograph_harness_worker"},
+                            {"worker_id", "undeclared"},
+                        }},
+                    }},
+                }},
+            }},
+            {"use", json::array({{
+                {"template", "worker"}, {"prefix", "panel"},
+                {"args", json::object()},
+            }})},
+        }},
+    };
+
+    auto compiled = service.compile(authored);
+    ASSERT_FALSE(compiled["ok"].get<bool>());
+    bool found = false;
+    for (const auto& diagnostic : compiled["diagnostics"]) {
+        if (diagnostic["code"] != "H_UNKNOWN_WORKER") continue;
+        found = true;
+        EXPECT_NE(diagnostic["source"].get<std::string>().find("use[0]"),
+                  std::string::npos);
+        EXPECT_NE(diagnostic["source"].get<std::string>().find("'worker'"),
+                  std::string::npos);
+    }
+    EXPECT_TRUE(found) << compiled.dump();
+}
+
+TEST(HarnessServiceTest, RepairsInvalidWorkerOutputBeforeJudgeAndReportsZeroFindings) {
+    std::atomic<int> calls{0};
+    HarnessServiceConfig config;
+    config.worker_executor = [&calls](const HarnessWorkerCall& call, const auto&) {
+        ++calls;
+        if (call.attempt == 1) {
+            EXPECT_TRUE(call.repair_feedback.empty());
+            return HarnessWorkerResponse::success({{"status", "ok"}});
+        }
+        EXPECT_NE(call.repair_feedback.find("missing required property findings"),
+                  std::string::npos);
+        return HarnessWorkerResponse::success({
+            {"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+    auto compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    ASSERT_TRUE(started["started"].get<bool>());
+
+    auto finished = wait_terminal(service, started["run_id"].get<std::string>());
+    ASSERT_EQ(finished["status"], "completed") << finished.dump();
+    EXPECT_EQ(finished["result"]["outcome"], "zero_findings");
+    ASSERT_EQ(finished["result"]["workers"].size(), 1u);
+    EXPECT_EQ(finished["result"]["workers"][0]["attempts"], 2);
+    EXPECT_TRUE(finished["result"]["workers"][0].contains("output"));
+    EXPECT_EQ(calls.load(), 2);
+}
+
+TEST(HarnessServiceTest, InvalidWorkerOutputNeverReachesJudgeAsOutput) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::parse_error("invalid JSON at byte 4");
+    };
+    HarnessService service(std::move(config));
+    auto compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    auto finished = wait_terminal(service, started["run_id"].get<std::string>());
+
+    ASSERT_EQ(finished["status"], "completed") << finished.dump();
+    EXPECT_EQ(finished["result"]["outcome"], "failed");
+    const auto rejected = finished["result"]["workers"][0];
+    EXPECT_EQ(rejected["failure_kind"], "parse_error");
+    EXPECT_FALSE(rejected.contains("output"));
+    EXPECT_EQ(rejected["attempts"], 2);
+}
+
+TEST(HarnessServiceTest, PreservesPartialWorkerOutcome) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall& call, const auto&) {
+        return HarnessWorkerResponse::success({
+            {"status", call.worker["id"] == "a" ? "ok" : "partial"},
+            {"findings", json::array()},
+        });
+    };
+    HarnessService service(std::move(config));
+    auto compiled = service.compile(request(json::array({worker("a"), worker("b")})));
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    auto finished = wait_terminal(service, started["run_id"].get<std::string>());
+    ASSERT_EQ(finished["status"], "completed") << finished.dump();
+    EXPECT_EQ(finished["result"]["outcome"], "partial");
+}
+
+TEST(HarnessServiceTest, DistinguishesEmptyResponseAndWorkerTimeout) {
+    {
+        HarnessServiceConfig config;
+        config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+            return HarnessWorkerResponse::empty("model returned no content");
+        };
+        HarnessService service(std::move(config));
+        auto compiled = service.compile(request());
+        ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+        auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+        auto finished = wait_terminal(service, started["run_id"].get<std::string>());
+        ASSERT_EQ(finished["status"], "completed") << finished.dump();
+        EXPECT_EQ(finished["result"]["workers"][0]["failure_kind"],
+                  "empty_response");
+        EXPECT_EQ(finished["result"]["workers"][0]["attempts"], 2);
+    }
+    {
+        HarnessServiceConfig config;
+        config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+            return HarnessWorkerResponse::timeout("downstream worker timed out");
+        };
+        HarnessService service(std::move(config));
+        auto compiled = service.compile(request());
+        ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+        auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+        auto finished = wait_terminal(service, started["run_id"].get<std::string>());
+        ASSERT_EQ(finished["status"], "completed") << finished.dump();
+        EXPECT_EQ(finished["result"]["workers"][0]["failure_kind"], "timeout");
+        EXPECT_EQ(finished["result"]["workers"][0]["attempts"], 1);
+    }
+}
+
+TEST(HarnessServiceTest, GlobalDeadlineHasDistinctRunState) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto& cancel) {
+        while (!cancel->is_cancelled()) std::this_thread::sleep_for(1ms);
+        return HarnessWorkerResponse::cancelled("deadline cancellation");
+    };
+    HarnessService service(std::move(config));
+    auto timed_request = request();
+    timed_request["budgets"]["timeout_seconds"] = 1;
+    auto compiled = service.compile(timed_request);
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    auto finished = wait_terminal(service, started["run_id"].get<std::string>(), 2s);
+    EXPECT_EQ(finished["status"], "timeout") << finished.dump();
+}
+
+TEST(HarnessServiceTest, CooperativeCancellationHasDistinctRunState) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto& cancel) {
+        while (!cancel->is_cancelled()) std::this_thread::sleep_for(1ms);
+        return HarnessWorkerResponse::cancelled("test cancellation");
+    };
+    HarnessService service(std::move(config));
+    auto compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto run_id = started["run_id"].get<std::string>();
+
+    const auto deadline = std::chrono::steady_clock::now() + 1s;
+    while (service.get(run_id)["status"] == "queued"
+           && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    EXPECT_TRUE(service.cancel(run_id));
+    auto finished = wait_terminal(service, run_id);
+    EXPECT_EQ(finished["status"], "cancelled") << finished.dump();
+}
+
+TEST(HarnessServiceTest, ExhaustedMaxStepsHasDistinctRunState) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success({
+            {"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+    auto loop_request = request();
+    auto preset = service.compile(loop_request);
+    ASSERT_TRUE(preset["ok"].get<bool>()) << preset.dump();
+    auto core = preset["artifacts"]["core_lockfile"]["content"];
+    core["edges"] = json::array({
+        {{"from", "__start__"}, {"to", "worker_0"}},
+        {{"from", "worker_0"}, {"to", "worker_0"}},
+        {{"from", "worker_0"}, {"to", "judge"}},
+        {{"from", "judge"}, {"to", "__end__"}},
+    });
+    loop_request["harness"] = {{"mode", "dsl"}, {"definition", core}};
+    loop_request["budgets"]["max_steps"] = 2;
+    auto compiled = service.compile(loop_request);
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    auto finished = wait_terminal(service, started["run_id"].get<std::string>());
+    EXPECT_EQ(finished["status"], "max_steps_exhausted") << finished.dump();
+}
+
+} // namespace

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -100,6 +100,19 @@ std::filesystem::path unique_temp_path(const std::string& stem) {
             std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
 }
 
+class TempDirectoryCleanup {
+public:
+    explicit TempDirectoryCleanup(std::filesystem::path path) : path_(std::move(path)) {}
+
+    ~TempDirectoryCleanup() {
+        std::error_code error;
+        std::filesystem::remove_all(path_, error);
+    }
+
+private:
+    std::filesystem::path path_;
+};
+
 struct ServerResponses {
     std::mutex              mutex;
     std::condition_variable cv;
@@ -470,8 +483,9 @@ TEST(HarnessServiceTest, ProviderExecutorRejectsSymlinkWorkspaceEscape) {
 }
 
 TEST(HarnessServiceTest, ExperimentalTasksProfileNegotiatesAndResumesInput) {
-    const auto               root     = unique_temp_path("neograph-harness-tasks");
-    auto                     provider = std::make_shared<ScriptedProvider>();
+    const auto           root = unique_temp_path("neograph-harness-tasks");
+    TempDirectoryCleanup cleanup(root);
+    auto                 provider = std::make_shared<ScriptedProvider>();
     neograph::ChatCompletion tool_request;
     tool_request.message.tool_calls.push_back(
         {"provider-call", "host.lookup", R"({"query":"needle"})"});
@@ -579,11 +593,11 @@ TEST(HarnessServiceTest, ExperimentalTasksProfileNegotiatesAndResumesInput) {
     });
     EXPECT_EQ(completed["result"]["status"], "completed") << completed.dump();
     EXPECT_EQ(completed["result"]["result"]["structuredContent"]["status"], "completed");
-    std::filesystem::remove_all(root);
 }
 
 TEST(HarnessServiceTest, ExperimentalTasksProfileFallsBackWithoutRequestOptIn) {
     const auto           root = unique_temp_path("neograph-harness-tasks-fallback");
+    TempDirectoryCleanup cleanup(root);
     HarnessServiceConfig config;
     config.checkpoint_store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
     config.record_store = std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
@@ -661,7 +675,6 @@ TEST(HarnessServiceTest, ExperimentalTasksProfileFallsBackWithoutRequestOptIn) {
         {"params", {{"taskId", run_id}}},
     });
     EXPECT_EQ(rejected["error"]["code"], -32602);
-    std::filesystem::remove_all(root);
 }
 
 TEST(HarnessServiceTest, HostBrokeredToolsRequireDurableStores) {

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -3,9 +3,11 @@
 #include <neograph/graph/compiler.h>
 #include <neograph/mcp/harness.h>
 #include <neograph/mcp/server.h>
+#include <neograph/provider.h>
 
 #include <atomic>
 #include <chrono>
+#include <filesystem>
 #include <string>
 #include <thread>
 
@@ -64,11 +66,30 @@ json wait_terminal(HarnessService& service, const std::string& run_id,
     while (std::chrono::steady_clock::now() < deadline) {
         auto snapshot = service.get(run_id);
         const auto status = snapshot["status"].get<std::string>();
-        if (status != "queued" && status != "running") return snapshot;
+        if (status != "queued" && status != "running") {
+            return service.get(run_id, "details");
+        }
         std::this_thread::sleep_for(2ms);
     }
-    return service.get(run_id);
+    return service.get(run_id, "details");
 }
+
+class ScriptedProvider final : public neograph::Provider {
+public:
+    std::vector<neograph::ChatCompletion> completions;
+    std::vector<neograph::CompletionParams> calls;
+
+    neograph::ChatCompletion complete(
+        const neograph::CompletionParams& params) override {
+        calls.push_back(params);
+        if (completions.empty()) throw std::runtime_error("no scripted completion");
+        auto result = completions.front();
+        completions.erase(completions.begin());
+        return result;
+    }
+
+    std::string get_name() const override { return "scripted-harness-provider"; }
+};
 
 TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
     HarnessService service;
@@ -100,7 +121,18 @@ TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
     EXPECT_EQ(listed["result"]["tools"][4]["name"], "neograph_start");
     for (const auto& tool : listed["result"]["tools"]) {
         EXPECT_TRUE(tool.contains("outputSchema"));
+        EXPECT_EQ(tool["inputSchema"].value("type", ""), "object");
     }
+
+    auto invalid_get = server.handle_message({
+        {"jsonrpc", "2.0"}, {"id", 3}, {"method", "tools/call"},
+        {"params", {{"name", "neograph_get"}, {"arguments", json::object()}}},
+    });
+    ASSERT_TRUE(invalid_get.contains("result"));
+    EXPECT_TRUE(invalid_get["result"]["isError"].get<bool>());
+    EXPECT_NE(invalid_get["result"]["content"][0]["text"]
+                  .get<std::string>().find("missing required property run_id"),
+              std::string::npos);
 }
 
 TEST(HarnessServiceTest, MalformedHarnessCannotProduceExecutableArtifact) {
@@ -146,6 +178,218 @@ TEST(HarnessServiceTest, PresetAndEquivalentDslCompileToCanonicalCore) {
                   preset["artifacts"]["core_lockfile"]["content"]),
               neograph::graph::GraphCompiler::canon(
                   dsl["artifacts"]["core_lockfile"]["content"]));
+}
+
+TEST(HarnessServiceTest, ShipsReviewTriageAndResearchPresets) {
+    HarnessService service;
+    auto schema = service.schema();
+    EXPECT_EQ(schema["preset_contracts"].size(), 4u);
+    for (const auto* preset : {
+             "pr_review_panel", "bug_triage", "research_synthesis"}) {
+        auto value = request();
+        value["harness"]["preset"] = preset;
+        auto compiled = service.compile(value);
+        ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+        EXPECT_EQ(compiled["artifacts"]["core_lockfile"]["content"]["name"],
+                  std::string("harness_") + preset);
+    }
+}
+
+TEST(HarnessServiceTest, EnforcesReadOnlyWorkspaceAndEvidenceContracts) {
+    HarnessService service;
+    auto value = request();
+    value["harness"]["preset"] = "pr_review_panel";
+    value["policy"] = {
+        {"read_only", true},
+        {"workspace_roots", json::array({"/workspace"})},
+        {"evidence_required", json::array({"file", "line", "evidence"})},
+    };
+    value["workers"][0]["tools"] = json::array({"repo.read"});
+    value["tool_catalog"] = json::array({{
+        {"id", "repo.read"},
+        {"description", "Read a workspace file"},
+        {"input_schema", {
+            {"type", "object"},
+            {"properties", {{"path", {{"type", "string"}}}}},
+            {"required", json::array({"path"})},
+        }},
+        {"read_only", true},
+        {"path_arguments", json::array({"path"})},
+        {"executor", {{"kind", "mcp"}, {"server_ref", "repo"},
+                       {"tool", "read_file"}}},
+    }});
+
+    auto rejected = service.compile(value);
+    EXPECT_FALSE(rejected["ok"].get<bool>());
+    bool saw_evidence = false;
+    for (const auto& diagnostic : rejected["diagnostics"]) {
+        if (diagnostic["code"] == "H_EVIDENCE_SCHEMA") saw_evidence = true;
+    }
+    EXPECT_TRUE(saw_evidence) << rejected.dump();
+
+    value["workers"][0]["output_schema"]["properties"]["findings"]["items"] = {
+        {"type", "object"},
+        {"required", json::array({"file", "line", "evidence"})},
+        {"properties", {
+            {"file", {{"type", "string"}}},
+            {"line", {{"type", "integer"}}},
+            {"evidence", {{"type", "string"}}},
+        }},
+    };
+    auto accepted = service.compile(value);
+    EXPECT_TRUE(accepted["ok"].get<bool>()) << accepted.dump();
+
+    value["tool_catalog"][0]["read_only"] = false;
+    auto write_rejected = service.compile(value);
+    EXPECT_FALSE(write_rejected["ok"].get<bool>());
+}
+
+TEST(HarnessServiceTest, ProviderExecutorRunsDeclaredToolsAndValidatesPaths) {
+    auto provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion tool_request;
+    tool_request.message.role = "assistant";
+    tool_request.message.tool_calls.push_back(
+        {"call-1", "repo.read", R"({"path":"src/main.cpp"})"});
+    neograph::ChatCompletion final;
+    final.message.role = "assistant";
+    final.message.content = R"({"status":"ok","findings":[]})";
+    provider->completions = {tool_request, final};
+
+    int capability_calls = 0;
+    neograph::mcp::HarnessProviderExecutorConfig config;
+    config.provider = provider;
+    config.model = "test-model";
+    config.capability_executor = [&capability_calls](
+        const json& tool, const json& arguments, const auto&) {
+        ++capability_calls;
+        EXPECT_EQ(tool["id"], "repo.read");
+        EXPECT_EQ(arguments["path"], "/workspace/src/main.cpp");
+        return json{{"content", "int main() {}"}};
+    };
+    auto executor = neograph::mcp::make_provider_harness_executor(
+        std::move(config));
+
+    HarnessWorkerCall call;
+    call.task = {{"objective", "Review"}};
+    call.worker = worker("reviewer", json::array({"repo.read"}));
+    call.tool_catalog = json::array({{
+        {"id", "repo.read"},
+        {"description", "Read file"},
+        {"input_schema", {
+            {"type", "object"},
+            {"required", json::array({"path"})},
+            {"properties", {{"path", {{"type", "string"}}}}},
+        }},
+        {"path_arguments", json::array({"path"})},
+        {"executor", {{"kind", "builtin"}}},
+    }});
+    call.policy = {{"workspace_roots", json::array({"/workspace"})}};
+    auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
+
+    EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::VALUE);
+    EXPECT_EQ(response.value["status"], "ok");
+    EXPECT_EQ(capability_calls, 1);
+    ASSERT_EQ(provider->calls.size(), 2u);
+    EXPECT_EQ(provider->calls[0].model, "test-model");
+    ASSERT_EQ(provider->calls[1].messages.size(), 3u);
+    EXPECT_EQ(provider->calls[1].messages.back().role, "tool");
+}
+
+TEST(HarnessServiceTest, ProviderExecutorRejectsWorkspaceEscapeBeforeToolCall) {
+    auto provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion tool_request;
+    tool_request.message.tool_calls.push_back(
+        {"call-1", "repo.read", R"({"path":"../secret.txt"})"});
+    provider->completions = {tool_request};
+
+    int capability_calls = 0;
+    neograph::mcp::HarnessProviderExecutorConfig config;
+    config.provider = provider;
+    config.capability_executor = [&capability_calls](const json&, const json&,
+                                                     const auto&) {
+        ++capability_calls;
+        return json::object();
+    };
+    auto executor = neograph::mcp::make_provider_harness_executor(
+        std::move(config));
+    HarnessWorkerCall call;
+    call.task = {{"objective", "Review"}};
+    call.worker = worker("reviewer");
+    call.tool_catalog = json::array({{
+        {"id", "repo.read"},
+        {"description", "Read file"},
+        {"input_schema", {
+            {"type", "object"},
+            {"properties", {{"path", {{"type", "string"}}}}},
+        }},
+        {"path_arguments", json::array({"path"})},
+        {"executor", {{"kind", "builtin"}}},
+    }});
+    call.policy = {{"workspace_roots", json::array({"/workspace"})}};
+
+    auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
+    EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::TOOL_ERROR);
+    EXPECT_NE(response.message.find("escapes configured workspace roots"),
+              std::string::npos);
+    EXPECT_EQ(capability_calls, 0);
+}
+
+TEST(HarnessServiceTest, ProviderExecutorRejectsSymlinkWorkspaceEscape) {
+#ifdef _WIN32
+    GTEST_SKIP() << "directory symlink creation requires host privileges on Windows";
+#else
+    const auto base = std::filesystem::temp_directory_path()
+        / ("neograph-harness-path-" + std::to_string(
+            std::chrono::steady_clock::now().time_since_epoch().count()));
+    const auto workspace = base / "workspace";
+    const auto outside = base / "outside";
+    std::filesystem::create_directories(workspace);
+    std::filesystem::create_directories(outside);
+    std::error_code link_error;
+    std::filesystem::create_directory_symlink(
+        outside, workspace / "link", link_error);
+    if (link_error) {
+        std::filesystem::remove_all(base);
+        GTEST_SKIP() << "cannot create test symlink: " << link_error.message();
+    }
+
+    auto provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion tool_request;
+    tool_request.message.tool_calls.push_back(
+        {"call-1", "repo.read", R"({"path":"link/secret.txt"})"});
+    provider->completions = {tool_request};
+    int capability_calls = 0;
+    neograph::mcp::HarnessProviderExecutorConfig config;
+    config.provider = provider;
+    config.capability_executor = [&capability_calls](const json&, const json&,
+                                                     const auto&) {
+        ++capability_calls;
+        return json::object();
+    };
+    auto executor = neograph::mcp::make_provider_harness_executor(
+        std::move(config));
+    HarnessWorkerCall call;
+    call.task = {{"objective", "Review"}};
+    call.worker = worker("reviewer");
+    call.tool_catalog = json::array({{
+        {"id", "repo.read"},
+        {"description", "Read file"},
+        {"input_schema", {
+            {"type", "object"},
+            {"properties", {{"path", {{"type", "string"}}}}},
+        }},
+        {"path_arguments", json::array({"path"})},
+        {"executor", {{"kind", "builtin"}}},
+    }});
+    call.policy = {{"workspace_roots", json::array({workspace.string()})}};
+
+    auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
+    EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::TOOL_ERROR);
+    EXPECT_NE(response.message.find("escapes configured workspace roots"),
+              std::string::npos);
+    EXPECT_EQ(capability_calls, 0);
+    std::filesystem::remove_all(base);
+#endif
 }
 
 TEST(HarnessServiceTest, BindingDiagnosticCarriesElaboratorSourceCoordinate) {
@@ -266,6 +510,38 @@ TEST(HarnessServiceTest, PreservesPartialWorkerOutcome) {
     auto finished = wait_terminal(service, started["run_id"].get<std::string>());
     ASSERT_EQ(finished["status"], "completed") << finished.dump();
     EXPECT_EQ(finished["result"]["outcome"], "partial");
+}
+
+TEST(HarnessServiceTest, ReturnsCompactResultAndUriLinkedDetails) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success({
+            {"status", "ok"},
+            {"findings", json::array({{{"evidence", "line 1"}}})},
+        });
+    };
+    HarnessService service(std::move(config));
+    auto compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto run_id = started["run_id"].get<std::string>();
+    (void)wait_terminal(service, run_id);
+
+    auto compact = service.get(run_id);
+    ASSERT_EQ(compact["status"], "completed");
+    EXPECT_EQ(compact["result"]["finding_count"], 1);
+    EXPECT_FALSE(compact["result"].contains("workers"));
+    EXPECT_EQ(compact["result"]["artifacts"]["details"]["uri"],
+              "neograph://runs/" + run_id + "/details");
+    auto details = service.get(run_id, "details");
+    EXPECT_EQ(details["result"]["workers"].size(), 1u);
+    auto linked = service.read(
+        compact["result"]["artifacts"]["details"]["uri"]
+            .get<std::string>());
+    EXPECT_EQ(linked, details);
+    auto trace = service.get(run_id, "trace");
+    EXPECT_TRUE(trace["result"]["execution_trace"].is_array());
+    EXPECT_THROW(service.get(run_id, "invalid"), std::invalid_argument);
 }
 
 TEST(HarnessServiceTest, DistinguishesEmptyResponseAndWorkerTimeout) {

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -1,13 +1,19 @@
-#include <gtest/gtest.h>
-
+#include <neograph/graph/checkpoint.h>
 #include <neograph/graph/compiler.h>
+
+#include <gtest/gtest.h>
+#ifdef NEOGRAPH_TESTS_HAVE_SQLITE
+#include <neograph/graph/sqlite_checkpoint.h>
+#endif
 #include <neograph/mcp/harness.h>
 #include <neograph/mcp/server.h>
 #include <neograph/provider.h>
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <filesystem>
+#include <mutex>
 #include <string>
 #include <thread>
 
@@ -44,23 +50,86 @@ json worker(std::string id, json tools = json::array()) {
 
 json request(json workers = json::array({worker("reviewer")})) {
     return {
-        {"task", {
-            {"objective", "Review the change"},
-            {"acceptance", json::array({"Use structured output"})},
-        }},
+        {"task",
+         {
+             {"objective", "Review the change"},
+             {"acceptance", json::array({"Use structured output"})},
+         }},
         {"harness", {{"mode", "preset"}, {"preset", "fanout_judge"}}},
         {"workers", std::move(workers)},
         {"tool_catalog", json::array()},
-        {"budgets", {
-            {"max_steps", 10},
-            {"timeout_seconds", 5},
-            {"max_parallel_workers", 2},
-            {"max_worker_retries", 1},
-        }},
+        {"budgets",
+         {
+             {"max_steps", 10},
+             {"timeout_seconds", 5},
+             {"max_parallel_workers", 2},
+             {"max_worker_retries", 1},
+         }},
     };
 }
 
-json wait_terminal(HarnessService& service, const std::string& run_id,
+json host_brokered_request(std::string interaction = "tool_result") {
+    auto value                   = request();
+    value["workers"][0]["tools"] = json::array({"host.lookup"});
+    value["tool_catalog"]        = json::array({{
+        {"id", "host.lookup"},
+        {"description", "Look up a value through the host"},
+        {"input_schema",
+                {
+             {"type", "object"},
+             {"required", json::array({"query"})},
+             {"properties", {{"query", {{"type", "string"}}}}},
+             {"additionalProperties", false},
+         }},
+        {"output_schema",
+                {
+             {"type", "object"},
+             {"required", json::array({"answer"})},
+             {"properties", {{"answer", {{"type", "string"}}}}},
+             {"additionalProperties", false},
+         }},
+        {"read_only", true},
+        {"executor", {{"kind", "host_brokered"}, {"interaction", std::move(interaction)}}},
+    }});
+    return value;
+}
+
+std::filesystem::path unique_temp_path(const std::string& stem) {
+    return std::filesystem::temp_directory_path() /
+           (stem + "-" +
+            std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+}
+
+struct ServerResponses {
+    std::mutex              mutex;
+    std::condition_variable cv;
+    std::vector<json>       values;
+
+    neograph::mcp::MCPServer::ResponseSink sink() {
+        return [this](const json& value) {
+            std::lock_guard lock(mutex);
+            values.push_back(value);
+            cv.notify_all();
+        };
+    }
+
+    json wait(const json& id) {
+        std::unique_lock lock(mutex);
+        cv.wait_for(lock, 3s, [&] {
+            for (const auto& value : values) {
+                if (value.value("id", json(nullptr)) == id) return true;
+            }
+            return false;
+        });
+        for (const auto& value : values) {
+            if (value.value("id", json(nullptr)) == id) return value;
+        }
+        return nullptr;
+    }
+};
+
+json wait_terminal(HarnessService&           service,
+                   const std::string&        run_id,
                    std::chrono::milliseconds timeout = 3s) {
     const auto deadline = std::chrono::steady_clock::now() + timeout;
     while (std::chrono::steady_clock::now() < deadline) {
@@ -79,8 +148,7 @@ public:
     std::vector<neograph::ChatCompletion> completions;
     std::vector<neograph::CompletionParams> calls;
 
-    neograph::ChatCompletion complete(
-        const neograph::CompletionParams& params) override {
+    neograph::ChatCompletion complete(const neograph::CompletionParams& params) override {
         calls.push_back(params);
         if (completions.empty()) throw std::runtime_error("no scripted completion");
         auto result = completions.front();
@@ -99,39 +167,48 @@ TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
     service.register_tools(server);
 
     auto initialize = server.handle_message({
-        {"jsonrpc", "2.0"}, {"id", 1}, {"method", "initialize"},
-        {"params", {
-            {"protocolVersion", "2025-11-25"},
-            {"capabilities", json::object()},
-            {"clientInfo", {{"name", "test"}, {"version", "1"}}},
-        }},
+        {"jsonrpc", "2.0"},
+        {"id", 1},
+        {"method", "initialize"},
+        {"params",
+         {
+             {"protocolVersion", "2025-11-25"},
+             {"capabilities", json::object()},
+             {"clientInfo", {{"name", "test"}, {"version", "1"}}},
+         }},
     });
     ASSERT_TRUE(initialize.contains("result"));
     server.handle_message({
-        {"jsonrpc", "2.0"}, {"method", "notifications/initialized"},
+        {"jsonrpc", "2.0"},
+        {"method", "notifications/initialized"},
         {"params", json::object()},
     });
     auto listed = server.handle_message({
-        {"jsonrpc", "2.0"}, {"id", 2}, {"method", "tools/list"},
+        {"jsonrpc", "2.0"},
+        {"id", 2},
+        {"method", "tools/list"},
         {"params", json::object()},
     });
     ASSERT_TRUE(listed.contains("result"));
-    ASSERT_EQ(listed["result"]["tools"].size(), 5u);
+    ASSERT_EQ(listed["result"]["tools"].size(), 6u);
     EXPECT_EQ(listed["result"]["tools"][0]["name"], "neograph_cancel");
-    EXPECT_EQ(listed["result"]["tools"][4]["name"], "neograph_start");
+    EXPECT_EQ(listed["result"]["tools"][4]["name"], "neograph_schema");
+    EXPECT_EQ(listed["result"]["tools"][5]["name"], "neograph_start");
     for (const auto& tool : listed["result"]["tools"]) {
         EXPECT_TRUE(tool.contains("outputSchema"));
         EXPECT_EQ(tool["inputSchema"].value("type", ""), "object");
     }
 
     auto invalid_get = server.handle_message({
-        {"jsonrpc", "2.0"}, {"id", 3}, {"method", "tools/call"},
+        {"jsonrpc", "2.0"},
+        {"id", 3},
+        {"method", "tools/call"},
         {"params", {{"name", "neograph_get"}, {"arguments", json::object()}}},
     });
     ASSERT_TRUE(invalid_get.contains("result"));
     EXPECT_TRUE(invalid_get["result"]["isError"].get<bool>());
-    EXPECT_NE(invalid_get["result"]["content"][0]["text"]
-                  .get<std::string>().find("missing required property run_id"),
+    EXPECT_NE(invalid_get["result"]["content"][0]["text"].get<std::string>().find(
+                  "missing required property run_id"),
               std::string::npos);
 }
 
@@ -174,18 +251,16 @@ TEST(HarnessServiceTest, PresetAndEquivalentDslCompileToCanonicalCore) {
     auto dsl = service.compile(dsl_request);
     ASSERT_TRUE(dsl["ok"].get<bool>()) << dsl.dump();
 
-    EXPECT_EQ(neograph::graph::GraphCompiler::canon(
-                  preset["artifacts"]["core_lockfile"]["content"]),
-              neograph::graph::GraphCompiler::canon(
-                  dsl["artifacts"]["core_lockfile"]["content"]));
+    EXPECT_EQ(
+        neograph::graph::GraphCompiler::canon(preset["artifacts"]["core_lockfile"]["content"]),
+        neograph::graph::GraphCompiler::canon(dsl["artifacts"]["core_lockfile"]["content"]));
 }
 
 TEST(HarnessServiceTest, ShipsReviewTriageAndResearchPresets) {
     HarnessService service;
     auto schema = service.schema();
     EXPECT_EQ(schema["preset_contracts"].size(), 4u);
-    for (const auto* preset : {
-             "pr_review_panel", "bug_triage", "research_synthesis"}) {
+    for (const auto* preset : {"pr_review_panel", "bug_triage", "research_synthesis"}) {
         auto value = request();
         value["harness"]["preset"] = preset;
         auto compiled = service.compile(value);
@@ -205,18 +280,18 @@ TEST(HarnessServiceTest, EnforcesReadOnlyWorkspaceAndEvidenceContracts) {
         {"evidence_required", json::array({"file", "line", "evidence"})},
     };
     value["workers"][0]["tools"] = json::array({"repo.read"});
-    value["tool_catalog"] = json::array({{
+    value["tool_catalog"]        = json::array({{
         {"id", "repo.read"},
         {"description", "Read a workspace file"},
-        {"input_schema", {
-            {"type", "object"},
-            {"properties", {{"path", {{"type", "string"}}}}},
-            {"required", json::array({"path"})},
-        }},
+        {"input_schema",
+                {
+             {"type", "object"},
+             {"properties", {{"path", {{"type", "string"}}}}},
+             {"required", json::array({"path"})},
+         }},
         {"read_only", true},
         {"path_arguments", json::array({"path"})},
-        {"executor", {{"kind", "mcp"}, {"server_ref", "repo"},
-                       {"tool", "read_file"}}},
+        {"executor", {{"kind", "mcp"}, {"server_ref", "repo"}, {"tool", "read_file"}}},
     }});
 
     auto rejected = service.compile(value);
@@ -230,11 +305,12 @@ TEST(HarnessServiceTest, EnforcesReadOnlyWorkspaceAndEvidenceContracts) {
     value["workers"][0]["output_schema"]["properties"]["findings"]["items"] = {
         {"type", "object"},
         {"required", json::array({"file", "line", "evidence"})},
-        {"properties", {
-            {"file", {{"type", "string"}}},
-            {"line", {{"type", "integer"}}},
-            {"evidence", {{"type", "string"}}},
-        }},
+        {"properties",
+         {
+             {"file", {{"type", "string"}}},
+             {"line", {{"type", "integer"}}},
+             {"evidence", {{"type", "string"}}},
+         }},
     };
     auto accepted = service.compile(value);
     EXPECT_TRUE(accepted["ok"].get<bool>()) << accepted.dump();
@@ -259,15 +335,14 @@ TEST(HarnessServiceTest, ProviderExecutorRunsDeclaredToolsAndValidatesPaths) {
     neograph::mcp::HarnessProviderExecutorConfig config;
     config.provider = provider;
     config.model = "test-model";
-    config.capability_executor = [&capability_calls](
-        const json& tool, const json& arguments, const auto&) {
+    config.capability_executor = [&capability_calls](const json& tool, const json& arguments,
+                                                     const auto&) {
         ++capability_calls;
         EXPECT_EQ(tool["id"], "repo.read");
         EXPECT_EQ(arguments["path"], "/workspace/src/main.cpp");
         return json{{"content", "int main() {}"}};
     };
-    auto executor = neograph::mcp::make_provider_harness_executor(
-        std::move(config));
+    auto executor = neograph::mcp::make_provider_harness_executor(std::move(config));
 
     HarnessWorkerCall call;
     call.task = {{"objective", "Review"}};
@@ -275,11 +350,12 @@ TEST(HarnessServiceTest, ProviderExecutorRunsDeclaredToolsAndValidatesPaths) {
     call.tool_catalog = json::array({{
         {"id", "repo.read"},
         {"description", "Read file"},
-        {"input_schema", {
-            {"type", "object"},
-            {"required", json::array({"path"})},
-            {"properties", {{"path", {{"type", "string"}}}}},
-        }},
+        {"input_schema",
+         {
+             {"type", "object"},
+             {"required", json::array({"path"})},
+             {"properties", {{"path", {{"type", "string"}}}}},
+         }},
         {"path_arguments", json::array({"path"})},
         {"executor", {{"kind", "builtin"}}},
     }});
@@ -305,23 +381,22 @@ TEST(HarnessServiceTest, ProviderExecutorRejectsWorkspaceEscapeBeforeToolCall) {
     int capability_calls = 0;
     neograph::mcp::HarnessProviderExecutorConfig config;
     config.provider = provider;
-    config.capability_executor = [&capability_calls](const json&, const json&,
-                                                     const auto&) {
+    config.capability_executor = [&capability_calls](const json&, const json&, const auto&) {
         ++capability_calls;
         return json::object();
     };
-    auto executor = neograph::mcp::make_provider_harness_executor(
-        std::move(config));
+    auto              executor = neograph::mcp::make_provider_harness_executor(std::move(config));
     HarnessWorkerCall call;
     call.task = {{"objective", "Review"}};
     call.worker = worker("reviewer");
     call.tool_catalog = json::array({{
         {"id", "repo.read"},
         {"description", "Read file"},
-        {"input_schema", {
-            {"type", "object"},
-            {"properties", {{"path", {{"type", "string"}}}}},
-        }},
+        {"input_schema",
+         {
+             {"type", "object"},
+             {"properties", {{"path", {{"type", "string"}}}}},
+         }},
         {"path_arguments", json::array({"path"})},
         {"executor", {{"kind", "builtin"}}},
     }});
@@ -329,8 +404,7 @@ TEST(HarnessServiceTest, ProviderExecutorRejectsWorkspaceEscapeBeforeToolCall) {
 
     auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
     EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::TOOL_ERROR);
-    EXPECT_NE(response.message.find("escapes configured workspace roots"),
-              std::string::npos);
+    EXPECT_NE(response.message.find("escapes configured workspace roots"), std::string::npos);
     EXPECT_EQ(capability_calls, 0);
 }
 
@@ -338,16 +412,15 @@ TEST(HarnessServiceTest, ProviderExecutorRejectsSymlinkWorkspaceEscape) {
 #ifdef _WIN32
     GTEST_SKIP() << "directory symlink creation requires host privileges on Windows";
 #else
-    const auto base = std::filesystem::temp_directory_path()
-        / ("neograph-harness-path-" + std::to_string(
-            std::chrono::steady_clock::now().time_since_epoch().count()));
+    const auto base = std::filesystem::temp_directory_path() /
+                      ("neograph-harness-path-" +
+                       std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
     const auto workspace = base / "workspace";
     const auto outside = base / "outside";
     std::filesystem::create_directories(workspace);
     std::filesystem::create_directories(outside);
     std::error_code link_error;
-    std::filesystem::create_directory_symlink(
-        outside, workspace / "link", link_error);
+    std::filesystem::create_directory_symlink(outside, workspace / "link", link_error);
     if (link_error) {
         std::filesystem::remove_all(base);
         GTEST_SKIP() << "cannot create test symlink: " << link_error.message();
@@ -361,23 +434,22 @@ TEST(HarnessServiceTest, ProviderExecutorRejectsSymlinkWorkspaceEscape) {
     int capability_calls = 0;
     neograph::mcp::HarnessProviderExecutorConfig config;
     config.provider = provider;
-    config.capability_executor = [&capability_calls](const json&, const json&,
-                                                     const auto&) {
+    config.capability_executor = [&capability_calls](const json&, const json&, const auto&) {
         ++capability_calls;
         return json::object();
     };
-    auto executor = neograph::mcp::make_provider_harness_executor(
-        std::move(config));
+    auto              executor = neograph::mcp::make_provider_harness_executor(std::move(config));
     HarnessWorkerCall call;
     call.task = {{"objective", "Review"}};
     call.worker = worker("reviewer");
     call.tool_catalog = json::array({{
         {"id", "repo.read"},
         {"description", "Read file"},
-        {"input_schema", {
-            {"type", "object"},
-            {"properties", {{"path", {{"type", "string"}}}}},
-        }},
+        {"input_schema",
+         {
+             {"type", "object"},
+             {"properties", {{"path", {{"type", "string"}}}}},
+         }},
         {"path_arguments", json::array({"path"})},
         {"executor", {{"kind", "builtin"}}},
     }});
@@ -385,52 +457,555 @@ TEST(HarnessServiceTest, ProviderExecutorRejectsSymlinkWorkspaceEscape) {
 
     auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
     EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::TOOL_ERROR);
-    EXPECT_NE(response.message.find("escapes configured workspace roots"),
-              std::string::npos);
+    EXPECT_NE(response.message.find("escapes configured workspace roots"), std::string::npos);
     EXPECT_EQ(capability_calls, 0);
     std::filesystem::remove_all(base);
 #endif
 }
 
+TEST(HarnessServiceTest, ExperimentalTasksProfileNegotiatesAndResumesInput) {
+    const auto               root     = unique_temp_path("neograph-harness-tasks");
+    auto                     provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion tool_request;
+    tool_request.message.tool_calls.push_back(
+        {"provider-call", "host.lookup", R"({"query":"needle"})"});
+    neograph::ChatCompletion final;
+    final.message.content = R"({"status":"ok","findings":[]})";
+    provider->completions = {tool_request, final};
+
+    HarnessServiceConfig config;
+    config.checkpoint_store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    config.record_store = std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+    config.enable_experimental_tasks = true;
+    config.poll_interval             = 25ms;
+    neograph::mcp::HarnessProviderExecutorConfig provider_config;
+    provider_config.provider = provider;
+    config.worker_executor =
+        neograph::mcp::make_provider_harness_executor(std::move(provider_config));
+    HarnessService service(std::move(config));
+    auto           compiled = service.compile(host_brokered_request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+
+    neograph::mcp::MCPServerConfig server_config;
+    server_config.server_info = {{"name", "tasks-test"}, {"version", "1"}};
+    neograph::mcp::MCPServer server(server_config);
+    ServerResponses          responses;
+    server.set_response_sink(responses.sink());
+    service.register_tools(server);
+    auto initialized = server.handle_message({
+        {"jsonrpc", "2.0"},
+        {"id", 1},
+        {"method", "initialize"},
+        {"params",
+         {
+             {"protocolVersion", "2025-11-25"},
+             {"capabilities",
+              {{"extensions", {{"io.modelcontextprotocol/tasks", json::object()}}}}},
+             {"clientInfo", {{"name", "test"}, {"version", "1"}}},
+         }},
+    });
+    ASSERT_TRUE(initialized.contains("result"));
+    EXPECT_TRUE(initialized["result"]["capabilities"]["extensions"].contains(
+        "io.modelcontextprotocol/tasks"));
+    server.handle_message({
+        {"jsonrpc", "2.0"},
+        {"method", "notifications/initialized"},
+        {"params", json::object()},
+    });
+
+    EXPECT_TRUE(
+        server
+            .handle_message({
+                {"jsonrpc", "2.0"},
+                {"id", 2},
+                {"method", "tools/call"},
+                {"params",
+                 {
+                     {"name", "neograph_start"},
+                     {"arguments", {{"artifact_id", compiled["artifact_id"]}}},
+                     {"_meta",
+                      {{"io.modelcontextprotocol/clientCapabilities",
+                        {{"extensions", {{"io.modelcontextprotocol/tasks", json::object()}}}}}}},
+                 }},
+            })
+            .is_null());
+    auto created = responses.wait(2);
+    ASSERT_TRUE(created.contains("result")) << created.dump();
+    EXPECT_EQ(created["result"]["resultType"], "task");
+    EXPECT_EQ(created["result"]["pollIntervalMs"], 25);
+    const auto task_id = created["result"]["taskId"].get<std::string>();
+
+    auto waiting = wait_terminal(service, task_id);
+    ASSERT_EQ(waiting["status"], "awaiting_tool_results") << waiting.dump();
+    auto polled = server.handle_message({
+        {"jsonrpc", "2.0"},
+        {"id", 3},
+        {"method", "tasks/get"},
+        {"params", {{"taskId", task_id}}},
+    });
+    ASSERT_EQ(polled["result"]["status"], "input_required") << polled.dump();
+    ASSERT_EQ(polled["result"]["inputRequests"].size(), 1u);
+    const auto call_id = polled["result"]["inputRequests"].begin().key();
+
+    auto updated = server.handle_message({
+        {"jsonrpc", "2.0"},
+        {"id", 4},
+        {"method", "tasks/update"},
+        {"params",
+         {
+             {"taskId", task_id},
+             {"inputResponses",
+              {{call_id,
+                {
+                    {"action", "accept"},
+                    {"content", {{"answer", "found"}}},
+                }}}},
+         }},
+    });
+    EXPECT_EQ(updated["result"]["resultType"], "complete") << updated.dump();
+    auto finished = wait_terminal(service, task_id);
+    ASSERT_EQ(finished["status"], "completed") << finished.dump();
+    auto completed = server.handle_message({
+        {"jsonrpc", "2.0"},
+        {"id", 5},
+        {"method", "tasks/get"},
+        {"params", {{"taskId", task_id}}},
+    });
+    EXPECT_EQ(completed["result"]["status"], "completed") << completed.dump();
+    EXPECT_EQ(completed["result"]["result"]["structuredContent"]["status"], "completed");
+    std::filesystem::remove_all(root);
+}
+
+TEST(HarnessServiceTest, ExperimentalTasksProfileFallsBackWithoutRequestOptIn) {
+    const auto           root = unique_temp_path("neograph-harness-tasks-fallback");
+    HarnessServiceConfig config;
+    config.checkpoint_store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    config.record_store = std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+    config.enable_experimental_tasks = true;
+    config.worker_executor           = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+    auto           compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+
+    neograph::mcp::MCPServerConfig server_config;
+    server_config.server_info = {{"name", "tasks-fallback"}, {"version", "1"}};
+    neograph::mcp::MCPServer server(server_config);
+    ServerResponses          responses;
+    server.set_response_sink(responses.sink());
+    service.register_tools(server);
+    server.handle_message({
+        {"jsonrpc", "2.0"},
+        {"id", 1},
+        {"method", "initialize"},
+        {"params",
+         {
+             {"protocolVersion", "2025-11-25"},
+             {"capabilities",
+              {{"extensions", {{"io.modelcontextprotocol/tasks", json::object()}}}}},
+             {"clientInfo", {{"name", "test"}, {"version", "1"}}},
+         }},
+    });
+    server.handle_message({
+        {"jsonrpc", "2.0"},
+        {"method", "notifications/initialized"},
+        {"params", json::object()},
+    });
+    EXPECT_TRUE(server
+                    .handle_message({
+                        {"jsonrpc", "2.0"},
+                        {"id", 2},
+                        {"method", "tools/call"},
+                        {"params",
+                         {
+                             {"name", "neograph_start"},
+                             {"arguments", {{"artifact_id", compiled["artifact_id"]}}},
+                         }},
+                    })
+                    .is_null());
+    auto response = responses.wait(2);
+    ASSERT_TRUE(response["result"].contains("structuredContent")) << response.dump();
+    EXPECT_FALSE(response["result"].contains("resultType"));
+    const auto run_id = response["result"]["structuredContent"]["run_id"].get<std::string>();
+    EXPECT_EQ(wait_terminal(service, run_id)["status"], "completed");
+
+    neograph::mcp::MCPServer unnegotiated(server_config);
+    service.register_tools(unnegotiated);
+    unnegotiated.handle_message({
+        {"jsonrpc", "2.0"},
+        {"id", 10},
+        {"method", "initialize"},
+        {"params",
+         {
+             {"protocolVersion", "2025-11-25"},
+             {"capabilities", json::object()},
+             {"clientInfo", {{"name", "test"}, {"version", "1"}}},
+         }},
+    });
+    unnegotiated.handle_message({
+        {"jsonrpc", "2.0"},
+        {"method", "notifications/initialized"},
+        {"params", json::object()},
+    });
+    auto rejected = unnegotiated.handle_message({
+        {"jsonrpc", "2.0"},
+        {"id", 11},
+        {"method", "tasks/get"},
+        {"params", {{"taskId", run_id}}},
+    });
+    EXPECT_EQ(rejected["error"]["code"], -32602);
+    std::filesystem::remove_all(root);
+}
+
+TEST(HarnessServiceTest, HostBrokeredToolsRequireDurableStores) {
+    HarnessService service;
+    auto           compiled = service.compile(host_brokered_request());
+    ASSERT_FALSE(compiled["ok"].get<bool>());
+    bool saw_durability_error = false;
+    for (const auto& diagnostic : compiled["diagnostics"]) {
+        if (diagnostic["code"] == "H_HOST_BROKER_UNAVAILABLE") {
+            saw_durability_error = true;
+        }
+    }
+    EXPECT_TRUE(saw_durability_error) << compiled.dump();
+}
+
+TEST(HarnessServiceTest, ProviderExecutorReturnsTypedHostPendingStates) {
+    for (const auto& [interaction, expected] :
+         std::vector<std::pair<std::string, neograph::mcp::HarnessWorkerResponseKind>>{
+             {"tool_result", neograph::mcp::HarnessWorkerResponseKind::AWAITING_TOOL_RESULTS},
+             {"input", neograph::mcp::HarnessWorkerResponseKind::INPUT_REQUIRED}}) {
+        auto                     provider = std::make_shared<ScriptedProvider>();
+        neograph::ChatCompletion tool_request;
+        tool_request.message.tool_calls.push_back(
+            {"provider-call", "host.lookup", R"({"query":"needle"})"});
+        provider->completions = {tool_request};
+        neograph::mcp::HarnessProviderExecutorConfig config;
+        config.provider = provider;
+        auto executor   = neograph::mcp::make_provider_harness_executor(std::move(config));
+
+        auto              authored = host_brokered_request(interaction);
+        HarnessWorkerCall call;
+        call.task         = authored["task"];
+        call.worker       = authored["workers"][0];
+        call.tool_catalog = authored["tool_catalog"];
+        auto response     = executor(call, std::make_shared<neograph::graph::CancelToken>());
+        ASSERT_EQ(response.kind, expected);
+        EXPECT_EQ(response.value["tool_id"], "host.lookup");
+        EXPECT_EQ(response.value["provider_call_id"], "provider-call");
+        EXPECT_EQ(response.value["arguments"]["query"], "needle");
+        EXPECT_FALSE(response.value.value("call_id", "").empty());
+    }
+}
+
+TEST(HarnessServiceTest, WaitingHostCallCanBeCancelled) {
+    const auto               root     = unique_temp_path("neograph-harness-cancel");
+    auto                     provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion tool_request;
+    tool_request.message.tool_calls.push_back(
+        {"provider-call", "host.lookup", R"({"query":"needle"})"});
+    provider->completions = {tool_request};
+
+    HarnessServiceConfig config;
+    config.checkpoint_store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    config.record_store = std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+    neograph::mcp::HarnessProviderExecutorConfig provider_config;
+    provider_config.provider = provider;
+    config.worker_executor =
+        neograph::mcp::make_provider_harness_executor(std::move(provider_config));
+    {
+        HarnessService service(std::move(config));
+        auto           compiled = service.compile(host_brokered_request("input"));
+        ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+        auto       started = service.start({{"artifact_id", compiled["artifact_id"]}});
+        const auto run_id  = started["run_id"].get<std::string>();
+        auto       waiting = wait_terminal(service, run_id);
+        ASSERT_EQ(waiting["status"], "input_required") << waiting.dump();
+        EXPECT_TRUE(service.cancel(run_id));
+        EXPECT_EQ(service.get(run_id)["status"], "cancelled");
+        EXPECT_FALSE(service.cancel(run_id));
+    }
+    std::filesystem::remove_all(root);
+}
+
+TEST(HarnessServiceTest, CancellationPropagatesIntoResumedWorker) {
+    const auto           root = unique_temp_path("neograph-harness-resume-cancel");
+    HarnessServiceConfig config;
+    config.checkpoint_store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    config.record_store    = std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+    config.worker_executor = [](const HarnessWorkerCall& call, const auto& cancel) {
+        if (!call.resume_value) {
+            return HarnessWorkerResponse::awaiting_tool_results({
+                {"call_id", "host-call"},
+                {"tool_id", "host.lookup"},
+                {"arguments", {{"query", "needle"}}},
+                {"result_schema",
+                 {
+                     {"type", "object"},
+                     {"required", json::array({"answer"})},
+                     {"properties", {{"answer", {{"type", "string"}}}}},
+                 }},
+            });
+        }
+        while (!cancel->is_cancelled())
+            std::this_thread::sleep_for(1ms);
+        return HarnessWorkerResponse::cancelled("resumed worker cancelled");
+    };
+    {
+        HarnessService service(std::move(config));
+        auto           compiled = service.compile(host_brokered_request());
+        ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+        auto       started = service.start({{"artifact_id", compiled["artifact_id"]}});
+        const auto run_id  = started["run_id"].get<std::string>();
+        auto       waiting = wait_terminal(service, run_id);
+        ASSERT_EQ(waiting["status"], "awaiting_tool_results");
+        auto resumed = service.resume(
+            {{"run_id", run_id}, {"call_id", "host-call"}, {"result", {{"answer", "found"}}}});
+        EXPECT_TRUE(resumed["accepted"].get<bool>());
+        const auto deadline = std::chrono::steady_clock::now() + 1s;
+        while (service.get(run_id)["status"] == "queued" &&
+               std::chrono::steady_clock::now() < deadline) {
+            std::this_thread::sleep_for(1ms);
+        }
+        EXPECT_TRUE(service.cancel(run_id));
+        auto finished = wait_terminal(service, run_id);
+        EXPECT_EQ(finished["status"], "cancelled") << finished.dump();
+    }
+    std::filesystem::remove_all(root);
+}
+
+TEST(HarnessServiceTest, ExpiredHostResultIsRejectedAndPersisted) {
+    const auto               root     = unique_temp_path("neograph-harness-expiry");
+    auto                     provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion tool_request;
+    tool_request.message.tool_calls.push_back(
+        {"provider-call", "host.lookup", R"({"query":"needle"})"});
+    provider->completions = {tool_request};
+
+    std::string run_id;
+    std::string call_id;
+    {
+        HarnessServiceConfig config;
+        config.checkpoint_store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+        config.record_store =
+            std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+        config.run_ttl = 20ms;
+        neograph::mcp::HarnessProviderExecutorConfig provider_config;
+        provider_config.provider = provider;
+        config.worker_executor =
+            neograph::mcp::make_provider_harness_executor(std::move(provider_config));
+        HarnessService service(std::move(config));
+        auto           compiled = service.compile(host_brokered_request());
+        ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+        auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+        run_id       = started["run_id"].get<std::string>();
+        auto waiting = wait_terminal(service, run_id);
+        ASSERT_EQ(waiting["status"], "awaiting_tool_results");
+        call_id = waiting["pending"]["call_id"].get<std::string>();
+        std::this_thread::sleep_for(30ms);
+        EXPECT_THROW(
+            service.resume(
+                {{"run_id", run_id}, {"call_id", call_id}, {"result", {{"answer", "late"}}}}),
+            std::invalid_argument);
+        EXPECT_EQ(service.get(run_id)["status"], "expired");
+    }
+    auto records   = std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+    auto persisted = records->load_run(run_id);
+    ASSERT_TRUE(persisted.has_value());
+    EXPECT_EQ((*persisted)["status"], "expired");
+    std::filesystem::remove_all(root);
+}
+
+#ifdef NEOGRAPH_TESTS_HAVE_SQLITE
+TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
+    const auto root     = unique_temp_path("neograph-harness-resume");
+    const auto database = root / "checkpoints.db";
+    std::filesystem::create_directories(root);
+    auto                     provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion tool_request;
+    tool_request.message.tool_calls.push_back(
+        {"provider-call", "host.lookup", R"({"query":"needle"})"});
+    neograph::ChatCompletion final;
+    final.message.content = R"({"status":"ok","findings":[]})";
+    provider->completions = {tool_request, final};
+
+    std::string run_id;
+    std::string call_id;
+    {
+        HarnessServiceConfig config;
+        config.checkpoint_store =
+            std::make_shared<neograph::graph::SqliteCheckpointStore>(database.string());
+        config.record_store =
+            std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+        neograph::mcp::HarnessProviderExecutorConfig provider_config;
+        provider_config.provider = provider;
+        config.worker_executor =
+            neograph::mcp::make_provider_harness_executor(std::move(provider_config));
+        HarnessService service(std::move(config));
+        auto           compiled = service.compile(host_brokered_request());
+        ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+        auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+        run_id       = started["run_id"].get<std::string>();
+        auto waiting = wait_terminal(service, run_id);
+        ASSERT_EQ(waiting["status"], "awaiting_tool_results") << waiting.dump();
+        call_id = waiting["pending"]["call_id"].get<std::string>();
+    }
+
+    {
+        HarnessServiceConfig config;
+        config.checkpoint_store =
+            std::make_shared<neograph::graph::SqliteCheckpointStore>(database.string());
+        config.record_store =
+            std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+        neograph::mcp::HarnessProviderExecutorConfig provider_config;
+        provider_config.provider = provider;
+        config.worker_executor =
+            neograph::mcp::make_provider_harness_executor(std::move(provider_config));
+        HarnessService service(std::move(config));
+
+        auto restored = service.get(run_id);
+        ASSERT_EQ(restored["status"], "awaiting_tool_results");
+        EXPECT_EQ(restored["pending"]["call_id"], call_id);
+        EXPECT_THROW(
+            service.resume(
+                {{"run_id", run_id}, {"call_id", "wrong"}, {"result", {{"answer", "found"}}}}),
+            std::invalid_argument);
+        EXPECT_THROW(
+            service.resume(
+                {{"run_id", run_id}, {"call_id", call_id}, {"result", {{"unexpected", true}}}}),
+            std::invalid_argument);
+
+        auto accepted = service.resume(
+            {{"run_id", run_id}, {"call_id", call_id}, {"result", {{"answer", "found"}}}});
+        EXPECT_TRUE(accepted["accepted"].get<bool>());
+        auto duplicate = service.resume(
+            {{"run_id", run_id}, {"call_id", call_id}, {"result", {{"answer", "found"}}}});
+        EXPECT_TRUE(duplicate["duplicate"].get<bool>());
+
+        auto finished = wait_terminal(service, run_id);
+        ASSERT_EQ(finished["status"], "completed") << finished.dump();
+        EXPECT_EQ(finished["result"]["outcome"], "zero_findings");
+        EXPECT_THROW(
+            service.resume(
+                {{"run_id", run_id}, {"call_id", "late"}, {"result", {{"answer", "found"}}}}),
+            std::invalid_argument);
+    }
+    ASSERT_EQ(provider->calls.size(), 2u);
+    EXPECT_NE(provider->calls[1].messages[0].content.find("host_resume"), std::string::npos);
+    std::filesystem::remove_all(root);
+}
+
+TEST(HarnessServiceTest, PersistedResumeIntentRecoversBeforeThreadSpawn) {
+    const auto root     = unique_temp_path("neograph-harness-resume-intent");
+    const auto database = root / "checkpoints.db";
+    std::filesystem::create_directories(root);
+    auto                     provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion tool_request;
+    tool_request.message.tool_calls.push_back(
+        {"provider-call", "host.lookup", R"({"query":"needle"})"});
+    neograph::ChatCompletion final;
+    final.message.content = R"({"status":"ok","findings":[]})";
+    provider->completions = {tool_request, final};
+
+    std::string run_id;
+    std::string call_id;
+    {
+        HarnessServiceConfig config;
+        config.checkpoint_store =
+            std::make_shared<neograph::graph::SqliteCheckpointStore>(database.string());
+        config.record_store =
+            std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+        neograph::mcp::HarnessProviderExecutorConfig provider_config;
+        provider_config.provider = provider;
+        config.worker_executor =
+            neograph::mcp::make_provider_harness_executor(std::move(provider_config));
+        HarnessService service(std::move(config));
+        auto           compiled = service.compile(host_brokered_request());
+        ASSERT_TRUE(compiled["ok"].get<bool>());
+        auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+        run_id       = started["run_id"].get<std::string>();
+        auto waiting = wait_terminal(service, run_id);
+        ASSERT_EQ(waiting["status"], "awaiting_tool_results");
+        call_id = waiting["pending"]["call_id"].get<std::string>();
+    }
+
+    auto records = std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+    auto record  = records->load_run(run_id);
+    ASSERT_TRUE(record.has_value());
+    (*record)["consumed"][call_id] = {{"answer", "found"}};
+    (*record)["pending"]           = nullptr;
+    (*record)["resume_value"]      = {{"call_id", call_id}, {"result", {{"answer", "found"}}}};
+    (*record)["status"]            = "queued";
+    records->save_run(run_id, *record);
+
+    {
+        HarnessServiceConfig config;
+        config.checkpoint_store =
+            std::make_shared<neograph::graph::SqliteCheckpointStore>(database.string());
+        config.record_store = records;
+        neograph::mcp::HarnessProviderExecutorConfig provider_config;
+        provider_config.provider = provider;
+        config.worker_executor =
+            neograph::mcp::make_provider_harness_executor(std::move(provider_config));
+        HarnessService service(std::move(config));
+        (void)service.get(run_id);
+        auto finished = wait_terminal(service, run_id);
+        ASSERT_EQ(finished["status"], "completed") << finished.dump();
+        EXPECT_EQ(finished["result"]["outcome"], "zero_findings");
+    }
+    std::filesystem::remove_all(root);
+}
+#endif
+
 TEST(HarnessServiceTest, BindingDiagnosticCarriesElaboratorSourceCoordinate) {
     HarnessService service;
     auto authored = request();
-    authored["harness"] = {
+    authored["harness"]     = {
         {"mode", "dsl"},
-        {"definition", {
-            {"schema_version", 1},
-            {"channels", {
-                {"task", {{"reducer", "overwrite"}, {"initial", json::object()}}},
-                {"worker_results", {{"reducer", "append"}, {"initial", json::array()}}},
-                {"final_result", {{"reducer", "overwrite"}, {"initial", nullptr}}},
-            }},
-            {"nodes", {
-                {"judge", {
-                    {"type", "neograph_harness_judge"},
-                    {"barrier", {{"wait_for", json::array({"panel_worker"})}}},
-                }},
-            }},
-            {"edges", json::array({
-                {{"from", "__start__"}, {"to", "panel_worker"}},
-                {{"from", "panel_worker"}, {"to", "judge"}},
-                {{"from", "judge"}, {"to", "__end__"}},
-            })},
-            {"templates", {
-                {"worker", {
-                    {"params", json::array()},
-                    {"nodes", {
-                        {"worker", {
-                            {"type", "neograph_harness_worker"},
-                            {"worker_id", "undeclared"},
+        {"definition",
+             {
+             {"schema_version", 1},
+             {"channels",
+                  {
+                  {"task", {{"reducer", "overwrite"}, {"initial", json::object()}}},
+                  {"worker_results", {{"reducer", "append"}, {"initial", json::array()}}},
+                  {"final_result", {{"reducer", "overwrite"}, {"initial", nullptr}}},
+              }},
+             {"nodes",
+                  {
+                  {"judge",
+                       {
+                       {"type", "neograph_harness_judge"},
+                       {"barrier", {{"wait_for", json::array({"panel_worker"})}}},
+                   }},
+              }},
+             {"edges", json::array({
+                           {{"from", "__start__"}, {"to", "panel_worker"}},
+                           {{"from", "panel_worker"}, {"to", "judge"}},
+                           {{"from", "judge"}, {"to", "__end__"}},
+                       })},
+             {"templates",
+                  {
+                  {"worker",
+                       {
+                       {"params", json::array()},
+                       {"nodes",
+                            {
+                            {"worker",
+                                 {
+                                 {"type", "neograph_harness_worker"},
+                                 {"worker_id", "undeclared"},
+                             }},
                         }},
-                    }},
-                }},
-            }},
-            {"use", json::array({{
-                {"template", "worker"}, {"prefix", "panel"},
-                {"args", json::object()},
-            }})},
-        }},
+                   }},
+              }},
+             {"use", json::array({{
+                         {"template", "worker"},
+                         {"prefix", "panel"},
+                         {"args", json::object()},
+                     }})},
+         }},
     };
 
     auto compiled = service.compile(authored);
@@ -439,10 +1014,8 @@ TEST(HarnessServiceTest, BindingDiagnosticCarriesElaboratorSourceCoordinate) {
     for (const auto& diagnostic : compiled["diagnostics"]) {
         if (diagnostic["code"] != "H_UNKNOWN_WORKER") continue;
         found = true;
-        EXPECT_NE(diagnostic["source"].get<std::string>().find("use[0]"),
-                  std::string::npos);
-        EXPECT_NE(diagnostic["source"].get<std::string>().find("'worker'"),
-                  std::string::npos);
+        EXPECT_NE(diagnostic["source"].get<std::string>().find("use[0]"), std::string::npos);
+        EXPECT_NE(diagnostic["source"].get<std::string>().find("'worker'"), std::string::npos);
     }
     EXPECT_TRUE(found) << compiled.dump();
 }
@@ -458,8 +1031,7 @@ TEST(HarnessServiceTest, RepairsInvalidWorkerOutputBeforeJudgeAndReportsZeroFind
         }
         EXPECT_NE(call.repair_feedback.find("missing required property findings"),
                   std::string::npos);
-        return HarnessWorkerResponse::success({
-            {"status", "ok"}, {"findings", json::array()}});
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
     };
     HarnessService service(std::move(config));
     auto compiled = service.compile(request());
@@ -535,9 +1107,7 @@ TEST(HarnessServiceTest, ReturnsCompactResultAndUriLinkedDetails) {
               "neograph://runs/" + run_id + "/details");
     auto details = service.get(run_id, "details");
     EXPECT_EQ(details["result"]["workers"].size(), 1u);
-    auto linked = service.read(
-        compact["result"]["artifacts"]["details"]["uri"]
-            .get<std::string>());
+    auto linked = service.read(compact["result"]["artifacts"]["details"]["uri"].get<std::string>());
     EXPECT_EQ(linked, details);
     auto trace = service.get(run_id, "trace");
     EXPECT_TRUE(trace["result"]["execution_trace"].is_array());
@@ -556,8 +1126,7 @@ TEST(HarnessServiceTest, DistinguishesEmptyResponseAndWorkerTimeout) {
         auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
         auto finished = wait_terminal(service, started["run_id"].get<std::string>());
         ASSERT_EQ(finished["status"], "completed") << finished.dump();
-        EXPECT_EQ(finished["result"]["workers"][0]["failure_kind"],
-                  "empty_response");
+        EXPECT_EQ(finished["result"]["workers"][0]["failure_kind"], "empty_response");
         EXPECT_EQ(finished["result"]["workers"][0]["attempts"], 2);
     }
     {
@@ -579,7 +1148,8 @@ TEST(HarnessServiceTest, DistinguishesEmptyResponseAndWorkerTimeout) {
 TEST(HarnessServiceTest, GlobalDeadlineHasDistinctRunState) {
     HarnessServiceConfig config;
     config.worker_executor = [](const HarnessWorkerCall&, const auto& cancel) {
-        while (!cancel->is_cancelled()) std::this_thread::sleep_for(1ms);
+        while (!cancel->is_cancelled())
+            std::this_thread::sleep_for(1ms);
         return HarnessWorkerResponse::cancelled("deadline cancellation");
     };
     HarnessService service(std::move(config));
@@ -595,7 +1165,8 @@ TEST(HarnessServiceTest, GlobalDeadlineHasDistinctRunState) {
 TEST(HarnessServiceTest, CooperativeCancellationHasDistinctRunState) {
     HarnessServiceConfig config;
     config.worker_executor = [](const HarnessWorkerCall&, const auto& cancel) {
-        while (!cancel->is_cancelled()) std::this_thread::sleep_for(1ms);
+        while (!cancel->is_cancelled())
+            std::this_thread::sleep_for(1ms);
         return HarnessWorkerResponse::cancelled("test cancellation");
     };
     HarnessService service(std::move(config));
@@ -605,8 +1176,8 @@ TEST(HarnessServiceTest, CooperativeCancellationHasDistinctRunState) {
     const auto run_id = started["run_id"].get<std::string>();
 
     const auto deadline = std::chrono::steady_clock::now() + 1s;
-    while (service.get(run_id)["status"] == "queued"
-           && std::chrono::steady_clock::now() < deadline) {
+    while (service.get(run_id)["status"] == "queued" &&
+           std::chrono::steady_clock::now() < deadline) {
         std::this_thread::sleep_for(1ms);
     }
     EXPECT_TRUE(service.cancel(run_id));
@@ -617,8 +1188,7 @@ TEST(HarnessServiceTest, CooperativeCancellationHasDistinctRunState) {
 TEST(HarnessServiceTest, ExhaustedMaxStepsHasDistinctRunState) {
     HarnessServiceConfig config;
     config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
-        return HarnessWorkerResponse::success({
-            {"status", "ok"}, {"findings", json::array()}});
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
     };
     HarnessService service(std::move(config));
     auto loop_request = request();

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -321,6 +321,10 @@ TEST(HarnessServiceTest, EnforcesReadOnlyWorkspaceAndEvidenceContracts) {
 }
 
 TEST(HarnessServiceTest, ProviderExecutorRunsDeclaredToolsAndValidatesPaths) {
+    const auto workspace = unique_temp_path("neograph-harness-path-policy");
+    std::filesystem::create_directories(workspace / "src");
+    const auto expected_path =
+        std::filesystem::weakly_canonical(workspace / "src/main.cpp").string();
     auto provider = std::make_shared<ScriptedProvider>();
     neograph::ChatCompletion tool_request;
     tool_request.message.role = "assistant";
@@ -335,11 +339,12 @@ TEST(HarnessServiceTest, ProviderExecutorRunsDeclaredToolsAndValidatesPaths) {
     neograph::mcp::HarnessProviderExecutorConfig config;
     config.provider = provider;
     config.model = "test-model";
-    config.capability_executor = [&capability_calls](const json& tool, const json& arguments,
-                                                     const auto&) {
+    config.capability_executor = [&capability_calls, expected_path](const json& tool,
+                                                                    const json& arguments,
+                                                                    const auto&) {
         ++capability_calls;
         EXPECT_EQ(tool["id"], "repo.read");
-        EXPECT_EQ(arguments["path"], "/workspace/src/main.cpp");
+        EXPECT_EQ(arguments["path"], expected_path);
         return json{{"content", "int main() {}"}};
     };
     auto executor = neograph::mcp::make_provider_harness_executor(std::move(config));
@@ -359,7 +364,7 @@ TEST(HarnessServiceTest, ProviderExecutorRunsDeclaredToolsAndValidatesPaths) {
         {"path_arguments", json::array({"path"})},
         {"executor", {{"kind", "builtin"}}},
     }});
-    call.policy = {{"workspace_roots", json::array({"/workspace"})}};
+    call.policy = {{"workspace_roots", json::array({workspace.string()})}};
     auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
 
     EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::VALUE);
@@ -369,6 +374,7 @@ TEST(HarnessServiceTest, ProviderExecutorRunsDeclaredToolsAndValidatesPaths) {
     EXPECT_EQ(provider->calls[0].model, "test-model");
     ASSERT_EQ(provider->calls[1].messages.size(), 3u);
     EXPECT_EQ(provider->calls[1].messages.back().role, "tool");
+    std::filesystem::remove_all(workspace);
 }
 
 TEST(HarnessServiceTest, ProviderExecutorRejectsWorkspaceEscapeBeforeToolCall) {
@@ -790,7 +796,7 @@ TEST(HarnessServiceTest, ExpiredHostResultIsRejectedAndPersisted) {
         config.checkpoint_store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
         config.record_store =
             std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
-        config.run_ttl = 20ms;
+        config.run_ttl = 500ms;
         neograph::mcp::HarnessProviderExecutorConfig provider_config;
         provider_config.provider = provider;
         config.worker_executor =
@@ -803,7 +809,12 @@ TEST(HarnessServiceTest, ExpiredHostResultIsRejectedAndPersisted) {
         auto waiting = wait_terminal(service, run_id);
         ASSERT_EQ(waiting["status"], "awaiting_tool_results");
         call_id = waiting["pending"]["call_id"].get<std::string>();
-        std::this_thread::sleep_for(30ms);
+        const auto expires_at = waiting["expires_at"].get<int64_t>();
+        while (std::chrono::duration_cast<std::chrono::milliseconds>(
+                   std::chrono::system_clock::now().time_since_epoch())
+                   .count() <= expires_at) {
+            std::this_thread::sleep_for(1ms);
+        }
         EXPECT_THROW(
             service.resume(
                 {{"run_id", run_id}, {"call_id", call_id}, {"result", {{"answer", "late"}}}}),

--- a/tests/test_mcp_http_server.cpp
+++ b/tests/test_mcp_http_server.cpp
@@ -1,0 +1,374 @@
+#include <neograph/mcp/http_server.h>
+
+#include <gtest/gtest.h>
+#ifdef NEOGRAPH_TESTS_HAVE_MCP_CLIENT
+#include <neograph/mcp/client.h>
+#endif
+
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#include <httplib.h>
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+
+using neograph::json;
+using neograph::mcp::CallToolResult;
+using neograph::mcp::MCPHttpServer;
+using neograph::mcp::MCPHttpServerConfig;
+using neograph::mcp::MCPHttpServerSession;
+using neograph::mcp::MCPServer;
+using neograph::mcp::MCPServerConfig;
+using neograph::mcp::ToolDefinition;
+#ifdef NEOGRAPH_TESTS_HAVE_MCP_CLIENT
+using neograph::mcp::MCPClient;
+#endif
+
+namespace {
+
+using namespace std::chrono_literals;
+
+std::unique_ptr<MCPServer> make_server() {
+    MCPServerConfig config;
+    config.server_info = {{"name", "http-test"}, {"version", "1"}};
+    auto server        = std::make_unique<MCPServer>(std::move(config));
+
+    ToolDefinition echo;
+    echo.name         = "echo";
+    echo.description  = "Echo a value";
+    echo.input_schema = {
+        {"type", "object"},
+        {"required", json::array({"value"})},
+        {"properties", {{"value", {{"type", "string"}}}}},
+        {"additionalProperties", false},
+    };
+    echo.output_schema = {
+        {"type", "object"},
+        {"required", json::array({"echoed"})},
+        {"properties", {{"echoed", {{"type", "string"}}}}},
+        {"additionalProperties", false},
+    };
+    server->register_tool(std::move(echo), [](const json& arguments, const auto&) {
+        const auto     value = arguments.at("value").get<std::string>();
+        CallToolResult result;
+        result.content            = json::array({{{"type", "text"}, {"text", value}}});
+        result.structured_content = {{"echoed", value}};
+        return result;
+    });
+    return server;
+}
+
+MCPHttpServerSession make_http_session(std::string_view) {
+    return {make_server(), {}};
+}
+
+json request(json id, std::string method, json params = json::object()) {
+    return {
+        {"jsonrpc", "2.0"},
+        {"id", std::move(id)},
+        {"method", std::move(method)},
+        {"params", std::move(params)},
+    };
+}
+
+httplib::Headers base_headers() {
+    return {{"Accept", "application/json, text/event-stream"}};
+}
+
+httplib::Headers session_headers(const std::string& session_id, const std::string& bearer = {}) {
+    auto headers = base_headers();
+    headers.emplace("Mcp-Session-Id", session_id);
+    headers.emplace("MCP-Protocol-Version", "2025-11-25");
+    if (!bearer.empty()) headers.emplace("Authorization", "Bearer " + bearer);
+    return headers;
+}
+
+class HttpServerGuard {
+public:
+    explicit HttpServerGuard(MCPHttpServer& server) : server_(server) {}
+    ~HttpServerGuard() { server_.stop(); }
+
+private:
+    MCPHttpServer& server_;
+};
+
+TEST(MCPHttpServerTest, DefaultsRejectUnauthenticatedRemoteBind) {
+    MCPHttpServerConfig config;
+    config.host = "0.0.0.0";
+    EXPECT_THROW(MCPHttpServer(make_http_session, std::move(config)), std::invalid_argument);
+}
+
+TEST(MCPHttpServerTest, RejectsInitializeWhenSessionCapacityIsExhausted) {
+    MCPHttpServerConfig config;
+    config.max_sessions = 1;
+    MCPHttpServer server(make_http_session, std::move(config));
+    ASSERT_TRUE(server.start_async());
+    HttpServerGuard guard(server);
+    httplib::Client client("127.0.0.1", server.port());
+
+    const auto initialize_body =
+        request(1, "initialize",
+                {{"protocolVersion", "2025-11-25"},
+                 {"capabilities", json::object()},
+                 {"clientInfo", {{"name", "capacity-test"}, {"version", "1"}}}});
+    auto first = client.Post("/mcp", base_headers(), initialize_body.dump(), "application/json");
+    ASSERT_TRUE(first);
+    ASSERT_EQ(first->status, 200);
+
+    initialize_body["id"] = 2;
+    auto second = client.Post("/mcp", base_headers(), initialize_body.dump(), "application/json");
+    ASSERT_TRUE(second);
+    EXPECT_EQ(second->status, 503);
+}
+
+TEST(MCPHttpServerTest, JsonPostLifecycleAndDeleteRoundTrip) {
+    MCPHttpServer server(make_http_session);
+    ASSERT_TRUE(server.start_async());
+    HttpServerGuard guard(server);
+    httplib::Client client("127.0.0.1", server.port());
+
+    auto invalid_accept = base_headers();
+    invalid_accept.erase("Accept");
+    invalid_accept.emplace("Accept", "application/json-ld, text/event-stream");
+    auto rejected_accept =
+        client.Post("/mcp", invalid_accept,
+                    request(0, "initialize",
+                            {{"protocolVersion", "2025-11-25"},
+                             {"capabilities", json::object()},
+                             {"clientInfo", {{"name", "bad-accept"}, {"version", "1"}}}})
+                        .dump(),
+                    "application/json");
+    ASSERT_TRUE(rejected_accept);
+    EXPECT_EQ(rejected_accept->status, 406);
+
+    auto initialize =
+        client.Post("/mcp", base_headers(),
+                    request(1, "initialize",
+                            {{"protocolVersion", "2025-11-25"},
+                             {"capabilities", json::object()},
+                             {"clientInfo", {{"name", "http-test"}, {"version", "1"}}}})
+                        .dump(),
+                    "application/json");
+    ASSERT_TRUE(initialize);
+    ASSERT_EQ(initialize->status, 200);
+    const auto session_id = initialize->get_header_value("Mcp-Session-Id");
+    ASSERT_FALSE(session_id.empty());
+    EXPECT_EQ(json::parse(initialize->body)["result"]["protocolVersion"], "2025-11-25");
+
+    auto missing_version_headers = base_headers();
+    missing_version_headers.emplace("Mcp-Session-Id", session_id);
+    auto missing_version = client.Post("/mcp", missing_version_headers,
+                                       request(9, "tools/list").dump(), "application/json");
+    ASSERT_TRUE(missing_version);
+    EXPECT_EQ(missing_version->status, 400);
+
+    auto repeated_initialize =
+        client.Post("/mcp", session_headers(session_id),
+                    request(10, "initialize",
+                            {{"protocolVersion", "2025-11-25"},
+                             {"capabilities", json::object()},
+                             {"clientInfo", {{"name", "repeat"}, {"version", "1"}}}})
+                        .dump(),
+                    "application/json");
+    ASSERT_TRUE(repeated_initialize);
+    EXPECT_EQ(repeated_initialize->status, 400);
+
+    json initialized = {
+        {"jsonrpc", "2.0"},
+        {"method", "notifications/initialized"},
+        {"params", json::object()},
+    };
+    auto accepted =
+        client.Post("/mcp", session_headers(session_id), initialized.dump(), "application/json");
+    ASSERT_TRUE(accepted);
+    EXPECT_EQ(accepted->status, 202);
+    EXPECT_TRUE(accepted->body.empty());
+
+    auto call = client.Post(
+        "/mcp", session_headers(session_id),
+        request("call", "tools/call", {{"name", "echo"}, {"arguments", {{"value", "hello"}}}})
+            .dump(),
+        "application/json");
+    ASSERT_TRUE(call);
+    ASSERT_EQ(call->status, 200);
+    EXPECT_EQ(json::parse(call->body)["result"]["structuredContent"]["echoed"], "hello");
+
+    auto get = client.Get("/mcp", base_headers());
+    ASSERT_TRUE(get);
+    EXPECT_EQ(get->status, 405);
+
+    auto removed = client.Delete("/mcp", session_headers(session_id));
+    ASSERT_TRUE(removed);
+    EXPECT_EQ(removed->status, 204);
+
+    auto after_delete = client.Post("/mcp", session_headers(session_id),
+                                    request(2, "tools/list").dump(), "application/json");
+    ASSERT_TRUE(after_delete);
+    EXPECT_EQ(after_delete->status, 404);
+}
+
+TEST(MCPHttpServerTest, RejectsUnlistedOrigin) {
+    MCPHttpServer server(make_http_session);
+    ASSERT_TRUE(server.start_async());
+    HttpServerGuard guard(server);
+    httplib::Client client("127.0.0.1", server.port());
+    auto            headers = base_headers();
+    headers.emplace("Origin", "https://attacker.example");
+
+    auto response =
+        client.Post("/mcp", headers,
+                    request(1, "initialize",
+                            {{"protocolVersion", "2025-11-25"},
+                             {"capabilities", json::object()},
+                             {"clientInfo", {{"name", "origin-test"}, {"version", "1"}}}})
+                        .dump(),
+                    "application/json");
+    ASSERT_TRUE(response);
+    EXPECT_EQ(response->status, 403);
+}
+
+TEST(MCPHttpServerTest, DuplicateRequestDoesNotOrphanOriginalResponse) {
+    struct BlockState {
+        std::atomic<int>         calls{0};
+        std::promise<void>       entered;
+        std::promise<void>       release;
+        std::shared_future<void> released = release.get_future().share();
+    };
+    auto          state = std::make_shared<BlockState>();
+    MCPHttpServer server([state](std::string_view) {
+        MCPServerConfig config;
+        config.server_info     = {{"name", "duplicate-test"}, {"version", "1"}};
+        auto           session = std::make_unique<MCPServer>(std::move(config));
+        ToolDefinition block;
+        block.name         = "block";
+        block.input_schema = {{"type", "object"}};
+        session->register_tool(std::move(block), [state](const json&, const auto&) {
+            if (state->calls.fetch_add(1) == 0) state->entered.set_value();
+            state->released.wait();
+            CallToolResult result;
+            result.content = json::array({{{"type", "text"}, {"text", "released"}}});
+            return result;
+        });
+        return MCPHttpServerSession{std::move(session), state};
+    });
+    ASSERT_TRUE(server.start_async());
+    HttpServerGuard guard(server);
+    httplib::Client client("127.0.0.1", server.port());
+
+    auto initialize =
+        client.Post("/mcp", base_headers(),
+                    request(1, "initialize",
+                            {{"protocolVersion", "2025-11-25"},
+                             {"capabilities", json::object()},
+                             {"clientInfo", {{"name", "duplicate-test"}, {"version", "1"}}}})
+                        .dump(),
+                    "application/json");
+    ASSERT_TRUE(initialize);
+    const auto session_id  = initialize->get_header_value("Mcp-Session-Id");
+    json       initialized = {
+        {"jsonrpc", "2.0"},
+        {"method", "notifications/initialized"},
+        {"params", json::object()},
+    };
+    auto initialized_response =
+        client.Post("/mcp", session_headers(session_id), initialized.dump(), "application/json");
+    ASSERT_TRUE(initialized_response);
+    ASSERT_EQ(initialized_response->status, 202);
+
+    const auto call =
+        request("same-id", "tools/call", {{"name", "block"}, {"arguments", json::object()}}).dump();
+    auto       first   = std::async(std::launch::async, [port = server.port(), session_id, call] {
+        httplib::Client first_client("127.0.0.1", port);
+        return first_client.Post("/mcp", session_headers(session_id), call, "application/json");
+    });
+    const auto entered = state->entered.get_future().wait_for(2s);
+    if (entered != std::future_status::ready) state->release.set_value();
+    ASSERT_EQ(entered, std::future_status::ready);
+
+    auto duplicate = client.Post("/mcp", session_headers(session_id), call, "application/json");
+    state->release.set_value();
+    EXPECT_TRUE(duplicate);
+    if (duplicate) {
+        EXPECT_EQ(duplicate->status, 200);
+        EXPECT_EQ(json::parse(duplicate->body)["error"]["code"], -32600);
+    }
+
+    auto original = first.get();
+    ASSERT_TRUE(original);
+    ASSERT_EQ(original->status, 200);
+    EXPECT_EQ(json::parse(original->body)["result"]["content"][0]["text"], "released");
+    EXPECT_EQ(state->calls.load(), 1);
+}
+
+#ifdef NEOGRAPH_TESTS_HAVE_MCP_CLIENT
+TEST(MCPHttpServerTest, ExistingMcpClientUsesNegotiatedHttpSession) {
+    MCPHttpServer server(make_http_session);
+    ASSERT_TRUE(server.start_async());
+    HttpServerGuard guard(server);
+
+    MCPClient client("http://127.0.0.1:" + std::to_string(server.port()));
+    ASSERT_TRUE(client.initialize("neograph-http-test"));
+    auto definitions = client.get_tool_definitions();
+    ASSERT_EQ(definitions.size(), 1u);
+    EXPECT_EQ(definitions[0].name, "echo");
+    auto result = client.call_tool_result("echo", {{"value", "client-roundtrip"}});
+    EXPECT_FALSE(result.is_error);
+    EXPECT_EQ(result.structured_content["echoed"], "client-roundtrip");
+}
+#endif
+
+TEST(MCPHttpServerTest, BindsSessionsToBearerAuthorizationScope) {
+    MCPHttpServerConfig config;
+    config.bearer_authorizer = [](std::string_view token) -> std::optional<std::string> {
+        if (token == "token-a") return "principal-a";
+        if (token == "token-b") return "principal-b";
+        return std::nullopt;
+    };
+    MCPHttpServer server(make_http_session, std::move(config));
+    ASSERT_TRUE(server.start_async());
+    HttpServerGuard guard(server);
+    httplib::Client client("127.0.0.1", server.port());
+
+    auto init_headers = base_headers();
+    init_headers.emplace("Authorization", "Bearer token-a");
+    auto initialize =
+        client.Post("/mcp", init_headers,
+                    request(1, "initialize",
+                            {{"protocolVersion", "2025-11-25"},
+                             {"capabilities", json::object()},
+                             {"clientInfo", {{"name", "auth-test"}, {"version", "1"}}}})
+                        .dump(),
+                    "application/json");
+    ASSERT_TRUE(initialize);
+    ASSERT_EQ(initialize->status, 200);
+    const auto session_id = initialize->get_header_value("Mcp-Session-Id");
+
+    auto wrong_scope = client.Post("/mcp", session_headers(session_id, "token-b"),
+                                   request(2, "tools/list").dump(), "application/json");
+    ASSERT_TRUE(wrong_scope);
+    EXPECT_EQ(wrong_scope->status, 403);
+
+    auto missing_auth = client.Post("/mcp", session_headers(session_id),
+                                    request(3, "tools/list").dump(), "application/json");
+    ASSERT_TRUE(missing_auth);
+    EXPECT_EQ(missing_auth->status, 401);
+
+    auto correct_scope = client.Post("/mcp", session_headers(session_id, "token-a"),
+                                     request(4, "tools/list").dump(), "application/json");
+    ASSERT_TRUE(correct_scope);
+    EXPECT_EQ(correct_scope->status, 200);
+
+    auto wrong_scope_delete = client.Delete("/mcp", session_headers(session_id, "token-b"));
+    ASSERT_TRUE(wrong_scope_delete);
+    EXPECT_EQ(wrong_scope_delete->status, 403);
+
+    auto correct_scope_delete = client.Delete("/mcp", session_headers(session_id, "token-a"));
+    ASSERT_TRUE(correct_scope_delete);
+    EXPECT_EQ(correct_scope_delete->status, 204);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

- add a compiler-backed Harness MCP service with presets, strict worker/tool contracts, compact artifacts, and provider/MCP/A2A backends
- add durable host-brokered resume, persisted pending calls, cooperative cancellation, and the optional Tasks extension with stable run-ID fallback
- add an opt-in MCP 2025-11-25 Streamable HTTP server with bounded sessions, Origin validation, bearer authorization scopes, and session isolation
- add the portable Harness authoring Skill, installable `neograph-harness-mcp` binary, packaging guidance, and remote deployment documentation

## Verification

- client-enabled CTest: 757/757 passed, 34 configured live/Postgres tests skipped
- server-only ASan CTest: 633/633 passed, 4 opt-in/live tests skipped
- focused HTTP ASan: 6/6 passed
- static/shared server-only and HTTP-only builds passed
- installed `find_package(NeoGraph)` consumers passed
- Claude Code, Codex, OpenCode, and MCP Inspector host interoperability was verified across the milestone series

Closes #147