### PR TITLE
fix(acp): preserve interrupt resume state

### DIFF
--- a/include/neograph/acp/server.h
+++ b/include/neograph/acp/server.h
@@ -10,6 +10,7 @@
  * Methods served (client → agent):
  *   - initialize
  *   - session/new
+ *   - session/resume
  *   - session/prompt
  *   - session/cancel  (notification — no response)
  *
@@ -17,7 +18,7 @@
  *   - session/update  (streaming notification while a prompt is in flight)
  *
  * Deferred (return JSON-RPC -32601 Method not found until added):
- *   authenticate, session/load, session/resume, session/list, session/close,
+ *   authenticate, session/load, session/list, session/close,
  *   session/set_config_option, session/set_mode.
  *
  * Adapter pattern mirrors neograph::a2a — by default the inbound prompt
@@ -201,8 +202,8 @@ class NEOGRAPH_API ACPServer {
     ~ACPServer();
 
     /// Mutable access to the capabilities advertised in initialize.
-    /// Defaults: load_session=false, no prompt extras, no MCP transports
-    /// (stdio is required by spec — its presence is implicit).
+    /// Defaults: session.resume=true, load_session=false, no prompt extras,
+    /// no MCP transports (stdio is required by spec — its presence is implicit).
     AgentCapabilities&       capabilities();
     const AgentCapabilities& capabilities() const;
 

--- a/include/neograph/acp/types.h
+++ b/include/neograph/acp/types.h
@@ -14,13 +14,13 @@
  *   - Capabilities (Agent / Client / Prompt / Mcp / Fs)
  *   - Initialize request / response
  *   - ContentBlock variants (text / image / audio / resource_link / resource)
- *   - session/new and session/prompt request/response shapes
+ *   - session/new, session/resume, and session/prompt request/response shapes
  *   - SessionNotification (session/update streamed by the agent)
  *   - StopReason
  *   - CancelNotification
  *
  * Deferred (modelled as free-form `json` for forward-compat):
- *   session/load, session/resume, session/list, session/close,
+ *   session/load, session/list, session/close,
  *   session/set_config_option, session/set_mode, fs/&#42; and terminal/&#42;
  *   (these are agent→client requests — added when the engine wants to
  *    use them). The wildcards are HTML-entity-escaped because the
@@ -160,6 +160,18 @@ struct NEOGRAPH_API NewSessionResponse {
     /// populated by adapters that want to expose runtime knobs.
     json        config_options;
     json        modes;
+};
+
+// ---------------------------------------------------------------------------
+// session/resume
+// ---------------------------------------------------------------------------
+
+/// Reconnect to a persisted session without replaying conversation history.
+/// ACP v1 requires the client to resend cwd and MCP server configuration.
+struct NEOGRAPH_API ResumeSessionRequest {
+    std::string                  session_id;
+    std::string                  cwd;
+    std::vector<McpServerConfig> mcp_servers;
 };
 
 // ---------------------------------------------------------------------------
@@ -363,6 +375,9 @@ NEOGRAPH_API void from_json(const json& j, NewSessionRequest& r);
 
 NEOGRAPH_API void to_json(json& j, const NewSessionResponse& r);
 NEOGRAPH_API void from_json(const json& j, NewSessionResponse& r);
+
+NEOGRAPH_API void to_json(json& j, const ResumeSessionRequest& r);
+NEOGRAPH_API void from_json(const json& j, ResumeSessionRequest& r);
 
 NEOGRAPH_API void to_json(json& j, const PromptRequest& r);
 NEOGRAPH_API void from_json(const json& j, PromptRequest& r);

--- a/src/acp/server.cpp
+++ b/src/acp/server.cpp
@@ -112,6 +112,12 @@ std::string fresh_session_id() {
     return buf;
 }
 
+bool is_interrupt_phase(neograph::graph::CheckpointPhase phase) {
+    return phase == neograph::graph::CheckpointPhase::Before ||
+           phase == neograph::graph::CheckpointPhase::After ||
+           phase == neograph::graph::CheckpointPhase::NodeInterrupt;
+}
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -140,6 +146,9 @@ struct ACPServer::Impl {
 
     std::mutex                                    sessions_mu;
     std::map<std::string, std::string>            sessions;
+    /// Sessions whose latest engine result is paused. The next prompt is
+    /// consumed as the resume value exactly once instead of starting at entry.
+    std::set<std::string>                         interrupted_sessions;
     /// Per-session cancel flags held behind shared_ptrs so a worker
     /// thread can capture the pointer at dispatch time (under the
     /// lock) and read/write the flag thereafter without re-traversing
@@ -176,6 +185,9 @@ struct ACPServer::Impl {
     std::condition_variable                       workers_cv;
     int                                           inflight_count = 0;
     std::set<std::string>                         inflight_sessions;
+    /// Sessions currently being restored from checkpoint. Prompt admission
+    /// rejects these until the persisted interrupt state is installed.
+    std::set<std::string>                         resuming_sessions;
     int                                           max_inflight_prompts = 32;
 #if defined(NEOGRAPH_ACP_TESTING)
     std::atomic<bool>                             fail_next_worker_launch{false};
@@ -186,6 +198,7 @@ struct ACPServer::Impl {
         Impl*       owner;
         std::string session_id;
         bool        active = false;
+        bool        session_active = false;
 
         WorkerReservation(Impl* owner_in, std::string session_id_in)
             : owner(owner_in), session_id(std::move(session_id_in)) {}
@@ -194,10 +207,32 @@ struct ACPServer::Impl {
             if (!active) return;
             std::lock_guard lk(owner->workers_mu);
             --owner->inflight_count;
-            owner->inflight_sessions.erase(session_id);
+            if (session_active) owner->inflight_sessions.erase(session_id);
             // Keep notify under the lock. A waiter cannot destroy the cv
             // after seeing count==0 while this notify is still executing.
             owner->workers_cv.notify_all();
+        }
+
+        void release_session() {
+            std::lock_guard lk(owner->workers_mu);
+            if (!session_active) return;
+            owner->inflight_sessions.erase(session_id);
+            session_active = false;
+        }
+    };
+
+    struct ResumeReservation {
+        Impl*       owner;
+        std::string session_id;
+        bool        active = false;
+
+        ResumeReservation(Impl* owner_in, std::string session_id_in)
+            : owner(owner_in), session_id(std::move(session_id_in)) {}
+
+        ~ResumeReservation() {
+            if (!active) return;
+            std::lock_guard lk(owner->workers_mu);
+            owner->resuming_sessions.erase(session_id);
         }
     };
 
@@ -209,7 +244,9 @@ struct ACPServer::Impl {
     neograph::json handle_initialize(const neograph::json& params,
                                      const neograph::json& id);
     neograph::json handle_session_new(const neograph::json& params,
-                                      const neograph::json& id);
+                                       const neograph::json& id);
+    neograph::json handle_session_resume(const neograph::json& params,
+                                          const neograph::json& id);
     void           handle_session_prompt(ACPServer& owner,
                                          const neograph::json& params,
                                          const neograph::json& id);
@@ -289,6 +326,64 @@ ACPServer::Impl::handle_session_new(const neograph::json& params,
     return jsonrpc_result(std::move(rj), id);
 }
 
+neograph::json
+ACPServer::Impl::handle_session_resume(const neograph::json& params,
+                                       const neograph::json& id) {
+    ResumeSessionRequest req;
+    try { from_json(params, req); }
+    catch (const std::exception& e) {
+        return jsonrpc_error(-32602, std::string("Invalid params: ") + e.what(), id);
+    }
+
+    ResumeReservation reservation(this, req.session_id);
+    {
+        std::lock_guard lk(workers_mu);
+        if (inflight_sessions.count(req.session_id) ||
+            resuming_sessions.count(req.session_id)) {
+            return jsonrpc_error(
+                -32000,
+                "session_id " + req.session_id + " is already in use",
+                id);
+        }
+        resuming_sessions.insert(req.session_id);
+        reservation.active = true;
+    }
+
+    std::vector<neograph::graph::Checkpoint> history;
+    try {
+        history = engine->get_state_history(req.session_id, 1);
+    } catch (const std::exception& e) {
+        return jsonrpc_error(
+            -32603, std::string("Failed to restore session: ") + e.what(), id);
+    }
+    if (history.empty()) {
+        return jsonrpc_error(-32001, "Unknown session: " + req.session_id, id);
+    }
+
+    {
+        std::lock_guard lk(sessions_mu);
+        auto existing = sessions.find(req.session_id);
+        if (existing != sessions.end() && !existing->second.empty() &&
+            existing->second != req.cwd) {
+            return jsonrpc_error(
+                -32602, "session/resume cwd does not match the existing session", id);
+        }
+        sessions[req.session_id] = req.cwd;
+        if (!cancel_flags.count(req.session_id)) {
+            cancel_flags[req.session_id] =
+                std::make_shared<std::atomic<bool>>(false);
+        }
+        if (is_interrupt_phase(history.front().interrupt_phase)) {
+            interrupted_sessions.insert(req.session_id);
+        } else {
+            interrupted_sessions.erase(req.session_id);
+        }
+    }
+
+    // ACP v1 session/resume restores context without replaying session/update.
+    return jsonrpc_result(neograph::json::object(), id);
+}
+
 void
 ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
                                        const neograph::json& params,
@@ -300,25 +395,10 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
         return;
     }
 
-    // Capture the cancel-flag shared_ptr while holding sessions_mu so the
-    // worker can read/write it later without re-traversing the map.
-    std::shared_ptr<std::atomic<bool>> my_cancel;
-    {
-        std::lock_guard lk(sessions_mu);
-        if (sessions.count(req.session_id) == 0) {
-            sessions[req.session_id] = "";
-        }
-        auto it = cancel_flags.find(req.session_id);
-        if (it == cancel_flags.end() || !it->second) {
-            my_cancel = std::make_shared<std::atomic<bool>>(false);
-            cancel_flags[req.session_id] = my_cancel;
-        } else {
-            my_cancel = it->second;
-        }
-    }
-
     // Backpressure: refuse new prompts when the in-flight cap is hit
-    // or the same session_id is already executing. Without these
+    // or the same session_id is already executing/restoring. Reserve the
+    // session before reading its interrupt state so session/resume cannot
+    // install that state between the read and worker admission. Without these
     // guards a misbehaving peer that pipelines prompts faster than
     // the engine completes would (a) exhaust the host's thread quota
     // and unbounded-grow the worker tracking, or (b) race two prompts
@@ -335,20 +415,41 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
                 std::string("ACP server overloaded: ")
                 + std::to_string(max_inflight_prompts)
                 + " concurrent prompts in flight; retry shortly", id);
-        } else if (inflight_sessions.count(req.session_id)) {
+        } else if (inflight_sessions.count(req.session_id) ||
+                   resuming_sessions.count(req.session_id)) {
             rejection = jsonrpc_error(-32000,
                 std::string("session_id ") + req.session_id
-                + " already has a prompt in flight; ACP requires "
-                  "single-flight per session", id);
+                + " is already in use; ACP requires single-flight "
+                  "per session", id);
         } else {
             inflight_sessions.insert(req.session_id);
             ++inflight_count;
             reservation->active = true;
+            reservation->session_active = true;
         }
     }
     if (!rejection.is_null()) {
         emit(rejection);
         return;
+    }
+
+    // Capture the cancel-flag shared_ptr while holding sessions_mu so the
+    // worker can read/write it later without re-traversing the map.
+    std::shared_ptr<std::atomic<bool>> my_cancel;
+    bool resume_pending = false;
+    {
+        std::lock_guard lk(sessions_mu);
+        if (sessions.count(req.session_id) == 0) {
+            sessions[req.session_id] = "";
+        }
+        auto it = cancel_flags.find(req.session_id);
+        if (it == cancel_flags.end() || !it->second) {
+            my_cancel = std::make_shared<std::atomic<bool>>(false);
+            cancel_flags[req.session_id] = my_cancel;
+        } else {
+            my_cancel = it->second;
+        }
+        resume_pending = interrupted_sessions.count(req.session_id) != 0;
     }
 
     // Run the engine on a detached worker so the run-loop reader can
@@ -366,7 +467,8 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
         }
 #endif
         std::thread worker(
-            [this, req = std::move(req), id, my_cancel, reservation]() mutable {
+            [this, req = std::move(req), id, my_cancel, reservation,
+             resume_pending]() mutable {
                 try {
                     auto& a = *adapter;
 
@@ -377,12 +479,20 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
                     bool        graph_failed = false;
                     std::string agent_text;
                     std::string graph_error;
+                    neograph::graph::RunResult run_result;
 
                     try {
-                        cfg.input = a.build_initial_state(
-                            req.prompt, req.session_id);
-                        auto rr = engine->run(cfg);
-                        agent_text = a.extract_agent_text(rr.output);
+                        if (resume_pending) {
+                            run_result = engine->resume(
+                                cfg, neograph::json(a.extract_user_text(req.prompt)));
+                        } else {
+                            cfg.input = a.build_initial_state(
+                                req.prompt, req.session_id);
+                            run_result = engine->run(cfg);
+                        }
+                        if (!run_result.interrupted) {
+                            agent_text = a.extract_agent_text(run_result.output);
+                        }
                     } catch (const std::exception& e) {
                         graph_failed = true;
                         graph_error = e.what();
@@ -404,10 +514,46 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
                         to_json(nj, n);
                         emit(jsonrpc_notify("session/update", std::move(nj)));
                     } else {
+                        {
+                            std::lock_guard lk(sessions_mu);
+                            if (run_result.interrupted) {
+                                interrupted_sessions.insert(req.session_id);
+                            } else {
+                                interrupted_sessions.erase(req.session_id);
+                            }
+                        }
                         bool was_cancelled = my_cancel->exchange(
                             false, std::memory_order_acq_rel);
                         if (was_cancelled) {
                             stop = StopReason::Cancelled;
+                        } else if (run_result.interrupted) {
+                            const auto reason = run_result.interrupt_value.value(
+                                "reason", run_result.interrupt_value.value(
+                                    "message", std::string("Graph execution interrupted")));
+                            const auto payload = run_result.interrupt_value.contains("value")
+                                ? run_result.interrupt_value["value"]
+                                : neograph::json();
+
+                            SessionNotification n;
+                            n.session_id = req.session_id;
+                            n.update.session_update = "agent_message_chunk";
+                            n.update.content = ContentBlock::text_block(reason);
+                            // ACP v1 reserves `_meta` for implementation metadata.
+                            // Source: agent-client-protocol-schema/src/v1/ext.rs
+                            // (fetched 2026-07-21 for NeoGraph #153).
+                            n.update.raw = {
+                                {"_meta", {
+                                    {"neograph/interrupt", {
+                                        {"node", run_result.interrupt_node},
+                                        {"reason", reason},
+                                        {"payload", payload},
+                                        {"checkpointId", run_result.checkpoint_id},
+                                    }},
+                                }},
+                            };
+                            neograph::json nj;
+                            to_json(nj, n);
+                            emit(jsonrpc_notify("session/update", std::move(nj)));
                         } else {
                             SessionNotification n;
                             n.session_id = req.session_id;
@@ -425,11 +571,17 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
                     resp.stop_reason = stop;
                     neograph::json rj;
                     to_json(rj, resp);
+                    // The graph and all session-state updates are complete.
+                    // Admit the next turn before publishing this response so a
+                    // reentrant/fast client cannot observe a stale busy state.
+                    reservation->release_session();
                     emit(jsonrpc_result(std::move(rj), id));
                 } catch (const std::exception& e) {
+                    reservation->release_session();
                     emit_internal_error(
                         id, "ACP prompt worker failed: ", e.what());
                 } catch (...) {
+                    reservation->release_session();
                     emit_internal_error(
                         id, "ACP prompt worker failed: unknown exception");
                 }
@@ -495,6 +647,7 @@ ACPServer::ACPServer(std::shared_ptr<neograph::graph::GraphEngine> engine,
     impl_->engine  = std::move(engine);
     impl_->info    = std::move(info);
     impl_->adapter = adapter ? adapter : std::make_shared<ACPGraphAdapter>();
+    impl_->caps.session.resume = true;
 }
 
 ACPServer::~ACPServer() {
@@ -657,6 +810,9 @@ ACPServer::handle_message(const neograph::json& env) {
     }
     if (method == "session/new") {
         return impl_->handle_session_new(params, id);
+    }
+    if (method == "session/resume") {
+        return impl_->handle_session_resume(params, id);
     }
     if (method == "session/prompt") {
         // Async dispatch — the worker will emit the response via the sink.

--- a/src/acp/types.cpp
+++ b/src/acp/types.cpp
@@ -247,6 +247,28 @@ void from_json(const json& j, NewSessionResponse& r) {
     if (j.contains("modes"))         r.modes          = j["modes"];
 }
 
+void to_json(json& j, const ResumeSessionRequest& r) {
+    j = json::object();
+    j["sessionId"] = r.session_id;
+    j["cwd"] = r.cwd;
+    auto arr = json::array();
+    for (const auto& server : r.mcp_servers) {
+        arr.push_back(server.raw.is_null() ? json::object() : server.raw);
+    }
+    j["mcpServers"] = std::move(arr);
+}
+
+void from_json(const json& j, ResumeSessionRequest& r) {
+    r.session_id = j.at("sessionId").get<std::string>();
+    r.cwd = j.at("cwd").get<std::string>();
+    r.mcp_servers.clear();
+    if (j.contains("mcpServers") && j["mcpServers"].is_array()) {
+        for (const auto& value : j["mcpServers"]) {
+            r.mcp_servers.push_back(McpServerConfig{value});
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // session/prompt
 // ---------------------------------------------------------------------------

--- a/tests/test_acp_server.cpp
+++ b/tests/test_acp_server.cpp
@@ -91,6 +91,102 @@ std::shared_ptr<GraphEngine> build_echo_engine() {
     return std::shared_ptr<GraphEngine>(std::move(unique));
 }
 
+class InterruptNode : public GraphNode {
+  public:
+    InterruptNode(std::string n,
+                  std::atomic<int>* visits,
+                  std::atomic<int>* side_effects)
+        : name_(std::move(n)), visits_(visits), side_effects_(side_effects) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        visits_->fetch_add(1, std::memory_order_relaxed);
+        if (!in.ctx.resume_value) {
+            throw neograph::graph::NodeInterrupt(
+                "external knowledge required",
+                neograph::json{{"need", "web_search"}, {"query", "ACP resume"}});
+        }
+
+        side_effects_->fetch_add(1, std::memory_order_relaxed);
+        const auto& answer = *in.ctx.resume_value;
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{
+            "response",
+            neograph::json("resumed:" + (answer.is_string()
+                                            ? answer.get<std::string>()
+                                            : answer.dump()))});
+        co_return out;
+    }
+
+    std::string get_name() const override { return name_; }
+
+  private:
+    std::string       name_;
+    std::atomic<int>* visits_;
+    std::atomic<int>* side_effects_;
+};
+
+std::shared_ptr<GraphEngine> build_interrupt_engine(
+    const std::shared_ptr<neograph::graph::CheckpointStore>& store,
+    std::atomic<int>* visits,
+    std::atomic<int>* side_effects) {
+    NodeFactory::instance().register_type(
+        "acp_interrupt",
+        [visits, side_effects](const std::string& n,
+                               const neograph::json&,
+                               const NodeContext&) {
+            return std::make_unique<InterruptNode>(n, visits, side_effects);
+        });
+    neograph::json def = {
+        {"name", "acp-interrupt"},
+        {"channels", {
+            {"prompt",          {{"reducer", "overwrite"}}},
+            {"response",        {{"reducer", "overwrite"}}},
+            {"_acp_session_id", {{"reducer", "overwrite"}}},
+        }},
+        {"nodes", {
+            {"knowledge", {{"type", "acp_interrupt"}}},
+        }},
+        {"edges", neograph::json::array({
+            neograph::json{{"from", "__start__"},  {"to", "knowledge"}},
+            neograph::json{{"from", "knowledge"}, {"to", "__end__"}},
+        })},
+    };
+    auto unique = GraphEngine::compile(def, NodeContext{}, store);
+    return std::shared_ptr<GraphEngine>(std::move(unique));
+}
+
+class BlockingListCheckpointStore : public neograph::graph::InMemoryCheckpointStore {
+  public:
+    std::vector<neograph::graph::Checkpoint> list(
+        const std::string& thread_id, int limit) override {
+        {
+            std::unique_lock lk(mu_);
+            list_entered_ = true;
+            cv_.notify_all();
+            cv_.wait(lk, [this] { return release_list_; });
+        }
+        return InMemoryCheckpointStore::list(thread_id, limit);
+    }
+
+    void wait_for_list() {
+        std::unique_lock lk(mu_);
+        ASSERT_TRUE(cv_.wait_for(lk, std::chrono::seconds(2),
+                                 [this] { return list_entered_; }));
+    }
+
+    void release_list() {
+        std::lock_guard lk(mu_);
+        release_list_ = true;
+        cv_.notify_all();
+    }
+
+  private:
+    std::mutex              mu_;
+    std::condition_variable cv_;
+    bool                    list_entered_ = false;
+    bool                    release_list_ = false;
+};
+
 class ThrowingAdapter : public ACPGraphAdapter {
   public:
     enum class Stage { BuildInitialState, ExtractAgentText };
@@ -214,6 +310,8 @@ TEST(ACPServer, InitializeAdvertisesCapabilities) {
     EXPECT_EQ(resp["result"].value("protocolVersion", 0), 1);
     EXPECT_EQ(resp["result"]["agentCapabilities"].value("loadSession", false), true);
     EXPECT_EQ(resp["result"]["agentCapabilities"]["promptCapabilities"].value("image", false), true);
+    EXPECT_TRUE(resp["result"]["agentCapabilities"]["sessionCapabilities"]
+                    .contains("resume"));
     EXPECT_EQ(resp["result"]["agentInfo"].value("name", std::string()), "test-acp");
     EXPECT_TRUE(server.initialized());
 }
@@ -258,6 +356,209 @@ TEST(ACPServer, PromptRunsGraphAndEmitsUpdate) {
         }
     }
     EXPECT_TRUE(saw_chunk);
+}
+
+TEST(ACPServer, InterruptMetadataAndAnswerResumeCrossProtocolBoundary) {
+    std::atomic<int> visits{0};
+    std::atomic<int> side_effects{0};
+    auto store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    CapturingSink cap;
+    ACPServer server(
+        build_interrupt_engine(store, &visits, &side_effects),
+        {{"name", "test-acp"}, {"version", "0.0.1"}});
+    server.set_notification_sink(cap.as_sink());
+
+    auto session = server.handle_message(make_request(1, "session/new",
+        {{"cwd", "/work"}, {"mcpServers", neograph::json::array()}}));
+    const auto sid = session["result"].value("sessionId", std::string());
+
+    auto prompt = [](std::string text) {
+        return neograph::json::array({
+            neograph::json{{"type", "text"}, {"text", std::move(text)}}});
+    };
+    server.handle_message(make_request(2, "session/prompt",
+        {{"sessionId", sid}, {"prompt", prompt("find it")}}));
+
+    auto paused = cap.wait_for_response(2);
+    ASSERT_TRUE(paused.contains("result")) << paused.dump();
+    EXPECT_EQ(paused["result"].value("stopReason", std::string()), "end_turn");
+    EXPECT_EQ(visits.load(), 1);
+    EXPECT_EQ(side_effects.load(), 0);
+
+    bool saw_interrupt = false;
+    std::string checkpoint_id;
+    for (const auto& notification : cap.notifications_for("session/update")) {
+        const auto& update = notification["params"]["update"];
+        if (!update.contains("_meta") ||
+            !update["_meta"].contains("neograph/interrupt")) {
+            continue;
+        }
+        const auto& interrupt = update["_meta"]["neograph/interrupt"];
+        EXPECT_EQ(update.value("sessionUpdate", std::string()),
+                  "agent_message_chunk");
+        EXPECT_EQ(update["content"].value("text", std::string()),
+                  "external knowledge required");
+        EXPECT_EQ(interrupt.value("node", std::string()), "knowledge");
+        EXPECT_EQ(interrupt.value("reason", std::string()),
+                  "external knowledge required");
+        EXPECT_EQ(interrupt["payload"].value("need", std::string()),
+                  "web_search");
+        checkpoint_id = interrupt.value("checkpointId", std::string());
+        saw_interrupt = true;
+    }
+    EXPECT_TRUE(saw_interrupt);
+    EXPECT_FALSE(checkpoint_id.empty());
+
+    server.handle_message(make_request(3, "session/prompt",
+        {{"sessionId", sid}, {"prompt", prompt("approved")}}));
+    auto resumed = cap.wait_for_response(3);
+    ASSERT_TRUE(resumed.contains("result")) << resumed.dump();
+    EXPECT_EQ(resumed["result"].value("stopReason", std::string()), "end_turn");
+    EXPECT_EQ(visits.load(), 2);
+    EXPECT_EQ(side_effects.load(), 1);
+
+    bool saw_resumed_text = false;
+    for (const auto& notification : cap.notifications_for("session/update")) {
+        const auto& update = notification["params"]["update"];
+        if (update.value("sessionUpdate", std::string()) == "agent_message_chunk" &&
+            update.contains("content") &&
+            update["content"].value("text", std::string()) == "resumed:approved") {
+            saw_resumed_text = true;
+        }
+    }
+    EXPECT_TRUE(saw_resumed_text);
+
+    // A duplicate answer is a new turn, not a second resume of the consumed
+    // checkpoint. The node pauses again before its side effect.
+    server.handle_message(make_request(4, "session/prompt",
+        {{"sessionId", sid}, {"prompt", prompt("approved")}}));
+    auto duplicate = cap.wait_for_response(4);
+    ASSERT_TRUE(duplicate.contains("result")) << duplicate.dump();
+    EXPECT_EQ(visits.load(), 3);
+    EXPECT_EQ(side_effects.load(), 1);
+}
+
+TEST(ACPServer, SessionResumeRestoresPersistedInterruptWithoutReplay) {
+    std::atomic<int> visits{0};
+    std::atomic<int> side_effects{0};
+    auto store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    std::string sid;
+
+    {
+        CapturingSink first_cap;
+        ACPServer first(
+            build_interrupt_engine(store, &visits, &side_effects),
+            {{"name", "test-acp"}, {"version", "0.0.1"}});
+        first.set_notification_sink(first_cap.as_sink());
+        auto session = first.handle_message(make_request(1, "session/new",
+            {{"cwd", "/work"}, {"mcpServers", neograph::json::array()}}));
+        sid = session["result"].value("sessionId", std::string());
+        first.handle_message(make_request(2, "session/prompt",
+            {{"sessionId", sid},
+             {"prompt", neograph::json::array({
+                 neograph::json{{"type", "text"}, {"text", "find it"}}})}}));
+        ASSERT_TRUE(first_cap.wait_for_response(2).contains("result"));
+    }
+
+    CapturingSink resumed_cap;
+    ACPServer resumed_server(
+        build_interrupt_engine(store, &visits, &side_effects),
+        {{"name", "test-acp"}, {"version", "0.0.1"}});
+    resumed_server.set_notification_sink(resumed_cap.as_sink());
+    EXPECT_TRUE(resumed_server.capabilities().session.resume);
+
+    auto resumed_session = resumed_server.handle_message(make_request(
+        3, "session/resume",
+        {{"sessionId", sid},
+         {"cwd", "/work"},
+         {"mcpServers", neograph::json::array()}}));
+    ASSERT_TRUE(resumed_session.contains("result")) << resumed_session.dump();
+    EXPECT_TRUE(resumed_session["result"].is_object());
+    EXPECT_TRUE(resumed_cap.notifications_for("session/update").empty());
+
+    resumed_server.handle_message(make_request(4, "session/prompt",
+        {{"sessionId", sid},
+         {"prompt", neograph::json::array({
+             neograph::json{{"type", "text"}, {"text", "approved"}}})}}));
+    auto answer = resumed_cap.wait_for_response(4);
+    ASSERT_TRUE(answer.contains("result")) << answer.dump();
+    EXPECT_EQ(visits.load(), 2);
+    EXPECT_EQ(side_effects.load(), 1);
+    for (const auto& notification :
+         resumed_cap.notifications_for("session/update")) {
+        const auto& update = notification["params"]["update"];
+        EXPECT_FALSE(update.contains("_meta") &&
+                     update["_meta"].contains("neograph/interrupt"));
+    }
+}
+
+TEST(ACPServer, SessionResumeRejectsUnknownSession) {
+    auto store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    std::atomic<int> visits{0};
+    std::atomic<int> side_effects{0};
+    ACPServer server(
+        build_interrupt_engine(store, &visits, &side_effects),
+        {{"name", "test-acp"}, {"version", "0.0.1"}});
+
+    auto response = server.handle_message(make_request(1, "session/resume",
+        {{"sessionId", "missing"},
+         {"cwd", "/work"},
+         {"mcpServers", neograph::json::array()}}));
+    ASSERT_TRUE(response.contains("error")) << response.dump();
+    EXPECT_EQ(response["error"].value("code", 0), -32001);
+}
+
+TEST(ACPServer, PromptCannotRaceSessionResumeStateRestore) {
+    std::atomic<int> visits{0};
+    std::atomic<int> side_effects{0};
+    auto store = std::make_shared<BlockingListCheckpointStore>();
+    std::string sid;
+
+    {
+        CapturingSink first_cap;
+        ACPServer first(
+            build_interrupt_engine(store, &visits, &side_effects),
+            {{"name", "test-acp"}, {"version", "0.0.1"}});
+        first.set_notification_sink(first_cap.as_sink());
+        auto session = first.handle_message(make_request(1, "session/new",
+            {{"cwd", "/work"}, {"mcpServers", neograph::json::array()}}));
+        sid = session["result"].value("sessionId", std::string());
+        first.handle_message(make_request(2, "session/prompt",
+            {{"sessionId", sid},
+             {"prompt", neograph::json::array({
+                 neograph::json{{"type", "text"}, {"text", "find it"}}})}}));
+        ASSERT_TRUE(first_cap.wait_for_response(2).contains("result"));
+    }
+
+    CapturingSink cap;
+    ACPServer server(
+        build_interrupt_engine(store, &visits, &side_effects),
+        {{"name", "test-acp"}, {"version", "0.0.1"}});
+    server.set_notification_sink(cap.as_sink());
+
+    neograph::json resume_response;
+    std::thread resume_thread([&] {
+        resume_response = server.handle_message(make_request(
+            3, "session/resume",
+            {{"sessionId", sid},
+             {"cwd", "/work"},
+             {"mcpServers", neograph::json::array()}}));
+    });
+    store->wait_for_list();
+
+    server.handle_message(make_request(4, "session/prompt",
+        {{"sessionId", sid},
+         {"prompt", neograph::json::array({
+             neograph::json{{"type", "text"}, {"text", "approved"}}})}}));
+    auto rejected = cap.wait_for_response(4);
+    store->release_list();
+    resume_thread.join();
+
+    ASSERT_TRUE(rejected.contains("error")) << rejected.dump();
+    EXPECT_EQ(rejected["error"].value("code", 0), -32000);
+    ASSERT_TRUE(resume_response.contains("result")) << resume_response.dump();
+    EXPECT_EQ(visits.load(), 1);
+    EXPECT_EQ(side_effects.load(), 0);
 }
 
 TEST(ACPServer, BuildInitialStateExceptionIsContained) {

--- a/tests/test_acp_types.cpp
+++ b/tests/test_acp_types.cpp
@@ -232,4 +232,27 @@ TEST(ACPTypes, NewSessionRequestCarriesMcpServers) {
     EXPECT_EQ(decoded.mcp_servers[0].raw.value("name", std::string()), "fs");
 }
 
+TEST(ACPTypes, ResumeSessionRequestUsesCamelCase) {
+    ResumeSessionRequest req;
+    req.session_id = "sess-abc";
+    req.cwd = "/home/user/proj";
+    req.mcp_servers.push_back(McpServerConfig{
+        json{{"name", "fs"}, {"command", "fs-mcp"}}});
+
+    json j;
+    to_json(j, req);
+    EXPECT_EQ(j.value("sessionId", std::string()), "sess-abc");
+    EXPECT_EQ(j.value("cwd", std::string()), "/home/user/proj");
+    ASSERT_EQ(j["mcpServers"].size(), 1u);
+    EXPECT_EQ(j["mcpServers"][0].value("name", std::string()), "fs");
+
+    ResumeSessionRequest decoded;
+    from_json(j, decoded);
+    EXPECT_EQ(decoded.session_id, "sess-abc");
+    EXPECT_EQ(decoded.cwd, "/home/user/proj");
+    ASSERT_EQ(decoded.mcp_servers.size(), 1u);
+    EXPECT_EQ(decoded.mcp_servers[0].raw.value("command", std::string()),
+              "fs-mcp");
+}
+
 }  // namespace


### PR DESCRIPTION
## Summary

- surface `RunResult` interrupt node, reason, payload, and checkpoint ID through ACP `_meta`
- route the next prompt for an interrupted session through `GraphEngine::resume` exactly once
- implement ACP v1 `session/resume` for persisted sessions without replay
- serialize prompt admission with session restoration and release per-session admission before the final response is published

## Verification

- `ACPServer.*:ACPTypes.*`: 40/40 passed
- full CTest: 755/755 passed; configured live/Postgres tests skipped
- ASan/UBSan full suite completed without sanitizer findings; missing separately-built ABI helper was built and passed
- latest-code ASan/UBSan ACP suite: 40/40 passed
- `git diff --check`: passed

Closes #153