### PR TITLE
feat(mcp): add SQLite harness record store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **SQLite Harness record store (issue #147 follow-up).** Added the optional
+  `neograph::mcp_sqlite` target and `SqliteHarnessRecordStore` for WAL-backed,
+  schema-versioned artifact/run persistence with immutable artifact and run-to-
+  artifact bindings. The Harness MCP binary now stores records in `runs.db`,
+  while checkpoints remain in `checkpoints.db`.
+
 ### Changed
 
 - **Provider API 영구 호환 정책 (issue #5).** `Provider::complete()`,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -683,6 +683,23 @@ if(NEOGRAPH_BUILD_MCP_SERVER)
     add_library(neograph::mcp_server ALIAS neograph_mcp_server)
 endif()
 
+if(NEOGRAPH_BUILD_MCP_SERVER AND NEOGRAPH_BUILD_SQLITE)
+    add_library(neograph_mcp_sqlite
+        src/mcp/sqlite_harness_store.cpp
+    )
+    target_include_directories(neograph_mcp_sqlite
+        PUBLIC
+            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+            $<INSTALL_INTERFACE:include>
+    )
+    target_compile_definitions(neograph_mcp_sqlite PRIVATE NEOGRAPH_BUILDING_LIBRARY)
+    target_link_libraries(neograph_mcp_sqlite
+        PUBLIC  neograph_mcp_server
+        PRIVATE SQLite::SQLite3
+    )
+    add_library(neograph::mcp_sqlite ALIAS neograph_mcp_sqlite)
+endif()
+
 if(NEOGRAPH_BUILD_MCP_HTTP_SERVER)
     if(NOT NEOGRAPH_BUILD_MCP_SERVER)
         message(FATAL_ERROR
@@ -859,7 +876,8 @@ if(NEOGRAPH_BUILD_HARNESS_MCP_BINARY)
     target_link_libraries(neograph_harness_mcp PRIVATE
         neograph::mcp_server neograph::llm)
     if(NEOGRAPH_BUILD_SQLITE)
-        target_link_libraries(neograph_harness_mcp PRIVATE neograph::sqlite)
+        target_link_libraries(neograph_harness_mcp PRIVATE
+            neograph::sqlite neograph::mcp_sqlite)
         target_compile_definitions(neograph_harness_mcp PRIVATE
             NEOGRAPH_HARNESS_HAVE_SQLITE)
     endif()
@@ -1416,7 +1434,7 @@ if(NEOGRAPH_BUILD_EXAMPLES)
                 neograph::mcp_server neograph::llm)
             if(NEOGRAPH_BUILD_SQLITE)
                 target_link_libraries(example_harness_mcp_server PRIVATE
-                    neograph::sqlite)
+                    neograph::sqlite neograph::mcp_sqlite)
                 target_compile_definitions(example_harness_mcp_server PRIVATE
                     NEOGRAPH_HARNESS_HAVE_SQLITE)
             endif()
@@ -1630,7 +1648,7 @@ if(NEOGRAPH_INSTALL_EXPORT)
         list(APPEND NEOGRAPH_EXPORT_TARGETS neograph_mcp_types)
     endif()
 
-    foreach(_comp async llm mcp mcp_server mcp_http_server a2a acp util postgres sqlite)
+    foreach(_comp async llm mcp mcp_server mcp_sqlite mcp_http_server a2a acp util postgres sqlite)
         if(TARGET neograph_${_comp})
             list(APPEND NEOGRAPH_EXPORT_TARGETS neograph_${_comp})
             list(APPEND NEOGRAPH_COMPONENTS_BUILT ${_comp})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -676,7 +676,8 @@ if(NEOGRAPH_BUILD_MCP_SERVER)
             $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>
     )
-    target_compile_definitions(neograph_mcp_server PRIVATE NEOGRAPH_BUILDING_LIBRARY)
+    target_compile_definitions(neograph_mcp_server PRIVATE
+        NEOGRAPH_BUILDING_LIBRARY NEOGRAPH_BUILDING_MCP_SERVER)
     target_link_libraries(neograph_mcp_server
         PUBLIC neograph_core neograph_mcp_types
     )

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ any custom vendor via JSON schema) · ReAct `Agent` loop with streaming.
 
 **Integrations** — MCP client (`neograph::mcp`, HTTP + stdio) · local MCP server
 (`neograph::mcp_server`, stdio) · opt-in Streamable HTTP server
-(`neograph::mcp_http_server`) · compiler-backed multi-worker
+(`neograph::mcp_http_server`) · SQLite Harness records
+(`neograph::mcp_sqlite`) · compiler-backed multi-worker
 [Harness MCP](docs/HARNESS_MCP.md) · Agent-to-Agent
 (`neograph::a2a`, server + client + caller node) · Agent Client Protocol
 (`neograph::acp`, editor-driven) · gRPC service (`neograph::grpc`, opt-in) ·
@@ -232,7 +233,9 @@ async HTTP/HTTPS/WS + SSE (`neograph::async`).
 
 **Durable state** — `PostgresCheckpointStore`, `SqliteCheckpointStore`, and
 `InMemoryCheckpointStore` behind one `CheckpointStore` interface (all
-Python-bound). Lock-free `RequestQueue` + `AsyncTool` in `neograph::util`.
+Python-bound), plus `SqliteHarnessRecordStore` for immutable Harness artifacts
+and restart-safe run records. Lock-free `RequestQueue` + `AsyncTool` in
+`neograph::util`.
 
 `NEOGRAPH_BUILD_MCP` remains the compatibility umbrella for both MCP roles.
 Use `NEOGRAPH_BUILD_MCP_CLIENT` or `NEOGRAPH_BUILD_MCP_SERVER` for a narrow

--- a/bindings/python/examples/26_mcp_tools.py
+++ b/bindings/python/examples/26_mcp_tools.py
@@ -27,12 +27,12 @@ instead of queueing. This program measures it.
 But the two transports are not the same, and it would be easy to overstate:
 
   - **HTTP** — each call is its own request. Three 0.4 s calls take ~0.4 s.
-  - **stdio** — one subprocess, one pipe. Our client takes a capacity-1 lock
-    around it, so calls are serialized *by us*. Three 0.4 s calls take 1.2 s,
-    and nothing about the graph engine can change that.
+  - **stdio** — one subprocess and one framed pipe, multiplexed by JSON-RPC ID.
+    Calls overlap when the server processes requests concurrently; a serial
+    server still makes three 0.4 s calls take 1.2 s.
 
-Both numbers are printed below. If you want MCP calls to overlap, you want the
-HTTP transport, and that is a property of MCP, not of NeoGraph.
+The test suite measures both stdio server policies instead of attributing either
+behavior to the transport itself.
 """
 
 import json
@@ -174,21 +174,20 @@ def main():
         assert http.initialize("demo"), "handshake failed"
         concurrent = run_against(http, "overlapped", "mcp-http")
 
-        print("\nstdio transport  (a subprocess, one pipe)\n")
+        print("\nstdio transport  (a subprocess, one multiplexed pipe)\n")
         stdio_server = os.path.join(
             os.path.dirname(os.path.dirname(__file__)),
             "tests", "mcp_echo_server.py")
         if os.path.exists(stdio_server):
             stdio = ng.mcp.MCPClient([sys.executable, stdio_server])
             assert stdio.initialize("demo"), "handshake failed"
-            # the echo server names its slow tool differently; skip the timing
-            print("  (see tests/test_mcp.py for the stdio timing — one pipe,")
-            print("   one call at a time: 3 x 0.3s takes 0.90s)")
+            print("  (tests/test_mcp.py measures concurrent and --serial")
+            print("   server policies over this same multiplexed transport)")
 
         print(f"\n  -> HTTP overlapped: {N * DELAY:.1f}s of work in "
               f"{concurrent:.2f}s ({N * DELAY / concurrent:.1f}x).")
-        print("     stdio cannot: one pipe, one request in flight. That is MCP,")
-        print("     not NeoGraph — and it is why the client says so out loud.\n")
+        print("     stdio request IDs also permit overlap; the server decides")
+        print("     whether requests execute concurrently or serially.\n")
     finally:
         server.shutdown()
         server.server_close()

--- a/bindings/python/tests/mcp_echo_server.py
+++ b/bindings/python/tests/mcp_echo_server.py
@@ -6,8 +6,8 @@ That is the whole of MCP that matters here — it is JSON-RPC with a handshake a
 a tool-listing convention, which is precisely why "Python users can just reach
 for fastmcp" was never a real design boundary.
 
-`slow_echo` sleeps, so a test can prove that several MCP tool calls in one turn
-overlap rather than queueing.
+`slow_echo` sleeps, so tests can prove that the same multiplexed client overlaps
+against a concurrent server and waits against a `--serial` server.
 """
 
 import json
@@ -19,6 +19,7 @@ _write_lock = threading.Lock()
 _state_lock = threading.Lock()
 _initialized = False
 _initializing = False
+_serial = "--serial" in sys.argv[1:]
 
 
 TOOLS = [
@@ -122,10 +123,14 @@ def main():
                         _initializing = False
             continue
 
-        # The write lock preserves one-line framing while request IDs let the
-        # client correlate out-of-order replies.
-        threading.Thread(target=handle_request, args=(request,),
-                         daemon=True).start()
+        # The wire remains one framed pipe in both modes. Execution policy is
+        # deliberately selectable so tests do not confuse transport
+        # multiplexing with server-side concurrency.
+        if _serial:
+            handle_request(request)
+        else:
+            threading.Thread(target=handle_request, args=(request,),
+                             daemon=True).start()
 
 
 if __name__ == "__main__":

--- a/bindings/python/tests/test_mcp.py
+++ b/bindings/python/tests/test_mcp.py
@@ -164,6 +164,13 @@ def stdio_client():
     return client
 
 
+@pytest.fixture
+def serial_stdio_client():
+    client = mcp.MCPClient([sys.executable, SERVER, "--serial"])
+    assert client.initialize("neograph-test"), "the MCP handshake failed"
+    return client
+
+
 # ── Helpers ─────────────────────────────────────────────────────────────────
 
 def _graph_calling(tool_name, count, arguments='{"text": "x"}'):
@@ -277,6 +284,22 @@ def test_stdio_calls_overlap_when_server_is_concurrent(stdio_client):
           f"(request-ID multiplexed)")
     assert elapsed < 2 * delay, (
         f"stdio requests serialized unexpectedly: {elapsed:.2f}s")
+
+
+def test_stdio_calls_wait_when_server_is_serial(serial_stdio_client):
+    """Request-ID multiplexing cannot make a serial server execute in parallel."""
+    delay = 0.3
+    definition = _graph_calling(
+        "slow_echo", 3, '{"text": "x", "delay": %s}' % delay)
+
+    tool_msgs, elapsed = _run(definition, serial_stdio_client.get_tools(),
+                              "mcp-stdio-serial", expect_text="x")
+
+    assert len(tool_msgs) == 3
+    print(f"\n[MEASURE] serial stdio server, 3 MCP calls x {delay}s: "
+          f"{elapsed:.2f}s")
+    assert elapsed >= 2.5 * delay, (
+        f"serial stdio server unexpectedly overlapped requests: {elapsed:.2f}s")
 
 
 # ── HTTP ────────────────────────────────────────────────────────────────────

--- a/cmake/NeoGraphConfig.cmake.in
+++ b/cmake/NeoGraphConfig.cmake.in
@@ -12,6 +12,7 @@
 #
 #   find_package(NeoGraph CONFIG REQUIRED)
 #   target_link_libraries(app PRIVATE neograph::core neograph::llm)
+#   target_link_libraries(harness PRIVATE neograph::mcp_sqlite)
 
 include(CMakeFindDependencyMacro)
 

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -44,10 +44,16 @@ The example enables both with one explicit directory:
 export NEOGRAPH_HARNESS_STATE_DIR="$PWD/.neograph-harness-state"
 ```
 
-This stores immutable artifacts and run records as atomic JSON files and graph
-checkpoints in `checkpoints.db`. The directory survives server restarts. A
+This stores immutable artifacts and mutable run records in `runs.db`, and graph
+checkpoints in `checkpoints.db`. Both SQLite stores use WAL mode and a bounded
+busy timeout. The directory survives server restarts. A
 `host_brokered` catalog entry is rejected at compile time when either store is
 missing, so a workflow cannot advertise resumability it does not have.
+
+Custom embeddings can construct the same backend through
+`SqliteHarnessRecordStore` from the optional `neograph::mcp_sqlite` target.
+`FileHarnessRecordStore` remains available for deployments that prefer atomic
+JSON files.
 
 ## Streamable HTTP
 

--- a/examples/60_harness_mcp_server.cpp
+++ b/examples/60_harness_mcp_server.cpp
@@ -9,6 +9,7 @@
 #endif
 #ifdef NEOGRAPH_HARNESS_HAVE_SQLITE
 #include <neograph/graph/sqlite_checkpoint.h>
+#include <neograph/mcp/sqlite_harness_store.h>
 #endif
 
 #ifdef NEOGRAPH_HARNESS_HAVE_HTTP
@@ -19,6 +20,7 @@
 #include <vector>
 #endif
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <string>
 #include <utility>
@@ -104,8 +106,9 @@ int main() {
         neograph::mcp::make_provider_harness_executor(std::move(executor_config));
 #ifdef NEOGRAPH_HARNESS_HAVE_SQLITE
     if (const auto state_dir = environment("NEOGRAPH_HARNESS_STATE_DIR"); !state_dir.empty()) {
+        std::filesystem::create_directories(state_dir);
         harness_config.record_store =
-            std::make_shared<neograph::mcp::FileHarnessRecordStore>(state_dir);
+            std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(state_dir + "/runs.db");
         harness_config.checkpoint_store =
             std::make_shared<neograph::graph::SqliteCheckpointStore>(state_dir + "/checkpoints.db");
         harness_config.enable_experimental_tasks =

--- a/include/neograph/api.h
+++ b/include/neograph/api.h
@@ -17,18 +17,14 @@
  * The CMake target machinery sets ``NEOGRAPH_BUILDING_LIBRARY`` (a
  * ``target_compile_definitions`` PRIVATE on each ``neograph_*``
  * library) and ``NEOGRAPH_STATIC_BUILD`` (when ``BUILD_SHARED_LIBS``
- * is OFF). Headers don't need any other glue.
+ * is OFF). Component-specific macros also receive their owning target's
+ * private build definition.
  *
- * Why a custom macro instead of CMake's ``generate_export_header``?
- * The engine ships several libraries (``neograph_core``,
- * ``neograph_async``, ``neograph_llm``, ...) that can include each
- * other's public headers. ``generate_export_header`` produces a
- * per-library macro; managing four separate ``XXX_EXPORT`` ifdefs
- * across the headers gets tangled fast. A single ``NEOGRAPH_API``
- * keyed on whether ANY neograph_* TU is being compiled keeps the
- * source tree clean — at the cost of treating cross-library calls
- * inside the engine as if every public symbol were a same-library
- * call (which they effectively are during the engine's own build).
+ * Most engine libraries use the shared ``NEOGRAPH_API`` macro. Components
+ * whose public headers are intentionally consumed by another NeoGraph DLL
+ * may define a narrower macro below. MSVC eagerly emits helpers for exported
+ * classes, so treating those cross-DLL declarations as exports can create
+ * references to implementations owned by the wrong DLL.
  */
 #pragma once
 
@@ -48,6 +44,22 @@
     #define NEOGRAPH_API __attribute__((visibility("default")))
 #else
     #define NEOGRAPH_API
+#endif
+
+// Harness declarations belong to neograph_mcp_server but are also consumed by
+// the MCP client, A2A adapter, and SQLite store libraries.
+#if defined(NEOGRAPH_STATIC_BUILD)
+    #define NEOGRAPH_MCP_SERVER_API
+#elif defined(_WIN32) || defined(__CYGWIN__)
+    #if defined(NEOGRAPH_BUILDING_MCP_SERVER)
+        #define NEOGRAPH_MCP_SERVER_API __declspec(dllexport)
+    #else
+        #define NEOGRAPH_MCP_SERVER_API __declspec(dllimport)
+    #endif
+#elif defined(__GNUC__) && __GNUC__ >= 4
+    #define NEOGRAPH_MCP_SERVER_API __attribute__((visibility("default")))
+#else
+    #define NEOGRAPH_MCP_SERVER_API
 #endif
 
 // PR 4 (v0.4.0): cross-compiler deprecation-warning suppression.

--- a/include/neograph/graph/sqlite_checkpoint.h
+++ b/include/neograph/graph/sqlite_checkpoint.h
@@ -46,6 +46,7 @@
 
 #include <neograph/api.h>
 #include <neograph/graph/checkpoint.h>
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -68,6 +69,9 @@ public:
     /// @param db_path Filesystem path or ":memory:". Anything sqlite3_open accepts.
     /// @throws std::runtime_error on open or DDL failure.
     explicit SqliteCheckpointStore(const std::string& db_path);
+    /// Configure how long writes wait for a competing SQLite writer.
+    SqliteCheckpointStore(const std::string& db_path,
+                          std::chrono::milliseconds busy_timeout);
 
     ~SqliteCheckpointStore() override;
 

--- a/include/neograph/mcp/harness.h
+++ b/include/neograph/mcp/harness.h
@@ -47,7 +47,7 @@ struct HarnessWorkerCall {
 };
 
 /** Typed worker response; failure classes never masquerade as valid output. */
-struct NEOGRAPH_API HarnessWorkerResponse {
+struct NEOGRAPH_MCP_SERVER_API HarnessWorkerResponse {
     HarnessWorkerResponseKind kind = HarnessWorkerResponseKind::VALUE;
     json value;
     std::string message;
@@ -77,11 +77,11 @@ struct HarnessProviderExecutorConfig {
 };
 
 /// Build a worker executor that calls a NeoGraph Provider directly.
-NEOGRAPH_API HarnessWorkerExecutor
+NEOGRAPH_MCP_SERVER_API HarnessWorkerExecutor
 make_provider_harness_executor(HarnessProviderExecutorConfig config);
 
 /** Durable storage boundary for retained Harness artifacts and run records. */
-class NEOGRAPH_API HarnessRecordStore {
+class NEOGRAPH_MCP_SERVER_API HarnessRecordStore {
 public:
     virtual ~HarnessRecordStore() = default;
 
@@ -92,7 +92,7 @@ public:
 };
 
 /** Atomic JSON-file implementation suitable for local process restarts. */
-class NEOGRAPH_API FileHarnessRecordStore final : public HarnessRecordStore {
+class NEOGRAPH_MCP_SERVER_API FileHarnessRecordStore final : public HarnessRecordStore {
 public:
     explicit FileHarnessRecordStore(std::string root_directory);
     ~FileHarnessRecordStore() override;
@@ -124,7 +124,7 @@ struct HarnessServiceConfig {
  * `register_tools()` captures this service by reference; the service must
  * outlive the MCPServer and be destroyed only after the server has stopped.
  */
-class NEOGRAPH_API HarnessService {
+class NEOGRAPH_MCP_SERVER_API HarnessService {
 public:
     explicit HarnessService(HarnessServiceConfig config = {});
     ~HarnessService();

--- a/include/neograph/mcp/harness_mcp_backend.h
+++ b/include/neograph/mcp/harness_mcp_backend.h
@@ -5,10 +5,8 @@
 #pragma once
 
 #include <neograph/api.h>
-#include <neograph/graph/cancel.h>
-#include <neograph/json.h>
+#include <neograph/mcp/harness.h>
 
-#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -18,9 +16,7 @@ namespace neograph::mcp {
 class MCPClient;
 
 /// Resolve tool executor.server_ref against preconfigured, initialized clients.
-NEOGRAPH_API std::function<json(
-    const json&, const json&, const std::shared_ptr<graph::CancelToken>&)>
-make_mcp_harness_capability_executor(
+NEOGRAPH_API HarnessCapabilityExecutor make_mcp_harness_capability_executor(
     std::map<std::string, std::shared_ptr<MCPClient>> clients);
 
 } // namespace neograph::mcp

--- a/include/neograph/mcp/harness_mcp_backend.h
+++ b/include/neograph/mcp/harness_mcp_backend.h
@@ -5,8 +5,10 @@
 #pragma once
 
 #include <neograph/api.h>
-#include <neograph/mcp/harness.h>
+#include <neograph/graph/cancel.h>
+#include <neograph/json.h>
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
@@ -16,7 +18,9 @@ namespace neograph::mcp {
 class MCPClient;
 
 /// Resolve tool executor.server_ref against preconfigured, initialized clients.
-NEOGRAPH_API HarnessCapabilityExecutor make_mcp_harness_capability_executor(
+NEOGRAPH_API std::function<json(
+    const json&, const json&, const std::shared_ptr<graph::CancelToken>&)>
+make_mcp_harness_capability_executor(
     std::map<std::string, std::shared_ptr<MCPClient>> clients);
 
 } // namespace neograph::mcp

--- a/include/neograph/mcp/sqlite_harness_store.h
+++ b/include/neograph/mcp/sqlite_harness_store.h
@@ -1,0 +1,38 @@
+/**
+ * @file mcp/sqlite_harness_store.h
+ * @brief SQLite-backed durable storage for Harness artifacts and runs.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/mcp/harness.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+
+namespace neograph::mcp {
+
+/** Local SQLite implementation of the Harness record-store boundary. */
+class NEOGRAPH_API SqliteHarnessRecordStore final : public HarnessRecordStore {
+public:
+    /// Open or create a store with a five-second SQLite busy timeout.
+    explicit SqliteHarnessRecordStore(const std::string& db_path);
+    /// Open or create a store with an explicit competing-writer wait budget.
+    SqliteHarnessRecordStore(const std::string& db_path, std::chrono::milliseconds busy_timeout);
+    ~SqliteHarnessRecordStore() override;
+
+    SqliteHarnessRecordStore(const SqliteHarnessRecordStore&)            = delete;
+    SqliteHarnessRecordStore& operator=(const SqliteHarnessRecordStore&) = delete;
+
+    void                save_artifact(const std::string& artifact_id, const json& record) override;
+    std::optional<json> load_artifact(const std::string& artifact_id) override;
+    void                save_run(const std::string& run_id, const json& record) override;
+    std::optional<json> load_run(const std::string& run_id) override;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace neograph::mcp

--- a/scripts/test_find_package.sh
+++ b/scripts/test_find_package.sh
@@ -8,7 +8,7 @@
 # unit test in the repo links against the build tree, where the headers, the
 # vendored deps and the libraries are all reachable by accident.
 #
-#   exit 0 — a consumer can find_package(NeoGraph), link neograph::core, and run
+#   exit 0 — a consumer can find_package(NeoGraph), link core/mcp_sqlite, and run
 #   exit 1 — it cannot, at whichever of the four stages failed
 #
 # Usage: scripts/test_find_package.sh [--keep] [--shared]

--- a/src/core/sqlite_checkpoint.cpp
+++ b/src/core/sqlite_checkpoint.cpp
@@ -21,6 +21,7 @@
 #include <sqlite3.h>
 
 #include <chrono>
+#include <limits>
 #include <stdexcept>
 
 namespace neograph::graph {
@@ -245,7 +246,15 @@ constexpr const char* kSelectCols =
 
 // ── Construction / lifetime ───────────────────────────────────────────
 
-SqliteCheckpointStore::SqliteCheckpointStore(const std::string& db_path) {
+SqliteCheckpointStore::SqliteCheckpointStore(const std::string& db_path)
+    : SqliteCheckpointStore(db_path, std::chrono::seconds(5)) {}
+
+SqliteCheckpointStore::SqliteCheckpointStore(
+    const std::string& db_path, std::chrono::milliseconds busy_timeout) {
+    if (busy_timeout.count() < 0 ||
+        busy_timeout.count() > std::numeric_limits<int>::max()) {
+        throw std::invalid_argument("SqliteCheckpointStore: busy timeout is out of range");
+    }
     if (sqlite3_open(db_path.c_str(), &db_) != SQLITE_OK) {
         std::string msg = "SqliteCheckpointStore: open failed: ";
         msg += sqlite3_errmsg(db_);
@@ -253,19 +262,30 @@ SqliteCheckpointStore::SqliteCheckpointStore(const std::string& db_path) {
         db_ = nullptr;
         throw std::runtime_error(std::move(msg));
     }
-    // WAL gives us non-blocking readers and durable writes via fsync at
-    // checkpoint time. Foreign keys aren't used (we manage references in
-    // app code), but enabling them now would future-proof the schema.
-    exec_ddl("PRAGMA journal_mode=WAL;");
-    exec_ddl("PRAGMA foreign_keys=ON;");
-    // synchronous=NORMAL is the WAL-recommended default — fsyncs on
-    // checkpoint, not every commit. ~10× faster than FULL with no
-    // durability loss for crashes; only OS crashes can lose the last
-    // few transactions in WAL. For a CheckpointStore that's a good
-    // trade because the engine is the source of truth in RAM until
-    // commit anyway.
-    exec_ddl("PRAGMA synchronous=NORMAL;");
-    ensure_schema();
+    try {
+        // https://www.sqlite.org/c3ref/busy_timeout.html (fetched 2026-07-21)
+        // waits through transient writer contention up to the configured budget.
+        if (sqlite3_busy_timeout(db_, static_cast<int>(busy_timeout.count())) != SQLITE_OK) {
+            throw_sqlite_error(db_, "cannot configure busy timeout");
+        }
+        // WAL gives us non-blocking readers and durable writes via fsync at
+        // checkpoint time. Foreign keys aren't used (we manage references in
+        // app code), but enabling them now would future-proof the schema.
+        exec_ddl("PRAGMA journal_mode=WAL;");
+        exec_ddl("PRAGMA foreign_keys=ON;");
+        // synchronous=NORMAL is the WAL-recommended default — fsyncs on
+        // checkpoint, not every commit. ~10× faster than FULL with no
+        // durability loss for crashes; only OS crashes can lose the last
+        // few transactions in WAL. For a CheckpointStore that's a good
+        // trade because the engine is the source of truth in RAM until
+        // commit anyway.
+        exec_ddl("PRAGMA synchronous=NORMAL;");
+        ensure_schema();
+    } catch (...) {
+        sqlite3_close(db_);
+        db_ = nullptr;
+        throw;
+    }
 }
 
 SqliteCheckpointStore::~SqliteCheckpointStore() {

--- a/src/mcp/harness_mcp_backend.cpp
+++ b/src/mcp/harness_mcp_backend.cpp
@@ -7,7 +7,8 @@
 
 namespace neograph::mcp {
 
-HarnessCapabilityExecutor make_mcp_harness_capability_executor(
+std::function<json(const json&, const json&, const std::shared_ptr<graph::CancelToken>&)>
+make_mcp_harness_capability_executor(
     std::map<std::string, std::shared_ptr<MCPClient>> clients) {
     return [clients = std::move(clients)](
                const json& tool, const json& arguments,

--- a/src/mcp/harness_mcp_backend.cpp
+++ b/src/mcp/harness_mcp_backend.cpp
@@ -7,8 +7,7 @@
 
 namespace neograph::mcp {
 
-std::function<json(const json&, const json&, const std::shared_ptr<graph::CancelToken>&)>
-make_mcp_harness_capability_executor(
+HarnessCapabilityExecutor make_mcp_harness_capability_executor(
     std::map<std::string, std::shared_ptr<MCPClient>> clients) {
     return [clients = std::move(clients)](
                const json& tool, const json& arguments,

--- a/src/mcp/sqlite_harness_store.cpp
+++ b/src/mcp/sqlite_harness_store.cpp
@@ -1,0 +1,257 @@
+#include <neograph/mcp/sqlite_harness_store.h>
+
+#include <sqlite3.h>
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <limits>
+#include <mutex>
+#include <stdexcept>
+#include <utility>
+
+namespace neograph::mcp {
+namespace {
+
+[[noreturn]] void throw_sqlite_error(sqlite3* db, const char* operation) {
+    throw std::runtime_error(std::string("SqliteHarnessRecordStore: ") + operation + ": " +
+                             (db ? sqlite3_errmsg(db) : "out of memory"));
+}
+
+class Statement {
+public:
+    Statement(sqlite3* db, const char* sql) : db_(db) {
+        if (sqlite3_prepare_v2(db, sql, -1, &statement_, nullptr) != SQLITE_OK) {
+            throw_sqlite_error(db, "prepare failed");
+        }
+    }
+    ~Statement() { sqlite3_finalize(statement_); }
+
+    Statement(const Statement&)            = delete;
+    Statement& operator=(const Statement&) = delete;
+
+    void bind_text(int index, const std::string& value) {
+        if (sqlite3_bind_text(statement_, index, value.data(), static_cast<int>(value.size()),
+                              SQLITE_TRANSIENT) != SQLITE_OK) {
+            throw_sqlite_error(db_, "bind failed");
+        }
+    }
+
+    void bind_int64(int index, int64_t value) {
+        if (sqlite3_bind_int64(statement_, index, value) != SQLITE_OK) {
+            throw_sqlite_error(db_, "bind failed");
+        }
+    }
+
+    int step() { return sqlite3_step(statement_); }
+
+    std::string text(int column) const {
+        const auto* value = sqlite3_column_text(statement_, column);
+        if (!value) return {};
+        return {reinterpret_cast<const char*>(value),
+                static_cast<std::size_t>(sqlite3_column_bytes(statement_, column))};
+    }
+
+    int integer(int column) const { return sqlite3_column_int(statement_, column); }
+
+private:
+    sqlite3*      db_        = nullptr;
+    sqlite3_stmt* statement_ = nullptr;
+};
+
+void validate_id(const std::string& id) {
+    if (id.empty() || !std::all_of(id.begin(), id.end(), [](unsigned char character) {
+            return std::isalnum(character) || character == '-' || character == '_';
+        })) {
+        throw std::invalid_argument("invalid Harness record identifier");
+    }
+}
+
+int64_t unix_millis() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+}  // namespace
+
+struct SqliteHarnessRecordStore::Impl {
+    Impl(const std::string& db_path, std::chrono::milliseconds busy_timeout) {
+        if (db_path.empty()) {
+            throw std::invalid_argument("SqliteHarnessRecordStore path must not be empty");
+        }
+        if (busy_timeout.count() < 0 || busy_timeout.count() > std::numeric_limits<int>::max()) {
+            throw std::invalid_argument("SqliteHarnessRecordStore busy timeout is out of range");
+        }
+        if (sqlite3_open_v2(db_path.c_str(), &db,
+                            SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX,
+                            nullptr) != SQLITE_OK) {
+            const std::string message = std::string("SqliteHarnessRecordStore: open failed: ") +
+                                        (db ? sqlite3_errmsg(db) : "out of memory");
+            sqlite3_close(db);
+            db = nullptr;
+            throw std::runtime_error(message);
+        }
+
+        try {
+            // SQLite documents that this handler waits for transient locks until
+            // the configured budget is exhausted.
+            // https://www.sqlite.org/c3ref/busy_timeout.html (fetched 2026-07-21)
+            if (sqlite3_busy_timeout(db, static_cast<int>(busy_timeout.count())) != SQLITE_OK) {
+                throw_sqlite_error(db, "cannot configure busy timeout");
+            }
+            exec("PRAGMA journal_mode=WAL;");
+            exec("PRAGMA foreign_keys=ON;");
+            exec("PRAGMA synchronous=NORMAL;");
+            ensure_schema();
+        } catch (...) {
+            sqlite3_close(db);
+            db = nullptr;
+            throw;
+        }
+    }
+
+    ~Impl() { sqlite3_close(db); }
+
+    void exec(const char* sql) {
+        char* error = nullptr;
+        if (sqlite3_exec(db, sql, nullptr, nullptr, &error) != SQLITE_OK) {
+            std::string message = "SqliteHarnessRecordStore: SQL execution failed";
+            if (error) {
+                message += ": ";
+                message += error;
+                sqlite3_free(error);
+            }
+            throw std::runtime_error(std::move(message));
+        }
+    }
+
+    void ensure_schema() {
+        // Version 1 is the first shipped schema. A future bump must migrate
+        // older versions inside this transaction before updating the singleton;
+        // rejecting an unknown version is safer than opening it partially.
+        exec("BEGIN IMMEDIATE;");
+        try {
+            exec(R"SQL(
+CREATE TABLE IF NOT EXISTS neograph_harness_schema (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    version   INTEGER NOT NULL
+);
+INSERT INTO neograph_harness_schema (singleton, version)
+VALUES (1, 1)
+ON CONFLICT(singleton) DO NOTHING;
+CREATE TABLE IF NOT EXISTS neograph_harness_artifacts (
+    artifact_id  TEXT PRIMARY KEY,
+    record_json  TEXT    NOT NULL,
+    created_at_ms INTEGER NOT NULL
+);
+CREATE TABLE IF NOT EXISTS neograph_harness_runs (
+    run_id        TEXT PRIMARY KEY,
+    artifact_id   TEXT    NOT NULL,
+    record_json   TEXT    NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    FOREIGN KEY (artifact_id) REFERENCES neograph_harness_artifacts (artifact_id)
+        ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS neograph_harness_runs_artifact
+    ON neograph_harness_runs (artifact_id);
+)SQL");
+            Statement version(db,
+                              "SELECT version FROM neograph_harness_schema WHERE singleton = 1");
+            if (version.step() != SQLITE_ROW || version.integer(0) != 1) {
+                throw std::runtime_error("SqliteHarnessRecordStore: unsupported schema version");
+            }
+            exec("COMMIT;");
+        } catch (...) {
+            try {
+                exec("ROLLBACK;");
+            } catch (...) {}
+            throw;
+        }
+    }
+
+    std::optional<json> load(const char* table, const char* id_column, const std::string& id) {
+        validate_id(id);
+        std::lock_guard   lock(mutex);
+        const std::string sql =
+            std::string("SELECT record_json FROM ") + table + " WHERE " + id_column + " = ?";
+        Statement statement(db, sql.c_str());
+        statement.bind_text(1, id);
+        const auto result = statement.step();
+        if (result == SQLITE_DONE) return std::nullopt;
+        if (result != SQLITE_ROW) throw_sqlite_error(db, "read failed");
+        return json::parse(statement.text(0));
+    }
+
+    sqlite3*   db = nullptr;
+    std::mutex mutex;
+};
+
+SqliteHarnessRecordStore::SqliteHarnessRecordStore(const std::string& db_path)
+    : SqliteHarnessRecordStore(db_path, std::chrono::seconds(5)) {}
+
+SqliteHarnessRecordStore::SqliteHarnessRecordStore(const std::string&        db_path,
+                                                   std::chrono::milliseconds busy_timeout)
+    : impl_(std::make_unique<Impl>(db_path, busy_timeout)) {}
+
+SqliteHarnessRecordStore::~SqliteHarnessRecordStore() = default;
+
+void SqliteHarnessRecordStore::save_artifact(const std::string& artifact_id, const json& record) {
+    validate_id(artifact_id);
+    if (record.value("artifact_id", "") != artifact_id) {
+        throw std::invalid_argument("Harness artifact record id mismatch");
+    }
+    const auto      serialized = record.dump();
+    std::lock_guard lock(impl_->mutex);
+    Statement       insert(impl_->db,
+                           "INSERT INTO neograph_harness_artifacts "
+                                 "(artifact_id, record_json, created_at_ms) VALUES (?, ?, ?) "
+                                 "ON CONFLICT(artifact_id) DO NOTHING");
+    insert.bind_text(1, artifact_id);
+    insert.bind_text(2, serialized);
+    insert.bind_int64(3, unix_millis());
+    if (insert.step() != SQLITE_DONE) throw_sqlite_error(impl_->db, "artifact write failed");
+    if (sqlite3_changes(impl_->db) == 1) return;
+
+    Statement existing(impl_->db,
+                       "SELECT record_json FROM neograph_harness_artifacts WHERE artifact_id = ?");
+    existing.bind_text(1, artifact_id);
+    if (existing.step() != SQLITE_ROW || existing.text(0) != serialized) {
+        throw std::invalid_argument("Harness artifacts are immutable");
+    }
+}
+
+std::optional<json> SqliteHarnessRecordStore::load_artifact(const std::string& artifact_id) {
+    return impl_->load("neograph_harness_artifacts", "artifact_id", artifact_id);
+}
+
+void SqliteHarnessRecordStore::save_run(const std::string& run_id, const json& record) {
+    validate_id(run_id);
+    if (record.value("run_id", "") != run_id || !record.contains("artifact_id") ||
+        !record["artifact_id"].is_string()) {
+        throw std::invalid_argument("Harness run record id or artifact id mismatch");
+    }
+    const auto artifact_id = record["artifact_id"].get<std::string>();
+    validate_id(artifact_id);
+    std::lock_guard lock(impl_->mutex);
+    Statement       save(impl_->db,
+                         "INSERT INTO neograph_harness_runs "
+                               "(run_id, artifact_id, record_json, updated_at_ms) VALUES (?, ?, ?, ?) "
+                               "ON CONFLICT(run_id) DO UPDATE SET "
+                               "record_json=excluded.record_json, updated_at_ms=excluded.updated_at_ms "
+                               "WHERE neograph_harness_runs.artifact_id=excluded.artifact_id");
+    save.bind_text(1, run_id);
+    save.bind_text(2, artifact_id);
+    save.bind_text(3, record.dump());
+    save.bind_int64(4, unix_millis());
+    if (save.step() != SQLITE_DONE) throw_sqlite_error(impl_->db, "run write failed");
+    if (sqlite3_changes(impl_->db) == 0) {
+        throw std::invalid_argument("Harness run revision binding is immutable");
+    }
+}
+
+std::optional<json> SqliteHarnessRecordStore::load_run(const std::string& run_id) {
+    return impl_->load("neograph_harness_runs", "run_id", run_id);
+}
+
+}  // namespace neograph::mcp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -186,6 +186,9 @@ endif()
 
 if(NEOGRAPH_BUILD_SQLITE)
     target_link_libraries(neograph_tests PRIVATE neograph::sqlite)
+    if(NEOGRAPH_BUILD_MCP_SERVER)
+        target_link_libraries(neograph_tests PRIVATE neograph::mcp_sqlite SQLite::SQLite3)
+    endif()
 endif()
 
 include(GoogleTest)

--- a/tests/integration/find_package/CMakeLists.txt
+++ b/tests/integration/find_package/CMakeLists.txt
@@ -11,3 +11,7 @@ find_package(NeoGraph CONFIG REQUIRED)
 
 add_executable(consumer main.cpp)
 target_link_libraries(consumer PRIVATE neograph::core)
+if(TARGET neograph::mcp_sqlite)
+    target_link_libraries(consumer PRIVATE neograph::mcp_sqlite)
+    target_compile_definitions(consumer PRIVATE NEOGRAPH_CONSUMER_HAS_MCP_SQLITE)
+endif()

--- a/tests/integration/find_package/main.cpp
+++ b/tests/integration/find_package/main.cpp
@@ -10,6 +10,9 @@
 
 #include <neograph/neograph.h>
 #include <neograph/async/run_sync.h>
+#ifdef NEOGRAPH_CONSUMER_HAS_MCP_SQLITE
+#include <neograph/mcp/sqlite_harness_store.h>
+#endif
 
 #include <cstdlib>
 #include <iostream>
@@ -58,5 +61,22 @@ int main() {
         std::cerr << "unexpected channel value\n";
         return EXIT_FAILURE;
     }
+
+#ifdef NEOGRAPH_CONSUMER_HAS_MCP_SQLITE
+    neograph::mcp::SqliteHarnessRecordStore records(":memory:");
+    records.save_artifact("artifact_installed", {
+        {"artifact_id", "artifact_installed"},
+        {"request", json::object()},
+    });
+    records.save_run("run_installed", {
+        {"run_id", "run_installed"},
+        {"artifact_id", "artifact_installed"},
+        {"status", "completed"},
+    });
+    if (records.load_run("run_installed")->value("status", "") != "completed") {
+        std::cerr << "installed SqliteHarnessRecordStore failed\n";
+        return EXIT_FAILURE;
+    }
+#endif
     return EXIT_SUCCESS;
 }

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -4,6 +4,8 @@
 #include <gtest/gtest.h>
 #ifdef NEOGRAPH_TESTS_HAVE_SQLITE
 #include <neograph/graph/sqlite_checkpoint.h>
+#include <neograph/mcp/sqlite_harness_store.h>
+#include <sqlite3.h>
 #endif
 #include <neograph/mcp/harness.h>
 #include <neograph/mcp/server.h>
@@ -842,9 +844,94 @@ TEST(HarnessServiceTest, ExpiredHostResultIsRejectedAndPersisted) {
 }
 
 #ifdef NEOGRAPH_TESTS_HAVE_SQLITE
+TEST(HarnessServiceTest, SqliteRecordStoreReopensAndKeepsArtifactsImmutable) {
+    const auto root = unique_temp_path("neograph-harness-sqlite-records");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    const auto database = root / "runs.db";
+
+    const json artifact = {
+        {"artifact_id", "artifact_1"},
+        {"request", {{"task", "review"}}},
+    };
+    const json run = {
+        {"run_id", "run_1"},
+        {"artifact_id", "artifact_1"},
+        {"status", "queued"},
+    };
+    {
+        neograph::mcp::SqliteHarnessRecordStore records(database.string());
+        records.save_artifact("artifact_1", artifact);
+        records.save_artifact("artifact_1", artifact);
+        records.save_run("run_1", run);
+
+        auto changed = artifact;
+        changed["request"]["task"] = "mutated";
+        EXPECT_THROW(records.save_artifact("artifact_1", changed), std::invalid_argument);
+    }
+    {
+        neograph::mcp::SqliteHarnessRecordStore records(database.string());
+        ASSERT_EQ(records.load_artifact("artifact_1"), std::optional<json>(artifact));
+        ASSERT_EQ(records.load_run("run_1"), std::optional<json>(run));
+
+        auto completed = run;
+        completed["status"] = "completed";
+        records.save_run("run_1", completed);
+        EXPECT_EQ((*records.load_run("run_1"))["status"], "completed");
+
+        auto rebound = completed;
+        rebound["artifact_id"] = "artifact_2";
+        EXPECT_THROW(records.save_run("run_1", rebound), std::invalid_argument);
+        EXPECT_THROW(records.save_run("run_missing", {
+            {"run_id", "run_missing"},
+            {"artifact_id", "artifact_missing"},
+            {"status", "queued"},
+        }), std::runtime_error);
+    }
+}
+
+TEST(HarnessServiceTest, SqliteRecordStoreBusyTimeoutWaitsForWriter) {
+    const auto root = unique_temp_path("neograph-harness-sqlite-busy");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    const auto database = root / "runs.db";
+
+    neograph::mcp::SqliteHarnessRecordStore records(database.string(), 500ms);
+    records.save_artifact("artifact_1", {
+        {"artifact_id", "artifact_1"},
+        {"request", json::object()},
+    });
+    sqlite3*                                 blocker = nullptr;
+    ASSERT_EQ(sqlite3_open(database.string().c_str(), &blocker), SQLITE_OK);
+    ASSERT_EQ(sqlite3_exec(blocker, "BEGIN IMMEDIATE;", nullptr, nullptr, nullptr), SQLITE_OK);
+
+    std::exception_ptr failure;
+    const auto started = std::chrono::steady_clock::now();
+    std::thread writer([&] {
+        try {
+            records.save_run("run_waiting", {
+                {"run_id", "run_waiting"},
+                {"artifact_id", "artifact_1"},
+                {"status", "queued"},
+            });
+        } catch (...) {
+            failure = std::current_exception();
+        }
+    });
+    std::this_thread::sleep_for(75ms);
+    EXPECT_EQ(sqlite3_exec(blocker, "COMMIT;", nullptr, nullptr, nullptr), SQLITE_OK);
+    writer.join();
+    sqlite3_close(blocker);
+
+    EXPECT_FALSE(failure);
+    EXPECT_GE(std::chrono::steady_clock::now() - started, 75ms);
+    EXPECT_TRUE(records.load_run("run_waiting").has_value());
+}
+
 TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
     const auto root     = unique_temp_path("neograph-harness-resume");
     const auto database = root / "checkpoints.db";
+    const auto records_database = root / "runs.db";
     std::filesystem::create_directories(root);
     auto                     provider = std::make_shared<ScriptedProvider>();
     neograph::ChatCompletion tool_request;
@@ -861,7 +948,7 @@ TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
         config.checkpoint_store =
             std::make_shared<neograph::graph::SqliteCheckpointStore>(database.string());
         config.record_store =
-            std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+            std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(records_database.string());
         neograph::mcp::HarnessProviderExecutorConfig provider_config;
         provider_config.provider = provider;
         config.worker_executor =
@@ -881,7 +968,7 @@ TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
         config.checkpoint_store =
             std::make_shared<neograph::graph::SqliteCheckpointStore>(database.string());
         config.record_store =
-            std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+            std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(records_database.string());
         neograph::mcp::HarnessProviderExecutorConfig provider_config;
         provider_config.provider = provider;
         config.worker_executor =
@@ -923,6 +1010,7 @@ TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
 TEST(HarnessServiceTest, PersistedResumeIntentRecoversBeforeThreadSpawn) {
     const auto root     = unique_temp_path("neograph-harness-resume-intent");
     const auto database = root / "checkpoints.db";
+    const auto records_database = root / "runs.db";
     std::filesystem::create_directories(root);
     auto                     provider = std::make_shared<ScriptedProvider>();
     neograph::ChatCompletion tool_request;
@@ -939,7 +1027,7 @@ TEST(HarnessServiceTest, PersistedResumeIntentRecoversBeforeThreadSpawn) {
         config.checkpoint_store =
             std::make_shared<neograph::graph::SqliteCheckpointStore>(database.string());
         config.record_store =
-            std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+            std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(records_database.string());
         neograph::mcp::HarnessProviderExecutorConfig provider_config;
         provider_config.provider = provider;
         config.worker_executor =
@@ -954,7 +1042,8 @@ TEST(HarnessServiceTest, PersistedResumeIntentRecoversBeforeThreadSpawn) {
         call_id = waiting["pending"]["call_id"].get<std::string>();
     }
 
-    auto records = std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+    auto records =
+        std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(records_database.string());
     auto record  = records->load_run(run_id);
     ASSERT_TRUE(record.has_value());
     (*record)["consumed"][call_id] = {{"answer", "found"}};


### PR DESCRIPTION
## Summary

- add optional `neograph::mcp_sqlite` and `SqliteHarnessRecordStore` with WAL, configurable busy timeout, schema versioning, immutable artifacts, immutable run-to-artifact binding, and foreign-key enforcement
- move the Harness MCP binary from JSON run files to `runs.db` while retaining `checkpoints.db` for GraphEngine state
- preserve SQLite-free server-only builds and verify both full and narrow installed consumers
- correct the stale Python stdio concurrency explanation and measure both concurrent and serial stdio server policies

Follow-up to #147. The remaining causal journal, deterministic replay, compatible fork, redaction, and retention work is tracked in #155.

## Verification

- offline CTest: `758/758` passed
- Python suite: `255 passed, 3 skipped`
- focused Python MCP: `9/9` passed
- ASan/UBSan SQLite/Harness focus: `4/4` passed
- default installed `find_package(NeoGraph)` consumer: passed with `neograph::mcp_sqlite`
- SQLite-disabled minimal `neograph::mcp_server` build and installed consumer: passed
- `git diff --check`: passed
- independent correctness review: no blocking findings