### PR TITLE
feat(mcp): add durable Harness journal and replay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -669,6 +669,7 @@ if(NEOGRAPH_BUILD_MCP_SERVER)
     add_library(neograph_mcp_server
         src/mcp/server.cpp
         src/mcp/harness.cpp
+        src/mcp/harness_journal.cpp
         src/mcp/harness_provider.cpp
     )
     target_include_directories(neograph_mcp_server

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -51,7 +51,7 @@ and Harness profile. Worker attempts include duration, validation/retry outcome,
 and correlation IDs that join provider, capability, and host-brokered calls to
 their issuing attempt. Both SQLite stores use WAL mode and a bounded busy
 timeout. Existing version-1 record databases migrate transactionally to version
-2 when opened. The directory survives server restarts. A
+3 when opened. The directory survives server restarts. A
 `host_brokered` catalog entry is rejected at compile time when either store is
 missing, so a workflow cannot advertise resumability it does not have.
 
@@ -64,6 +64,32 @@ and should only be enabled for data approved for storage. Events can be read in
 run order through `HarnessJournal::list_events(run_id, after_sequence, limit)`.
 `FileHarnessRecordStore` remains available for deployments that prefer atomic
 JSON files; it does not implement the journal boundary.
+
+### Retention
+
+The SQLite store implements the optional `HarnessRetentionStore` sibling
+interface; the stable `HarnessRecordStore` vtable is unchanged. Before retaining
+an artifact or starting a run, `HarnessService` applies `max_artifacts` and
+`max_runs` from `HarnessServiceConfig`. Defaults are 128 each.
+
+Cleanup removes only terminal leaf runs. Queued, running, and input-waiting runs
+are protected, as are in-process executions that have not finished journal
+finalization. A replay or fork row records `source_run_id`, so its source cannot
+be removed while that dependent remains retained. If space is needed, the
+dependent leaf is removed first; the source becomes eligible only in a later
+step after no retained row references it. Limits are therefore soft when every
+candidate is active, explicitly protected, or still referenced.
+
+Within `runs.db`, one transaction deletes a run's journal rows before its run
+row and deletes an artifact only after no run references it. After that commit,
+the Harness removes the deleted run's checkpoint thread from the separately
+configured checkpoint store. A crash or checkpoint-backend failure during that
+second phase can leave unreachable checkpoint storage, but cannot leave a
+retained replay/fork pointing at a deleted source record. A later administrative
+or backend-specific orphan sweep may reclaim such checkpoint-only residue.
+
+`FileHarnessRecordStore` does not implement durable cleanup; its historical
+in-memory artifact-cache eviction and hard run-capacity behavior remain.
 
 ## Debugger Views
 

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -46,10 +46,11 @@ export NEOGRAPH_HARNESS_STATE_DIR="$PWD/.neograph-harness-state"
 
 This stores immutable artifacts, mutable run records, and an append-only causal
 journal in `runs.db`, and graph checkpoints in `checkpoints.db`. Journal rows
-bind the run to its immutable compiled revision digest, MCP protocol version,
-and Harness profile. Worker attempts include duration, validation/retry outcome,
-and correlation IDs that join provider, capability, and host-brokered calls to
-their issuing attempt. Both SQLite stores use WAL mode and a bounded busy
+and every Harness-created checkpoint bind the run to its immutable artifact,
+compiled revision digest, MCP protocol version, and Harness profile. Worker
+attempts include duration, validation/retry outcome, and correlation IDs that
+join provider, capability, and host-brokered calls to their issuing attempt.
+Both SQLite stores use WAL mode and a bounded busy
 timeout. Existing version-1 record databases migrate transactionally to version
 3 when opened. The directory survives server restarts. A
 `host_brokered` catalog entry is rejected at compile time when either store is

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -112,6 +112,44 @@ Use `mode: "live"` to execute the same retained artifact with live providers and
 tools. Snapshots and journal lifecycle events label runs as `recorded_replay` or
 `live_replay` and include `source_run_id`; ordinary starts remain `live`.
 
+## Compatible Fork
+
+Compile a repaired Harness first, then branch an exact preceding checkpoint into
+that target artifact through the existing `neograph_start` tool:
+
+```json
+{
+  "fork": {
+    "source_run_id": "run_123",
+    "checkpoint_id": "550e8400-e29b-41d4-a716-446655440000",
+    "artifact_id": "artifact_repaired"
+  }
+}
+```
+
+The source checkpoint must belong to `source_run_id`. Before allocating a run,
+the Harness verifies the checkpoint schema, source revision, MCP protocol,
+Harness profile, every restored channel and reducer, every continuation node,
+and any active barrier interface against the target artifact. An incompatible
+branch returns `started: false`, `status: "incompatible_fork"`, and
+machine-readable `H_FORK_*` diagnostics with `path` and `witness`; it creates no
+run or fork checkpoint.
+
+A compatible branch is labeled `compatible_fork` and carries both
+`source_run_id` and `source_checkpoint_id` in start responses, snapshots, and
+lifecycle journal events. Execution resumes at the selected checkpoint's
+`next_nodes`; already committed predecessors do not run again. The target
+artifact supplies the repaired topology, worker contracts, and tool catalogue,
+while restored channel values, including the original task channel, come from
+the source checkpoint. Use a fresh start rather than a fork when the task input
+itself must change.
+
+The source run, artifact, and selected checkpoint are references of the fork and
+must remain retained while compatibility checking or fork execution can use
+them. Retention cleanup must remove dependents first or preserve referenced
+sources; it must never delete a source checkpoint between preflight and branch
+creation.
+
 ## Streamable HTTP
 
 Remote transport is opt-in so the existing stdio-only target remains small and

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -65,6 +65,33 @@ run order through `HarnessJournal::list_events(run_id, after_sequence, limit)`.
 `FileHarnessRecordStore` remains available for deployments that prefer atomic
 JSON files; it does not implement the journal boundary.
 
+## Debugger Views
+
+`neograph_get` keeps `status` as its compact default and adds four debugger
+views without adding another MCP tool:
+
+| View | Result |
+|---|---|
+| `attempts` | Journaled worker attempt start/completion/interruption events |
+| `trace` | Existing ordered GraphEngine node trace plus the causal journal timeline |
+| `checkpoints` | Payload-free checkpoint metadata: ID, parent, node, phase, step, and channel names |
+| `diff` | Channel values and versions changed between each checkpoint and its parent |
+
+`attempts` and `trace` accept `after_sequence` as an opaque forward cursor. All
+four views accept `limit` from 1 through 1000. Returned artifact URIs can carry
+the same pagination as a query, for example:
+
+```text
+neograph://runs/run_123/attempts?after_sequence=17&limit=50
+```
+
+Only `after_sequence` and `limit` are accepted in these URIs. Unknown or
+malformed query fields fail instead of being ignored. Journal-backed views
+return the payload exactly as persisted, so the configured redaction mode is
+preserved. The `diff` view is computed from the checkpoint store rather than
+the journal and can contain full channel values; treat access to it like access
+to the existing detailed run result.
+
 ## Streamable HTTP
 
 Remote transport is opt-in so the existing stdio-only target remains small and

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -92,6 +92,26 @@ preserved. The `diff` view is computed from the checkpoint store rather than
 the journal and can contain full channel values; treat access to it like access
 to the existing detailed run result.
 
+## Replay Modes
+
+`neograph_start` can replay a completed run without adding another MCP tool:
+
+```json
+{"replay":{"source_run_id":"run_123","mode":"recorded"}}
+```
+
+`recorded` re-executes the compiler-locked graph with the source journal's
+completed worker-attempt results. It never calls the configured worker,
+provider, MCP, A2A, or capability executor. The source artifact revision,
+protocol, and profile must still match, and the journal must use `FULL` payload
+mode. `REDACTED` and `METADATA_ONLY` journals deliberately cannot replay because
+they do not retain the exact worker output. Interrupted attempts are discarded;
+the completed post-resume worker invocation is replayed.
+
+Use `mode: "live"` to execute the same retained artifact with live providers and
+tools. Snapshots and journal lifecycle events label runs as `recorded_replay` or
+`live_replay` and include `source_run_id`; ordinary starts remain `live`.
+
 ## Streamable HTTP
 
 Remote transport is opt-in so the existing stdio-only target remains small and

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -161,6 +161,10 @@ branch returns `started: false`, `status: "incompatible_fork"`, and
 machine-readable `H_FORK_*` diagnostics with `path` and `witness`; it creates no
 run or fork checkpoint.
 
+A checkpoint store is required. Without a record store, a fork may reference
+only source runs and artifacts still resident in the current service process;
+configure both stores for fork lineage that must survive a restart.
+
 A compatible branch is labeled `compatible_fork` and carries both
 `source_run_id` and `source_checkpoint_id` in start responses, snapshots, and
 lifecycle journal events. Execution resumes at the selected checkpoint's

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -44,16 +44,26 @@ The example enables both with one explicit directory:
 export NEOGRAPH_HARNESS_STATE_DIR="$PWD/.neograph-harness-state"
 ```
 
-This stores immutable artifacts and mutable run records in `runs.db`, and graph
-checkpoints in `checkpoints.db`. Both SQLite stores use WAL mode and a bounded
-busy timeout. The directory survives server restarts. A
+This stores immutable artifacts, mutable run records, and an append-only causal
+journal in `runs.db`, and graph checkpoints in `checkpoints.db`. Journal rows
+bind the run to its immutable compiled revision digest, MCP protocol version,
+and Harness profile. Worker attempts include duration, validation/retry outcome,
+and correlation IDs that join provider, capability, and host-brokered calls to
+their issuing attempt. Both SQLite stores use WAL mode and a bounded busy
+timeout. Existing version-1 record databases migrate transactionally to version
+2 when opened. The directory survives server restarts. A
 `host_brokered` catalog entry is rejected at compile time when either store is
 missing, so a workflow cannot advertise resumability it does not have.
 
 Custom embeddings can construct the same backend through
 `SqliteHarnessRecordStore` from the optional `neograph::mcp_sqlite` target.
+The default journal mode recursively replaces common secret and content fields
+with `[REDACTED]` before SQLite sees them. `METADATA_ONLY` discards every event
+payload; `FULL` preserves provider content, tool arguments, and results exactly
+and should only be enabled for data approved for storage. Events can be read in
+run order through `HarnessJournal::list_events(run_id, after_sequence, limit)`.
 `FileHarnessRecordStore` remains available for deployments that prefer atomic
-JSON files.
+JSON files; it does not implement the journal boundary.
 
 ## Streamable HTTP
 

--- a/include/neograph/async/run_sync.h
+++ b/include/neograph/async/run_sync.h
@@ -94,6 +94,9 @@ T run_sync_operation(
         }
         std::rethrow_exception(err);
     }
+    if (!result && operation && operation->is_cancelled()) {
+        throw neograph::graph::CancelledException("run_sync operation aborted before entry");
+    }
     return std::move(*result);
 }
 

--- a/include/neograph/mcp/harness.h
+++ b/include/neograph/mcp/harness.h
@@ -163,6 +163,12 @@ public:
     /// Return a compact snapshot for a run.
     json get(const std::string& run_id, const std::string& view = "status") const;
 
+    /// Return a paginated debugger view without changing the compact default.
+    json get(const std::string& run_id,
+             const std::string& view,
+             std::size_t        after_sequence,
+             std::size_t        limit) const;
+
     /// Dereference a neograph://runs/<run_id>/<view> result URI.
     json read(const std::string& uri) const;
 

--- a/include/neograph/mcp/harness.h
+++ b/include/neograph/mcp/harness.h
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <cstddef>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -101,6 +102,27 @@ public:
     virtual std::optional<json> load_artifact(const std::string& artifact_id)           = 0;
     virtual void                save_run(const std::string& run_id, const json& record) = 0;
     virtual std::optional<json> load_run(const std::string& run_id)                     = 0;
+};
+
+/** Count-bounded cleanup policy for stores that support durable retention. */
+struct HarnessRetentionPolicy {
+    std::size_t              max_artifacts = std::numeric_limits<std::size_t>::max();
+    std::size_t              max_runs      = std::numeric_limits<std::size_t>::max();
+    std::vector<std::string> protected_artifact_ids;
+    std::vector<std::string> protected_run_ids;
+};
+
+/** Records removed by one atomic record-store cleanup pass. */
+struct HarnessRetentionResult {
+    std::vector<std::string> artifact_ids;
+    std::vector<std::string> run_ids;
+};
+
+/** Optional sibling boundary; HarnessRecordStore's stable vtable remains unchanged. */
+class NEOGRAPH_MCP_SERVER_API HarnessRetentionStore {
+public:
+    virtual ~HarnessRetentionStore()                                                      = default;
+    virtual HarnessRetentionResult cleanup_retained(const HarnessRetentionPolicy& policy) = 0;
 };
 
 /** Atomic JSON-file implementation suitable for local process restarts. */

--- a/include/neograph/mcp/harness.h
+++ b/include/neograph/mcp/harness.h
@@ -15,6 +15,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace neograph {
 class Provider;
@@ -80,6 +81,17 @@ struct HarnessProviderExecutorConfig {
 NEOGRAPH_MCP_SERVER_API HarnessWorkerExecutor
 make_provider_harness_executor(HarnessProviderExecutorConfig config);
 
+/** Append-only causal event boundary, separate from mutable run snapshots. */
+class NEOGRAPH_MCP_SERVER_API HarnessJournal {
+public:
+    virtual ~HarnessJournal() = default;
+
+    virtual void append_event(const json& event) = 0;
+    virtual std::vector<json> list_events(const std::string& run_id,
+                                          std::size_t        after_sequence = 0,
+                                          std::size_t        limit = 1000) = 0;
+};
+
 /** Durable storage boundary for retained Harness artifacts and run records. */
 class NEOGRAPH_MCP_SERVER_API HarnessRecordStore {
 public:
@@ -127,6 +139,7 @@ struct HarnessServiceConfig {
 class NEOGRAPH_MCP_SERVER_API HarnessService {
 public:
     explicit HarnessService(HarnessServiceConfig config = {});
+    HarnessService(HarnessServiceConfig config, std::shared_ptr<HarnessJournal> journal);
     ~HarnessService();
 
     HarnessService(const HarnessService&) = delete;

--- a/include/neograph/mcp/sqlite_harness_store.h
+++ b/include/neograph/mcp/sqlite_harness_store.h
@@ -30,7 +30,8 @@ struct SqliteHarnessJournalConfig {
 
 /** Local SQLite implementation of Harness snapshots and the causal journal. */
 class NEOGRAPH_API SqliteHarnessRecordStore final : public HarnessRecordStore,
-                                                    public HarnessJournal {
+                                                    public HarnessJournal,
+                                                    public HarnessRetentionStore {
 public:
     /// Open or create a store with a five-second SQLite busy timeout.
     explicit SqliteHarnessRecordStore(const std::string& db_path);
@@ -53,6 +54,7 @@ public:
     std::vector<json>   list_events(const std::string& run_id,
                                     std::size_t        after_sequence = 0,
                                     std::size_t        limit = 1000) override;
+    HarnessRetentionResult cleanup_retained(const HarnessRetentionPolicy& policy) override;
 
 private:
     struct Impl;

--- a/include/neograph/mcp/sqlite_harness_store.h
+++ b/include/neograph/mcp/sqlite_harness_store.h
@@ -10,16 +10,36 @@
 #include <chrono>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace neograph::mcp {
 
-/** Local SQLite implementation of the Harness record-store boundary. */
-class NEOGRAPH_API SqliteHarnessRecordStore final : public HarnessRecordStore {
+enum class HarnessJournalPayloadMode {
+    REDACTED,
+    METADATA_ONLY,
+    FULL,
+};
+
+struct SqliteHarnessJournalConfig {
+    HarnessJournalPayloadMode mode = HarnessJournalPayloadMode::REDACTED;
+    std::vector<std::string> redacted_keys = {
+        "api_key", "authorization", "content", "messages", "output",
+        "password", "result", "secret", "token",
+    };
+};
+
+/** Local SQLite implementation of Harness snapshots and the causal journal. */
+class NEOGRAPH_API SqliteHarnessRecordStore final : public HarnessRecordStore,
+                                                    public HarnessJournal {
 public:
     /// Open or create a store with a five-second SQLite busy timeout.
     explicit SqliteHarnessRecordStore(const std::string& db_path);
     /// Open or create a store with an explicit competing-writer wait budget.
     SqliteHarnessRecordStore(const std::string& db_path, std::chrono::milliseconds busy_timeout);
+    /// Open or create a store with explicit journal payload handling.
+    SqliteHarnessRecordStore(const std::string&         db_path,
+                             std::chrono::milliseconds  busy_timeout,
+                             SqliteHarnessJournalConfig journal_config);
     ~SqliteHarnessRecordStore() override;
 
     SqliteHarnessRecordStore(const SqliteHarnessRecordStore&)            = delete;
@@ -29,6 +49,10 @@ public:
     std::optional<json> load_artifact(const std::string& artifact_id) override;
     void                save_run(const std::string& run_id, const json& record) override;
     std::optional<json> load_run(const std::string& run_id) override;
+    void                append_event(const json& event) override;
+    std::vector<json>   list_events(const std::string& run_id,
+                                    std::size_t        after_sequence = 0,
+                                    std::size_t        limit = 1000) override;
 
 private:
     struct Impl;

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -1475,6 +1475,7 @@ struct HarnessService::Impl {
         json                                consumed = json::object();
         json                                resume_value;
         bool                                resume_scheduled = false;
+        bool                                execution_finished = false;
         std::string error;
         int64_t                             created_at = unix_millis();
         int64_t                             updated_at = created_at;
@@ -1484,8 +1485,10 @@ struct HarnessService::Impl {
 
     Impl(HarnessServiceConfig value, std::shared_ptr<HarnessJournal> journal_value)
         : config(std::move(value)), journal(std::move(journal_value)), nonce(std::random_device{}()) {
-        if (config.poll_interval.count() <= 0 || config.run_ttl.count() <= 0) {
-            throw std::invalid_argument("Harness poll_interval and run_ttl must be positive");
+        if (config.poll_interval.count() <= 0 || config.run_ttl.count() <= 0 ||
+            config.max_artifacts == 0 || config.max_runs == 0) {
+            throw std::invalid_argument(
+                "Harness limits, poll_interval, and run_ttl must be positive");
         }
         if (config.enable_experimental_tasks && !config.record_store) {
             throw std::invalid_argument(
@@ -1581,6 +1584,42 @@ struct HarnessService::Impl {
         config.record_store->save_run(run->id, record);
     }
 
+    void cleanup_retained_locked(std::size_t                     max_artifacts,
+                                 std::size_t                     max_runs,
+                                 const std::vector<std::string>& protected_artifacts = {},
+                                 const std::vector<std::string>& protected_runs      = {}) {
+        auto* retention = dynamic_cast<HarnessRetentionStore*>(config.record_store.get());
+        if (!retention) return;
+
+        HarnessRetentionPolicy policy;
+        policy.max_artifacts          = max_artifacts;
+        policy.max_runs               = max_runs;
+        policy.protected_artifact_ids = protected_artifacts;
+        policy.protected_run_ids      = protected_runs;
+        for (const auto& [run_id, run] : runs) {
+            std::lock_guard run_lock(run->mutex);
+            if (run->execution_finished) continue;
+            policy.protected_run_ids.push_back(run_id);
+            policy.protected_artifact_ids.push_back(run->artifact_id);
+        }
+
+        const auto removed = retention->cleanup_retained(policy);
+        for (const auto& run_id : removed.run_ids) {
+            runs.erase(run_id);
+            if (config.checkpoint_store) {
+                try {
+                    config.checkpoint_store->delete_thread(run_id);
+                } catch (...) {
+                    // The authoritative run record is gone; a failed secondary
+                    // checkpoint cleanup leaves only unreachable storage.
+                }
+            }
+        }
+        for (const auto& artifact_id : removed.artifact_ids) {
+            artifacts_by_id.erase(artifact_id);
+        }
+    }
+
     std::shared_ptr<Artifact> find_artifact(const std::string& artifact_id) {
         {
             std::lock_guard lock(mutex);
@@ -1639,6 +1678,9 @@ struct HarnessService::Impl {
         run->created_at   = record->value("created_at", unix_millis());
         run->updated_at   = record->value("updated_at", run->created_at);
         run->expires_at   = record->value("expires_at", int64_t{0});
+        run->execution_finished   = run->status == "completed" || run->status == "failed" ||
+                                  run->status == "cancelled" || run->status == "timeout" ||
+                                  run->status == "expired" || run->status == "max_steps_exhausted";
         if (run->revision_digest.empty()) {
             auto artifact = find_artifact(run->artifact_id);
             if (!artifact) {
@@ -1764,7 +1806,9 @@ struct HarnessService::Impl {
         result["artifacts"]["diagnostics"]["uri"] = base_uri + "/diagnostics";
 
         std::lock_guard lock(mutex);
-        if (artifacts_by_id.size() >= config.max_artifacts && !artifacts_by_id.empty()) {
+        cleanup_retained_locked(config.max_artifacts - 1, config.max_runs);
+        if (!dynamic_cast<HarnessRetentionStore*>(config.record_store.get()) &&
+            artifacts_by_id.size() >= config.max_artifacts && !artifacts_by_id.empty()) {
             artifacts_by_id.erase(artifacts_by_id.begin());
         }
         artifacts_by_id[artifact->id] = std::move(artifact);
@@ -1807,6 +1851,13 @@ struct HarnessService::Impl {
                  std::shared_ptr<Artifact>               artifact,
                  std::optional<json>                     resume_value     = std::nullopt,
                  std::shared_ptr<RecordedHarnessResults> recorded_results = nullptr) {
+        struct ExecutionFinished {
+            std::shared_ptr<Run> run;
+            ~ExecutionFinished() {
+                std::lock_guard lock(run->mutex);
+                run->execution_finished = true;
+            }
+        } execution_finished{run};
         {
             std::lock_guard lock(run->mutex);
             run->status = "running";
@@ -2357,7 +2408,25 @@ json HarnessService::start(const json& arguments) {
     auto run = std::make_shared<Impl::Run>();
     {
         std::lock_guard lock(impl_->mutex);
-        if (impl_->runs.size() >= impl_->config.max_runs) {
+        std::vector<std::string> protected_runs;
+        if (!source_run_id.empty()) protected_runs.push_back(source_run_id);
+        impl_->cleanup_retained_locked(impl_->config.max_artifacts, impl_->config.max_runs - 1,
+                                       {artifact_id}, protected_runs);
+        std::size_t active_runs = 0;
+        for (const auto& [id, existing] : impl_->runs) {
+            (void)id;
+            std::lock_guard run_lock(existing->mutex);
+            if (existing->status == "queued" || existing->status == "running" ||
+                existing->status == "awaiting_tool_results" ||
+                existing->status == "input_required") {
+                ++active_runs;
+            }
+        }
+        const auto retained_capacity =
+            dynamic_cast<HarnessRetentionStore*>(impl_->config.record_store.get())
+                ? active_runs
+                : impl_->runs.size();
+        if (retained_capacity >= impl_->config.max_runs) {
             throw std::runtime_error("Harness run capacity is exhausted");
         }
         run->id = impl_->id("run");

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -235,8 +235,9 @@ json run_snapshot_schema() {
             "revision_digest":{"type":"string"},
             "protocol_version":{"type":"string"},
             "profile":{"type":"string"},
-            "execution_mode":{"enum":["live","live_replay","recorded_replay"]},
+            "execution_mode":{"enum":["live","live_replay","recorded_replay","compatible_fork"]},
             "source_run_id":{"type":"string"},
+            "source_checkpoint_id":{"type":"string"},
             "status":{"type":"string"},
             "created_at":{"type":"integer"},
             "updated_at":{"type":"integer"},
@@ -441,6 +442,93 @@ json make_diagnostic(std::string phase,
         {"source", std::move(source)},
     };
     return value;
+}
+
+json fork_compatibility_diagnostics(const json&              source_core,
+                                    const json&              target_core,
+                                    const graph::Checkpoint& checkpoint) {
+    json       diagnostics = json::array();
+    const auto path        = "$.fork.checkpoint_id";
+    if (checkpoint.schema_version != graph::CHECKPOINT_SCHEMA_VERSION) {
+        diagnostics.push_back(
+            make_diagnostic("compatibility", "H_FORK_CHECKPOINT_SCHEMA", "error", path,
+                            "fork checkpoint schema is incompatible with this runtime",
+                            {{"checkpoint_schema_version", checkpoint.schema_version},
+                             {"runtime_schema_version", graph::CHECKPOINT_SCHEMA_VERSION}}));
+    }
+
+    const auto source_channels = source_core.value("channels", json::object());
+    const auto target_channels = target_core.value("channels", json::object());
+    if (!checkpoint.channel_values.is_object() || !checkpoint.channel_values.contains("channels") ||
+        !checkpoint.channel_values["channels"].is_object()) {
+        diagnostics.push_back(
+            make_diagnostic("compatibility", "H_FORK_CHECKPOINT_STATE", "error", path,
+                            "fork checkpoint does not contain serialized channel state"));
+    } else {
+        for (const auto& [name, state] : checkpoint.channel_values["channels"].items()) {
+            (void)state;
+            const auto channel_path = "$.harness.definition.channels." + name;
+            if (!source_channels.is_object() || !source_channels.contains(name)) {
+                diagnostics.push_back(
+                    make_diagnostic("compatibility", "H_FORK_SOURCE_CHANNEL", "error", channel_path,
+                                    "fork checkpoint channel is absent from its source artifact",
+                                    {{"channel", name}, {"checkpoint_id", checkpoint.id}}));
+                continue;
+            }
+            if (!target_channels.is_object() || !target_channels.contains(name)) {
+                diagnostics.push_back(make_diagnostic(
+                    "compatibility", "H_FORK_CHANNEL_MISSING", "error", channel_path,
+                    "target artifact would discard a checkpoint channel",
+                    {{"channel", name}, {"checkpoint_id", checkpoint.id}}));
+                continue;
+            }
+            const auto source_reducer = source_channels[name].value("reducer", "overwrite");
+            const auto target_reducer = target_channels[name].value("reducer", "overwrite");
+            if (source_reducer != target_reducer) {
+                diagnostics.push_back(make_diagnostic(
+                    "compatibility", "H_FORK_CHANNEL_REDUCER", "error", channel_path,
+                    "target artifact changes the reducer for a restored checkpoint channel",
+                    {{"channel", name},
+                     {"source_reducer", source_reducer},
+                     {"target_reducer", target_reducer}}));
+            }
+        }
+    }
+
+    const auto target_nodes = target_core.value("nodes", json::object());
+    for (const auto& node : checkpoint.next_nodes) {
+        if (node == graph::END_NODE) continue;
+        if (!target_nodes.is_object() || !target_nodes.contains(node)) {
+            diagnostics.push_back(make_diagnostic(
+                "compatibility", "H_FORK_NEXT_NODE", "error", "$.harness.definition.nodes." + node,
+                "target artifact does not expose a checkpoint continuation node",
+                {{"node_id", node}, {"checkpoint_id", checkpoint.id}}));
+        }
+    }
+
+    const auto source_nodes = source_core.value("nodes", json::object());
+    for (const auto& [node, arrivals] : checkpoint.barrier_state) {
+        const auto source_interface = source_nodes.is_object() && source_nodes.contains(node)
+                                          ? source_nodes[node].value("barrier", json())
+                                          : json();
+        const auto target_interface = target_nodes.is_object() && target_nodes.contains(node)
+                                          ? target_nodes[node].value("barrier", json())
+                                          : json();
+        if (source_interface != target_interface) {
+            json arrived = json::array();
+            for (const auto& upstream : arrivals)
+                arrived.push_back(upstream);
+            diagnostics.push_back(
+                make_diagnostic("compatibility", "H_FORK_BARRIER_INTERFACE", "error",
+                                "$.harness.definition.nodes." + node + ".barrier",
+                                "target artifact changes an active checkpoint barrier interface",
+                                {{"node_id", node},
+                                 {"arrived", std::move(arrived)},
+                                 {"source_barrier", source_interface},
+                                 {"target_barrier", target_interface}}));
+        }
+    }
+    return diagnostics;
 }
 
 bool diagnostics_have_errors(const json& diagnostics) {
@@ -1361,6 +1449,8 @@ struct HarnessService::Impl {
     struct Artifact {
         std::string id;
         std::string revision_digest;
+        std::string protocol_version = MCP_PROTOCOL_VERSION;
+        std::string profile          = kHarnessProfile;
         json request;
         json core;
         json sourcemap;
@@ -1376,6 +1466,7 @@ struct HarnessService::Impl {
         std::string profile = kHarnessProfile;
         std::string                         execution_mode   = "live";
         std::string                         source_run_id;
+        std::string                         source_checkpoint_id;
         std::string status = "queued";
         json result;
         json details;
@@ -1436,8 +1527,8 @@ struct HarnessService::Impl {
         return {
             {"artifact_id", artifact.id},
             {"revision_digest", artifact.revision_digest},
-            {"protocol_version", MCP_PROTOCOL_VERSION},
-            {"profile", kHarnessProfile},
+            {"protocol_version", artifact.protocol_version},
+            {"profile", artifact.profile},
             {"request", artifact.request},
             {"core", artifact.core},
             {"sourcemap", artifact.sourcemap},
@@ -1454,6 +1545,7 @@ struct HarnessService::Impl {
             {"profile", run.profile},
             {"execution_mode", run.execution_mode},
             {"source_run_id", run.source_run_id},
+            {"source_checkpoint_id", run.source_checkpoint_id},
             {"status", run.status},
             {"result", run.result},
             {"details", run.details},
@@ -1506,6 +1598,8 @@ struct HarnessService::Impl {
         artifact->core        = record->at("core");
         artifact->revision_digest = record->value(
             "revision_digest", revision_digest(artifact->request, artifact->core));
+        artifact->protocol_version = record->value("protocol_version", MCP_PROTOCOL_VERSION);
+        artifact->profile          = record->value("profile", kHarnessProfile);
         artifact->sourcemap   = record->value("sourcemap", json::array());
         artifact->diagnostics = record->value("diagnostics", json::array());
         std::lock_guard lock(mutex);
@@ -1533,6 +1627,7 @@ struct HarnessService::Impl {
         run->profile = record->value("profile", kHarnessProfile);
         run->execution_mode   = record->value("execution_mode", "live");
         run->source_run_id    = record->value("source_run_id", "");
+        run->source_checkpoint_id = record->value("source_checkpoint_id", "");
         run->status       = record->at("status").get<std::string>();
         run->result       = record->value("result", json());
         run->details      = record->value("details", json());
@@ -1724,6 +1819,9 @@ struct HarnessService::Impl {
                 {"status", "running"},
             };
             if (!run->source_run_id.empty()) lifecycle["source_run_id"] = run->source_run_id;
+            if (!run->source_checkpoint_id.empty()) {
+                lifecycle["source_checkpoint_id"] = run->source_checkpoint_id;
+            }
             detail::append_harness_journal_event(journal_context(*run),
                                                  resume_value ? "run.resumed" : "run.started",
                                                  std::move(lifecycle));
@@ -1767,13 +1865,24 @@ struct HarnessService::Impl {
             engine->set_worker_count(
                 static_cast<std::size_t>(budgets.value("max_parallel_workers", 4)));
 
+            if (!run->source_checkpoint_id.empty()) {
+                const auto fork_checkpoint_id =
+                    engine->fork(run->source_run_id, run->id, run->source_checkpoint_id);
+                detail::append_harness_journal_event(
+                    journal_context(*run), "run.forked",
+                    {{"source_run_id", run->source_run_id},
+                     {"source_checkpoint_id", run->source_checkpoint_id},
+                     {"fork_checkpoint_id", fork_checkpoint_id}});
+            }
+
             graph::RunConfig run_config;
             run_config.thread_id = run->id;
             run_config.input = {{"task", artifact->request["task"]}};
             run_config.max_steps = budgets.value("max_steps", 40);
             run_config.cancel_token = run->cancel;
-            auto graph_result =
-                resume_value ? engine->resume(run_config, *resume_value) : engine->run(run_config);
+            auto graph_result = !run->source_checkpoint_id.empty() ? engine->resume(run_config)
+                                : resume_value ? engine->resume(run_config, *resume_value)
+                                               : engine->run(run_config);
             if (recorded_results && graph_result.interrupted) {
                 throw std::runtime_error(
                     "recorded replay cannot request live input or tool results");
@@ -2042,6 +2151,8 @@ json HarnessService::schema() const {
              {"durable_runs", static_cast<bool>(impl_->config.record_store)},
              {"recorded_result_replay", static_cast<bool>(impl_->journal)},
              {"live_replay", true},
+             {"compatible_fork",
+              static_cast<bool>(impl_->config.checkpoint_store && impl_->config.record_store)},
              {"host_brokered_resume",
               static_cast<bool>(impl_->config.checkpoint_store && impl_->config.record_store)},
              {"experimental_tasks", impl_->config.enable_experimental_tasks},
@@ -2060,9 +2171,11 @@ json HarnessService::start(const json& arguments) {
     std::string artifact_id;
     std::string                             execution_mode = "live";
     std::string                             source_run_id;
+    std::string                             source_checkpoint_id;
     std::string                             source_revision_digest;
     std::string                             source_protocol_version;
     std::string                             source_profile;
+    std::shared_ptr<Impl::Run>              fork_source;
     std::shared_ptr<RecordedHarnessResults> recorded_results;
     if (arguments.contains("replay")) {
         if (arguments.contains("request") || arguments.contains("artifact_id")) {
@@ -2107,6 +2220,36 @@ json HarnessService::start(const json& arguments) {
                 impl_->load_recorded_results(source_run_id, artifact_id, source_revision_digest,
                                              source_protocol_version, source_profile);
         }
+    } else if (arguments.contains("fork")) {
+        if (arguments.size() != 1) {
+            throw std::invalid_argument("neograph_start fork cannot include other start modes");
+        }
+        const auto& fork = arguments["fork"];
+        if (!fork.is_object() || fork.size() != 3 || !fork.contains("source_run_id") ||
+            !fork["source_run_id"].is_string() || !fork.contains("checkpoint_id") ||
+            !fork["checkpoint_id"].is_string() || !fork.contains("artifact_id") ||
+            !fork["artifact_id"].is_string()) {
+            throw std::invalid_argument(
+                "neograph_start fork requires only string source_run_id, checkpoint_id, and "
+                "artifact_id");
+        }
+        source_run_id        = fork["source_run_id"].get<std::string>();
+        source_checkpoint_id = fork["checkpoint_id"].get<std::string>();
+        artifact_id          = fork["artifact_id"].get<std::string>();
+        if (source_run_id.empty() || source_checkpoint_id.empty() || artifact_id.empty()) {
+            throw std::invalid_argument("neograph_start fork identifiers must not be empty");
+        }
+        fork_source = impl_->find_run(source_run_id);
+        if (!fork_source) {
+            throw std::invalid_argument("unknown Harness fork source_run_id: " + source_run_id);
+        }
+        {
+            std::lock_guard lock(fork_source->mutex);
+            source_revision_digest  = fork_source->revision_digest;
+            source_protocol_version = fork_source->protocol_version;
+            source_profile          = fork_source->profile;
+        }
+        execution_mode = "compatible_fork";
     } else if (arguments.contains("request")) {
         if (arguments.contains("artifact_id")) {
             throw std::invalid_argument(
@@ -2125,16 +2268,89 @@ json HarnessService::start(const json& arguments) {
     } else if (arguments.contains("artifact_id") && arguments["artifact_id"].is_string()) {
         artifact_id = arguments["artifact_id"].get<std::string>();
     } else {
-        throw std::invalid_argument("neograph_start requires artifact_id, request, or replay");
+        throw std::invalid_argument(
+            "neograph_start requires artifact_id, request, replay, or fork");
     }
 
     auto artifact = impl_->find_artifact(artifact_id);
     if (!artifact) {
         throw std::invalid_argument("unknown Harness artifact_id: " + artifact_id);
     }
-    if (!source_run_id.empty()) {
+    if (!source_run_id.empty() && execution_mode != "compatible_fork") {
         if (source_revision_digest != artifact->revision_digest) {
             throw std::invalid_argument("Harness replay source revision is unavailable");
+        }
+    }
+    if (execution_mode == "compatible_fork") {
+        json diagnostics = json::array();
+        if (!impl_->config.checkpoint_store) {
+            diagnostics.push_back(make_diagnostic("compatibility", "H_FORK_CHECKPOINT_STORE",
+                                                  "error", "$.fork.checkpoint_id",
+                                                  "compatible fork requires a checkpoint store"));
+        }
+        if (source_protocol_version != MCP_PROTOCOL_VERSION ||
+            artifact->protocol_version != MCP_PROTOCOL_VERSION) {
+            diagnostics.push_back(
+                make_diagnostic("compatibility", "H_FORK_PROTOCOL", "error", "$.fork",
+                                "source run and target artifact must use the current MCP protocol",
+                                {{"source_protocol_version", source_protocol_version},
+                                 {"target_protocol_version", artifact->protocol_version},
+                                 {"runtime_protocol_version", MCP_PROTOCOL_VERSION}}));
+        }
+        if (source_profile != kHarnessProfile || artifact->profile != kHarnessProfile) {
+            diagnostics.push_back(make_diagnostic(
+                "compatibility", "H_FORK_PROFILE", "error", "$.fork",
+                "source run and target artifact must use the current Harness profile",
+                {{"source_profile", source_profile},
+                 {"target_profile", artifact->profile},
+                 {"runtime_profile", kHarnessProfile}}));
+        }
+        auto source_artifact = impl_->find_artifact(fork_source->artifact_id);
+        if (!source_artifact) {
+            diagnostics.push_back(make_diagnostic(
+                "compatibility", "H_FORK_SOURCE_ARTIFACT", "error", "$.fork.source_run_id",
+                "fork source run references an unavailable artifact",
+                {{"source_run_id", source_run_id}, {"artifact_id", fork_source->artifact_id}}));
+        } else if (source_artifact->revision_digest != source_revision_digest) {
+            diagnostics.push_back(make_diagnostic(
+                "compatibility", "H_FORK_SOURCE_REVISION", "error", "$.fork.source_run_id",
+                "fork source run revision does not match its retained artifact",
+                {{"run_revision_digest", source_revision_digest},
+                 {"artifact_revision_digest", source_artifact->revision_digest}}));
+        }
+
+        std::optional<graph::Checkpoint> checkpoint;
+        if (impl_->config.checkpoint_store) {
+            checkpoint = impl_->config.checkpoint_store->load_by_id(source_checkpoint_id);
+            if (!checkpoint) {
+                diagnostics.push_back(make_diagnostic(
+                    "compatibility", "H_FORK_CHECKPOINT_NOT_FOUND", "error", "$.fork.checkpoint_id",
+                    "fork checkpoint is unavailable", {{"checkpoint_id", source_checkpoint_id}}));
+            } else if (checkpoint->thread_id != source_run_id) {
+                diagnostics.push_back(make_diagnostic(
+                    "compatibility", "H_FORK_CHECKPOINT_OWNER", "error", "$.fork.checkpoint_id",
+                    "fork checkpoint does not belong to the source run",
+                    {{"checkpoint_id", source_checkpoint_id},
+                     {"checkpoint_run_id", checkpoint->thread_id},
+                     {"source_run_id", source_run_id}}));
+            } else if (source_artifact) {
+                const auto interface_diagnostics = fork_compatibility_diagnostics(
+                    source_artifact->core, artifact->core, *checkpoint);
+                for (const auto& diagnostic : interface_diagnostics) {
+                    diagnostics.push_back(diagnostic);
+                }
+            }
+        }
+        if (diagnostics_have_errors(diagnostics)) {
+            return {
+                {"started", false},
+                {"status", "incompatible_fork"},
+                {"artifact_id", artifact_id},
+                {"execution_mode", execution_mode},
+                {"source_run_id", source_run_id},
+                {"source_checkpoint_id", source_checkpoint_id},
+                {"diagnostics", std::move(diagnostics)},
+            };
         }
     }
     auto run = std::make_shared<Impl::Run>();
@@ -2148,6 +2364,7 @@ json HarnessService::start(const json& arguments) {
         run->revision_digest = artifact->revision_digest;
         run->execution_mode  = execution_mode;
         run->source_run_id   = source_run_id;
+        run->source_checkpoint_id = source_checkpoint_id;
         run->expires_at      = run->created_at + impl_->config.run_ttl.count();
         impl_->runs[run->id] = run;
         try {
@@ -2157,6 +2374,9 @@ json HarnessService::start(const json& arguments) {
                 {"status", "queued"},
             };
             if (!source_run_id.empty()) lifecycle["source_run_id"] = source_run_id;
+            if (!source_checkpoint_id.empty()) {
+                lifecycle["source_checkpoint_id"] = source_checkpoint_id;
+            }
             detail::append_harness_journal_event(impl_->journal_context(*run), "run.queued",
                                                  std::move(lifecycle));
             impl_->threads.emplace_back([impl             = impl_.get(), run, artifact,
@@ -2176,6 +2396,7 @@ json HarnessService::start(const json& arguments) {
         {"status", "queued"},
     };
     if (!source_run_id.empty()) response["source_run_id"] = source_run_id;
+    if (!source_checkpoint_id.empty()) response["source_checkpoint_id"] = source_checkpoint_id;
     return response;
 }
 
@@ -2316,6 +2537,9 @@ json HarnessService::get(const std::string& run_id,
             {"poll_after_ms", impl_->config.poll_interval.count()},
         };
         if (!run->source_run_id.empty()) snapshot["source_run_id"] = run->source_run_id;
+        if (!run->source_checkpoint_id.empty()) {
+            snapshot["source_checkpoint_id"] = run->source_checkpoint_id;
+        }
         if (!run->pending.is_null()) snapshot["pending"] = run->pending;
         result  = run->result;
         details = run->details;
@@ -2480,11 +2704,11 @@ void HarnessService::register_tools(MCPServer& server) {
     auto start_definition = tool_definition(
         "neograph_start", "Start Harness",
         "Start a retained artifact, compile-and-start an inline request, or replay a completed "
-        "run.",
+        "run, or compatibility-check and fork a retained artifact from an exact checkpoint.",
         json::parse(
-            R"JSON({"type":"object","description":"Provide exactly one of artifact_id, request, or replay.","properties":{"artifact_id":{"type":"string","description":"Artifact returned by neograph_compile."},"request":{"type":"object","description":"Inline Harness request; do not also provide artifact_id."},"replay":{"type":"object","required":["source_run_id","mode"],"properties":{"source_run_id":{"type":"string"},"mode":{"enum":["recorded","live"],"description":"recorded injects FULL journal results without live calls; live executes the source artifact again."}},"additionalProperties":false}},"additionalProperties":false})JSON"),
+            R"JSON({"type":"object","description":"Provide exactly one of artifact_id, request, replay, or fork.","properties":{"artifact_id":{"type":"string","description":"Artifact returned by neograph_compile."},"request":{"type":"object","description":"Inline Harness request; do not also provide artifact_id."},"replay":{"type":"object","required":["source_run_id","mode"],"properties":{"source_run_id":{"type":"string"},"mode":{"enum":["recorded","live"],"description":"recorded injects FULL journal results without live calls; live executes the source artifact again."}},"additionalProperties":false},"fork":{"type":"object","required":["source_run_id","checkpoint_id","artifact_id"],"properties":{"source_run_id":{"type":"string"},"checkpoint_id":{"type":"string","description":"Exact preceding checkpoint to branch from."},"artifact_id":{"type":"string","description":"Compiled target artifact whose channel and continuation interfaces are compatibility-checked before the fork is retained."}},"additionalProperties":false}},"additionalProperties":false})JSON"),
         json::parse(
-            R"JSON({"type":"object","required":["started","status"],"properties":{"started":{"type":"boolean"},"run_id":{"type":"string"},"artifact_id":{"type":"string"},"execution_mode":{"enum":["live","live_replay","recorded_replay"]},"source_run_id":{"type":"string"},"status":{"type":"string"},"diagnostics":{"type":"array"},"artifacts":{"type":"object"}},"additionalProperties":true})JSON"));
+            R"JSON({"type":"object","required":["started","status"],"properties":{"started":{"type":"boolean"},"run_id":{"type":"string"},"artifact_id":{"type":"string"},"execution_mode":{"enum":["live","live_replay","recorded_replay","compatible_fork"]},"source_run_id":{"type":"string"},"source_checkpoint_id":{"type":"string"},"status":{"type":"string"},"diagnostics":{"type":"array"},"artifacts":{"type":"object"}},"additionalProperties":true})JSON"));
     if (impl_->config.enable_experimental_tasks) {
         start_definition.execution = {{"taskSupport", "optional"}};
         server.register_raw_tool(

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -455,6 +455,7 @@ json fork_compatibility_diagnostics(const json&              source_core,
                             "fork checkpoint schema is incompatible with this runtime",
                             {{"checkpoint_schema_version", checkpoint.schema_version},
                              {"runtime_schema_version", graph::CHECKPOINT_SCHEMA_VERSION}}));
+        return diagnostics;
     }
 
     const auto source_channels = source_core.value("channels", json::object());
@@ -1872,6 +1873,7 @@ struct HarnessService::Impl {
                     journal_context(*run), "run.forked",
                     {{"source_run_id", run->source_run_id},
                      {"source_checkpoint_id", run->source_checkpoint_id},
+                     {"target_artifact_id", run->artifact_id},
                      {"fork_checkpoint_id", fork_checkpoint_id}});
             }
 
@@ -2151,8 +2153,7 @@ json HarnessService::schema() const {
              {"durable_runs", static_cast<bool>(impl_->config.record_store)},
              {"recorded_result_replay", static_cast<bool>(impl_->journal)},
              {"live_replay", true},
-             {"compatible_fork",
-              static_cast<bool>(impl_->config.checkpoint_store && impl_->config.record_store)},
+             {"compatible_fork", static_cast<bool>(impl_->config.checkpoint_store)},
              {"host_brokered_resume",
               static_cast<bool>(impl_->config.checkpoint_store && impl_->config.record_store)},
              {"experimental_tasks", impl_->config.enable_experimental_tasks},

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -444,9 +444,24 @@ json make_diagnostic(std::string phase,
     return value;
 }
 
+json harness_checkpoint_binding(const std::string& run_id,
+                                const std::string& artifact_id,
+                                const std::string& revision_digest,
+                                const std::string& protocol_version,
+                                const std::string& profile) {
+    return {
+        {"run_id", run_id},
+        {"artifact_id", artifact_id},
+        {"revision_digest", revision_digest},
+        {"protocol_version", protocol_version},
+        {"profile", profile},
+    };
+}
+
 json fork_compatibility_diagnostics(const json&              source_core,
                                     const json&              target_core,
-                                    const graph::Checkpoint& checkpoint) {
+                                    const graph::Checkpoint& checkpoint,
+                                    const json&              expected_binding) {
     json       diagnostics = json::array();
     const auto path        = "$.fork.checkpoint_id";
     if (checkpoint.schema_version != graph::CHECKPOINT_SCHEMA_VERSION) {
@@ -455,6 +470,15 @@ json fork_compatibility_diagnostics(const json&              source_core,
                             "fork checkpoint schema is incompatible with this runtime",
                             {{"checkpoint_schema_version", checkpoint.schema_version},
                              {"runtime_schema_version", graph::CHECKPOINT_SCHEMA_VERSION}}));
+        return diagnostics;
+    }
+    const auto binding =
+        checkpoint.metadata.is_object() ? checkpoint.metadata.value("harness", json()) : json();
+    if (binding != expected_binding) {
+        diagnostics.push_back(
+            make_diagnostic("compatibility", "H_FORK_CHECKPOINT_BINDING", "error", path,
+                            "fork checkpoint Harness binding does not match its source run",
+                            {{"expected", expected_binding}, {"actual", binding}}));
         return diagnostics;
     }
 
@@ -531,6 +555,86 @@ json fork_compatibility_diagnostics(const json&              source_core,
     }
     return diagnostics;
 }
+
+class BoundHarnessCheckpointStore final : public graph::CheckpointStore {
+public:
+    BoundHarnessCheckpointStore(std::shared_ptr<graph::CheckpointStore> inner, json binding)
+        : inner_(std::move(inner)), binding_(std::move(binding)) {
+        if (!inner_) throw std::invalid_argument("Harness checkpoint store must not be null");
+    }
+
+    void save(const graph::Checkpoint& checkpoint) override { inner_->save(bound(checkpoint)); }
+    std::optional<graph::Checkpoint> load_latest(const std::string& thread_id) override {
+        return inner_->load_latest(thread_id);
+    }
+    std::optional<graph::Checkpoint> load_by_id(const std::string& id) override {
+        return inner_->load_by_id(id);
+    }
+    std::vector<graph::Checkpoint> list(const std::string& thread_id, int limit) override {
+        return inner_->list(thread_id, limit);
+    }
+    void delete_thread(const std::string& thread_id) override { inner_->delete_thread(thread_id); }
+
+    asio::awaitable<void> save_async(const graph::Checkpoint& checkpoint) override {
+        auto     copy = bound(checkpoint);
+        co_await inner_->save_async(copy);
+    }
+    asio::awaitable<std::optional<graph::Checkpoint>> load_latest_async(
+        const std::string& thread_id) override {
+        co_return co_await inner_->load_latest_async(thread_id);
+    }
+    asio::awaitable<std::optional<graph::Checkpoint>> load_by_id_async(
+        const std::string& id) override {
+        co_return co_await inner_->load_by_id_async(id);
+    }
+    asio::awaitable<std::vector<graph::Checkpoint>> list_async(const std::string& thread_id,
+                                                               int                limit) override {
+        co_return co_await inner_->list_async(thread_id, limit);
+    }
+    asio::awaitable<void> delete_thread_async(const std::string& thread_id) override {
+        co_await inner_->delete_thread_async(thread_id);
+    }
+
+    void put_writes(const std::string&         thread_id,
+                    const std::string&         parent_checkpoint_id,
+                    const graph::PendingWrite& write) override {
+        inner_->put_writes(thread_id, parent_checkpoint_id, write);
+    }
+    std::vector<graph::PendingWrite> get_writes(const std::string& thread_id,
+                                                const std::string& parent_checkpoint_id) override {
+        return inner_->get_writes(thread_id, parent_checkpoint_id);
+    }
+    void clear_writes(const std::string& thread_id,
+                      const std::string& parent_checkpoint_id) override {
+        inner_->clear_writes(thread_id, parent_checkpoint_id);
+    }
+    asio::awaitable<void> put_writes_async(const std::string&         thread_id,
+                                           const std::string&         parent_checkpoint_id,
+                                           const graph::PendingWrite& write) override {
+        auto     thread = thread_id;
+        auto     parent = parent_checkpoint_id;
+        auto     copy   = write;
+        co_await inner_->put_writes_async(thread, parent, copy);
+    }
+    asio::awaitable<std::vector<graph::PendingWrite>> get_writes_async(
+        const std::string& thread_id, const std::string& parent_checkpoint_id) override {
+        co_return co_await inner_->get_writes_async(thread_id, parent_checkpoint_id);
+    }
+    asio::awaitable<void> clear_writes_async(const std::string& thread_id,
+                                             const std::string& parent_checkpoint_id) override {
+        co_await inner_->clear_writes_async(thread_id, parent_checkpoint_id);
+    }
+
+private:
+    graph::Checkpoint bound(graph::Checkpoint checkpoint) const {
+        if (!checkpoint.metadata.is_object()) checkpoint.metadata = json::object();
+        checkpoint.metadata["harness"] = binding_;
+        return checkpoint;
+    }
+
+    std::shared_ptr<graph::CheckpointStore> inner_;
+    json                                    binding_;
+};
 
 bool diagnostics_have_errors(const json& diagnostics) {
     for (const auto& diagnostic : diagnostics) {
@@ -1917,7 +2021,15 @@ struct HarnessService::Impl {
                 artifact->request, config.worker_executor, journal_context(*run), recorded_results);
             graph::NodeContext context;
             context.provider = std::move(provider);
-            engine = graph::GraphEngine::compile(artifact->core, context, config.checkpoint_store);
+            std::shared_ptr<graph::CheckpointStore> checkpoint_store = config.checkpoint_store;
+            if (checkpoint_store) {
+                checkpoint_store = std::make_shared<BoundHarnessCheckpointStore>(
+                    std::move(checkpoint_store),
+                    harness_checkpoint_binding(run->id, run->artifact_id, run->revision_digest,
+                                               run->protocol_version, run->profile));
+            }
+            engine =
+                graph::GraphEngine::compile(artifact->core, context, std::move(checkpoint_store));
             engine->set_worker_count(
                 static_cast<std::size_t>(budgets.value("max_parallel_workers", 4)));
 
@@ -2392,7 +2504,10 @@ json HarnessService::start(const json& arguments) {
                      {"source_run_id", source_run_id}}));
             } else if (source_artifact) {
                 const auto interface_diagnostics = fork_compatibility_diagnostics(
-                    source_artifact->core, artifact->core, *checkpoint);
+                    source_artifact->core, artifact->core, *checkpoint,
+                    harness_checkpoint_binding(source_run_id, source_artifact->id,
+                                               source_revision_digest, source_protocol_version,
+                                               source_profile));
                 for (const auto& diagnostic : interface_diagnostics) {
                     diagnostics.push_back(diagnostic);
                 }

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -1,3 +1,4 @@
+#include <neograph/graph/checkpoint.h>
 #include <neograph/graph/compiler.h>
 #include <neograph/graph/elaborator.h>
 #include <neograph/graph/engine.h>
@@ -21,6 +22,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <mutex>
 #include <random>
@@ -229,11 +231,182 @@ json run_snapshot_schema() {
         "properties":{
             "run_id":{"type":"string"},
             "artifact_id":{"type":"string"},
+            "revision_digest":{"type":"string"},
+            "protocol_version":{"type":"string"},
+            "profile":{"type":"string"},
             "status":{"type":"string"},
+            "created_at":{"type":"integer"},
+            "updated_at":{"type":"integer"},
+            "expires_at":{"type":"integer"},
+            "poll_after_ms":{"type":"integer"},
+            "pending":{"type":"object"},
             "result":{"type":"object"},
             "error":{"type":"string"}
         },"additionalProperties":true
     })JSON");
+}
+
+json checkpoint_summary(const graph::Checkpoint& checkpoint) {
+    json channel_names = json::array();
+    if (checkpoint.channel_values.is_object() && checkpoint.channel_values.contains("channels") &&
+        checkpoint.channel_values["channels"].is_object()) {
+        for (const auto [name, value] : checkpoint.channel_values["channels"].items()) {
+            (void)value;
+            channel_names.push_back(name);
+        }
+    }
+    return {
+        {"checkpoint_id", checkpoint.id},
+        {"parent_checkpoint_id", checkpoint.parent_id},
+        {"current_node", checkpoint.current_node},
+        {"next_nodes", checkpoint.next_nodes},
+        {"phase", graph::to_string(checkpoint.interrupt_phase)},
+        {"step", checkpoint.step},
+        {"timestamp", checkpoint.timestamp},
+        {"schema_version", checkpoint.schema_version},
+        {"channel_names", std::move(channel_names)},
+    };
+}
+
+std::map<std::string, json> checkpoint_channels(const graph::Checkpoint& checkpoint) {
+    std::map<std::string, json> channels;
+    if (!checkpoint.channel_values.is_object() || !checkpoint.channel_values.contains("channels") ||
+        !checkpoint.channel_values["channels"].is_object()) {
+        return channels;
+    }
+    for (const auto [name, value] : checkpoint.channel_values["channels"].items()) {
+        channels.emplace(name, value);
+    }
+    return channels;
+}
+
+void add_channel_snapshot(json&       entry,
+                          const char* value_key,
+                          const char* version_key,
+                          const json& channel) {
+    if (!channel.is_object()) {
+        entry[value_key] = channel;
+        return;
+    }
+    entry[value_key] = channel.value("value", json());
+    if (channel.contains("version")) entry[version_key] = channel["version"];
+}
+
+json checkpoint_diff(const graph::Checkpoint&                checkpoint,
+                     const std::optional<graph::Checkpoint>& parent) {
+    if (!checkpoint.parent_id.empty() && !parent) {
+        return {
+            {"checkpoint_id", checkpoint.id},
+            {"parent_checkpoint_id", checkpoint.parent_id},
+            {"node_id", checkpoint.current_node},
+            {"phase", graph::to_string(checkpoint.interrupt_phase)},
+            {"step", checkpoint.step},
+            {"timestamp", checkpoint.timestamp},
+            {"parent_available", false},
+            {"changed_channels", json::array()},
+        };
+    }
+    const auto before = parent ? checkpoint_channels(*parent) : std::map<std::string, json>{};
+    const auto after  = checkpoint_channels(checkpoint);
+    std::set<std::string> names;
+    for (const auto& [name, value] : before) {
+        (void)value;
+        names.insert(name);
+    }
+    for (const auto& [name, value] : after) {
+        (void)value;
+        names.insert(name);
+    }
+
+    json changed = json::array();
+    for (const auto& name : names) {
+        const auto before_it = before.find(name);
+        const auto after_it  = after.find(name);
+        if (before_it != before.end() && after_it != after.end() &&
+            before_it->second == after_it->second) {
+            continue;
+        }
+        json entry = {{"channel", name}};
+        if (before_it == before.end()) {
+            entry["operation"] = "added";
+            entry["before"]    = nullptr;
+        } else {
+            entry["operation"] = after_it == after.end() ? "removed" : "changed";
+            add_channel_snapshot(entry, "before", "before_version", before_it->second);
+        }
+        if (after_it == after.end()) {
+            entry["after"] = nullptr;
+        } else {
+            add_channel_snapshot(entry, "after", "after_version", after_it->second);
+        }
+        changed.push_back(std::move(entry));
+    }
+    return {
+        {"checkpoint_id", checkpoint.id},
+        {"parent_checkpoint_id", checkpoint.parent_id},
+        {"node_id", checkpoint.current_node},
+        {"phase", graph::to_string(checkpoint.interrupt_phase)},
+        {"step", checkpoint.step},
+        {"timestamp", checkpoint.timestamp},
+        {"parent_available", true},
+        {"changed_channels", std::move(changed)},
+    };
+}
+
+std::size_t parse_view_size(const std::string& value, const char* name) {
+    if (value.empty() || !std::all_of(value.begin(), value.end(), [](unsigned char character) {
+            return std::isdigit(character);
+        })) {
+        throw std::invalid_argument(std::string("invalid Harness ") + name);
+    }
+    std::size_t        parsed = 0;
+    unsigned long long number = 0;
+    try {
+        number = std::stoull(value, &parsed);
+    } catch (const std::exception&) {
+        throw std::invalid_argument(std::string("invalid Harness ") + name);
+    }
+    if (parsed != value.size() || number > std::numeric_limits<std::size_t>::max()) {
+        throw std::invalid_argument(std::string("invalid Harness ") + name);
+    }
+    return static_cast<std::size_t>(number);
+}
+
+json journal_page(const std::shared_ptr<HarnessJournal>& journal,
+                  const std::string&                     run_id,
+                  std::size_t                            after_sequence,
+                  std::size_t                            limit,
+                  bool                                   attempts_only) {
+    json        events              = json::array();
+    std::size_t scan_cursor         = after_sequence;
+    std::size_t next_after_sequence = after_sequence;
+    bool        has_more            = false;
+    if (journal) {
+        while (true) {
+            const auto batch = journal->list_events(run_id, scan_cursor, 1000);
+            if (batch.empty()) break;
+            for (const auto& event : batch) {
+                scan_cursor           = event["sequence"].get<std::size_t>();
+                const auto event_type = event.value("event_type", "");
+                if (attempts_only && event_type.rfind("worker.attempt.", 0) != 0) continue;
+                if (events.size() == limit) {
+                    has_more = true;
+                    break;
+                }
+                events.push_back(event);
+                next_after_sequence = scan_cursor;
+            }
+            if (has_more || batch.size() < 1000) break;
+        }
+        if (!has_more && events.empty()) next_after_sequence = scan_cursor;
+    }
+    return {
+        {"events", std::move(events)},
+        {"journal_available", static_cast<bool>(journal)},
+        {"after_sequence", after_sequence},
+        {"next_after_sequence", next_after_sequence},
+        {"has_more", has_more},
+    };
 }
 
 json worker_result_schema() {
@@ -1435,6 +1608,9 @@ struct HarnessService::Impl {
                                              {
                              {"details", {{"uri", base_uri + "/details"}}},
                              {"trace", {{"uri", base_uri + "/trace"}}},
+                             {"attempts", {{"uri", base_uri + "/attempts"}}},
+                             {"checkpoints", {{"uri", base_uri + "/checkpoints"}}},
+                             {"diff", {{"uri", base_uri + "/diff"}}},
                          }},
                     };
                 }
@@ -1786,8 +1962,32 @@ json HarnessService::resume(const json& arguments) {
 }
 
 json HarnessService::get(const std::string& run_id, const std::string& view) const {
+    return get(run_id, view, 0, 100);
+}
+
+json HarnessService::get(const std::string& run_id,
+                         const std::string& view,
+                         std::size_t        after_sequence,
+                         std::size_t        limit) const {
+    if (limit == 0 || limit > 1000) {
+        throw std::invalid_argument("Harness view limit must be between 1 and 1000");
+    }
     auto run = impl_->find_run(run_id);
     if (!run) throw std::invalid_argument("unknown Harness run_id: " + run_id);
+    const bool journal_view    = view == "trace" || view == "attempts";
+    const bool checkpoint_view = view == "checkpoints" || view == "diff";
+    const bool unpaged_view    = view == "status" || view == "details" || view == "artifacts";
+    if (!journal_view && !checkpoint_view && !unpaged_view) {
+        throw std::invalid_argument(
+            "Harness view must be status, details, trace, attempts, checkpoints, diff, or "
+            "artifacts");
+    }
+    if (after_sequence != 0 && !journal_view) {
+        throw std::invalid_argument("after_sequence applies only to trace and attempts views");
+    }
+    if (limit != 100 && unpaged_view) {
+        throw std::invalid_argument("limit applies only to debugger views");
+    }
     bool expired = false;
     {
         std::lock_guard lock(run->mutex);
@@ -1801,35 +2001,79 @@ json HarnessService::get(const std::string& run_id, const std::string& view) con
     }
     if (expired) impl_->persist_run(run);
     impl_->ensure_resume_scheduled(run);
-    std::lock_guard lock(run->mutex);
-    json            snapshot = {
-        {"run_id", run->id},
-        {"artifact_id", run->artifact_id},
-        {"status", run->status},
-        {"created_at", run->created_at},
-        {"updated_at", run->updated_at},
-        {"expires_at", run->expires_at},
-        {"poll_after_ms", impl_->config.poll_interval.count()},
-    };
-    if (!run->pending.is_null()) snapshot["pending"] = run->pending;
-    if (view == "status") {
-        if (!run->result.is_null()) snapshot["result"] = run->result;
-    } else if (view == "details") {
-        if (!run->details.is_null()) snapshot["result"] = run->details;
-    } else if (view == "trace") {
-        if (!run->details.is_null()) {
-            snapshot["result"] = {
-                {"execution_trace", run->details.value("execution_trace", json::array())},
-            };
-        }
-    } else if (view == "artifacts") {
-        if (!run->result.is_null()) {
-            snapshot["result"] = run->result.value("artifacts", json::object());
-        }
-    } else {
-        throw std::invalid_argument("Harness view must be status, details, trace, or artifacts");
+    json        snapshot;
+    json        result;
+    json        details;
+    std::string error;
+    {
+        std::lock_guard lock(run->mutex);
+        snapshot = {
+            {"run_id", run->id},
+            {"artifact_id", run->artifact_id},
+            {"revision_digest", run->revision_digest},
+            {"protocol_version", run->protocol_version},
+            {"profile", run->profile},
+            {"status", run->status},
+            {"created_at", run->created_at},
+            {"updated_at", run->updated_at},
+            {"expires_at", run->expires_at},
+            {"poll_after_ms", impl_->config.poll_interval.count()},
+        };
+        if (!run->pending.is_null()) snapshot["pending"] = run->pending;
+        result  = run->result;
+        details = run->details;
+        error   = run->error;
     }
-    if (!run->error.empty()) snapshot["error"] = run->error;
+
+    if (view == "status") {
+        if (!result.is_null()) snapshot["result"] = std::move(result);
+    } else if (view == "details") {
+        if (!details.is_null()) snapshot["result"] = std::move(details);
+    } else if (view == "trace") {
+        auto page = journal_page(impl_->journal, run_id, after_sequence, limit, false);
+        page["execution_trace"] =
+            details.is_object() ? details.value("execution_trace", json::array()) : json::array();
+        snapshot["result"] = std::move(page);
+    } else if (view == "attempts") {
+        snapshot["result"] = journal_page(impl_->journal, run_id, after_sequence, limit, true);
+    } else if (view == "checkpoints") {
+        json checkpoints = json::array();
+        if (impl_->config.checkpoint_store) {
+            for (const auto& checkpoint :
+                 impl_->config.checkpoint_store->list(run_id, static_cast<int>(limit))) {
+                checkpoints.push_back(checkpoint_summary(checkpoint));
+            }
+        }
+        snapshot["result"] = {
+            {"available", static_cast<bool>(impl_->config.checkpoint_store)},
+            {"checkpoints", std::move(checkpoints)},
+            {"limit", limit},
+        };
+    } else if (view == "diff") {
+        json diffs = json::array();
+        if (impl_->config.checkpoint_store) {
+            const auto checkpoints =
+                impl_->config.checkpoint_store->list(run_id, static_cast<int>(limit));
+            for (const auto& checkpoint : checkpoints) {
+                std::optional<graph::Checkpoint> parent;
+                if (!checkpoint.parent_id.empty()) {
+                    parent = impl_->config.checkpoint_store->load_by_id(checkpoint.parent_id);
+                    if (parent && parent->thread_id != run_id) parent.reset();
+                }
+                diffs.push_back(checkpoint_diff(checkpoint, parent));
+            }
+        }
+        snapshot["result"] = {
+            {"available", static_cast<bool>(impl_->config.checkpoint_store)},
+            {"diffs", std::move(diffs)},
+            {"limit", limit},
+        };
+    } else if (view == "artifacts") {
+        if (!result.is_null()) {
+            snapshot["result"] = result.value("artifacts", json::object());
+        }
+    }
+    if (!error.empty()) snapshot["error"] = std::move(error);
     return snapshot;
 }
 
@@ -1839,11 +2083,51 @@ json HarnessService::read(const std::string& uri) const {
         throw std::invalid_argument("unsupported Harness artifact URI: " + uri);
     }
     const auto remainder = uri.substr(prefix.size());
-    const auto separator = remainder.rfind('/');
-    if (separator == std::string::npos || separator == 0 || separator + 1 == remainder.size()) {
+    const auto query_separator = remainder.find('?');
+    const auto path            = remainder.substr(0, query_separator);
+    const auto separator       = path.rfind('/');
+    if (separator == std::string::npos || separator == 0 || separator + 1 == path.size()) {
         throw std::invalid_argument("malformed Harness artifact URI: " + uri);
     }
-    return get(remainder.substr(0, separator), remainder.substr(separator + 1));
+    std::size_t after_sequence     = 0;
+    std::size_t limit              = 100;
+    bool        saw_after_sequence = false;
+    bool        saw_limit          = false;
+    if (query_separator != std::string::npos) {
+        const auto query = remainder.substr(query_separator + 1);
+        if (query.empty() || query.back() == '&') {
+            throw std::invalid_argument("malformed Harness artifact URI query: " + uri);
+        }
+        std::size_t offset = 0;
+        while (offset < query.size()) {
+            const auto end    = query.find('&', offset);
+            const auto part   = query.substr(offset, end == std::string::npos ? end : end - offset);
+            const auto equals = part.find('=');
+            if (equals == std::string::npos || equals == 0 || equals + 1 == part.size()) {
+                throw std::invalid_argument("malformed Harness artifact URI query: " + uri);
+            }
+            const auto key   = part.substr(0, equals);
+            const auto value = part.substr(equals + 1);
+            if (key == "after_sequence") {
+                if (saw_after_sequence) {
+                    throw std::invalid_argument("duplicate Harness artifact URI query: " + key);
+                }
+                saw_after_sequence = true;
+                after_sequence     = parse_view_size(value, "after_sequence");
+            } else if (key == "limit") {
+                if (saw_limit) {
+                    throw std::invalid_argument("duplicate Harness artifact URI query: " + key);
+                }
+                saw_limit = true;
+                limit     = parse_view_size(value, "limit");
+            } else {
+                throw std::invalid_argument("unknown Harness artifact URI query: " + key);
+            }
+            if (end == std::string::npos) break;
+            offset = end + 1;
+        }
+    }
+    return get(path.substr(0, separator), path.substr(separator + 1), after_sequence, limit);
 }
 
 bool HarnessService::cancel(const std::string& run_id) {
@@ -1933,13 +2217,15 @@ void HarnessService::register_tools(MCPServer& server) {
             "neograph_get", "Get Harness run",
             "Read compact run status or dereference a detailed neograph:// run artifact URI.",
             json::parse(
-                R"JSON({"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string"},"view":{"enum":["status","details","trace","artifacts"],"description":"Named view used when uri is absent."},"uri":{"type":"string","description":"Returned artifact URI. When present, its embedded view is authoritative."}},"additionalProperties":false})JSON"),
+                R"JSON({"type":"object","required":["run_id"],"properties":{"run_id":{"type":"string"},"view":{"enum":["status","details","trace","attempts","checkpoints","diff","artifacts"],"description":"Named view used when uri is absent."},"uri":{"type":"string","description":"Returned artifact URI. When present, its embedded view and query are authoritative."},"after_sequence":{"type":"integer","minimum":0,"description":"Journal cursor for trace and attempts views."},"limit":{"type":"integer","minimum":1,"maximum":1000,"description":"Maximum journal events, checkpoints, or diffs to return."}},"additionalProperties":false})JSON"),
             run_snapshot_schema(), true),
         [this](const json& arguments, const auto&) {
             const bool has_uri = arguments.contains("uri");
             const auto run_id = arguments["run_id"].get<std::string>();
             auto       value   = has_uri ? read(arguments["uri"].get<std::string>())
-                                         : get(run_id, arguments.value("view", "status"));
+                                         : get(run_id, arguments.value("view", "status"),
+                                               arguments.value("after_sequence", std::uint64_t{0}),
+                                               arguments.value("limit", std::uint64_t{100}));
             if (value.value("run_id", "") != run_id) {
                 throw std::invalid_argument("Harness artifact URI does not belong to run_id");
             }

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -9,6 +9,8 @@
 #include <neograph/mcp/server.h>
 #include <neograph/provider.h>
 
+#include "harness_journal_internal.h"
+
 #include <algorithm>
 #include <atomic>
 #include <cctype>
@@ -44,11 +46,28 @@ namespace {
 constexpr const char* kWorkerNodeType = "neograph_harness_worker";
 constexpr const char* kJudgeNodeType = "neograph_harness_judge";
 constexpr const char* kTasksExtension = "io.modelcontextprotocol/tasks";
+constexpr const char* kHarnessProfile = "harness-m4";
 
 int64_t unix_millis() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(
                std::chrono::system_clock::now().time_since_epoch())
         .count();
+}
+
+std::string revision_digest(const json& request, const json& core) {
+    const auto canonical = json({{"core", core},
+                                 {"profile", kHarnessProfile},
+                                 {"protocol_version", MCP_PROTOCOL_VERSION},
+                                 {"request", request}})
+                               .dump();
+    std::uint64_t hash = 14695981039346656037ULL;
+    for (const auto character : canonical) {
+        hash ^= static_cast<unsigned char>(character);
+        hash *= 1099511628211ULL;
+    }
+    std::ostringstream out;
+    out << "fnv1a64:" << std::hex << std::setfill('0') << std::setw(16) << hash;
+    return out.str();
 }
 
 std::string iso8601(int64_t millis) {
@@ -313,8 +332,12 @@ std::string response_kind_name(HarnessWorkerResponseKind kind) {
 
 class HarnessRuntimeProvider final : public Provider {
 public:
-    HarnessRuntimeProvider(json request, HarnessWorkerExecutor executor)
-        : request_(std::move(request)), executor_(std::move(executor)) {
+    HarnessRuntimeProvider(json                          request,
+                           HarnessWorkerExecutor         executor,
+                           detail::HarnessJournalContext journal_context = {})
+        : request_(std::move(request)),
+          executor_(std::move(executor)),
+          journal_context_(std::move(journal_context)) {
         for (const auto& worker : request_["workers"]) {
             workers_[worker["id"].get<std::string>()] = worker;
         }
@@ -326,7 +349,8 @@ public:
 
     std::string get_name() const override { return "harness-worker-executor"; }
 
-    json execute(const std::string&                         worker_id,
+    json execute(const std::string&                         node_id,
+                 const std::string&                         worker_id,
                  const json&                                task,
                  const std::optional<json>&                 resume_value,
                  const std::shared_ptr<graph::CancelToken>& cancel) const {
@@ -348,6 +372,17 @@ public:
         for (int attempt = 0; attempt <= max_retries_; ++attempt) {
             attempts_made = attempt + 1;
             cancel->throw_if_cancelled("before Harness worker " + worker_id);
+            auto attempt_context = journal_context_;
+            attempt_context.node_id = node_id;
+            attempt_context.worker_id = worker_id;
+            attempt_context.attempt = static_cast<std::size_t>(attempt + 1);
+            detail::ScopedHarnessJournalContext journal_scope(attempt_context);
+            const auto attempt_started = std::chrono::steady_clock::now();
+            detail::append_harness_journal_event(
+                attempt_context, "worker.attempt.started",
+                {{"has_resume_value", resume_value.has_value()},
+                 {"repair", !feedback.empty()},
+                 {"selected_tools", worker_it->second.value("tools", json::array())}});
             HarnessWorkerCall call;
             call.task = task;
             call.worker = worker_it->second;
@@ -366,6 +401,14 @@ public:
             }
 
             if (response.kind == HarnessWorkerResponseKind::CANCELLED) {
+                detail::append_harness_journal_event(
+                    attempt_context, "worker.attempt.completed",
+                    {{"duration_ms",
+                      std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - attempt_started)
+                          .count()},
+                     {"outcome", "cancelled"},
+                     {"message", response.message}});
                 throw graph::CancelledException(
                     response.message.empty() ? "Harness worker cancelled" : response.message);
             }
@@ -374,6 +417,15 @@ public:
                 response.kind == HarnessWorkerResponseKind::INPUT_REQUIRED) {
                 auto pending     = response.value;
                 pending["state"] = response_kind_name(response.kind);
+                detail::append_harness_journal_event(
+                    attempt_context, "worker.attempt.interrupted",
+                    {{"duration_ms",
+                      std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - attempt_started)
+                          .count()},
+                     {"pending", pending},
+                     {"reason", pending["state"]}},
+                    pending.value("call_id", ""));
                 throw graph::NodeInterrupt(
                     response.kind == HarnessWorkerResponseKind::INPUT_REQUIRED
                         ? "Harness worker requires host input"
@@ -390,6 +442,15 @@ public:
                     try {
                         validate_json_value(response.value, worker_it->second["output_schema"],
                                             "Harness worker output", "$");
+                        detail::append_harness_journal_event(
+                            attempt_context, "worker.attempt.completed",
+                            {{"duration_ms",
+                              std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  std::chrono::steady_clock::now() - attempt_started)
+                                  .count()},
+                             {"outcome", "valid"},
+                             {"output", response.value},
+                             {"validation", "passed"}});
                         return {
                             {"worker_id", worker_id},
                             {"status", "valid"},
@@ -409,6 +470,20 @@ public:
                     break;
                 }
             }
+            detail::append_harness_journal_event(
+                attempt_context, "worker.attempt.completed",
+                {{"duration_ms",
+                  std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::steady_clock::now() - attempt_started)
+                      .count()},
+                 {"outcome", "retryable_failure"},
+                 {"retry_scheduled", attempt < max_retries_},
+                 {"retry_reason", failure_kind},
+                 {"validation", failure_kind == "schema_validation" ? "failed" : "not_run"},
+                 {"message", feedback},
+                 {"output", response.kind == HarnessWorkerResponseKind::VALUE
+                                ? response.value
+                                : json(nullptr)}});
         }
 
         return {
@@ -423,6 +498,7 @@ private:
     std::map<std::string, json> workers_;
     std::map<std::string, json> tools_;
     int max_retries_ = 1;
+    detail::HarnessJournalContext journal_context_;
 };
 
 class HarnessWorkerNode final : public graph::GraphNode {
@@ -435,8 +511,8 @@ public:
     asio::awaitable<graph::NodeOutput> run(graph::NodeInput in) override {
         auto cancel = in.ctx.cancel_token;
         if (!cancel) cancel = std::make_shared<graph::CancelToken>();
-        auto result =
-            runtime_->execute(worker_id_, in.state.get("task"), in.ctx.resume_value, cancel);
+        auto result = runtime_->execute(name_, worker_id_, in.state.get("task"),
+                                        in.ctx.resume_value, cancel);
         graph::NodeOutput output;
         output.writes.push_back({"worker_results", std::move(result)});
         co_return output;
@@ -942,6 +1018,7 @@ std::optional<json> FileHarnessRecordStore::load_run(const std::string& run_id) 
 struct HarnessService::Impl {
     struct Artifact {
         std::string id;
+        std::string revision_digest;
         json request;
         json core;
         json sourcemap;
@@ -952,6 +1029,9 @@ struct HarnessService::Impl {
         mutable std::mutex mutex;
         std::string id;
         std::string artifact_id;
+        std::string revision_digest;
+        std::string protocol_version = MCP_PROTOCOL_VERSION;
+        std::string profile = kHarnessProfile;
         std::string status = "queued";
         json result;
         json details;
@@ -966,14 +1046,17 @@ struct HarnessService::Impl {
         std::shared_ptr<graph::CancelToken> cancel     = std::make_shared<graph::CancelToken>();
     };
 
-    explicit Impl(HarnessServiceConfig value)
-        : config(std::move(value)), nonce(std::random_device{}()) {
+    Impl(HarnessServiceConfig value, std::shared_ptr<HarnessJournal> journal_value)
+        : config(std::move(value)), journal(std::move(journal_value)), nonce(std::random_device{}()) {
         if (config.poll_interval.count() <= 0 || config.run_ttl.count() <= 0) {
             throw std::invalid_argument("Harness poll_interval and run_ttl must be positive");
         }
         if (config.enable_experimental_tasks && !config.record_store) {
             throw std::invalid_argument(
                 "experimental Tasks profile requires a durable record_store");
+        }
+        if (!journal && config.record_store) {
+            journal = std::dynamic_pointer_cast<HarnessJournal>(config.record_store);
         }
         register_harness_node_types();
     }
@@ -1008,6 +1091,9 @@ struct HarnessService::Impl {
     json artifact_record(const Artifact& artifact) const {
         return {
             {"artifact_id", artifact.id},
+            {"revision_digest", artifact.revision_digest},
+            {"protocol_version", MCP_PROTOCOL_VERSION},
+            {"profile", kHarnessProfile},
             {"request", artifact.request},
             {"core", artifact.core},
             {"sourcemap", artifact.sourcemap},
@@ -1019,6 +1105,9 @@ struct HarnessService::Impl {
         return {
             {"run_id", run.id},
             {"artifact_id", run.artifact_id},
+            {"revision_digest", run.revision_digest},
+            {"protocol_version", run.protocol_version},
+            {"profile", run.profile},
             {"status", run.status},
             {"result", run.result},
             {"details", run.details},
@@ -1029,6 +1118,17 @@ struct HarnessService::Impl {
             {"created_at", run.created_at},
             {"updated_at", run.updated_at},
             {"expires_at", run.expires_at},
+        };
+    }
+
+    detail::HarnessJournalContext journal_context(const Run& run) const {
+        return {
+            journal,
+            run.id,
+            run.artifact_id,
+            run.revision_digest,
+            run.protocol_version,
+            run.profile,
         };
     }
 
@@ -1058,6 +1158,8 @@ struct HarnessService::Impl {
         artifact->id          = artifact_id;
         artifact->request     = record->at("request");
         artifact->core        = record->at("core");
+        artifact->revision_digest = record->value(
+            "revision_digest", revision_digest(artifact->request, artifact->core));
         artifact->sourcemap   = record->value("sourcemap", json::array());
         artifact->diagnostics = record->value("diagnostics", json::array());
         std::lock_guard lock(mutex);
@@ -1080,6 +1182,9 @@ struct HarnessService::Impl {
         auto run          = std::make_shared<Run>();
         run->id           = run_id;
         run->artifact_id  = record->at("artifact_id").get<std::string>();
+        run->revision_digest = record->value("revision_digest", "");
+        run->protocol_version = record->value("protocol_version", MCP_PROTOCOL_VERSION);
+        run->profile = record->value("profile", kHarnessProfile);
         run->status       = record->at("status").get<std::string>();
         run->result       = record->value("result", json());
         run->details      = record->value("details", json());
@@ -1090,6 +1195,13 @@ struct HarnessService::Impl {
         run->created_at   = record->value("created_at", unix_millis());
         run->updated_at   = record->value("updated_at", run->created_at);
         run->expires_at   = record->value("expires_at", int64_t{0});
+        if (run->revision_digest.empty()) {
+            auto artifact = find_artifact(run->artifact_id);
+            if (!artifact) {
+                throw std::runtime_error("Harness run revision artifact is unavailable");
+            }
+            run->revision_digest = artifact->revision_digest;
+        }
         if (run->status == "running" && !run->resume_value.is_null()) {
             run->status = "queued";
         }
@@ -1198,6 +1310,7 @@ struct HarnessService::Impl {
         artifact->id = id("artifact");
         artifact->request = request;
         artifact->core = core;
+        artifact->revision_digest = revision_digest(request, core);
         artifact->sourcemap = sourcemap;
         artifact->diagnostics = diagnostics;
         const auto base_uri = "neograph://artifacts/" + artifact->id;
@@ -1229,11 +1342,20 @@ struct HarnessService::Impl {
         }
         try {
             persist_run(run);
+            detail::append_harness_journal_event(
+                journal_context(*run), resume_value ? "run.resumed" : "run.started",
+                {{"status", "running"}});
         } catch (const std::exception& error) {
-            std::lock_guard lock(run->mutex);
-            run->status           = "failed";
-            run->error            = std::string("cannot persist Harness run: ") + error.what();
-            run->resume_scheduled = false;
+            {
+                std::lock_guard lock(run->mutex);
+                run->status = "failed";
+                run->error = std::string("cannot initialize Harness journal: ") + error.what();
+                run->resume_scheduled = false;
+                run->updated_at = unix_millis();
+            }
+            try {
+                persist_run(run);
+            } catch (...) {}
             return;
         }
 
@@ -1255,8 +1377,8 @@ struct HarnessService::Impl {
 
         std::unique_ptr<graph::GraphEngine> engine;
         try {
-            auto provider =
-                std::make_shared<HarnessRuntimeProvider>(artifact->request, config.worker_executor);
+            auto provider = std::make_shared<HarnessRuntimeProvider>(
+                artifact->request, config.worker_executor, journal_context(*run));
             graph::NodeContext context;
             context.provider = std::move(provider);
             engine = graph::GraphEngine::compile(artifact->core, context, config.checkpoint_store);
@@ -1271,47 +1393,59 @@ struct HarnessService::Impl {
             auto graph_result =
                 resume_value ? engine->resume(run_config, *resume_value) : engine->run(run_config);
 
-            std::lock_guard lock(run->mutex);
-            // CancelToken callbacks are bound to the engine's executor. Drain
-            // that executor while holding the same lock used by cancel().
-            engine.reset();
-            run->cancel     = std::make_shared<graph::CancelToken>();
-            run->updated_at = unix_millis();
-            if (graph_result.interrupted) {
-                if (!graph_result.interrupt_value.contains("value") ||
-                    !graph_result.interrupt_value["value"].is_object()) {
-                    throw std::runtime_error("Harness interrupt omitted its pending-call payload");
+            json interrupt_payload;
+            std::string interrupt_correlation;
+            {
+                std::lock_guard lock(run->mutex);
+                // CancelToken callbacks are bound to the engine's executor. Drain
+                // that executor while holding the same lock used by cancel().
+                engine.reset();
+                run->cancel     = std::make_shared<graph::CancelToken>();
+                run->updated_at = unix_millis();
+                if (graph_result.interrupted) {
+                    if (!graph_result.interrupt_value.contains("value") ||
+                        !graph_result.interrupt_value["value"].is_object()) {
+                        throw std::runtime_error(
+                            "Harness interrupt omitted its pending-call payload");
+                    }
+                    auto       pending = graph_result.interrupt_value["value"];
+                    const auto state   = pending.value("state", "");
+                    if (state != "awaiting_tool_results" && state != "input_required") {
+                        throw std::runtime_error(
+                            "Harness interrupt returned an unsupported pending state");
+                    }
+                    run->pending = std::move(pending);
+                    run->status  = state;
+                    interrupt_payload = {{"pending", run->pending}, {"status", run->status}};
+                    interrupt_correlation = run->pending.value("call_id", "");
+                } else if (graph_result.max_steps_exhausted()) {
+                    run->status = "max_steps_exhausted";
+                } else {
+                    run->status = "completed";
+                    run->pending                    = nullptr;
+                    run->details = graph_result.channel_raw("final_result");
+                    run->details["execution_trace"] = graph_result.execution_trace;
+                    const auto base_uri = "neograph://runs/" + run->id;
+                    run->result                     = {
+                        {"outcome", run->details.value("outcome", "unknown")},
+                        {"valid_workers", run->details.value("valid_workers", 0)},
+                        {"failed_workers", run->details.value("failed_workers", 0)},
+                        {"finding_count", run->details.value("findings", json::array()).size()},
+                        {"artifacts",
+                                             {
+                             {"details", {{"uri", base_uri + "/details"}}},
+                             {"trace", {{"uri", base_uri + "/trace"}}},
+                         }},
+                    };
                 }
-                auto       pending = graph_result.interrupt_value["value"];
-                const auto state   = pending.value("state", "");
-                if (state != "awaiting_tool_results" && state != "input_required") {
-                    throw std::runtime_error(
-                        "Harness interrupt returned an unsupported pending state");
-                }
-                run->pending = std::move(pending);
-                run->status  = state;
-            } else if (graph_result.max_steps_exhausted()) {
-                run->status = "max_steps_exhausted";
-            } else {
-                run->status = "completed";
-                run->pending                    = nullptr;
-                run->details = graph_result.channel_raw("final_result");
-                run->details["execution_trace"] = graph_result.execution_trace;
-                const auto base_uri = "neograph://runs/" + run->id;
-                run->result                     = {
-                    {"outcome", run->details.value("outcome", "unknown")},
-                    {"valid_workers", run->details.value("valid_workers", 0)},
-                    {"failed_workers", run->details.value("failed_workers", 0)},
-                    {"finding_count", run->details.value("findings", json::array()).size()},
-                    {"artifacts",
-                                         {
-                         {"details", {{"uri", base_uri + "/details"}}},
-                         {"trace", {{"uri", base_uri + "/trace"}}},
-                     }},
-                };
+                run->resume_value     = nullptr;
+                run->resume_scheduled = false;
             }
-            run->resume_value     = nullptr;
-            run->resume_scheduled = false;
+            if (!interrupt_payload.is_null()) {
+                detail::append_harness_journal_event(
+                    journal_context(*run), "run.interrupted", std::move(interrupt_payload),
+                    std::move(interrupt_correlation));
+            }
         } catch (const graph::CancelledException& error) {
             std::lock_guard lock(run->mutex);
             engine.reset();
@@ -1349,10 +1483,28 @@ struct HarnessService::Impl {
         timer.join();
         try {
             persist_run(run);
+            json terminal_payload;
+            {
+                std::lock_guard lock(run->mutex);
+                if (run->status != "awaiting_tool_results" && run->status != "input_required") {
+                    terminal_payload = {
+                        {"error", run->error}, {"result", run->result}, {"status", run->status}};
+                }
+            }
+            if (!terminal_payload.is_null()) {
+                detail::append_harness_journal_event(
+                    journal_context(*run), "run.terminal", std::move(terminal_payload));
+            }
         } catch (const std::exception& error) {
-            std::lock_guard lock(run->mutex);
-            run->status = "failed";
-            run->error  = std::string("cannot persist Harness run: ") + error.what();
+            {
+                std::lock_guard lock(run->mutex);
+                run->status = "failed";
+                run->error = std::string("cannot finalize Harness journal: ") + error.what();
+                run->updated_at = unix_millis();
+            }
+            try {
+                persist_run(run);
+            } catch (...) {}
         }
     }
 
@@ -1398,6 +1550,7 @@ struct HarnessService::Impl {
     }
 
     HarnessServiceConfig config;
+    std::shared_ptr<HarnessJournal> journal;
     std::uint64_t nonce;
     std::atomic<std::uint64_t> next_id{1};
     mutable std::mutex mutex;
@@ -1407,7 +1560,11 @@ struct HarnessService::Impl {
 };
 
 HarnessService::HarnessService(HarnessServiceConfig config)
-    : impl_(std::make_unique<Impl>(std::move(config))) {}
+    : HarnessService(std::move(config), nullptr) {}
+
+HarnessService::HarnessService(HarnessServiceConfig config,
+                               std::shared_ptr<HarnessJournal> journal)
+    : impl_(std::make_unique<Impl>(std::move(config), std::move(journal))) {}
 
 HarnessService::~HarnessService() = default;
 
@@ -1529,10 +1686,13 @@ json HarnessService::start(const json& arguments) {
         }
         run->id = impl_->id("run");
         run->artifact_id = artifact_id;
+        run->revision_digest = artifact->revision_digest;
         run->expires_at      = run->created_at + impl_->config.run_ttl.count();
         impl_->runs[run->id] = run;
         try {
             impl_->persist_run(run);
+            detail::append_harness_journal_event(
+                impl_->journal_context(*run), "run.queued", {{"status", "queued"}});
             impl_->threads.emplace_back(
                 [impl = impl_.get(), run, artifact] { impl->execute(run, artifact); });
         } catch (...) {
@@ -1608,6 +1768,11 @@ json HarnessService::resume(const json& arguments) {
     }
     if (!duplicate) impl_->persist_run(run);
     if (expired) throw std::invalid_argument("Harness run has expired");
+    if (!duplicate) {
+        detail::append_harness_journal_event(
+            impl_->journal_context(*run), "host_brokered.result.accepted",
+            {{"result", arguments["result"]}}, call_id);
+    }
     impl_->ensure_resume_scheduled(run);
     std::string status;
     {
@@ -1694,9 +1859,11 @@ bool HarnessService::cancel(const std::string& run_id) {
             run->pending    = nullptr;
             run->updated_at = unix_millis();
         }
-    run->cancel->cancel();
+        run->cancel->cancel();
     }
     impl_->persist_run(run);
+    detail::append_harness_journal_event(
+        impl_->journal_context(*run), "run.cancel.requested", {{"status", "cancelled"}});
     return true;
 }
 

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -2713,6 +2713,13 @@ json HarnessService::get(const std::string& run_id,
     std::string error;
     {
         std::lock_guard lock(run->mutex);
+        auto            visible_status = run->status;
+        if (!run->execution_finished &&
+            (visible_status == "completed" || visible_status == "failed" ||
+             visible_status == "cancelled" || visible_status == "timeout" ||
+             visible_status == "max_steps_exhausted")) {
+            visible_status = "running";
+        }
         snapshot = {
             {"run_id", run->id},
             {"artifact_id", run->artifact_id},
@@ -2720,7 +2727,7 @@ json HarnessService::get(const std::string& run_id,
             {"protocol_version", run->protocol_version},
             {"profile", run->profile},
             {"execution_mode", run->execution_mode},
-            {"status", run->status},
+            {"status", std::move(visible_status)},
             {"created_at", run->created_at},
             {"updated_at", run->updated_at},
             {"expires_at", run->expires_at},

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -1598,6 +1598,9 @@ struct HarnessService::Impl {
         policy.protected_run_ids      = protected_runs;
         for (const auto& [run_id, run] : runs) {
             std::lock_guard run_lock(run->mutex);
+            // SQLite status/dependency predicates are authoritative. This flag
+            // additionally protects terminal state while its execution thread
+            // is still finalizing the journal and persistence sequence.
             if (run->execution_finished) continue;
             policy.protected_run_ids.push_back(run_id);
             policy.protected_artifact_ids.push_back(run->artifact_id);
@@ -1860,9 +1863,10 @@ struct HarnessService::Impl {
         } execution_finished{run};
         {
             std::lock_guard lock(run->mutex);
-            run->status = "running";
-            run->resume_scheduled = resume_value.has_value();
-            run->updated_at       = unix_millis();
+            run->status             = "running";
+            run->resume_scheduled   = resume_value.has_value();
+            run->execution_finished = false;
+            run->updated_at         = unix_millis();
         }
         try {
             persist_run(run);
@@ -2075,9 +2079,10 @@ struct HarnessService::Impl {
                 run->updated_at          = unix_millis();
                 rejected_recorded_resume = true;
             } else {
-                run->resume_scheduled = true;
-                value                 = run->resume_value;
-                artifact_id           = run->artifact_id;
+                run->resume_scheduled   = true;
+                run->execution_finished = false;
+                value                   = run->resume_value;
+                artifact_id             = run->artifact_id;
             }
         }
         if (rejected_recorded_resume) {

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -19,6 +19,7 @@
 #include <condition_variable>
 #include <cstdint>
 #include <ctime>
+#include <deque>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
@@ -234,6 +235,8 @@ json run_snapshot_schema() {
             "revision_digest":{"type":"string"},
             "protocol_version":{"type":"string"},
             "profile":{"type":"string"},
+            "execution_mode":{"enum":["live","live_replay","recorded_replay"]},
+            "source_run_id":{"type":"string"},
             "status":{"type":"string"},
             "created_at":{"type":"integer"},
             "updated_at":{"type":"integer"},
@@ -503,14 +506,164 @@ std::string response_kind_name(HarnessWorkerResponseKind kind) {
     return "unknown";
 }
 
+bool contains_redacted_marker(const json& value) {
+    if (value.is_string()) {
+        return value.get<std::string>() == detail::kHarnessRedactedMarker;
+    }
+    if (value.is_array()) {
+        for (const auto& entry : value) {
+            if (contains_redacted_marker(entry)) return true;
+        }
+    } else if (value.is_object()) {
+        for (const auto& [key, entry] : value.items()) {
+            (void)key;
+            if (contains_redacted_marker(entry)) return true;
+        }
+    }
+    return false;
+}
+
+class RecordedHarnessResults {
+public:
+    using Key        = std::pair<std::string, std::string>;
+    using Invocation = std::vector<json>;
+
+    explicit RecordedHarnessResults(std::map<Key, std::deque<Invocation>> invocations)
+        : invocations_(std::move(invocations)) {
+        for (const auto& [key, values] : invocations_) {
+            (void)key;
+            remaining_ += values.size();
+        }
+    }
+
+    Invocation take(const std::string& node_id, const std::string& worker_id) {
+        std::lock_guard lock(mutex_);
+        auto            it = invocations_.find({node_id, worker_id});
+        if (it == invocations_.end() || it->second.empty()) {
+            throw std::runtime_error("recorded replay has no result for node " + node_id +
+                                     " worker " + worker_id);
+        }
+        auto result = std::move(it->second.front());
+        it->second.pop_front();
+        --remaining_;
+        return result;
+    }
+
+    void require_exhausted() const {
+        std::lock_guard lock(mutex_);
+        if (remaining_ != 0) {
+            throw std::runtime_error("recorded replay did not consume every worker invocation");
+        }
+    }
+
+private:
+    mutable std::mutex                    mutex_;
+    std::map<Key, std::deque<Invocation>> invocations_;
+    std::size_t                           remaining_ = 0;
+};
+
+std::shared_ptr<RecordedHarnessResults> recorded_results_from_events(
+    const std::vector<json>& events,
+    const std::string&       run_id,
+    const std::string&       artifact_id,
+    const std::string&       revision_digest,
+    const std::string&       protocol_version,
+    const std::string&       profile) {
+    using Key = RecordedHarnessResults::Key;
+    std::map<Key, RecordedHarnessResults::Invocation>             pending;
+    std::map<Key, std::deque<RecordedHarnessResults::Invocation>> invocations;
+
+    for (const auto& event : events) {
+        if (event.value("run_id", "") != run_id || event.value("artifact_id", "") != artifact_id ||
+            event.value("revision_digest", "") != revision_digest ||
+            event.value("protocol_version", "") != protocol_version ||
+            event.value("profile", "") != profile) {
+            throw std::runtime_error("recorded replay journal binding mismatch");
+        }
+        const auto event_type = event.value("event_type", "");
+        if (event_type != "worker.attempt.completed" &&
+            event_type != "worker.attempt.interrupted") {
+            continue;
+        }
+        const auto node_id   = event.value("node_id", "");
+        const auto worker_id = event.value("worker_id", "");
+        if (node_id.empty() || worker_id.empty()) {
+            throw std::runtime_error("recorded replay worker event is missing its identity");
+        }
+        const Key key{node_id, worker_id};
+        if (event_type == "worker.attempt.interrupted") {
+            pending.erase(key);
+            continue;
+        }
+
+        if (!event.contains("payload") || !event["payload"].is_object()) {
+            throw std::runtime_error("recorded replay requires FULL journal worker payloads");
+        }
+        const auto& payload          = event["payload"];
+        const auto  outcome          = payload.value("outcome", "");
+        const auto  expected_attempt = pending[key].size() + 1;
+        if (event.value("attempt", std::size_t{0}) != expected_attempt) {
+            throw std::runtime_error("recorded replay worker attempts are incomplete or unordered");
+        }
+        if (outcome == "valid") {
+            if (!payload.contains("output") || contains_redacted_marker(payload["output"])) {
+                throw std::runtime_error("recorded replay requires FULL journal worker outputs");
+            }
+        } else if (outcome == "retryable_failure") {
+            const auto reason = payload.value("retry_reason", "");
+            if (reason.empty()) {
+                throw std::runtime_error("recorded replay requires FULL journal retry payloads");
+            }
+            if (!payload.contains("output") || contains_redacted_marker(payload["output"])) {
+                throw std::runtime_error("recorded replay requires FULL journal worker outputs");
+            }
+        } else {
+            throw std::runtime_error("recorded replay worker outcome is unsupported: " + outcome);
+        }
+
+        pending[key].push_back(event);
+        const bool terminal = outcome == "valid" || (outcome == "retryable_failure" &&
+                                                     !payload.value("retry_scheduled", false));
+        if (terminal) {
+            invocations[key].push_back(std::move(pending[key]));
+            pending.erase(key);
+        }
+    }
+    if (!pending.empty()) {
+        throw std::runtime_error("recorded replay journal ends inside a worker invocation");
+    }
+    if (invocations.empty()) {
+        throw std::runtime_error("recorded replay found no completed worker invocations");
+    }
+    return std::make_shared<RecordedHarnessResults>(std::move(invocations));
+}
+
+HarnessWorkerResponse recorded_worker_response(const json& event) {
+    const auto& payload = event["payload"];
+    const auto  outcome = payload.value("outcome", "");
+    if (outcome == "valid") return HarnessWorkerResponse::success(payload["output"]);
+    const auto reason  = payload.value("retry_reason", "");
+    const auto message = payload.value("message", "");
+    if (reason == "schema_validation") {
+        return HarnessWorkerResponse::success(payload.value("output", json(nullptr)));
+    }
+    if (reason == "empty_response") return HarnessWorkerResponse::empty(message);
+    if (reason == "parse_error") return HarnessWorkerResponse::parse_error(message);
+    if (reason == "tool_error") return HarnessWorkerResponse::tool_error(message);
+    if (reason == "timeout") return HarnessWorkerResponse::timeout(message);
+    throw std::runtime_error("recorded replay failure kind is unsupported: " + reason);
+}
+
 class HarnessRuntimeProvider final : public Provider {
 public:
-    HarnessRuntimeProvider(json                          request,
-                           HarnessWorkerExecutor         executor,
-                           detail::HarnessJournalContext journal_context = {})
+    HarnessRuntimeProvider(json                                    request,
+                           HarnessWorkerExecutor                   executor,
+                           detail::HarnessJournalContext           journal_context  = {},
+                           std::shared_ptr<RecordedHarnessResults> recorded_results = nullptr)
         : request_(std::move(request)),
           executor_(std::move(executor)),
-          journal_context_(std::move(journal_context)) {
+          journal_context_(std::move(journal_context)),
+          recorded_results_(std::move(recorded_results)) {
         for (const auto& worker : request_["workers"]) {
             workers_[worker["id"].get<std::string>()] = worker;
         }
@@ -542,6 +695,15 @@ public:
         std::string feedback;
         std::string failure_kind = "empty_response";
         int attempts_made = 0;
+        const auto  recorded_attempts         = recorded_results_
+                                                    ? recorded_results_->take(node_id, worker_id)
+                                                    : RecordedHarnessResults::Invocation{};
+        const auto  require_recorded_consumed = [&](std::size_t count) {
+            if (recorded_results_ && recorded_attempts.size() != count) {
+                throw std::runtime_error(
+                    "recorded replay worker attempt count diverged from the source run");
+            }
+        };
         for (int attempt = 0; attempt <= max_retries_; ++attempt) {
             attempts_made = attempt + 1;
             cancel->throw_if_cancelled("before Harness worker " + worker_id);
@@ -566,7 +728,13 @@ public:
             call.resume_value    = resume_value;
 
             HarnessWorkerResponse response;
-            if (!executor_) {
+            if (recorded_results_) {
+                if (static_cast<std::size_t>(attempt) >= recorded_attempts.size()) {
+                    throw std::runtime_error(
+                        "recorded replay exhausted worker attempts before execution completed");
+                }
+                response = recorded_worker_response(recorded_attempts[attempt]);
+            } else if (!executor_) {
                 response =
                     HarnessWorkerResponse::tool_error("no Harness worker executor is configured");
             } else {
@@ -574,6 +742,7 @@ public:
             }
 
             if (response.kind == HarnessWorkerResponseKind::CANCELLED) {
+                require_recorded_consumed(static_cast<std::size_t>(attempt + 1));
                 detail::append_harness_journal_event(
                     attempt_context, "worker.attempt.completed",
                     {{"duration_ms",
@@ -624,6 +793,7 @@ public:
                              {"outcome", "valid"},
                              {"output", response.value},
                              {"validation", "passed"}});
+                        require_recorded_consumed(static_cast<std::size_t>(attempt + 1));
                         return {
                             {"worker_id", worker_id},
                             {"status", "valid"},
@@ -637,28 +807,26 @@ public:
                 }
             } else {
                 failure_kind = response_kind_name(response.kind);
-                feedback = response.message.empty() ? failure_kind : response.message;
-                if (response.kind == HarnessWorkerResponseKind::TIMEOUT ||
-                    response.kind == HarnessWorkerResponseKind::TOOL_ERROR) {
-                    break;
-                }
+                feedback     = response.message.empty() ? failure_kind : response.message;
             }
+            const bool stop_retry = response.kind == HarnessWorkerResponseKind::TIMEOUT ||
+                                    response.kind == HarnessWorkerResponseKind::TOOL_ERROR;
             detail::append_harness_journal_event(
                 attempt_context, "worker.attempt.completed",
-                {{"duration_ms",
-                  std::chrono::duration_cast<std::chrono::milliseconds>(
-                      std::chrono::steady_clock::now() - attempt_started)
-                      .count()},
+                {{"duration_ms", std::chrono::duration_cast<std::chrono::milliseconds>(
+                                     std::chrono::steady_clock::now() - attempt_started)
+                                     .count()},
                  {"outcome", "retryable_failure"},
-                 {"retry_scheduled", attempt < max_retries_},
+                 {"retry_scheduled", !stop_retry && attempt < max_retries_},
                  {"retry_reason", failure_kind},
                  {"validation", failure_kind == "schema_validation" ? "failed" : "not_run"},
                  {"message", feedback},
-                 {"output", response.kind == HarnessWorkerResponseKind::VALUE
-                                ? response.value
-                                : json(nullptr)}});
+                 {"output", response.kind == HarnessWorkerResponseKind::VALUE ? response.value
+                                                                              : json(nullptr)}});
+            if (stop_retry) break;
         }
 
+        require_recorded_consumed(static_cast<std::size_t>(attempts_made));
         return {
             {"worker_id", worker_id}, {"status", "failed"},        {"failure_kind", failure_kind},
             {"message", feedback},    {"attempts", attempts_made},
@@ -672,6 +840,7 @@ private:
     std::map<std::string, json> tools_;
     int max_retries_ = 1;
     detail::HarnessJournalContext journal_context_;
+    std::shared_ptr<RecordedHarnessResults> recorded_results_;
 };
 
 class HarnessWorkerNode final : public graph::GraphNode {
@@ -1205,6 +1374,8 @@ struct HarnessService::Impl {
         std::string revision_digest;
         std::string protocol_version = MCP_PROTOCOL_VERSION;
         std::string profile = kHarnessProfile;
+        std::string                         execution_mode   = "live";
+        std::string                         source_run_id;
         std::string status = "queued";
         json result;
         json details;
@@ -1281,6 +1452,8 @@ struct HarnessService::Impl {
             {"revision_digest", run.revision_digest},
             {"protocol_version", run.protocol_version},
             {"profile", run.profile},
+            {"execution_mode", run.execution_mode},
+            {"source_run_id", run.source_run_id},
             {"status", run.status},
             {"result", run.result},
             {"details", run.details},
@@ -1358,6 +1531,8 @@ struct HarnessService::Impl {
         run->revision_digest = record->value("revision_digest", "");
         run->protocol_version = record->value("protocol_version", MCP_PROTOCOL_VERSION);
         run->profile = record->value("profile", kHarnessProfile);
+        run->execution_mode   = record->value("execution_mode", "live");
+        run->source_run_id    = record->value("source_run_id", "");
         run->status       = record->at("status").get<std::string>();
         run->result       = record->value("result", json());
         run->details      = record->value("details", json());
@@ -1504,9 +1679,38 @@ struct HarnessService::Impl {
         return result;
     }
 
-    void execute(std::shared_ptr<Run>      run,
-                 std::shared_ptr<Artifact> artifact,
-                 std::optional<json>       resume_value = std::nullopt) {
+    std::shared_ptr<RecordedHarnessResults> load_recorded_results(
+        const std::string& run_id,
+        const std::string& artifact_id,
+        const std::string& revision_digest,
+        const std::string& protocol_version,
+        const std::string& profile) const {
+        if (!journal) {
+            throw std::invalid_argument("recorded replay requires a Harness journal");
+        }
+        std::vector<json> events;
+        std::size_t       cursor = 0;
+        while (true) {
+            const auto page = journal->list_events(run_id, cursor, 1000);
+            if (page.empty()) break;
+            for (const auto& event : page) {
+                const auto sequence = event.value("sequence", std::size_t{0});
+                if (sequence <= cursor) {
+                    throw std::runtime_error("recorded replay journal sequence did not advance");
+                }
+                cursor = sequence;
+                events.push_back(event);
+            }
+            if (page.size() < 1000) break;
+        }
+        return recorded_results_from_events(events, run_id, artifact_id, revision_digest,
+                                            protocol_version, profile);
+    }
+
+    void execute(std::shared_ptr<Run>                    run,
+                 std::shared_ptr<Artifact>               artifact,
+                 std::optional<json>                     resume_value     = std::nullopt,
+                 std::shared_ptr<RecordedHarnessResults> recorded_results = nullptr) {
         {
             std::lock_guard lock(run->mutex);
             run->status = "running";
@@ -1515,9 +1719,14 @@ struct HarnessService::Impl {
         }
         try {
             persist_run(run);
-            detail::append_harness_journal_event(
-                journal_context(*run), resume_value ? "run.resumed" : "run.started",
-                {{"status", "running"}});
+            json lifecycle = {
+                {"execution_mode", run->execution_mode},
+                {"status", "running"},
+            };
+            if (!run->source_run_id.empty()) lifecycle["source_run_id"] = run->source_run_id;
+            detail::append_harness_journal_event(journal_context(*run),
+                                                 resume_value ? "run.resumed" : "run.started",
+                                                 std::move(lifecycle));
         } catch (const std::exception& error) {
             {
                 std::lock_guard lock(run->mutex);
@@ -1551,7 +1760,7 @@ struct HarnessService::Impl {
         std::unique_ptr<graph::GraphEngine> engine;
         try {
             auto provider = std::make_shared<HarnessRuntimeProvider>(
-                artifact->request, config.worker_executor, journal_context(*run));
+                artifact->request, config.worker_executor, journal_context(*run), recorded_results);
             graph::NodeContext context;
             context.provider = std::move(provider);
             engine = graph::GraphEngine::compile(artifact->core, context, config.checkpoint_store);
@@ -1565,6 +1774,11 @@ struct HarnessService::Impl {
             run_config.cancel_token = run->cancel;
             auto graph_result =
                 resume_value ? engine->resume(run_config, *resume_value) : engine->run(run_config);
+            if (recorded_results && graph_result.interrupted) {
+                throw std::runtime_error(
+                    "recorded replay cannot request live input or tool results");
+            }
+            if (recorded_results) recorded_results->require_exhausted();
 
             json interrupt_payload;
             std::string interrupt_correlation;
@@ -1687,13 +1901,26 @@ struct HarnessService::Impl {
     void ensure_resume_scheduled(const std::shared_ptr<Run>& run) {
         json        value;
         std::string artifact_id;
+        bool        rejected_recorded_resume = false;
         {
             std::lock_guard lock(run->mutex);
             if (run->status != "queued" || run->resume_value.is_null() || run->resume_scheduled)
                 return;
-            run->resume_scheduled = true;
-            value                 = run->resume_value;
-            artifact_id           = run->artifact_id;
+            if (run->execution_mode == "recorded_replay") {
+                run->status              = "failed";
+                run->error               = "recorded replay cannot resume with live input";
+                run->resume_value        = nullptr;
+                run->updated_at          = unix_millis();
+                rejected_recorded_resume = true;
+            } else {
+                run->resume_scheduled = true;
+                value                 = run->resume_value;
+                artifact_id           = run->artifact_id;
+            }
+        }
+        if (rejected_recorded_resume) {
+            persist_run(run);
+            return;
         }
         auto artifact = find_artifact(artifact_id);
         if (!artifact) {
@@ -1813,6 +2040,8 @@ json HarnessService::schema() const {
              {"read_only_workspace_policy", true},
              {"compact_results", true},
              {"durable_runs", static_cast<bool>(impl_->config.record_store)},
+             {"recorded_result_replay", static_cast<bool>(impl_->journal)},
+             {"live_replay", true},
              {"host_brokered_resume",
               static_cast<bool>(impl_->config.checkpoint_store && impl_->config.record_store)},
              {"experimental_tasks", impl_->config.enable_experimental_tasks},
@@ -1829,7 +2058,56 @@ json HarnessService::start(const json& arguments) {
         throw std::invalid_argument("neograph_start arguments must be an object");
     }
     std::string artifact_id;
-    if (arguments.contains("request")) {
+    std::string                             execution_mode = "live";
+    std::string                             source_run_id;
+    std::string                             source_revision_digest;
+    std::string                             source_protocol_version;
+    std::string                             source_profile;
+    std::shared_ptr<RecordedHarnessResults> recorded_results;
+    if (arguments.contains("replay")) {
+        if (arguments.contains("request") || arguments.contains("artifact_id")) {
+            throw std::invalid_argument(
+                "neograph_start replay cannot include artifact_id or request");
+        }
+        const auto& replay = arguments["replay"];
+        if (!replay.is_object() || replay.size() != 2 || !replay.contains("source_run_id") ||
+            !replay["source_run_id"].is_string() || !replay.contains("mode") ||
+            !replay["mode"].is_string()) {
+            throw std::invalid_argument(
+                "neograph_start replay requires only string source_run_id and mode");
+        }
+        source_run_id   = replay["source_run_id"].get<std::string>();
+        const auto mode = replay["mode"].get<std::string>();
+        if (source_run_id.empty() || (mode != "recorded" && mode != "live")) {
+            throw std::invalid_argument(
+                "neograph_start replay mode must be recorded or live with a source_run_id");
+        }
+        auto source = impl_->find_run(source_run_id);
+        if (!source) {
+            throw std::invalid_argument("unknown Harness replay source_run_id: " + source_run_id);
+        }
+        {
+            std::lock_guard lock(source->mutex);
+            if (source->status != "completed") {
+                throw std::invalid_argument("Harness replay source run must be completed");
+            }
+            if (source->protocol_version != MCP_PROTOCOL_VERSION ||
+                source->profile != kHarnessProfile) {
+                throw std::invalid_argument(
+                    "Harness replay source protocol or profile is incompatible");
+            }
+            artifact_id             = source->artifact_id;
+            source_revision_digest  = source->revision_digest;
+            source_protocol_version = source->protocol_version;
+            source_profile          = source->profile;
+            execution_mode          = mode == "recorded" ? "recorded_replay" : "live_replay";
+        }
+        if (mode == "recorded") {
+            recorded_results =
+                impl_->load_recorded_results(source_run_id, artifact_id, source_revision_digest,
+                                             source_protocol_version, source_profile);
+        }
+    } else if (arguments.contains("request")) {
         if (arguments.contains("artifact_id")) {
             throw std::invalid_argument(
                 "neograph_start accepts exactly one of artifact_id or request");
@@ -1847,12 +2125,17 @@ json HarnessService::start(const json& arguments) {
     } else if (arguments.contains("artifact_id") && arguments["artifact_id"].is_string()) {
         artifact_id = arguments["artifact_id"].get<std::string>();
     } else {
-        throw std::invalid_argument("neograph_start requires artifact_id or request");
+        throw std::invalid_argument("neograph_start requires artifact_id, request, or replay");
     }
 
     auto artifact = impl_->find_artifact(artifact_id);
     if (!artifact) {
         throw std::invalid_argument("unknown Harness artifact_id: " + artifact_id);
+    }
+    if (!source_run_id.empty()) {
+        if (source_revision_digest != artifact->revision_digest) {
+            throw std::invalid_argument("Harness replay source revision is unavailable");
+        }
     }
     auto run = std::make_shared<Impl::Run>();
     {
@@ -1863,25 +2146,37 @@ json HarnessService::start(const json& arguments) {
         run->id = impl_->id("run");
         run->artifact_id = artifact_id;
         run->revision_digest = artifact->revision_digest;
+        run->execution_mode  = execution_mode;
+        run->source_run_id   = source_run_id;
         run->expires_at      = run->created_at + impl_->config.run_ttl.count();
         impl_->runs[run->id] = run;
         try {
             impl_->persist_run(run);
-            detail::append_harness_journal_event(
-                impl_->journal_context(*run), "run.queued", {{"status", "queued"}});
-            impl_->threads.emplace_back(
-                [impl = impl_.get(), run, artifact] { impl->execute(run, artifact); });
+            json lifecycle = {
+                {"execution_mode", execution_mode},
+                {"status", "queued"},
+            };
+            if (!source_run_id.empty()) lifecycle["source_run_id"] = source_run_id;
+            detail::append_harness_journal_event(impl_->journal_context(*run), "run.queued",
+                                                 std::move(lifecycle));
+            impl_->threads.emplace_back([impl             = impl_.get(), run, artifact,
+                                         recorded_results = std::move(recorded_results)] {
+                impl->execute(run, artifact, std::nullopt, std::move(recorded_results));
+            });
         } catch (...) {
             impl_->runs.erase(run->id);
             throw;
         }
     }
-    return {
+    json response = {
         {"started", true},
         {"run_id", run->id},
         {"artifact_id", artifact_id},
+        {"execution_mode", execution_mode},
         {"status", "queued"},
     };
+    if (!source_run_id.empty()) response["source_run_id"] = source_run_id;
+    return response;
 }
 
 json HarnessService::resume(const json& arguments) {
@@ -2013,12 +2308,14 @@ json HarnessService::get(const std::string& run_id,
             {"revision_digest", run->revision_digest},
             {"protocol_version", run->protocol_version},
             {"profile", run->profile},
+            {"execution_mode", run->execution_mode},
             {"status", run->status},
             {"created_at", run->created_at},
             {"updated_at", run->updated_at},
             {"expires_at", run->expires_at},
             {"poll_after_ms", impl_->config.poll_interval.count()},
         };
+        if (!run->source_run_id.empty()) snapshot["source_run_id"] = run->source_run_id;
         if (!run->pending.is_null()) snapshot["pending"] = run->pending;
         result  = run->result;
         details = run->details;
@@ -2182,11 +2479,12 @@ void HarnessService::register_tools(MCPServer& server) {
 
     auto start_definition = tool_definition(
         "neograph_start", "Start Harness",
-        "Start a retained artifact or compile-and-start an inline Harness request.",
+        "Start a retained artifact, compile-and-start an inline request, or replay a completed "
+        "run.",
         json::parse(
-            R"JSON({"type":"object","description":"Provide exactly one of artifact_id or request.","properties":{"artifact_id":{"type":"string","description":"Artifact returned by neograph_compile."},"request":{"type":"object","description":"Inline Harness request; do not also provide artifact_id."}},"additionalProperties":false})JSON"),
+            R"JSON({"type":"object","description":"Provide exactly one of artifact_id, request, or replay.","properties":{"artifact_id":{"type":"string","description":"Artifact returned by neograph_compile."},"request":{"type":"object","description":"Inline Harness request; do not also provide artifact_id."},"replay":{"type":"object","required":["source_run_id","mode"],"properties":{"source_run_id":{"type":"string"},"mode":{"enum":["recorded","live"],"description":"recorded injects FULL journal results without live calls; live executes the source artifact again."}},"additionalProperties":false}},"additionalProperties":false})JSON"),
         json::parse(
-            R"JSON({"type":"object","required":["started","status"],"properties":{"started":{"type":"boolean"},"run_id":{"type":"string"},"artifact_id":{"type":"string"},"status":{"type":"string"},"diagnostics":{"type":"array"},"artifacts":{"type":"object"}},"additionalProperties":true})JSON"));
+            R"JSON({"type":"object","required":["started","status"],"properties":{"started":{"type":"boolean"},"run_id":{"type":"string"},"artifact_id":{"type":"string"},"execution_mode":{"enum":["live","live_replay","recorded_replay"]},"source_run_id":{"type":"string"},"status":{"type":"string"},"diagnostics":{"type":"array"},"artifacts":{"type":"object"}},"additionalProperties":true})JSON"));
     if (impl_->config.enable_experimental_tasks) {
         start_definition.execution = {{"taskSupport", "optional"}};
         server.register_raw_tool(

--- a/src/mcp/harness_journal.cpp
+++ b/src/mcp/harness_journal.cpp
@@ -1,0 +1,71 @@
+#include "harness_journal_internal.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <random>
+#include <sstream>
+#include <utility>
+
+namespace neograph::mcp::detail {
+namespace {
+
+thread_local const HarnessJournalContext* current_context = nullptr;
+
+int64_t unix_millis() {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+}  // namespace
+
+ScopedHarnessJournalContext::ScopedHarnessJournalContext(HarnessJournalContext context)
+    : context_(std::move(context)), previous_(current_context) {
+    current_context = &context_;
+}
+
+ScopedHarnessJournalContext::~ScopedHarnessJournalContext() {
+    current_context = previous_;
+}
+
+std::string journal_correlation_id(const char* prefix) {
+    static const std::uint64_t        nonce = std::random_device{}();
+    static std::atomic<std::uint64_t> sequence{1};
+    std::ostringstream                out;
+    out << prefix << '_' << std::hex << nonce << '_'
+        << sequence.fetch_add(1, std::memory_order_relaxed);
+    return out.str();
+}
+
+void append_harness_journal_event(const HarnessJournalContext& context,
+                                  const std::string&            event_type,
+                                  json                          payload,
+                                  std::string                   correlation_id) {
+    if (!context.journal) return;
+    json event = {
+        {"run_id", context.run_id},
+        {"artifact_id", context.artifact_id},
+        {"revision_digest", context.revision_digest},
+        {"protocol_version", context.protocol_version},
+        {"profile", context.profile},
+        {"event_type", event_type},
+        {"created_at_ms", unix_millis()},
+        {"payload", std::move(payload)},
+    };
+    if (!context.node_id.empty()) event["node_id"] = context.node_id;
+    if (!context.worker_id.empty()) event["worker_id"] = context.worker_id;
+    if (context.attempt > 0) event["attempt"] = context.attempt;
+    if (!correlation_id.empty()) event["correlation_id"] = std::move(correlation_id);
+    context.journal->append_event(event);
+}
+
+void append_current_harness_journal_event(const std::string& event_type,
+                                          json               payload,
+                                          std::string        correlation_id) {
+    if (!current_context) return;
+    append_harness_journal_event(*current_context, event_type, std::move(payload),
+                                 std::move(correlation_id));
+}
+
+}  // namespace neograph::mcp::detail

--- a/src/mcp/harness_journal_internal.h
+++ b/src/mcp/harness_journal_internal.h
@@ -8,6 +8,8 @@
 
 namespace neograph::mcp::detail {
 
+inline constexpr const char* kHarnessRedactedMarker = "[REDACTED]";
+
 struct HarnessJournalContext {
     std::shared_ptr<HarnessJournal> journal;
     std::string run_id;

--- a/src/mcp/harness_journal_internal.h
+++ b/src/mcp/harness_journal_internal.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <neograph/mcp/harness.h>
+
+#include <cstddef>
+#include <memory>
+#include <string>
+
+namespace neograph::mcp::detail {
+
+struct HarnessJournalContext {
+    std::shared_ptr<HarnessJournal> journal;
+    std::string run_id;
+    std::string artifact_id;
+    std::string revision_digest;
+    std::string protocol_version;
+    std::string profile;
+    std::string node_id;
+    std::string worker_id;
+    std::size_t attempt = 0;
+};
+
+class ScopedHarnessJournalContext {
+public:
+    explicit ScopedHarnessJournalContext(HarnessJournalContext context);
+    ~ScopedHarnessJournalContext();
+
+    ScopedHarnessJournalContext(const ScopedHarnessJournalContext&) = delete;
+    ScopedHarnessJournalContext& operator=(const ScopedHarnessJournalContext&) = delete;
+
+private:
+    HarnessJournalContext context_;
+    const HarnessJournalContext* previous_ = nullptr;
+};
+
+std::string journal_correlation_id(const char* prefix);
+
+void append_harness_journal_event(const HarnessJournalContext& context,
+                                  const std::string&           event_type,
+                                  json                         payload = json::object(),
+                                  std::string                  correlation_id = {});
+
+void append_current_harness_journal_event(const std::string& event_type,
+                                          json               payload = json::object(),
+                                          std::string        correlation_id = {});
+
+}  // namespace neograph::mcp::detail

--- a/src/mcp/harness_provider.cpp
+++ b/src/mcp/harness_provider.cpp
@@ -2,7 +2,10 @@
 #include <neograph/mcp/json_schema.h>
 #include <neograph/provider.h>
 
+#include "harness_journal_internal.h"
+
 #include <atomic>
+#include <chrono>
 #include <filesystem>
 #include <map>
 #include <random>
@@ -144,13 +147,53 @@ HarnessWorkerExecutor make_provider_harness_executor(HarnessProviderExecutorConf
         for (std::size_t round = 0; round < config.max_tool_rounds; ++round) {
             cancel->throw_if_cancelled("before provider Harness completion");
             ChatCompletion completion;
+            const auto provider_correlation = detail::journal_correlation_id("provider");
+            const auto provider_started = std::chrono::steady_clock::now();
+            detail::append_current_harness_journal_event(
+                "provider.call.started",
+                {{"message_count", params.messages.size()},
+                 {"model", params.model},
+                 {"round", round + 1},
+                 {"tool_count", params.tools.size()}},
+                provider_correlation);
             try {
                 completion = config.provider->complete(params);
             } catch (const graph::CancelledException&) {
+                detail::append_current_harness_journal_event(
+                    "provider.call.completed",
+                    {{"duration_ms",
+                      std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - provider_started)
+                          .count()},
+                     {"outcome", "cancelled"}},
+                    provider_correlation);
                 return HarnessWorkerResponse::cancelled();
             } catch (const std::exception& error) {
+                detail::append_current_harness_journal_event(
+                    "provider.call.completed",
+                    {{"duration_ms",
+                      std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - provider_started)
+                          .count()},
+                     {"error", error.what()},
+                     {"outcome", "error"}},
+                    provider_correlation);
                 return HarnessWorkerResponse::tool_error(error.what());
             }
+            detail::append_current_harness_journal_event(
+                "provider.call.completed",
+                {{"content", completion.message.content},
+                 {"duration_ms",
+                  std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::steady_clock::now() - provider_started)
+                      .count()},
+                 {"outcome", completion.message.tool_calls.empty() ? "content" : "tool_calls"},
+                 {"tool_call_count", completion.message.tool_calls.size()},
+                 {"usage",
+                  {{"completion_tokens", completion.usage.completion_tokens},
+                   {"prompt_tokens", completion.usage.prompt_tokens},
+                   {"total_tokens", completion.usage.total_tokens}}}},
+                provider_correlation);
 
             if (completion.message.tool_calls.empty()) {
                 if (completion.message.content.empty()) {
@@ -177,14 +220,22 @@ HarnessWorkerExecutor make_provider_harness_executor(HarnessProviderExecutorConf
                     arguments           = enforce_path_policy(call, tool_it->second, arguments);
                     const auto executor = tool_it->second.value("executor", json::object());
                     if (executor.value("kind", "") == "host_brokered") {
+                        const auto call_id = host_call_id();
                         json pending = {
-                            {"call_id", host_call_id()},
+                            {"call_id", call_id},
                             {"provider_call_id", tool_call.id},
                             {"tool_id", tool_call.name},
                             {"arguments", std::move(arguments)},
                             {"result_schema",
                              tool_it->second.value("output_schema", json::object())},
                         };
+                        detail::append_current_harness_journal_event(
+                            "host_brokered.call.requested",
+                            {{"arguments", pending["arguments"]},
+                             {"interaction", executor.value("interaction", "tool_result")},
+                             {"provider_call_id", tool_call.id},
+                             {"tool_id", tool_call.name}},
+                            call_id);
                         if (executor.value("interaction", "tool_result") == "input") {
                             return HarnessWorkerResponse::input_required(std::move(pending));
                         }
@@ -194,11 +245,48 @@ HarnessWorkerExecutor make_provider_harness_executor(HarnessProviderExecutorConf
                         return HarnessWorkerResponse::tool_error(
                             "provider requested a tool but no capability executor is configured");
                     }
-                    auto result = config.capability_executor(tool_it->second, arguments, cancel);
-                    if (tool_it->second.contains("output_schema")) {
-                        validate_json_value(result, tool_it->second["output_schema"],
-                                            "Harness tool result", "$");
+                    const auto capability_correlation =
+                        tool_call.id.empty() ? detail::journal_correlation_id("capability")
+                                             : tool_call.id;
+                    const auto capability_started = std::chrono::steady_clock::now();
+                    detail::append_current_harness_journal_event(
+                        "capability.call.started",
+                        {{"arguments", arguments},
+                         {"executor_kind", executor.value("kind", "builtin")},
+                         {"tool_id", tool_call.name}},
+                        capability_correlation);
+                    json result;
+                    try {
+                        result = config.capability_executor(tool_it->second, arguments, cancel);
+                        if (tool_it->second.contains("output_schema")) {
+                            validate_json_value(result, tool_it->second["output_schema"],
+                                                "Harness tool result", "$");
+                        }
+                    } catch (const std::exception& error) {
+                        detail::append_current_harness_journal_event(
+                            "capability.call.completed",
+                            {{"duration_ms",
+                              std::chrono::duration_cast<std::chrono::milliseconds>(
+                                  std::chrono::steady_clock::now() - capability_started)
+                                  .count()},
+                             {"error", error.what()},
+                             {"executor_kind", executor.value("kind", "builtin")},
+                             {"outcome", "error"},
+                             {"tool_id", tool_call.name}},
+                            capability_correlation);
+                        throw;
                     }
+                    detail::append_current_harness_journal_event(
+                        "capability.call.completed",
+                        {{"duration_ms",
+                          std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::steady_clock::now() - capability_started)
+                              .count()},
+                         {"executor_kind", executor.value("kind", "builtin")},
+                         {"outcome", "success"},
+                         {"result", result},
+                         {"tool_id", tool_call.name}},
+                        capability_correlation);
                     ChatMessage message;
                     message.role = "tool";
                     message.tool_call_id = tool_call.id;

--- a/src/mcp/sqlite_harness_store.cpp
+++ b/src/mcp/sqlite_harness_store.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <limits>
 #include <mutex>
+#include <set>
 #include <stdexcept>
 #include <utility>
 
@@ -53,6 +54,7 @@ public:
     }
 
     int integer(int column) const { return sqlite3_column_int(statement_, column); }
+    int64_t int64(int column) const { return sqlite3_column_int64(statement_, column); }
 
 private:
     sqlite3*      db_        = nullptr;
@@ -73,10 +75,40 @@ int64_t unix_millis() {
         .count();
 }
 
+std::string lowercase(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+    });
+    return value;
+}
+
+json redacted_json(const json& value, const std::set<std::string>& redacted_keys) {
+    if (value.is_object()) {
+        json result = json::object();
+        for (const auto [key, child] : value.items()) {
+            if (redacted_keys.contains(lowercase(key))) {
+                result[key] = "[REDACTED]";
+            } else {
+                result[key] = redacted_json(child, redacted_keys);
+            }
+        }
+        return result;
+    }
+    if (value.is_array()) {
+        json result = json::array();
+        for (const auto child : value) result.push_back(redacted_json(child, redacted_keys));
+        return result;
+    }
+    return value;
+}
+
 }  // namespace
 
 struct SqliteHarnessRecordStore::Impl {
-    Impl(const std::string& db_path, std::chrono::milliseconds busy_timeout) {
+    Impl(const std::string&              db_path,
+         std::chrono::milliseconds       busy_timeout,
+         SqliteHarnessJournalConfig journal_config_value)
+        : journal_config(std::move(journal_config_value)) {
         if (db_path.empty()) {
             throw std::invalid_argument("SqliteHarnessRecordStore path must not be empty");
         }
@@ -127,9 +159,6 @@ struct SqliteHarnessRecordStore::Impl {
     }
 
     void ensure_schema() {
-        // Version 1 is the first shipped schema. A future bump must migrate
-        // older versions inside this transaction before updating the singleton;
-        // rejecting an unknown version is safer than opening it partially.
         exec("BEGIN IMMEDIATE;");
         try {
             exec(R"SQL(
@@ -138,7 +167,7 @@ CREATE TABLE IF NOT EXISTS neograph_harness_schema (
     version   INTEGER NOT NULL
 );
 INSERT INTO neograph_harness_schema (singleton, version)
-VALUES (1, 1)
+VALUES (1, 2)
 ON CONFLICT(singleton) DO NOTHING;
 CREATE TABLE IF NOT EXISTS neograph_harness_artifacts (
     artifact_id  TEXT PRIMARY KEY,
@@ -146,10 +175,13 @@ CREATE TABLE IF NOT EXISTS neograph_harness_artifacts (
     created_at_ms INTEGER NOT NULL
 );
 CREATE TABLE IF NOT EXISTS neograph_harness_runs (
-    run_id        TEXT PRIMARY KEY,
-    artifact_id   TEXT    NOT NULL,
-    record_json   TEXT    NOT NULL,
-    updated_at_ms INTEGER NOT NULL,
+    run_id           TEXT PRIMARY KEY,
+    artifact_id      TEXT    NOT NULL,
+    revision_digest  TEXT    NOT NULL DEFAULT '',
+    protocol_version TEXT    NOT NULL DEFAULT '',
+    profile          TEXT    NOT NULL DEFAULT '',
+    record_json      TEXT    NOT NULL,
+    updated_at_ms    INTEGER NOT NULL,
     FOREIGN KEY (artifact_id) REFERENCES neograph_harness_artifacts (artifact_id)
         ON DELETE RESTRICT
 );
@@ -158,9 +190,49 @@ CREATE INDEX IF NOT EXISTS neograph_harness_runs_artifact
 )SQL");
             Statement version(db,
                               "SELECT version FROM neograph_harness_schema WHERE singleton = 1");
-            if (version.step() != SQLITE_ROW || version.integer(0) != 1) {
+            if (version.step() != SQLITE_ROW) {
                 throw std::runtime_error("SqliteHarnessRecordStore: unsupported schema version");
             }
+            const auto schema_version = version.integer(0);
+            if (schema_version == 1) {
+                exec(R"SQL(
+ALTER TABLE neograph_harness_runs
+    ADD COLUMN revision_digest TEXT NOT NULL DEFAULT '';
+ALTER TABLE neograph_harness_runs
+    ADD COLUMN protocol_version TEXT NOT NULL DEFAULT '';
+ALTER TABLE neograph_harness_runs
+    ADD COLUMN profile TEXT NOT NULL DEFAULT '';
+UPDATE neograph_harness_schema SET version = 2 WHERE singleton = 1;
+)SQL");
+            } else if (schema_version != 2) {
+                throw std::runtime_error("SqliteHarnessRecordStore: unsupported schema version");
+            }
+            exec(R"SQL(
+CREATE TABLE IF NOT EXISTS neograph_harness_journal (
+    journal_id       INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id           TEXT    NOT NULL,
+    sequence         INTEGER NOT NULL,
+    artifact_id      TEXT    NOT NULL,
+    revision_digest  TEXT    NOT NULL,
+    protocol_version TEXT    NOT NULL,
+    profile          TEXT    NOT NULL,
+    event_type       TEXT    NOT NULL,
+    correlation_id   TEXT    NOT NULL DEFAULT '',
+    node_id          TEXT    NOT NULL DEFAULT '',
+    worker_id        TEXT    NOT NULL DEFAULT '',
+    attempt          INTEGER NOT NULL DEFAULT 0,
+    payload_json     TEXT    NOT NULL,
+    created_at_ms    INTEGER NOT NULL,
+    UNIQUE (run_id, sequence),
+    FOREIGN KEY (run_id) REFERENCES neograph_harness_runs (run_id)
+        ON DELETE RESTRICT
+);
+CREATE INDEX IF NOT EXISTS neograph_harness_journal_run
+    ON neograph_harness_journal (run_id, sequence);
+CREATE INDEX IF NOT EXISTS neograph_harness_journal_correlation
+    ON neograph_harness_journal (correlation_id)
+    WHERE correlation_id <> '';
+)SQL");
             exec("COMMIT;");
         } catch (...) {
             try {
@@ -185,14 +257,21 @@ CREATE INDEX IF NOT EXISTS neograph_harness_runs_artifact
 
     sqlite3*   db = nullptr;
     std::mutex mutex;
+    SqliteHarnessJournalConfig journal_config;
 };
 
 SqliteHarnessRecordStore::SqliteHarnessRecordStore(const std::string& db_path)
-    : SqliteHarnessRecordStore(db_path, std::chrono::seconds(5)) {}
+    : SqliteHarnessRecordStore(db_path, std::chrono::seconds(5), {}) {}
 
 SqliteHarnessRecordStore::SqliteHarnessRecordStore(const std::string&        db_path,
-                                                   std::chrono::milliseconds busy_timeout)
-    : impl_(std::make_unique<Impl>(db_path, busy_timeout)) {}
+                                                    std::chrono::milliseconds busy_timeout)
+    : SqliteHarnessRecordStore(db_path, busy_timeout, {}) {}
+
+SqliteHarnessRecordStore::SqliteHarnessRecordStore(
+    const std::string& db_path,
+    std::chrono::milliseconds busy_timeout,
+    SqliteHarnessJournalConfig journal_config)
+    : impl_(std::make_unique<Impl>(db_path, busy_timeout, std::move(journal_config))) {}
 
 SqliteHarnessRecordStore::~SqliteHarnessRecordStore() = default;
 
@@ -233,17 +312,36 @@ void SqliteHarnessRecordStore::save_run(const std::string& run_id, const json& r
     }
     const auto artifact_id = record["artifact_id"].get<std::string>();
     validate_id(artifact_id);
+    const auto revision_digest = record.value("revision_digest", "");
+    const auto protocol_version = record.value("protocol_version", "");
+    const auto profile = record.value("profile", "");
     std::lock_guard lock(impl_->mutex);
     Statement       save(impl_->db,
                          "INSERT INTO neograph_harness_runs "
-                               "(run_id, artifact_id, record_json, updated_at_ms) VALUES (?, ?, ?, ?) "
-                               "ON CONFLICT(run_id) DO UPDATE SET "
-                               "record_json=excluded.record_json, updated_at_ms=excluded.updated_at_ms "
-                               "WHERE neograph_harness_runs.artifact_id=excluded.artifact_id");
+                                "(run_id, artifact_id, revision_digest, protocol_version, profile, "
+                                "record_json, updated_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?) "
+                                "ON CONFLICT(run_id) DO UPDATE SET "
+                                "revision_digest=CASE WHEN neograph_harness_runs.revision_digest='' "
+                                "THEN excluded.revision_digest ELSE neograph_harness_runs.revision_digest END, "
+                                "protocol_version=CASE WHEN neograph_harness_runs.protocol_version='' "
+                                "THEN excluded.protocol_version ELSE neograph_harness_runs.protocol_version END, "
+                                "profile=CASE WHEN neograph_harness_runs.profile='' THEN excluded.profile "
+                                "ELSE neograph_harness_runs.profile END, "
+                                "record_json=excluded.record_json, updated_at_ms=excluded.updated_at_ms "
+                                "WHERE neograph_harness_runs.artifact_id=excluded.artifact_id "
+                                "AND (neograph_harness_runs.revision_digest='' OR "
+                                "neograph_harness_runs.revision_digest=excluded.revision_digest) "
+                                "AND (neograph_harness_runs.protocol_version='' OR "
+                                "neograph_harness_runs.protocol_version=excluded.protocol_version) "
+                                "AND (neograph_harness_runs.profile='' OR "
+                                "neograph_harness_runs.profile=excluded.profile)");
     save.bind_text(1, run_id);
     save.bind_text(2, artifact_id);
-    save.bind_text(3, record.dump());
-    save.bind_int64(4, unix_millis());
+    save.bind_text(3, revision_digest);
+    save.bind_text(4, protocol_version);
+    save.bind_text(5, profile);
+    save.bind_text(6, record.dump());
+    save.bind_int64(7, unix_millis());
     if (save.step() != SQLITE_DONE) throw_sqlite_error(impl_->db, "run write failed");
     if (sqlite3_changes(impl_->db) == 0) {
         throw std::invalid_argument("Harness run revision binding is immutable");
@@ -252,6 +350,122 @@ void SqliteHarnessRecordStore::save_run(const std::string& run_id, const json& r
 
 std::optional<json> SqliteHarnessRecordStore::load_run(const std::string& run_id) {
     return impl_->load("neograph_harness_runs", "run_id", run_id);
+}
+
+void SqliteHarnessRecordStore::append_event(const json& event) {
+    if (!event.is_object()) throw std::invalid_argument("Harness journal event must be an object");
+    const auto required_string = [&](const char* key) {
+        if (!event.contains(key) || !event[key].is_string() || event[key].get<std::string>().empty()) {
+            throw std::invalid_argument(std::string("Harness journal event requires ") + key);
+        }
+        return event[key].get<std::string>();
+    };
+    const auto run_id = required_string("run_id");
+    const auto artifact_id = required_string("artifact_id");
+    const auto revision_digest = required_string("revision_digest");
+    const auto protocol_version = required_string("protocol_version");
+    const auto profile = required_string("profile");
+    const auto event_type = required_string("event_type");
+    validate_id(run_id);
+    validate_id(artifact_id);
+
+    json payload = event.value("payload", json::object());
+    if (impl_->journal_config.mode == HarnessJournalPayloadMode::METADATA_ONLY) {
+        payload = json::object();
+    } else if (impl_->journal_config.mode == HarnessJournalPayloadMode::REDACTED) {
+        std::set<std::string> keys;
+        for (const auto& key : impl_->journal_config.redacted_keys) keys.insert(lowercase(key));
+        payload = redacted_json(payload, keys);
+    }
+
+    std::lock_guard lock(impl_->mutex);
+    impl_->exec("BEGIN IMMEDIATE;");
+    try {
+        Statement next(impl_->db,
+                       "SELECT COALESCE(MAX(sequence), 0) + 1 "
+                       "FROM neograph_harness_journal WHERE run_id = ?");
+        next.bind_text(1, run_id);
+        if (next.step() != SQLITE_ROW) throw_sqlite_error(impl_->db, "journal sequence read failed");
+        const auto sequence = next.int64(0);
+
+        Statement insert(impl_->db,
+                         "INSERT INTO neograph_harness_journal "
+                         "(run_id, sequence, artifact_id, revision_digest, protocol_version, profile, "
+                         "event_type, correlation_id, node_id, worker_id, attempt, payload_json, "
+                         "created_at_ms) "
+                         "SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? "
+                         "FROM neograph_harness_runs WHERE run_id=? AND artifact_id=? "
+                         "AND revision_digest=? AND protocol_version=? AND profile=?");
+        insert.bind_text(1, run_id);
+        insert.bind_int64(2, sequence);
+        insert.bind_text(3, artifact_id);
+        insert.bind_text(4, revision_digest);
+        insert.bind_text(5, protocol_version);
+        insert.bind_text(6, profile);
+        insert.bind_text(7, event_type);
+        insert.bind_text(8, event.value("correlation_id", ""));
+        insert.bind_text(9, event.value("node_id", ""));
+        insert.bind_text(10, event.value("worker_id", ""));
+        insert.bind_int64(11, event.value("attempt", int64_t{0}));
+        insert.bind_text(12, payload.dump());
+        insert.bind_int64(13, event.value("created_at_ms", unix_millis()));
+        insert.bind_text(14, run_id);
+        insert.bind_text(15, artifact_id);
+        insert.bind_text(16, revision_digest);
+        insert.bind_text(17, protocol_version);
+        insert.bind_text(18, profile);
+        if (insert.step() != SQLITE_DONE) throw_sqlite_error(impl_->db, "journal write failed");
+        if (sqlite3_changes(impl_->db) != 1) {
+            throw std::invalid_argument("Harness journal metadata does not match its run binding");
+        }
+        impl_->exec("COMMIT;");
+    } catch (...) {
+        try {
+            impl_->exec("ROLLBACK;");
+        } catch (...) {}
+        throw;
+    }
+}
+
+std::vector<json> SqliteHarnessRecordStore::list_events(const std::string& run_id,
+                                                        std::size_t after_sequence,
+                                                        std::size_t limit) {
+    validate_id(run_id);
+    if (limit == 0 || limit > 10000 || after_sequence > static_cast<std::size_t>(INT64_MAX)) {
+        throw std::invalid_argument("Harness journal pagination is out of range");
+    }
+    std::lock_guard lock(impl_->mutex);
+    Statement list(impl_->db,
+                   "SELECT sequence, artifact_id, revision_digest, protocol_version, profile, "
+                   "event_type, correlation_id, node_id, worker_id, attempt, payload_json, "
+                   "created_at_ms FROM neograph_harness_journal "
+                   "WHERE run_id=? AND sequence>? ORDER BY sequence LIMIT ?");
+    list.bind_text(1, run_id);
+    list.bind_int64(2, static_cast<int64_t>(after_sequence));
+    list.bind_int64(3, static_cast<int64_t>(limit));
+    std::vector<json> events;
+    while (true) {
+        const auto result = list.step();
+        if (result == SQLITE_DONE) break;
+        if (result != SQLITE_ROW) throw_sqlite_error(impl_->db, "journal read failed");
+        json event = {
+            {"run_id", run_id},
+            {"sequence", list.int64(0)},
+            {"artifact_id", list.text(1)},
+            {"revision_digest", list.text(2)},
+            {"protocol_version", list.text(3)},
+            {"profile", list.text(4)},
+            {"event_type", list.text(5)},
+            {"payload", json::parse(list.text(10))},
+            {"created_at_ms", list.int64(11)},
+        };
+        if (!list.text(6).empty()) event["correlation_id"] = list.text(6);
+        if (!list.text(7).empty()) event["node_id"] = list.text(7);
+        if (!list.text(8).empty()) event["worker_id"] = list.text(8);
+        if (list.int64(9) > 0) event["attempt"] = list.int64(9);
+        events.push_back(std::move(event));
+    }
+    return events;
 }
 
 }  // namespace neograph::mcp

--- a/src/mcp/sqlite_harness_store.cpp
+++ b/src/mcp/sqlite_harness_store.cpp
@@ -1,5 +1,6 @@
 #include <neograph/mcp/sqlite_harness_store.h>
 
+#include "harness_journal_internal.h"
 #include <sqlite3.h>
 
 #include <algorithm>
@@ -87,7 +88,7 @@ json redacted_json(const json& value, const std::set<std::string>& redacted_keys
         json result = json::object();
         for (const auto [key, child] : value.items()) {
             if (redacted_keys.contains(lowercase(key))) {
-                result[key] = "[REDACTED]";
+                result[key] = detail::kHarnessRedactedMarker;
             } else {
                 result[key] = redacted_json(child, redacted_keys);
             }

--- a/src/mcp/sqlite_harness_store.cpp
+++ b/src/mcp/sqlite_harness_store.cpp
@@ -168,7 +168,7 @@ CREATE TABLE IF NOT EXISTS neograph_harness_schema (
     version   INTEGER NOT NULL
 );
 INSERT INTO neograph_harness_schema (singleton, version)
-VALUES (1, 2)
+VALUES (1, 3)
 ON CONFLICT(singleton) DO NOTHING;
 CREATE TABLE IF NOT EXISTS neograph_harness_artifacts (
     artifact_id  TEXT PRIMARY KEY,
@@ -181,6 +181,9 @@ CREATE TABLE IF NOT EXISTS neograph_harness_runs (
     revision_digest  TEXT    NOT NULL DEFAULT '',
     protocol_version TEXT    NOT NULL DEFAULT '',
     profile          TEXT    NOT NULL DEFAULT '',
+    status           TEXT    NOT NULL DEFAULT '',
+    source_run_id    TEXT    NOT NULL DEFAULT '',
+    source_checkpoint_id TEXT NOT NULL DEFAULT '',
     record_json      TEXT    NOT NULL,
     updated_at_ms    INTEGER NOT NULL,
     FOREIGN KEY (artifact_id) REFERENCES neograph_harness_artifacts (artifact_id)
@@ -194,7 +197,7 @@ CREATE INDEX IF NOT EXISTS neograph_harness_runs_artifact
             if (version.step() != SQLITE_ROW) {
                 throw std::runtime_error("SqliteHarnessRecordStore: unsupported schema version");
             }
-            const auto schema_version = version.integer(0);
+            auto schema_version = version.integer(0);
             if (schema_version == 1) {
                 exec(R"SQL(
 ALTER TABLE neograph_harness_runs
@@ -205,10 +208,49 @@ ALTER TABLE neograph_harness_runs
     ADD COLUMN profile TEXT NOT NULL DEFAULT '';
 UPDATE neograph_harness_schema SET version = 2 WHERE singleton = 1;
 )SQL");
-            } else if (schema_version != 2) {
+                schema_version = 2;
+            }
+            if (schema_version == 2) {
+                exec(R"SQL(
+ALTER TABLE neograph_harness_runs
+    ADD COLUMN status TEXT NOT NULL DEFAULT '';
+ALTER TABLE neograph_harness_runs
+    ADD COLUMN source_run_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE neograph_harness_runs
+    ADD COLUMN source_checkpoint_id TEXT NOT NULL DEFAULT '';
+)SQL");
+                std::vector<std::pair<std::string, json>> records;
+                Statement rows(db, "SELECT run_id, record_json FROM neograph_harness_runs");
+                while (true) {
+                    const auto result = rows.step();
+                    if (result == SQLITE_DONE) break;
+                    if (result != SQLITE_ROW) throw_sqlite_error(db, "run migration read failed");
+                    records.emplace_back(rows.text(0), json::parse(rows.text(1)));
+                }
+                for (const auto& [run_id, record] : records) {
+                    Statement update(db,
+                                     "UPDATE neograph_harness_runs SET status=?, "
+                                     "source_run_id=?, source_checkpoint_id=? WHERE run_id=?");
+                    update.bind_text(1, record.value("status", ""));
+                    update.bind_text(2, record.value("source_run_id", ""));
+                    update.bind_text(3, record.value("source_checkpoint_id", ""));
+                    update.bind_text(4, run_id);
+                    if (update.step() != SQLITE_DONE) {
+                        throw_sqlite_error(db, "run migration write failed");
+                    }
+                }
+                exec("UPDATE neograph_harness_schema SET version = 3 WHERE singleton = 1;");
+                schema_version = 3;
+            }
+            if (schema_version != 3) {
                 throw std::runtime_error("SqliteHarnessRecordStore: unsupported schema version");
             }
             exec(R"SQL(
+CREATE INDEX IF NOT EXISTS neograph_harness_runs_status
+    ON neograph_harness_runs (status, updated_at_ms);
+CREATE INDEX IF NOT EXISTS neograph_harness_runs_source
+    ON neograph_harness_runs (source_run_id)
+    WHERE source_run_id <> '';
 CREATE TABLE IF NOT EXISTS neograph_harness_journal (
     journal_id       INTEGER PRIMARY KEY AUTOINCREMENT,
     run_id           TEXT    NOT NULL,
@@ -316,36 +358,68 @@ void SqliteHarnessRecordStore::save_run(const std::string& run_id, const json& r
     const auto revision_digest = record.value("revision_digest", "");
     const auto protocol_version = record.value("protocol_version", "");
     const auto profile = record.value("profile", "");
+    const auto status               = record.value("status", "");
+    const auto source_run_id        = record.value("source_run_id", "");
+    const auto source_checkpoint_id = record.value("source_checkpoint_id", "");
+    if (!source_run_id.empty()) {
+        validate_id(source_run_id);
+        if (source_run_id == run_id) {
+            throw std::invalid_argument("Harness run cannot reference itself as a source");
+        }
+    }
+    if (!source_checkpoint_id.empty()) validate_id(source_checkpoint_id);
     std::lock_guard lock(impl_->mutex);
-    Statement       save(impl_->db,
-                         "INSERT INTO neograph_harness_runs "
-                                "(run_id, artifact_id, revision_digest, protocol_version, profile, "
-                                "record_json, updated_at_ms) VALUES (?, ?, ?, ?, ?, ?, ?) "
-                                "ON CONFLICT(run_id) DO UPDATE SET "
-                                "revision_digest=CASE WHEN neograph_harness_runs.revision_digest='' "
-                                "THEN excluded.revision_digest ELSE neograph_harness_runs.revision_digest END, "
-                                "protocol_version=CASE WHEN neograph_harness_runs.protocol_version='' "
-                                "THEN excluded.protocol_version ELSE neograph_harness_runs.protocol_version END, "
-                                "profile=CASE WHEN neograph_harness_runs.profile='' THEN excluded.profile "
-                                "ELSE neograph_harness_runs.profile END, "
-                                "record_json=excluded.record_json, updated_at_ms=excluded.updated_at_ms "
-                                "WHERE neograph_harness_runs.artifact_id=excluded.artifact_id "
-                                "AND (neograph_harness_runs.revision_digest='' OR "
-                                "neograph_harness_runs.revision_digest=excluded.revision_digest) "
-                                "AND (neograph_harness_runs.protocol_version='' OR "
-                                "neograph_harness_runs.protocol_version=excluded.protocol_version) "
-                                "AND (neograph_harness_runs.profile='' OR "
-                                "neograph_harness_runs.profile=excluded.profile)");
+    Statement       save(
+        impl_->db,
+        "INSERT INTO neograph_harness_runs "
+              "(run_id, artifact_id, revision_digest, protocol_version, profile, "
+              "status, source_run_id, source_checkpoint_id, record_json, "
+              "updated_at_ms) SELECT ?, ?, ?, ?, ?, ?, ?, ?, ?, ? "
+              "WHERE ?='' OR EXISTS (SELECT 1 FROM neograph_harness_runs "
+              "WHERE run_id=?) "
+              "ON CONFLICT(run_id) DO UPDATE SET "
+              "revision_digest=CASE WHEN neograph_harness_runs.revision_digest='' "
+              "THEN excluded.revision_digest ELSE neograph_harness_runs.revision_digest END, "
+              "protocol_version=CASE WHEN neograph_harness_runs.protocol_version='' "
+              "THEN excluded.protocol_version ELSE neograph_harness_runs.protocol_version END, "
+              "profile=CASE WHEN neograph_harness_runs.profile='' THEN excluded.profile "
+              "ELSE neograph_harness_runs.profile END, "
+              "status=excluded.status, "
+              "source_run_id=CASE WHEN neograph_harness_runs.source_run_id='' "
+              "THEN excluded.source_run_id ELSE neograph_harness_runs.source_run_id END, "
+              "source_checkpoint_id=CASE WHEN "
+              "neograph_harness_runs.source_checkpoint_id='' "
+              "THEN excluded.source_checkpoint_id ELSE "
+              "neograph_harness_runs.source_checkpoint_id END, "
+              "record_json=excluded.record_json, updated_at_ms=excluded.updated_at_ms "
+              "WHERE neograph_harness_runs.artifact_id=excluded.artifact_id "
+              "AND (neograph_harness_runs.revision_digest='' OR "
+              "neograph_harness_runs.revision_digest=excluded.revision_digest) "
+              "AND (neograph_harness_runs.protocol_version='' OR "
+              "neograph_harness_runs.protocol_version=excluded.protocol_version) "
+              "AND (neograph_harness_runs.profile='' OR "
+              "neograph_harness_runs.profile=excluded.profile) "
+              "AND (neograph_harness_runs.source_run_id='' OR "
+              "neograph_harness_runs.source_run_id=excluded.source_run_id) "
+              "AND (neograph_harness_runs.source_checkpoint_id='' OR "
+              "neograph_harness_runs.source_checkpoint_id="
+              "excluded.source_checkpoint_id)");
     save.bind_text(1, run_id);
     save.bind_text(2, artifact_id);
     save.bind_text(3, revision_digest);
     save.bind_text(4, protocol_version);
     save.bind_text(5, profile);
-    save.bind_text(6, record.dump());
-    save.bind_int64(7, unix_millis());
+    save.bind_text(6, status);
+    save.bind_text(7, source_run_id);
+    save.bind_text(8, source_checkpoint_id);
+    save.bind_text(9, record.dump());
+    save.bind_int64(10, unix_millis());
+    save.bind_text(11, source_run_id);
+    save.bind_text(12, source_run_id);
     if (save.step() != SQLITE_DONE) throw_sqlite_error(impl_->db, "run write failed");
     if (sqlite3_changes(impl_->db) == 0) {
-        throw std::invalid_argument("Harness run revision binding is immutable");
+        throw std::invalid_argument(
+            "Harness run binding is immutable or its source run is unavailable");
     }
 }
 
@@ -467,6 +541,121 @@ std::vector<json> SqliteHarnessRecordStore::list_events(const std::string& run_i
         events.push_back(std::move(event));
     }
     return events;
+}
+
+HarnessRetentionResult SqliteHarnessRecordStore::cleanup_retained(
+    const HarnessRetentionPolicy& policy) {
+    std::set<std::string> protected_runs;
+    std::set<std::string> protected_artifacts;
+    for (const auto& run_id : policy.protected_run_ids) {
+        validate_id(run_id);
+        protected_runs.insert(run_id);
+    }
+    for (const auto& artifact_id : policy.protected_artifact_ids) {
+        validate_id(artifact_id);
+        protected_artifacts.insert(artifact_id);
+    }
+
+    HarnessRetentionResult result;
+    std::lock_guard        lock(impl_->mutex);
+    impl_->exec("BEGIN IMMEDIATE;");
+    try {
+        const auto count = [&](const char* table) {
+            const std::string sql = std::string("SELECT COUNT(*) FROM ") + table;
+            Statement         statement(impl_->db, sql.c_str());
+            if (statement.step() != SQLITE_ROW) {
+                throw_sqlite_error(impl_->db, "retention count failed");
+            }
+            return static_cast<std::size_t>(statement.int64(0));
+        };
+
+        auto run_count = count("neograph_harness_runs");
+        while (run_count > policy.max_runs) {
+            Statement candidates(
+                impl_->db,
+                "SELECT candidate.run_id FROM neograph_harness_runs AS candidate "
+                "WHERE candidate.status IN "
+                "('completed','failed','cancelled','timeout','expired','max_steps_exhausted') "
+                "AND NOT EXISTS (SELECT 1 FROM neograph_harness_runs AS dependent "
+                "WHERE dependent.source_run_id=candidate.run_id) "
+                "ORDER BY candidate.updated_at_ms, candidate.run_id");
+            std::string run_id;
+            while (true) {
+                const auto step = candidates.step();
+                if (step == SQLITE_DONE) break;
+                if (step != SQLITE_ROW) {
+                    throw_sqlite_error(impl_->db, "retention run scan failed");
+                }
+                const auto candidate = candidates.text(0);
+                if (!protected_runs.contains(candidate)) {
+                    run_id = candidate;
+                    break;
+                }
+            }
+            if (run_id.empty()) break;
+
+            Statement delete_journal(impl_->db,
+                                     "DELETE FROM neograph_harness_journal WHERE run_id=?");
+            delete_journal.bind_text(1, run_id);
+            if (delete_journal.step() != SQLITE_DONE) {
+                throw_sqlite_error(impl_->db, "retention journal delete failed");
+            }
+            Statement delete_run(impl_->db, "DELETE FROM neograph_harness_runs WHERE run_id=?");
+            delete_run.bind_text(1, run_id);
+            if (delete_run.step() != SQLITE_DONE) {
+                throw_sqlite_error(impl_->db, "retention run delete failed");
+            }
+            if (sqlite3_changes(impl_->db) != 1) {
+                throw std::runtime_error("SqliteHarnessRecordStore: retention lost run candidate");
+            }
+            result.run_ids.push_back(std::move(run_id));
+            --run_count;
+        }
+
+        auto artifact_count = count("neograph_harness_artifacts");
+        while (artifact_count > policy.max_artifacts) {
+            Statement candidates(
+                impl_->db,
+                "SELECT artifact.artifact_id FROM neograph_harness_artifacts AS artifact "
+                "WHERE NOT EXISTS (SELECT 1 FROM neograph_harness_runs AS run "
+                "WHERE run.artifact_id=artifact.artifact_id) "
+                "ORDER BY artifact.created_at_ms, artifact.artifact_id");
+            std::string artifact_id;
+            while (true) {
+                const auto step = candidates.step();
+                if (step == SQLITE_DONE) break;
+                if (step != SQLITE_ROW) {
+                    throw_sqlite_error(impl_->db, "retention artifact scan failed");
+                }
+                const auto candidate = candidates.text(0);
+                if (!protected_artifacts.contains(candidate)) {
+                    artifact_id = candidate;
+                    break;
+                }
+            }
+            if (artifact_id.empty()) break;
+
+            Statement delete_artifact(impl_->db,
+                                      "DELETE FROM neograph_harness_artifacts WHERE artifact_id=?");
+            delete_artifact.bind_text(1, artifact_id);
+            if (delete_artifact.step() != SQLITE_DONE) {
+                throw_sqlite_error(impl_->db, "retention artifact delete failed");
+            }
+            if (sqlite3_changes(impl_->db) != 1) {
+                throw std::runtime_error(
+                    "SqliteHarnessRecordStore: retention lost artifact candidate");
+            }
+            result.artifact_ids.push_back(std::move(artifact_id));
+            --artifact_count;
+        }
+        impl_->exec("COMMIT;");
+    } catch (...) {
+        try {
+            impl_->exec("ROLLBACK;");
+        } catch (...) {}
+        throw;
+    }
+    return result;
 }
 
 }  // namespace neograph::mcp

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -1486,6 +1486,78 @@ TEST(HarnessServiceTest, CompatibleForkResumesExactCheckpointWithTargetArtifact)
     EXPECT_TRUE(saw_fork_anchor);
 }
 
+TEST(HarnessServiceTest, CompatibleForkLoadsSourceAndTargetAcrossSqliteReconnect) {
+    const auto           root = unique_temp_path("neograph-harness-fork-reconnect");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    const auto       records_database    = root / "runs.db";
+    const auto       checkpoint_database = root / "checkpoints.db";
+    std::atomic<int> live_calls{0};
+    std::string      source_run_id;
+    std::string      source_checkpoint_id;
+    std::string      target_artifact_id;
+
+    {
+        auto checkpoints =
+            std::make_shared<neograph::graph::SqliteCheckpointStore>(checkpoint_database.string());
+        HarnessServiceConfig config;
+        config.record_store =
+            std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(records_database.string());
+        config.checkpoint_store = checkpoints;
+        config.worker_executor  = [&](const HarnessWorkerCall&, const auto&) {
+            live_calls.fetch_add(1, std::memory_order_relaxed);
+            return HarnessWorkerResponse::success({
+                {"status", "ok"},
+                {"findings", json::array({{{"evidence", "durable source"}}})},
+            });
+        };
+        HarnessService service(std::move(config));
+        const auto     source_artifact = service.compile(dsl_request("judge"));
+        ASSERT_TRUE(source_artifact["ok"].get<bool>()) << source_artifact.dump();
+        const auto source_start = service.start({{"artifact_id", source_artifact["artifact_id"]}});
+        source_run_id           = source_start["run_id"].get<std::string>();
+        ASSERT_EQ(wait_terminal(service, source_run_id)["status"], "completed");
+        for (const auto& checkpoint : checkpoints->list(source_run_id)) {
+            if (checkpoint.next_nodes.size() == 1 && checkpoint.next_nodes[0] == "judge") {
+                source_checkpoint_id = checkpoint.id;
+                break;
+            }
+        }
+        ASSERT_FALSE(source_checkpoint_id.empty());
+
+        auto repaired                          = dsl_request("judge");
+        repaired["workers"][0]["instructions"] = "Durably repaired instructions";
+        const auto target_artifact             = service.compile(repaired);
+        ASSERT_TRUE(target_artifact["ok"].get<bool>()) << target_artifact.dump();
+        target_artifact_id = target_artifact["artifact_id"].get<std::string>();
+    }
+
+    {
+        HarnessServiceConfig config;
+        config.record_store =
+            std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(records_database.string());
+        config.checkpoint_store =
+            std::make_shared<neograph::graph::SqliteCheckpointStore>(checkpoint_database.string());
+        config.worker_executor = [&](const HarnessWorkerCall&, const auto&) {
+            live_calls.fetch_add(1, std::memory_order_relaxed);
+            return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+        };
+        HarnessService service(std::move(config));
+        const auto     started = service.start({
+            {"fork",
+                 {{"source_run_id", source_run_id},
+                  {"checkpoint_id", source_checkpoint_id},
+                  {"artifact_id", target_artifact_id}}},
+        });
+        ASSERT_TRUE(started["started"].get<bool>()) << started.dump();
+        const auto finished = wait_terminal(service, started["run_id"].get<std::string>());
+        ASSERT_EQ(finished["status"], "completed") << finished.dump();
+        ASSERT_EQ(finished["result"]["findings"].size(), 1u);
+        EXPECT_EQ(finished["result"]["findings"][0]["evidence"], "durable source");
+    }
+    EXPECT_EQ(live_calls.load(std::memory_order_relaxed), 1);
+}
+
 TEST(HarnessServiceTest, IncompatibleForkReturnsChannelAndContinuationDiagnosticsBeforeRun) {
     const auto           root = unique_temp_path("neograph-harness-incompatible-fork");
     TempDirectoryCleanup cleanup(root);

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -1497,6 +1497,15 @@ TEST(HarnessServiceTest, DebugViewsExposeJournalAndCheckpointHistoryThroughUris)
     ASSERT_FALSE(checkpoints["result"]["checkpoints"].empty());
     EXPECT_TRUE(checkpoints["result"]["checkpoints"][0].contains("checkpoint_id"));
     EXPECT_FALSE(checkpoints["result"]["checkpoints"][0].contains("channel_values"));
+    for (const auto& checkpoint : checkpoint_store->list(run_id)) {
+        ASSERT_TRUE(checkpoint.metadata.contains("harness"));
+        const auto binding = checkpoint.metadata["harness"];
+        EXPECT_EQ(binding["run_id"], run_id);
+        EXPECT_EQ(binding["artifact_id"], compiled["artifact_id"]);
+        EXPECT_EQ(binding["revision_digest"], finished["revision_digest"]);
+        EXPECT_EQ(binding["protocol_version"], "2025-11-25");
+        EXPECT_EQ(binding["profile"], "harness-m4");
+    }
 
     const auto diffs = service.read(artifacts["diff"]["uri"].get<std::string>() + "?limit=2");
     ASSERT_TRUE(diffs["result"]["available"].get<bool>());

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -70,6 +70,39 @@ json request(json workers = json::array({worker("reviewer")})) {
     };
 }
 
+json dsl_request(std::string judge_name, std::string worker_results_reducer = "append") {
+    auto       value       = request();
+    const auto worker_node = "worker_0";
+    value["harness"]       = {
+        {"mode", "dsl"},
+        {"definition",
+               {
+             {"schema_version", 1},
+             {"name", "fork_compatibility_test"},
+             {"channels",
+                    {
+                  {"task", {{"reducer", "overwrite"}, {"initial", json::object()}}},
+                  {"worker_results",
+                         {{"reducer", std::move(worker_results_reducer)}, {"initial", json::array()}}},
+                  {"final_result", {{"reducer", "overwrite"}, {"initial", nullptr}}},
+              }},
+             {"nodes",
+                    {
+                  {worker_node, {{"type", "neograph_harness_worker"}, {"worker_id", "reviewer"}}},
+                  {judge_name,
+                         {{"type", "neograph_harness_judge"},
+                          {"barrier", {{"wait_for", json::array({worker_node})}}}}},
+              }},
+             {"edges", json::array({
+                           {{"from", "__start__"}, {"to", worker_node}},
+                           {{"from", worker_node}, {"to", judge_name}},
+                           {{"from", judge_name}, {"to", "__end__"}},
+                       })},
+         }},
+    };
+    return value;
+}
+
 json host_brokered_request(std::string interaction = "tool_result") {
     auto value                   = request();
     value["workers"][0]["tools"] = json::array({"host.lookup"});
@@ -224,6 +257,7 @@ TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
     EXPECT_EQ(listed["result"]["tools"][5]["name"], "neograph_start");
     bool saw_debug_views = false;
     bool saw_replay      = false;
+    bool saw_fork        = false;
     for (const auto& tool : listed["result"]["tools"]) {
         EXPECT_TRUE(tool.contains("outputSchema"));
         EXPECT_EQ(tool["inputSchema"].value("type", ""), "object");
@@ -236,11 +270,15 @@ TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
         } else if (tool["name"] == "neograph_start") {
             const auto replay = tool["inputSchema"]["properties"]["replay"];
             EXPECT_EQ(replay["properties"]["mode"]["enum"].size(), 2u);
+            const auto fork = tool["inputSchema"]["properties"]["fork"];
+            EXPECT_EQ(fork["required"].size(), 3u);
             saw_replay = true;
+            saw_fork   = true;
         }
     }
     EXPECT_TRUE(saw_debug_views);
     EXPECT_TRUE(saw_replay);
+    EXPECT_TRUE(saw_fork);
 
     auto invalid_get = server.handle_message({
         {"jsonrpc", "2.0"},
@@ -1373,6 +1411,141 @@ TEST(HarnessServiceTest, DebugViewsExposeJournalAndCheckpointHistoryThroughUris)
                  std::invalid_argument);
     EXPECT_THROW(service.read(artifacts["trace"]["uri"].get<std::string>() + "?limit=1&limit=2"),
                  std::invalid_argument);
+}
+
+TEST(HarnessServiceTest, CompatibleForkResumesExactCheckpointWithTargetArtifact) {
+    const auto           root = unique_temp_path("neograph-harness-compatible-fork");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    auto records     = std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+    auto checkpoints = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    std::atomic<int>     live_calls{0};
+    HarnessServiceConfig config;
+    config.record_store     = records;
+    config.checkpoint_store = checkpoints;
+    config.worker_executor  = [&](const HarnessWorkerCall&, const auto&) {
+        live_calls.fetch_add(1, std::memory_order_relaxed);
+        return HarnessWorkerResponse::success({
+            {"status", "ok"},
+            {"findings", json::array({{{"evidence", "source checkpoint"}}})},
+        });
+    };
+    HarnessService service(std::move(config));
+
+    const auto source_artifact = service.compile(dsl_request("judge"));
+    ASSERT_TRUE(source_artifact["ok"].get<bool>()) << source_artifact.dump();
+    const auto source_start  = service.start({{"artifact_id", source_artifact["artifact_id"]}});
+    const auto source_run_id = source_start["run_id"].get<std::string>();
+    ASSERT_EQ(wait_terminal(service, source_run_id)["status"], "completed");
+    ASSERT_EQ(live_calls.load(std::memory_order_relaxed), 1);
+
+    std::string source_checkpoint_id;
+    for (const auto& checkpoint : checkpoints->list(source_run_id)) {
+        if (checkpoint.next_nodes.size() == 1 && checkpoint.next_nodes[0] == "judge") {
+            source_checkpoint_id = checkpoint.id;
+            break;
+        }
+    }
+    ASSERT_FALSE(source_checkpoint_id.empty());
+
+    auto repaired_request                          = dsl_request("judge");
+    repaired_request["workers"][0]["instructions"] = "Repaired worker instructions";
+    const auto target_artifact                     = service.compile(repaired_request);
+    ASSERT_TRUE(target_artifact["ok"].get<bool>()) << target_artifact.dump();
+    ASSERT_NE(target_artifact["artifact_id"], source_artifact["artifact_id"]);
+
+    const auto started = service.start({
+        {"fork",
+         {{"source_run_id", source_run_id},
+          {"checkpoint_id", source_checkpoint_id},
+          {"artifact_id", target_artifact["artifact_id"]}}},
+    });
+    ASSERT_TRUE(started["started"].get<bool>()) << started.dump();
+    EXPECT_EQ(started["execution_mode"], "compatible_fork");
+    EXPECT_EQ(started["source_run_id"], source_run_id);
+    EXPECT_EQ(started["source_checkpoint_id"], source_checkpoint_id);
+
+    const auto fork_run_id = started["run_id"].get<std::string>();
+    const auto finished    = wait_terminal(service, fork_run_id);
+    ASSERT_EQ(finished["status"], "completed") << finished.dump();
+    EXPECT_EQ(finished["execution_mode"], "compatible_fork");
+    EXPECT_EQ(finished["source_checkpoint_id"], source_checkpoint_id);
+    ASSERT_EQ(finished["result"]["findings"].size(), 1u);
+    EXPECT_EQ(finished["result"]["findings"][0]["evidence"], "source checkpoint");
+    EXPECT_EQ(live_calls.load(std::memory_order_relaxed), 1)
+        << "forking after the worker checkpoint must not execute the worker again";
+
+    bool saw_fork_anchor = false;
+    for (const auto& checkpoint : checkpoints->list(fork_run_id)) {
+        if (!checkpoint.metadata.contains("forked_from")) continue;
+        EXPECT_EQ(checkpoint.parent_id, source_checkpoint_id);
+        EXPECT_EQ(checkpoint.metadata["forked_from"]["thread_id"], source_run_id);
+        EXPECT_EQ(checkpoint.metadata["forked_from"]["checkpoint_id"], source_checkpoint_id);
+        saw_fork_anchor = true;
+    }
+    EXPECT_TRUE(saw_fork_anchor);
+}
+
+TEST(HarnessServiceTest, IncompatibleForkReturnsChannelAndContinuationDiagnosticsBeforeRun) {
+    const auto           root = unique_temp_path("neograph-harness-incompatible-fork");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    auto records     = std::make_shared<neograph::mcp::FileHarnessRecordStore>(root.string());
+    auto checkpoints = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    HarnessServiceConfig config;
+    config.record_store     = records;
+    config.checkpoint_store = checkpoints;
+    config.max_runs         = 1;
+    config.worker_executor  = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+
+    const auto source_artifact = service.compile(dsl_request("source_judge"));
+    ASSERT_TRUE(source_artifact["ok"].get<bool>()) << source_artifact.dump();
+    const auto source_start  = service.start({{"artifact_id", source_artifact["artifact_id"]}});
+    const auto source_run_id = source_start["run_id"].get<std::string>();
+    ASSERT_EQ(wait_terminal(service, source_run_id)["status"], "completed");
+
+    std::string source_checkpoint_id;
+    for (const auto& checkpoint : checkpoints->list(source_run_id)) {
+        if (checkpoint.next_nodes.size() == 1 && checkpoint.next_nodes[0] == "source_judge") {
+            source_checkpoint_id = checkpoint.id;
+            break;
+        }
+    }
+    ASSERT_FALSE(source_checkpoint_id.empty());
+
+    const auto target_artifact = service.compile(dsl_request("target_judge", "overwrite"));
+    ASSERT_TRUE(target_artifact["ok"].get<bool>()) << target_artifact.dump();
+    const auto rejected = service.start({
+        {"fork",
+         {{"source_run_id", source_run_id},
+          {"checkpoint_id", source_checkpoint_id},
+          {"artifact_id", target_artifact["artifact_id"]}}},
+    });
+    ASSERT_FALSE(rejected["started"].get<bool>());
+    EXPECT_EQ(rejected["status"], "incompatible_fork");
+    EXPECT_EQ(rejected["source_checkpoint_id"], source_checkpoint_id);
+
+    bool saw_reducer   = false;
+    bool saw_next_node = false;
+    for (const auto& diagnostic : rejected["diagnostics"]) {
+        EXPECT_EQ(diagnostic["phase"], "compatibility");
+        EXPECT_TRUE(diagnostic.contains("witness"));
+        if (diagnostic["code"] == "H_FORK_CHANNEL_REDUCER") {
+            EXPECT_EQ(diagnostic["witness"]["channel"], "worker_results");
+            EXPECT_EQ(diagnostic["witness"]["source_reducer"], "append");
+            EXPECT_EQ(diagnostic["witness"]["target_reducer"], "overwrite");
+            saw_reducer = true;
+        }
+        if (diagnostic["code"] == "H_FORK_NEXT_NODE") {
+            EXPECT_EQ(diagnostic["witness"]["node_id"], "source_judge");
+            saw_next_node = true;
+        }
+    }
+    EXPECT_TRUE(saw_reducer) << rejected.dump();
+    EXPECT_TRUE(saw_next_node) << rejected.dump();
 }
 
 TEST(HarnessServiceTest, RecordedReplaySurvivesReconnectWithoutCallingLiveExecutor) {

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -222,10 +222,19 @@ TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
     EXPECT_EQ(listed["result"]["tools"][0]["name"], "neograph_cancel");
     EXPECT_EQ(listed["result"]["tools"][4]["name"], "neograph_schema");
     EXPECT_EQ(listed["result"]["tools"][5]["name"], "neograph_start");
+    bool saw_debug_views = false;
     for (const auto& tool : listed["result"]["tools"]) {
         EXPECT_TRUE(tool.contains("outputSchema"));
         EXPECT_EQ(tool["inputSchema"].value("type", ""), "object");
+        if (tool["name"] == "neograph_get") {
+            const auto schema = tool["inputSchema"]["properties"];
+            EXPECT_EQ(schema["limit"]["maximum"], 1000);
+            EXPECT_EQ(schema["after_sequence"]["minimum"], 0);
+            EXPECT_EQ(schema["view"]["enum"].size(), 7u);
+            saw_debug_views = true;
+        }
     }
+    EXPECT_TRUE(saw_debug_views);
 
     auto invalid_get = server.handle_message({
         {"jsonrpc", "2.0"},
@@ -277,6 +286,60 @@ TEST(HarnessServiceTest, JournalFailureFailsRunWithoutEscapingWorkerThread) {
     const auto failed = wait_terminal(service, started["run_id"].get<std::string>());
     EXPECT_EQ(failed["status"], "failed");
     EXPECT_NE(failed["error"].get<std::string>().find("journal unavailable"), std::string::npos);
+}
+
+TEST(HarnessServiceTest, DebugViewsReportUnavailableWithoutDurableStores) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+    const auto     compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto run_id  = started["run_id"].get<std::string>();
+    ASSERT_EQ(wait_terminal(service, run_id)["status"], "completed");
+
+    const auto attempts = service.get(run_id, "attempts");
+    EXPECT_FALSE(attempts["result"]["journal_available"].get<bool>());
+    EXPECT_TRUE(attempts["result"]["events"].empty());
+    const auto checkpoints = service.get(run_id, "checkpoints");
+    EXPECT_FALSE(checkpoints["result"]["available"].get<bool>());
+    EXPECT_TRUE(checkpoints["result"]["checkpoints"].empty());
+    const auto diff = service.get(run_id, "diff");
+    EXPECT_FALSE(diff["result"]["available"].get<bool>());
+    EXPECT_TRUE(diff["result"]["diffs"].empty());
+
+    EXPECT_THROW(service.get(run_id, "status", 1, 100), std::invalid_argument);
+    EXPECT_THROW(service.get(run_id, "details", 0, 1), std::invalid_argument);
+    EXPECT_THROW(service.get(run_id, "attempts", 0, 0), std::invalid_argument);
+    EXPECT_THROW(service.get(run_id, "attempts", 0, 1001), std::invalid_argument);
+}
+
+TEST(HarnessServiceTest, TraceIsReadableBeforeRunDetailsExist) {
+    std::atomic<bool>    release_worker{false};
+    HarnessServiceConfig config;
+    config.worker_executor = [&](const HarnessWorkerCall&, const auto&) {
+        while (!release_worker.load(std::memory_order_acquire)) {
+            std::this_thread::sleep_for(1ms);
+        }
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+    const auto     compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto run_id  = started["run_id"].get<std::string>();
+
+    json trace;
+    try {
+        trace = service.get(run_id, "trace");
+    } catch (const std::exception& error) {
+        ADD_FAILURE() << error.what();
+    }
+    release_worker.store(true, std::memory_order_release);
+    EXPECT_TRUE(trace["result"]["execution_trace"].empty());
+    EXPECT_EQ(wait_terminal(service, run_id)["status"], "completed");
 }
 
 TEST(HarnessServiceTest, PresetAndEquivalentDslCompileToCanonicalCore) {
@@ -1202,6 +1265,108 @@ TEST(HarnessServiceTest, JournalCorrelatesProviderAndCapabilityCallsToWorkerAtte
     EXPECT_TRUE(capability_completed);
     EXPECT_TRUE(worker_completed);
     EXPECT_TRUE(terminal);
+}
+
+TEST(HarnessServiceTest, DebugViewsExposeJournalAndCheckpointHistoryThroughUris) {
+    const auto           root = unique_temp_path("neograph-harness-debug-views");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    auto records =
+        std::make_shared<neograph::mcp::SqliteHarnessRecordStore>((root / "runs.db").string());
+    auto checkpoint_store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    HarnessServiceConfig config;
+    config.record_store     = records;
+    config.checkpoint_store = checkpoint_store;
+    config.worker_executor  = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success({
+            {"status", "ok"},
+            {"findings", json::array({{{"evidence", "line 1"}}})},
+        });
+    };
+    HarnessService service(std::move(config));
+    const auto     compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started  = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto run_id   = started["run_id"].get<std::string>();
+    const auto finished = wait_terminal(service, run_id);
+    ASSERT_EQ(finished["status"], "completed") << finished.dump();
+
+    const auto artifacts = service.get(run_id, "artifacts")["result"];
+    ASSERT_TRUE(artifacts.contains("attempts"));
+    ASSERT_TRUE(artifacts.contains("checkpoints"));
+    ASSERT_TRUE(artifacts.contains("diff"));
+
+    json       attempts;
+    const auto journal_deadline = std::chrono::steady_clock::now() + 1s;
+    do {
+        attempts = service.get(run_id, "attempts", 0, 1);
+        if (attempts["result"]["has_more"].get<bool>()) break;
+        std::this_thread::sleep_for(2ms);
+    } while (std::chrono::steady_clock::now() < journal_deadline);
+    ASSERT_TRUE(attempts["result"]["journal_available"].get<bool>());
+    ASSERT_EQ(attempts["result"]["events"].size(), 1u);
+    ASSERT_TRUE(attempts["result"]["has_more"].get<bool>());
+    const auto cursor       = attempts["result"]["next_after_sequence"].get<std::size_t>();
+    const auto attempts_uri = artifacts["attempts"]["uri"].get<std::string>() +
+                              "?after_sequence=" + std::to_string(cursor) + "&limit=1";
+    const auto next_attempt = service.read(attempts_uri);
+    ASSERT_EQ(next_attempt["result"]["events"].size(), 1u);
+    EXPECT_GT(next_attempt["result"]["events"][0]["sequence"].get<std::size_t>(), cursor);
+    EXPECT_EQ(next_attempt["result"]["events"][0]["payload"]["output"], "[REDACTED]");
+
+    const auto trace = service.read(artifacts["trace"]["uri"].get<std::string>() + "?limit=2");
+    EXPECT_FALSE(trace["result"]["execution_trace"].empty());
+    EXPECT_LE(trace["result"]["events"].size(), 2u);
+
+    const auto checkpoints = service.read(artifacts["checkpoints"]["uri"].get<std::string>());
+    ASSERT_TRUE(checkpoints["result"]["available"].get<bool>());
+    ASSERT_FALSE(checkpoints["result"]["checkpoints"].empty());
+    EXPECT_TRUE(checkpoints["result"]["checkpoints"][0].contains("checkpoint_id"));
+    EXPECT_FALSE(checkpoints["result"]["checkpoints"][0].contains("channel_values"));
+
+    const auto diffs = service.read(artifacts["diff"]["uri"].get<std::string>() + "?limit=2");
+    ASSERT_TRUE(diffs["result"]["available"].get<bool>());
+    ASSERT_FALSE(diffs["result"]["diffs"].empty());
+    EXPECT_TRUE(diffs["result"]["diffs"][0].contains("changed_channels"));
+    bool saw_channel_change = false;
+    for (const auto& diff : diffs["result"]["diffs"]) {
+        if (!diff["changed_channels"].empty()) saw_channel_change = true;
+    }
+    EXPECT_TRUE(saw_channel_change);
+
+    neograph::graph::Checkpoint legacy_parent;
+    legacy_parent.id             = "legacy-parent";
+    legacy_parent.thread_id      = run_id;
+    legacy_parent.channel_values = {{"channels", {{"legacy", "before"}}}};
+    legacy_parent.step           = 100;
+    checkpoint_store->save(legacy_parent);
+    auto legacy_child           = legacy_parent;
+    legacy_child.id             = "legacy-child";
+    legacy_child.parent_id      = legacy_parent.id;
+    legacy_child.channel_values = {{"channels", {{"legacy", "after"}}}};
+    legacy_child.step           = 101;
+    checkpoint_store->save(legacy_child);
+    auto orphan      = legacy_child;
+    orphan.id        = "orphan";
+    orphan.parent_id = "missing-parent";
+    orphan.step      = 102;
+    checkpoint_store->save(orphan);
+
+    const auto legacy_diffs = service.get(run_id, "diff", 0, 3)["result"]["diffs"];
+    ASSERT_EQ(legacy_diffs.size(), 3u);
+    EXPECT_FALSE(legacy_diffs[0]["parent_available"].get<bool>());
+    ASSERT_EQ(legacy_diffs[1]["changed_channels"].size(), 1u);
+    EXPECT_EQ(legacy_diffs[1]["changed_channels"][0]["before"], "before");
+    EXPECT_EQ(legacy_diffs[1]["changed_channels"][0]["after"], "after");
+    EXPECT_THROW(
+        service.read(artifacts["checkpoints"]["uri"].get<std::string>() + "?after_sequence=1"),
+        std::invalid_argument);
+    EXPECT_THROW(service.read(artifacts["trace"]["uri"].get<std::string>() + "?unknown=1"),
+                 std::invalid_argument);
+    EXPECT_THROW(service.read(artifacts["trace"]["uri"].get<std::string>() + "?"),
+                 std::invalid_argument);
+    EXPECT_THROW(service.read(artifacts["trace"]["uri"].get<std::string>() + "?limit=1&limit=2"),
+                 std::invalid_argument);
 }
 
 TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -1283,6 +1283,64 @@ TEST(HarnessServiceTest, SqliteRetentionDeletesTerminalLeavesBeforeReferencedSou
     EXPECT_TRUE(records.load_artifact("artifact_3").has_value());
 }
 
+TEST(HarnessServiceTest, HarnessCapacityCleanupPreservesReplaySourceAndDropsLeafCheckpoints) {
+    const auto           root = unique_temp_path("neograph-harness-capacity-cleanup");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    auto records =
+        std::make_shared<neograph::mcp::SqliteHarnessRecordStore>((root / "runs.db").string());
+    auto                 checkpoints = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
+    std::atomic<int>     calls{0};
+    HarnessServiceConfig config;
+    config.record_store     = records;
+    config.checkpoint_store = checkpoints;
+    config.max_artifacts    = 2;
+    config.max_runs         = 2;
+    config.worker_executor  = [&](const HarnessWorkerCall&, const auto&) {
+        calls.fetch_add(1, std::memory_order_relaxed);
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+
+    auto first_request                       = request();
+    first_request["task"]["objective"]       = "first";
+    const auto first                         = service.compile(first_request);
+    auto       source_request                = request();
+    source_request["task"]["objective"]      = "source";
+    const auto source                        = service.compile(source_request);
+    auto       replacement_request           = request();
+    replacement_request["task"]["objective"] = "replacement";
+    const auto replacement                   = service.compile(replacement_request);
+    ASSERT_TRUE(first["ok"].get<bool>() && source["ok"].get<bool>() &&
+                replacement["ok"].get<bool>());
+    EXPECT_FALSE(records->load_artifact(first["artifact_id"].get<std::string>()).has_value());
+    EXPECT_TRUE(records->load_artifact(source["artifact_id"].get<std::string>()).has_value());
+
+    const auto source_start  = service.start({{"artifact_id", source["artifact_id"]}});
+    const auto source_run_id = source_start["run_id"].get<std::string>();
+    ASSERT_EQ(wait_terminal(service, source_run_id)["status"], "completed");
+    const auto replay_start  = service.start({
+        {"replay", {{"source_run_id", source_run_id}, {"mode", "live"}}},
+    });
+    const auto replay_run_id = replay_start["run_id"].get<std::string>();
+    ASSERT_EQ(wait_terminal(service, replay_run_id)["status"], "completed");
+
+    const auto deadline = std::chrono::steady_clock::now() + 1s;
+    while (records->list_events(replay_run_id).empty() &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(2ms);
+    }
+    std::this_thread::sleep_for(2ms);
+    const auto replacement_start = service.start({{"artifact_id", replacement["artifact_id"]}});
+    ASSERT_EQ(wait_terminal(service, replacement_start["run_id"].get<std::string>())["status"],
+              "completed");
+
+    EXPECT_TRUE(records->load_run(source_run_id).has_value());
+    EXPECT_FALSE(records->load_run(replay_run_id).has_value());
+    EXPECT_TRUE(checkpoints->list(replay_run_id).empty());
+    EXPECT_EQ(calls.load(std::memory_order_relaxed), 3);
+}
+
 TEST(HarnessServiceTest, JournalCorrelatesProviderAndCapabilityCallsToWorkerAttempt) {
     const auto root = unique_temp_path("neograph-harness-journal-correlation");
     TempDirectoryCleanup cleanup(root);

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -18,6 +18,10 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#ifndef _WIN32
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 
 using namespace std::chrono_literals;
 
@@ -1038,6 +1042,9 @@ TEST(HarnessServiceTest, SqliteRecordStoreBusyTimeoutWaitsForWriter) {
     sqlite3*                                 blocker = nullptr;
     ASSERT_EQ(sqlite3_open(database.string().c_str(), &blocker), SQLITE_OK);
     ASSERT_EQ(sqlite3_exec(blocker, "BEGIN IMMEDIATE;", nullptr, nullptr, nullptr), SQLITE_OK);
+    ASSERT_EQ(records.load_artifact("artifact_1"),
+              std::optional<json>({{"artifact_id", "artifact_1"}, {"request", json::object()}}))
+        << "WAL readers must remain available while another connection owns the writer lock";
 
     std::exception_ptr failure;
     const auto started = std::chrono::steady_clock::now();
@@ -1210,6 +1217,130 @@ INSERT INTO neograph_harness_runs VALUES
     ASSERT_EQ(records.list_events("run_1").size(), 1u);
     EXPECT_EQ(records.list_events("run_1")[0]["event_type"], "migration.verified");
 }
+
+TEST(HarnessServiceTest, SqliteSchemaMigrationRollsBackOnMalformedLegacyRecord) {
+    const auto           root = unique_temp_path("neograph-harness-migration-rollback");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    const auto database = root / "runs.db";
+    sqlite3*   legacy   = nullptr;
+    ASSERT_EQ(sqlite3_open(database.string().c_str(), &legacy), SQLITE_OK);
+    ASSERT_EQ(sqlite3_exec(legacy, R"SQL(
+CREATE TABLE neograph_harness_schema (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1), version INTEGER NOT NULL
+);
+INSERT INTO neograph_harness_schema VALUES (1, 2);
+CREATE TABLE neograph_harness_artifacts (
+    artifact_id TEXT PRIMARY KEY, record_json TEXT NOT NULL, created_at_ms INTEGER NOT NULL
+);
+CREATE TABLE neograph_harness_runs (
+    run_id TEXT PRIMARY KEY, artifact_id TEXT NOT NULL, revision_digest TEXT NOT NULL DEFAULT '',
+    protocol_version TEXT NOT NULL DEFAULT '', profile TEXT NOT NULL DEFAULT '',
+    record_json TEXT NOT NULL, updated_at_ms INTEGER NOT NULL,
+    FOREIGN KEY (artifact_id) REFERENCES neograph_harness_artifacts (artifact_id)
+);
+INSERT INTO neograph_harness_artifacts VALUES
+    ('artifact_1', '{"artifact_id":"artifact_1","request":{}}', 1);
+INSERT INTO neograph_harness_runs VALUES
+    ('run_1', 'artifact_1', '', '', '', '{malformed', 1);
+)SQL",
+                           nullptr, nullptr, nullptr),
+              SQLITE_OK);
+    sqlite3_close(legacy);
+
+    EXPECT_THROW(neograph::mcp::SqliteHarnessRecordStore records(database.string()),
+                 std::exception);
+    ASSERT_EQ(sqlite3_open(database.string().c_str(), &legacy), SQLITE_OK);
+    sqlite3_stmt* version = nullptr;
+    ASSERT_EQ(
+        sqlite3_prepare_v2(legacy, "SELECT version FROM neograph_harness_schema WHERE singleton=1",
+                           -1, &version, nullptr),
+        SQLITE_OK);
+    ASSERT_EQ(sqlite3_step(version), SQLITE_ROW);
+    EXPECT_EQ(sqlite3_column_int(version, 0), 2);
+    sqlite3_finalize(version);
+    sqlite3_stmt* columns = nullptr;
+    ASSERT_EQ(sqlite3_prepare_v2(legacy, "PRAGMA table_info(neograph_harness_runs)", -1, &columns,
+                                 nullptr),
+              SQLITE_OK);
+    bool saw_status = false;
+    while (sqlite3_step(columns) == SQLITE_ROW) {
+        const auto* name = sqlite3_column_text(columns, 1);
+        if (name && std::string(reinterpret_cast<const char*>(name)) == "status") {
+            saw_status = true;
+        }
+    }
+    sqlite3_finalize(columns);
+    EXPECT_FALSE(saw_status) << "failed migration must roll back its ALTER TABLE statements";
+    ASSERT_EQ(sqlite3_exec(legacy,
+                           "UPDATE neograph_harness_runs SET record_json="
+                           "'{\"run_id\":\"run_1\",\"artifact_id\":\"artifact_1\","
+                           "\"status\":\"completed\"}' WHERE run_id='run_1'",
+                           nullptr, nullptr, nullptr),
+              SQLITE_OK);
+    sqlite3_close(legacy);
+
+    neograph::mcp::SqliteHarnessRecordStore migrated(database.string());
+    ASSERT_TRUE(migrated.load_run("run_1").has_value());
+}
+
+#ifndef _WIN32
+TEST(HarnessServiceTest, SqliteJournalRollsBackAbruptWriterProcessDeath) {
+    const auto           root = unique_temp_path("neograph-harness-abrupt-death");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    const auto database = root / "runs.db";
+    {
+        neograph::mcp::SqliteHarnessRecordStore records(database.string());
+        records.save_artifact("artifact_1", {
+                                                {"artifact_id", "artifact_1"},
+                                                {"request", json::object()},
+                                            });
+        records.save_run("run_1", {
+                                      {"run_id", "run_1"},
+                                      {"artifact_id", "artifact_1"},
+                                      {"revision_digest", "revision"},
+                                      {"protocol_version", "protocol"},
+                                      {"profile", "profile"},
+                                      {"status", "running"},
+                                  });
+    }
+
+    const auto child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        sqlite3* writer = nullptr;
+        if (sqlite3_open(database.string().c_str(), &writer) != SQLITE_OK) _exit(2);
+        const auto result = sqlite3_exec(writer, R"SQL(
+BEGIN IMMEDIATE;
+INSERT INTO neograph_harness_journal
+    (run_id, sequence, artifact_id, revision_digest, protocol_version, profile,
+     event_type, payload_json, created_at_ms)
+VALUES ('run_1', 1, 'artifact_1', 'revision', 'protocol', 'profile',
+        'partial.event', '{}', 1);
+)SQL",
+                                         nullptr, nullptr, nullptr);
+        _exit(result == SQLITE_OK ? 0 : 3);
+    }
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+    ASSERT_TRUE(WIFEXITED(status));
+    ASSERT_EQ(WEXITSTATUS(status), 0);
+
+    neograph::mcp::SqliteHarnessRecordStore records(database.string());
+    EXPECT_TRUE(records.list_events("run_1").empty());
+    records.append_event({
+        {"run_id", "run_1"},
+        {"artifact_id", "artifact_1"},
+        {"revision_digest", "revision"},
+        {"protocol_version", "protocol"},
+        {"profile", "profile"},
+        {"event_type", "recovered.event"},
+        {"payload", json::object()},
+    });
+    ASSERT_EQ(records.list_events("run_1").size(), 1u);
+}
+#endif
 
 TEST(HarnessServiceTest, SqliteRetentionDeletesTerminalLeavesBeforeReferencedSources) {
     const auto           root = unique_temp_path("neograph-harness-retention");

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -223,6 +223,7 @@ TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
     EXPECT_EQ(listed["result"]["tools"][4]["name"], "neograph_schema");
     EXPECT_EQ(listed["result"]["tools"][5]["name"], "neograph_start");
     bool saw_debug_views = false;
+    bool saw_replay      = false;
     for (const auto& tool : listed["result"]["tools"]) {
         EXPECT_TRUE(tool.contains("outputSchema"));
         EXPECT_EQ(tool["inputSchema"].value("type", ""), "object");
@@ -232,9 +233,14 @@ TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
             EXPECT_EQ(schema["after_sequence"]["minimum"], 0);
             EXPECT_EQ(schema["view"]["enum"].size(), 7u);
             saw_debug_views = true;
+        } else if (tool["name"] == "neograph_start") {
+            const auto replay = tool["inputSchema"]["properties"]["replay"];
+            EXPECT_EQ(replay["properties"]["mode"]["enum"].size(), 2u);
+            saw_replay = true;
         }
     }
     EXPECT_TRUE(saw_debug_views);
+    EXPECT_TRUE(saw_replay);
 
     auto invalid_get = server.handle_message({
         {"jsonrpc", "2.0"},
@@ -1369,11 +1375,162 @@ TEST(HarnessServiceTest, DebugViewsExposeJournalAndCheckpointHistoryThroughUris)
                  std::invalid_argument);
 }
 
+TEST(HarnessServiceTest, RecordedReplaySurvivesReconnectWithoutCallingLiveExecutor) {
+    const auto           root = unique_temp_path("neograph-harness-recorded-replay");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    neograph::mcp::SqliteHarnessJournalConfig journal_config;
+    journal_config.mode = neograph::mcp::HarnessJournalPayloadMode::FULL;
+    auto records        = std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(
+        (root / "runs.db").string(), 5s, journal_config);
+    std::atomic<int> live_calls{0};
+    std::string      source_run_id;
+    json             source_workers;
+
+    {
+        HarnessServiceConfig config;
+        config.record_store    = records;
+        config.worker_executor = [&](const HarnessWorkerCall& call, const auto&) {
+            live_calls.fetch_add(1, std::memory_order_relaxed);
+            const auto worker_id = call.worker["id"].get<std::string>();
+            if (worker_id == "a" && call.attempt == 1) {
+                return HarnessWorkerResponse::parse_error("recorded parse failure");
+            }
+            return HarnessWorkerResponse::success({
+                {"status", "ok"},
+                {"findings", json::array({{{"evidence", "source " + worker_id}}})},
+            });
+        };
+        HarnessService service(std::move(config));
+        const auto     compiled = service.compile(request(json::array({worker("a"), worker("b")})));
+        ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+        const auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+        source_run_id      = started["run_id"].get<std::string>();
+        const auto source  = wait_terminal(service, source_run_id);
+        ASSERT_EQ(source["status"], "completed") << source.dump();
+        source_workers = source["result"]["workers"];
+        EXPECT_EQ(live_calls.load(std::memory_order_relaxed), 3);
+    }
+
+    HarnessServiceConfig config;
+    config.record_store    = records;
+    config.worker_executor = [&](const HarnessWorkerCall& call, const auto&) {
+        live_calls.fetch_add(1, std::memory_order_relaxed);
+        const auto worker_id = call.worker["id"].get<std::string>();
+        if (worker_id == "a" && call.attempt == 1) {
+            return HarnessWorkerResponse::parse_error("live parse failure");
+        }
+        return HarnessWorkerResponse::success({
+            {"status", "ok"},
+            {"findings", json::array({{{"evidence", "live " + worker_id}}})},
+        });
+    };
+    HarnessService service(std::move(config));
+
+    const auto recorded = service.start({
+        {"replay", {{"source_run_id", source_run_id}, {"mode", "recorded"}}},
+    });
+    ASSERT_TRUE(recorded["started"].get<bool>());
+    EXPECT_EQ(recorded["execution_mode"], "recorded_replay");
+    EXPECT_EQ(recorded["source_run_id"], source_run_id);
+    const auto recorded_run_id = recorded["run_id"].get<std::string>();
+    const auto replayed        = wait_terminal(service, recorded_run_id);
+    ASSERT_EQ(replayed["status"], "completed") << replayed.dump();
+    EXPECT_EQ(replayed["execution_mode"], "recorded_replay");
+    EXPECT_EQ(replayed["source_run_id"], source_run_id);
+    EXPECT_EQ(replayed["result"]["workers"], source_workers);
+    EXPECT_EQ(live_calls.load(std::memory_order_relaxed), 3)
+        << "recorded replay must not invoke provider/tool execution";
+
+    const auto live = service.start({
+        {"replay", {{"source_run_id", source_run_id}, {"mode", "live"}}},
+    });
+    EXPECT_EQ(live["execution_mode"], "live_replay");
+    const auto live_result = wait_terminal(service, live["run_id"].get<std::string>());
+    ASSERT_EQ(live_result["status"], "completed") << live_result.dump();
+    EXPECT_EQ(live_result["execution_mode"], "live_replay");
+    EXPECT_EQ(live_result["source_run_id"], source_run_id);
+    EXPECT_EQ(live_calls.load(std::memory_order_relaxed), 6);
+    ASSERT_EQ(live_result["result"]["findings"].size(), 2u);
+    EXPECT_EQ(live_result["result"]["findings"][0]["evidence"], "live a");
+    EXPECT_EQ(live_result["result"]["findings"][1]["evidence"], "live b");
+}
+
+TEST(HarnessServiceTest, RecordedReplayRejectsRedactedWorkerOutputs) {
+    const auto           root = unique_temp_path("neograph-harness-redacted-replay");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    auto records =
+        std::make_shared<neograph::mcp::SqliteHarnessRecordStore>((root / "runs.db").string());
+    HarnessServiceConfig config;
+    config.record_store    = records;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+    const auto     compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started       = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto source_run_id = started["run_id"].get<std::string>();
+    ASSERT_EQ(wait_terminal(service, source_run_id)["status"], "completed");
+
+    EXPECT_THROW(service.start({
+                     {"replay", {{"source_run_id", source_run_id}, {"mode", "recorded"}}},
+                 }),
+                 std::runtime_error);
+}
+
+TEST(HarnessServiceTest, RecordedReplayPreservesTerminalWorkerFailure) {
+    const auto           root = unique_temp_path("neograph-harness-failed-replay");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    neograph::mcp::SqliteHarnessJournalConfig journal_config;
+    journal_config.mode = neograph::mcp::HarnessJournalPayloadMode::FULL;
+    auto records        = std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(
+        (root / "runs.db").string(), 5s, journal_config);
+    std::atomic<int>     live_calls{0};
+    HarnessServiceConfig config;
+    config.record_store    = records;
+    config.worker_executor = [&](const HarnessWorkerCall&, const auto&) {
+        live_calls.fetch_add(1, std::memory_order_relaxed);
+        return HarnessWorkerResponse::timeout("recorded timeout");
+    };
+    HarnessService service(std::move(config));
+    const auto     compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started       = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto source_run_id = started["run_id"].get<std::string>();
+    const auto source        = wait_terminal(service, source_run_id);
+    ASSERT_EQ(source["status"], "completed") << source.dump();
+    ASSERT_EQ(source["result"]["workers"][0]["failure_kind"], "timeout");
+
+    const auto replay   = service.start({
+        {"replay", {{"source_run_id", source_run_id}, {"mode", "recorded"}}},
+    });
+    const auto replayed = wait_terminal(service, replay["run_id"].get<std::string>());
+    ASSERT_EQ(replayed["status"], "completed") << replayed.dump();
+    EXPECT_EQ(replayed["result"]["workers"], source["result"]["workers"]);
+    EXPECT_EQ(live_calls.load(std::memory_order_relaxed), 1);
+
+    const auto events               = records->list_events(source_run_id);
+    bool       saw_terminal_attempt = false;
+    for (const auto& event : events) {
+        if (event["event_type"] == "worker.attempt.completed" &&
+            event["payload"].value("retry_reason", "") == "timeout") {
+            EXPECT_FALSE(event["payload"]["retry_scheduled"].get<bool>());
+            saw_terminal_attempt = true;
+        }
+    }
+    EXPECT_TRUE(saw_terminal_attempt);
+}
+
 TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
     const auto root     = unique_temp_path("neograph-harness-resume");
     const auto database = root / "checkpoints.db";
     const auto records_database = root / "runs.db";
     std::filesystem::create_directories(root);
+    neograph::mcp::SqliteHarnessJournalConfig journal_config;
+    journal_config.mode               = neograph::mcp::HarnessJournalPayloadMode::FULL;
     auto                     provider = std::make_shared<ScriptedProvider>();
     neograph::ChatCompletion tool_request;
     tool_request.message.tool_calls.push_back(
@@ -1388,8 +1545,8 @@ TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
         HarnessServiceConfig config;
         config.checkpoint_store =
             std::make_shared<neograph::graph::SqliteCheckpointStore>(database.string());
-        config.record_store =
-            std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(records_database.string());
+        config.record_store = std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(
+            records_database.string(), 5s, journal_config);
         neograph::mcp::HarnessProviderExecutorConfig provider_config;
         provider_config.provider = provider;
         config.worker_executor =
@@ -1408,8 +1565,8 @@ TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
         HarnessServiceConfig config;
         config.checkpoint_store =
             std::make_shared<neograph::graph::SqliteCheckpointStore>(database.string());
-        config.record_store =
-            std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(records_database.string());
+        config.record_store = std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(
+            records_database.string(), 5s, journal_config);
         neograph::mcp::HarnessProviderExecutorConfig provider_config;
         provider_config.provider = provider;
         config.worker_executor =
@@ -1446,7 +1603,28 @@ TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
     ASSERT_EQ(provider->calls.size(), 2u);
     EXPECT_NE(provider->calls[1].messages[0].content.find("host_resume"), std::string::npos);
     {
-        neograph::mcp::SqliteHarnessRecordStore records(records_database.string());
+        HarnessServiceConfig config;
+        config.checkpoint_store =
+            std::make_shared<neograph::graph::SqliteCheckpointStore>(database.string());
+        config.record_store = std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(
+            records_database.string(), 5s, journal_config);
+        neograph::mcp::HarnessProviderExecutorConfig provider_config;
+        provider_config.provider = provider;
+        config.worker_executor =
+            neograph::mcp::make_provider_harness_executor(std::move(provider_config));
+        HarnessService service(std::move(config));
+        const auto     replay   = service.start({
+            {"replay", {{"source_run_id", run_id}, {"mode", "recorded"}}},
+        });
+        const auto     replayed = wait_terminal(service, replay["run_id"].get<std::string>());
+        ASSERT_EQ(replayed["status"], "completed") << replayed.dump();
+        EXPECT_EQ(replayed["execution_mode"], "recorded_replay");
+    }
+    EXPECT_EQ(provider->calls.size(), 2u)
+        << "replaying a resumed run must not repeat provider or host calls";
+    {
+        neograph::mcp::SqliteHarnessRecordStore records(records_database.string(), 5s,
+                                                        journal_config);
         const auto events = records.list_events(run_id);
         std::string requested;
         std::string accepted;

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -1211,6 +1211,78 @@ INSERT INTO neograph_harness_runs VALUES
     EXPECT_EQ(records.list_events("run_1")[0]["event_type"], "migration.verified");
 }
 
+TEST(HarnessServiceTest, SqliteRetentionDeletesTerminalLeavesBeforeReferencedSources) {
+    const auto           root = unique_temp_path("neograph-harness-retention");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    neograph::mcp::SqliteHarnessRecordStore records((root / "runs.db").string());
+    for (int index = 1; index <= 3; ++index) {
+        const auto artifact_id = "artifact_" + std::to_string(index);
+        records.save_artifact(artifact_id, {
+                                               {"artifact_id", artifact_id},
+                                               {"request", json::object()},
+                                           });
+    }
+    const auto run = [](std::string run_id, std::string artifact_id, std::string status,
+                        std::string source_run_id = {}) {
+        return json{
+            {"run_id", std::move(run_id)},
+            {"artifact_id", std::move(artifact_id)},
+            {"revision_digest", "revision"},
+            {"protocol_version", "protocol"},
+            {"profile", "profile"},
+            {"status", std::move(status)},
+            {"source_run_id", std::move(source_run_id)},
+        };
+    };
+    records.save_run("run_source", run("run_source", "artifact_1", "completed"));
+    records.save_run("run_fork", run("run_fork", "artifact_2", "completed", "run_source"));
+    records.save_run("run_active", run("run_active", "artifact_3", "running"));
+    EXPECT_THROW(
+        records.save_run("run_orphan", run("run_orphan", "artifact_2", "completed", "missing")),
+        std::invalid_argument);
+    records.append_event({
+        {"run_id", "run_fork"},
+        {"artifact_id", "artifact_2"},
+        {"revision_digest", "revision"},
+        {"protocol_version", "protocol"},
+        {"profile", "profile"},
+        {"event_type", "retention.test"},
+        {"payload", json::object()},
+    });
+
+    neograph::mcp::HarnessRetentionPolicy blocked;
+    blocked.max_runs      = 1;
+    blocked.max_artifacts = 1;
+    blocked.protected_run_ids.push_back("run_fork");
+    const auto blocked_result = records.cleanup_retained(blocked);
+    EXPECT_TRUE(blocked_result.run_ids.empty());
+    EXPECT_TRUE(blocked_result.artifact_ids.empty());
+    EXPECT_TRUE(records.load_run("run_source").has_value());
+    EXPECT_TRUE(records.load_run("run_fork").has_value());
+
+    neograph::mcp::HarnessRetentionPolicy remove_leaf;
+    remove_leaf.max_runs      = 2;
+    remove_leaf.max_artifacts = 2;
+    const auto leaf_result    = records.cleanup_retained(remove_leaf);
+    ASSERT_EQ(leaf_result.run_ids, std::vector<std::string>({"run_fork"}));
+    ASSERT_EQ(leaf_result.artifact_ids, std::vector<std::string>({"artifact_2"}));
+    EXPECT_FALSE(records.load_run("run_fork").has_value());
+    EXPECT_TRUE(records.list_events("run_fork").empty());
+    EXPECT_TRUE(records.load_run("run_source").has_value());
+    EXPECT_TRUE(records.load_run("run_active").has_value());
+
+    neograph::mcp::HarnessRetentionPolicy remove_source;
+    remove_source.max_runs      = 1;
+    remove_source.max_artifacts = 1;
+    const auto source_result    = records.cleanup_retained(remove_source);
+    ASSERT_EQ(source_result.run_ids, std::vector<std::string>({"run_source"}));
+    ASSERT_EQ(source_result.artifact_ids, std::vector<std::string>({"artifact_1"}));
+    EXPECT_FALSE(records.load_run("run_source").has_value());
+    EXPECT_TRUE(records.load_run("run_active").has_value());
+    EXPECT_TRUE(records.load_artifact("artifact_3").has_value());
+}
+
 TEST(HarnessServiceTest, JournalCorrelatesProviderAndCapabilityCallsToWorkerAttempt) {
     const auto root = unique_temp_path("neograph-harness-journal-correlation");
     TempDirectoryCleanup cleanup(root);

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -224,6 +224,24 @@ public:
     }
 };
 
+class BlockingTerminalJournal final : public neograph::mcp::HarnessJournal {
+public:
+    void append_event(const json& event) override {
+        if (event.value("event_type", "") != "run.terminal") return;
+        terminal_started.store(true, std::memory_order_release);
+        while (!release_terminal.load(std::memory_order_acquire)) {
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+
+    std::vector<json> list_events(const std::string&, std::size_t, std::size_t) override {
+        return {};
+    }
+
+    std::atomic<bool> terminal_started{false};
+    std::atomic<bool> release_terminal{false};
+};
+
 TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
     HarnessService service;
     neograph::mcp::MCPServerConfig server_config;
@@ -334,6 +352,30 @@ TEST(HarnessServiceTest, JournalFailureFailsRunWithoutEscapingWorkerThread) {
     const auto failed = wait_terminal(service, started["run_id"].get<std::string>());
     EXPECT_EQ(failed["status"], "failed");
     EXPECT_NE(failed["error"].get<std::string>().find("journal unavailable"), std::string::npos);
+}
+
+TEST(HarnessServiceTest, TerminalStatusIsPublishedAfterJournalFinalization) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    auto           journal = std::make_shared<BlockingTerminalJournal>();
+    HarnessService service(std::move(config), journal);
+    const auto     compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto run_id  = started["run_id"].get<std::string>();
+
+    const auto deadline = std::chrono::steady_clock::now() + 1s;
+    while (!journal->terminal_started.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(1ms);
+    }
+    EXPECT_TRUE(journal->terminal_started.load(std::memory_order_acquire));
+    EXPECT_EQ(service.get(run_id)["status"], "running");
+
+    journal->release_terminal.store(true, std::memory_order_release);
+    EXPECT_EQ(wait_terminal(service, run_id)["status"], "completed");
 }
 
 TEST(HarnessServiceTest, DebugViewsReportUnavailableWithoutDurableStores) {
@@ -1456,12 +1498,6 @@ TEST(HarnessServiceTest, HarnessCapacityCleanupPreservesReplaySourceAndDropsLeaf
     const auto replay_run_id = replay_start["run_id"].get<std::string>();
     ASSERT_EQ(wait_terminal(service, replay_run_id)["status"], "completed");
 
-    const auto deadline = std::chrono::steady_clock::now() + 1s;
-    while (records->list_events(replay_run_id).empty() &&
-           std::chrono::steady_clock::now() < deadline) {
-        std::this_thread::sleep_for(2ms);
-    }
-    std::this_thread::sleep_for(2ms);
     const auto replacement_start = service.start({{"artifact_id", replacement["artifact_id"]}});
     ASSERT_EQ(wait_terminal(service, replacement_start["run_id"].get<std::string>())["status"],
               "completed");

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -174,6 +174,19 @@ public:
     std::string get_name() const override { return "scripted-harness-provider"; }
 };
 
+class StartFailingJournal final : public neograph::mcp::HarnessJournal {
+public:
+    void append_event(const json& event) override {
+        if (event.value("event_type", "") == "run.started") {
+            throw std::runtime_error("journal unavailable");
+        }
+    }
+
+    std::vector<json> list_events(const std::string&, std::size_t, std::size_t) override {
+        return {};
+    }
+};
+
 TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
     HarnessService service;
     neograph::mcp::MCPServerConfig server_config;
@@ -250,6 +263,20 @@ TEST(HarnessServiceTest, MalformedHarnessCannotProduceExecutableArtifact) {
     auto started = service.start({{"request", malformed}});
     EXPECT_FALSE(started["started"].get<bool>());
     EXPECT_EQ(started["status"], "compile_failed");
+}
+
+TEST(HarnessServiceTest, JournalFailureFailsRunWithoutEscapingWorkerThread) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config), std::make_shared<StartFailingJournal>());
+    const auto compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto failed = wait_terminal(service, started["run_id"].get<std::string>());
+    EXPECT_EQ(failed["status"], "failed");
+    EXPECT_NE(failed["error"].get<std::string>().find("journal unavailable"), std::string::npos);
 }
 
 TEST(HarnessServiceTest, PresetAndEquivalentDslCompileToCanonicalCore) {
@@ -928,6 +955,255 @@ TEST(HarnessServiceTest, SqliteRecordStoreBusyTimeoutWaitsForWriter) {
     EXPECT_TRUE(records.load_run("run_waiting").has_value());
 }
 
+TEST(HarnessServiceTest, SqliteJournalOrdersEventsAndRedactsPayloadsAtRest) {
+    const auto root = unique_temp_path("neograph-harness-journal");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    const auto database = root / "runs.db";
+
+    neograph::mcp::SqliteHarnessRecordStore records(database.string());
+    records.save_artifact("artifact_1", {
+        {"artifact_id", "artifact_1"},
+        {"request", json::object()},
+    });
+    const json run = {
+        {"run_id", "run_1"},
+        {"artifact_id", "artifact_1"},
+        {"revision_digest", "fnv1a64:1234"},
+        {"protocol_version", "2025-11-25"},
+        {"profile", "harness-m4"},
+        {"status", "queued"},
+    };
+    records.save_run("run_1", run);
+    const auto event = [](std::string type, json payload) {
+        return json{
+            {"run_id", "run_1"},
+            {"artifact_id", "artifact_1"},
+            {"revision_digest", "fnv1a64:1234"},
+            {"protocol_version", "2025-11-25"},
+            {"profile", "harness-m4"},
+            {"event_type", std::move(type)},
+            {"correlation_id", "call_1"},
+            {"node_id", "worker_0"},
+            {"worker_id", "reviewer"},
+            {"attempt", 1},
+            {"payload", std::move(payload)},
+        };
+    };
+    records.append_event(event("worker.attempt.started", {
+        {"authorization", "Bearer secret"},
+        {"nested", {{"safe", "visible"}, {"token", "hidden"}}},
+    }));
+    records.append_event(event("worker.attempt.completed", {{"result", {{"answer", "42"}}}}));
+
+    const auto events = records.list_events("run_1");
+    ASSERT_EQ(events.size(), 2u);
+    EXPECT_EQ(events[0]["sequence"], 1);
+    EXPECT_EQ(events[1]["sequence"], 2);
+    EXPECT_EQ(events[0]["payload"]["authorization"], "[REDACTED]");
+    EXPECT_EQ(events[0]["payload"]["nested"]["token"], "[REDACTED]");
+    EXPECT_EQ(events[0]["payload"]["nested"]["safe"], "visible");
+    EXPECT_EQ(events[1]["payload"]["result"], "[REDACTED]");
+    ASSERT_EQ(records.list_events("run_1", 1, 1).size(), 1u);
+    EXPECT_EQ(records.list_events("run_1", 1, 1)[0]["sequence"], 2);
+
+    auto mismatched = event("tampered", json::object());
+    mismatched["revision_digest"] = "fnv1a64:different";
+    EXPECT_THROW(records.append_event(mismatched), std::invalid_argument);
+    auto rebound = run;
+    rebound["revision_digest"] = "fnv1a64:different";
+    EXPECT_THROW(records.save_run("run_1", rebound), std::invalid_argument);
+}
+
+TEST(HarnessServiceTest, SqliteJournalSupportsMetadataOnlyAndFullPayloadModes) {
+    const auto root = unique_temp_path("neograph-harness-journal-modes");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+
+    const auto exercise = [&](const std::string& name,
+                              neograph::mcp::HarnessJournalPayloadMode mode) {
+        neograph::mcp::SqliteHarnessJournalConfig journal_config;
+        journal_config.mode = mode;
+        neograph::mcp::SqliteHarnessRecordStore records(
+            (root / name).string(), 5s, std::move(journal_config));
+        records.save_artifact("artifact_1", {
+            {"artifact_id", "artifact_1"},
+            {"request", json::object()},
+        });
+        records.save_run("run_1", {
+            {"run_id", "run_1"},
+            {"artifact_id", "artifact_1"},
+            {"revision_digest", "revision"},
+            {"protocol_version", "protocol"},
+            {"profile", "profile"},
+            {"status", "queued"},
+        });
+        records.append_event({
+            {"run_id", "run_1"},
+            {"artifact_id", "artifact_1"},
+            {"revision_digest", "revision"},
+            {"protocol_version", "protocol"},
+            {"profile", "profile"},
+            {"event_type", "test.event"},
+            {"payload", {{"secret", "keep only in full"}, {"visible", true}}},
+        });
+        return records.list_events("run_1")[0]["payload"];
+    };
+
+    EXPECT_EQ(exercise("metadata.db", neograph::mcp::HarnessJournalPayloadMode::METADATA_ONLY),
+              json::object());
+    const auto full = exercise("full.db", neograph::mcp::HarnessJournalPayloadMode::FULL);
+    EXPECT_EQ(full["secret"], "keep only in full");
+    EXPECT_TRUE(full["visible"].get<bool>());
+}
+
+TEST(HarnessServiceTest, SqliteJournalMigratesVersionOneRunBindings) {
+    const auto root = unique_temp_path("neograph-harness-journal-migration");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    const auto database = root / "runs.db";
+    sqlite3* legacy = nullptr;
+    ASSERT_EQ(sqlite3_open(database.string().c_str(), &legacy), SQLITE_OK);
+    ASSERT_EQ(sqlite3_exec(legacy, R"SQL(
+CREATE TABLE neograph_harness_schema (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1), version INTEGER NOT NULL
+);
+INSERT INTO neograph_harness_schema VALUES (1, 1);
+CREATE TABLE neograph_harness_artifacts (
+    artifact_id TEXT PRIMARY KEY, record_json TEXT NOT NULL, created_at_ms INTEGER NOT NULL
+);
+CREATE TABLE neograph_harness_runs (
+    run_id TEXT PRIMARY KEY, artifact_id TEXT NOT NULL, record_json TEXT NOT NULL,
+    updated_at_ms INTEGER NOT NULL,
+    FOREIGN KEY (artifact_id) REFERENCES neograph_harness_artifacts (artifact_id)
+);
+INSERT INTO neograph_harness_artifacts VALUES
+    ('artifact_1', '{"artifact_id":"artifact_1","request":{}}', 1);
+INSERT INTO neograph_harness_runs VALUES
+    ('run_1', 'artifact_1', '{"run_id":"run_1","artifact_id":"artifact_1","status":"queued"}', 1);
+)SQL", nullptr, nullptr, nullptr), SQLITE_OK);
+    sqlite3_close(legacy);
+
+    neograph::mcp::SqliteHarnessRecordStore records(database.string());
+    auto run = records.load_run("run_1");
+    ASSERT_TRUE(run.has_value());
+    (*run)["revision_digest"] = "revision";
+    (*run)["protocol_version"] = "protocol";
+    (*run)["profile"] = "profile";
+    records.save_run("run_1", *run);
+    records.append_event({
+        {"run_id", "run_1"},
+        {"artifact_id", "artifact_1"},
+        {"revision_digest", "revision"},
+        {"protocol_version", "protocol"},
+        {"profile", "profile"},
+        {"event_type", "migration.verified"},
+        {"payload", json::object()},
+    });
+    ASSERT_EQ(records.list_events("run_1").size(), 1u);
+    EXPECT_EQ(records.list_events("run_1")[0]["event_type"], "migration.verified");
+}
+
+TEST(HarnessServiceTest, JournalCorrelatesProviderAndCapabilityCallsToWorkerAttempt) {
+    const auto root = unique_temp_path("neograph-harness-journal-correlation");
+    TempDirectoryCleanup cleanup(root);
+    std::filesystem::create_directories(root);
+    auto records = std::make_shared<neograph::mcp::SqliteHarnessRecordStore>(
+        (root / "runs.db").string());
+    auto provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion tool_request;
+    tool_request.message.tool_calls.push_back(
+        {"capability-call", "catalog.lookup", R"({"query":"needle"})"});
+    neograph::ChatCompletion final;
+    final.message.content = R"({"status":"ok","findings":[]})";
+    provider->completions = {tool_request, final};
+
+    auto authored = request();
+    authored["workers"][0]["tools"] = json::array({"catalog.lookup"});
+    authored["tool_catalog"] = json::array({{
+        {"id", "catalog.lookup"},
+        {"description", "Look up a catalog value"},
+        {"input_schema", {
+            {"type", "object"},
+            {"required", json::array({"query"})},
+            {"properties", {{"query", {{"type", "string"}}}}},
+            {"additionalProperties", false},
+        }},
+        {"output_schema", {
+            {"type", "object"},
+            {"required", json::array({"answer"})},
+            {"properties", {{"answer", {{"type", "string"}}}}},
+            {"additionalProperties", false},
+        }},
+        {"executor", {{"kind", "mcp"}, {"server_ref", "catalog-server"}}},
+    }});
+    HarnessServiceConfig config;
+    config.record_store = records;
+    neograph::mcp::HarnessProviderExecutorConfig provider_config;
+    provider_config.provider = provider;
+    provider_config.capability_executor = [](const json&, const json&, const auto&) {
+        return json{{"answer", "found"}};
+    };
+    config.worker_executor =
+        neograph::mcp::make_provider_harness_executor(std::move(provider_config));
+    HarnessService service(std::move(config));
+    const auto compiled = service.compile(authored);
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto run_id = started["run_id"].get<std::string>();
+    ASSERT_EQ(wait_terminal(service, run_id)["status"], "completed");
+
+    const auto persisted = records->load_run(run_id);
+    ASSERT_TRUE(persisted.has_value());
+    EXPECT_FALSE((*persisted)["revision_digest"].get<std::string>().empty());
+    EXPECT_EQ((*persisted)["protocol_version"], "2025-11-25");
+    EXPECT_EQ((*persisted)["profile"], "harness-m4");
+
+    std::vector<json> events;
+    const auto journal_deadline = std::chrono::steady_clock::now() + 1s;
+    do {
+        events = records->list_events(run_id);
+        bool flushed = false;
+        for (const auto& event : events) {
+            if (event["event_type"] == "run.terminal") {
+                flushed = true;
+                break;
+            }
+        }
+        if (flushed) break;
+        std::this_thread::sleep_for(2ms);
+    } while (std::chrono::steady_clock::now() < journal_deadline);
+    std::size_t provider_started = 0;
+    std::size_t provider_completed = 0;
+    bool capability_started = false;
+    bool capability_completed = false;
+    bool worker_completed = false;
+    bool terminal = false;
+    for (const auto& event : events) {
+        const auto type = event["event_type"].get<std::string>();
+        if (type == "provider.call.started") ++provider_started;
+        if (type == "provider.call.completed") ++provider_completed;
+        if (type == "capability.call.started") {
+            capability_started = event.value("correlation_id", "") == "capability-call";
+        }
+        if (type == "capability.call.completed") {
+            capability_completed = event.value("correlation_id", "") == "capability-call";
+        }
+        if (type == "worker.attempt.completed") {
+            worker_completed = event.value("node_id", "") == "worker_0" &&
+                               event.value("worker_id", "") == "reviewer" &&
+                               event.value("attempt", 0) == 1;
+        }
+        if (type == "run.terminal") terminal = event["payload"]["status"] == "completed";
+    }
+    EXPECT_EQ(provider_started, 2u);
+    EXPECT_EQ(provider_completed, 2u);
+    EXPECT_TRUE(capability_started);
+    EXPECT_TRUE(capability_completed);
+    EXPECT_TRUE(worker_completed);
+    EXPECT_TRUE(terminal);
+}
+
 TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
     const auto root     = unique_temp_path("neograph-harness-resume");
     const auto database = root / "checkpoints.db";
@@ -1004,6 +1280,22 @@ TEST(HarnessServiceTest, DurableHostResumeSurvivesServiceAndDatabaseReconnect) {
     }
     ASSERT_EQ(provider->calls.size(), 2u);
     EXPECT_NE(provider->calls[1].messages[0].content.find("host_resume"), std::string::npos);
+    {
+        neograph::mcp::SqliteHarnessRecordStore records(records_database.string());
+        const auto events = records.list_events(run_id);
+        std::string requested;
+        std::string accepted;
+        for (const auto& event : events) {
+            if (event["event_type"] == "host_brokered.call.requested") {
+                requested = event.value("correlation_id", "");
+            }
+            if (event["event_type"] == "host_brokered.result.accepted") {
+                accepted = event.value("correlation_id", "");
+            }
+        }
+        EXPECT_EQ(requested, call_id);
+        EXPECT_EQ(accepted, call_id);
+    }
     std::filesystem::remove_all(root);
 }
 


### PR DESCRIPTION
## Summary
- add an append-only Harness journal with trace, attempts, checkpoint, and diff debugger views
- add recorded/live replay and compatibility-checked checkpoint forks bound to immutable revisions
- add SQLite schema migration and reference-safe retention for runs, artifacts, journals, and checkpoints
- harden cancellation and terminal-state publication around asynchronous journal finalization
- document persistence, replay, fork, retention, and crash-consistency contracts

## Verification
- `env -u ANTHROPIC_API_KEY ctest --test-dir build --output-on-failure -j2` (`777/777` passed; 35 environment-gated skips)
- focused retention and terminal-finalization tests repeated 50 times
- SQLite-free `neograph_mcp_server` build
- `git diff --check`
- `git clang-format --diff HEAD`

Closes #155