### PR TITLE
feat(graph): link compiled graphs into runtimes

### DIFF
--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -467,6 +467,29 @@ struct RunResult {
 class NEOGRAPH_API GraphEngine {
 public:
     /**
+     * @brief Link an already compiled graph into a configured runtime.
+     *
+     * This is the canonical runtime boundary for callers that explicitly run
+     * GraphCompiler and inspect or transform the resulting CompiledGraph. It
+     * performs semantic validation, consumes the graph by move, and applies
+     * every EngineConfig option without parsing the source JSON again.
+     *
+     * Translation round-trip verification requires the original JSON and is
+     * therefore performed by build() before it delegates here. Callers using
+     * link() directly are responsible for calling GraphCompiler::verify_roundtrip
+     * when they need that source-to-IR guarantee.
+     *
+     * EngineConfig::node_context is ignored because CompiledGraph already owns
+     * its instantiated nodes. The remaining runtime configuration is applied.
+     *
+     * @param graph Compiled graph to consume.
+     * @param config Runtime configuration applied before the engine is returned.
+     * @return A configured GraphEngine ready for execution.
+     * @throws std::runtime_error If semantic validation fails in strict mode.
+     */
+    static std::unique_ptr<GraphEngine> link(CompiledGraph graph, EngineConfig config = {});
+
+    /**
      * @brief Build a ready-to-run engine from one construction-time config.
      *
      * New code should prefer this entry point when it needs runtime Store,

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -59,6 +59,10 @@ std::unique_ptr<GraphEngine> GraphEngine::build(const json& definition, EngineCo
     // documents get a stderr warning. Must run before the moves below.
     GraphCompiler::verify_roundtrip(definition, cg);
 
+    return link(std::move(cg), std::move(config));
+}
+
+std::unique_ptr<GraphEngine> GraphEngine::link(CompiledGraph cg, EngineConfig config) {
     // Static semantic analysis (issue #75 M2). Strict documents:
     // errors throw, warnings go to stderr. Legacy documents: only
     // errors are surfaced (as stderr warnings — they were silent

--- a/tests/test_engine_config.cpp
+++ b/tests/test_engine_config.cpp
@@ -81,6 +81,8 @@ public:
 
 std::atomic<int> CountingNode::calls{0};
 
+std::atomic<int> link_factory_calls{0};
+
 void register_node(const std::string& type, NodeFactoryFn factory) {
     NodeFactory::instance().register_type(
         type, std::move(factory), json::parse(R"({"type":"object","properties":{}})"),
@@ -166,4 +168,38 @@ TEST(EngineConfigTest, EnablesNodeCacheAtConstructionTime) {
     EXPECT_EQ(engine->run(run).channel<int>("output"), 7);
     EXPECT_EQ(engine->run(run).channel<int>("output"), 7);
     EXPECT_EQ(CountingNode::calls.load(), 1);
+}
+
+TEST(CompiledGraphLinkTest, ConsumesCompiledGraphWithoutRunningFactoriesAgain) {
+    link_factory_calls = 0;
+    register_node("compiled_graph_link", [](const std::string&, const json&, const NodeContext&) {
+        ++link_factory_calls;
+        return std::make_unique<EchoNode>();
+    });
+
+    const auto  definition = one_node_graph("compiled_graph_link");
+    NodeContext context;
+    auto        graph = GraphCompiler::compile(definition, context);
+    GraphCompiler::verify_roundtrip(definition, graph);
+    EXPECT_EQ(link_factory_calls.load(), 1);
+
+    auto engine = GraphEngine::link(std::move(graph));
+    EXPECT_EQ(link_factory_calls.load(), 1);
+
+    RunConfig run;
+    run.input = {{"input", "linked"}};
+    EXPECT_EQ(engine->run(run).channel<std::string>("output"), "linked");
+}
+
+TEST(CompiledGraphLinkTest, AppliesSemanticValidationBeforeRuntimeConstruction) {
+    register_node("compiled_graph_link_invalid",
+                  [](const std::string&, const json&, const NodeContext&) {
+                      return std::make_unique<EchoNode>();
+                  });
+
+    NodeContext context;
+    auto graph = GraphCompiler::compile(one_node_graph("compiled_graph_link_invalid"), context);
+    graph.edges.push_back({"missing", "work"});
+
+    EXPECT_THROW((void)GraphEngine::link(std::move(graph)), std::runtime_error);
 }


### PR DESCRIPTION
## Summary
- add `GraphEngine::link(CompiledGraph, EngineConfig)` as the canonical compiled-IR to runtime boundary
- make `GraphEngine::build()` delegate to `link()` after source round-trip verification
- preserve semantic validation and runtime configuration without reparsing JSON or rerunning node factories
- cover factory single-execution and strict semantic validation

## Stack
- depends on #160
- the non-`master` base is intentional; this PR contains only commit `5b2abc1`
- part of #159

## Verification
- `cmake --build build -j2` completed all configured library, example, cookbook, and test targets
- focused `EngineConfigTest` and `CompiledGraphLinkTest`: 5/5 passed
- changed-line formatting: `git clang-format --diff d6a7ac5 -- ...` reported no changes
- `git diff --check` passed
- serial full suite: 780/781 passed; the unrelated pre-existing `HarnessServiceTest.WaitingHostCallCanBeCancelled` timing race failed, then passed and failed again in isolated repetition