### PR TITLE
feat(graph): add owned tools and local registries

### DIFF
--- a/include/neograph/graph/compiler.h
+++ b/include/neograph/graph/compiler.h
@@ -28,6 +28,8 @@
 
 namespace neograph::graph {
 
+class GraphRegistry;
+
 class GraphNode;
 
 /**
@@ -153,6 +155,18 @@ public:
      */
     static CompiledGraph compile(const json& definition,
                                  const NodeContext& default_context);
+
+    /**
+     * @brief Compile with a local-first registry overlay.
+     *
+     * Missing entries fall back to the process-global registries, preserving
+     * built-ins and existing registrations without process-wide mutation.
+     * Pass the same registry through EngineResources when linking the result,
+     * so runtime reducer and condition lookup uses the same overlay.
+     */
+    static CompiledGraph compile(const json&          definition,
+                                 const NodeContext&   default_context,
+                                 const GraphRegistry& registry);
 
     /**
      * @brief Canonicalize a topology JSON document for equivalence

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -16,11 +16,13 @@
 #include <neograph/graph/executor.h>
 #include <neograph/graph/node.h>
 #include <neograph/graph/node_cache.h>
+#include <neograph/graph/registry.h>
 #include <neograph/graph/scheduler.h>
 #include <neograph/graph/state.h>
 #include <neograph/graph/store.h>
 #include <neograph/graph/types.h>
 #include <neograph/tool_dispatch.h>   // ToolGate (issue #89)
+#include <neograph/tool_set.h>
 
 #include <asio/awaitable.hpp>
 #include <asio/thread_pool.hpp>
@@ -73,6 +75,19 @@ struct EngineConfig {
 
     /// Pure nodes whose result cache should be enabled at construction time.
     std::set<std::string> cached_nodes;
+};
+
+/**
+ * @brief Owned construction resources layered beside EngineConfig.
+ *
+ * Kept as a sibling type so the already-public EngineConfig and NodeContext
+ * layouts remain unchanged. Empty resources preserve the legacy raw-tool and
+ * process-global registry behavior. Move this value into build() or link();
+ * ToolSet ownership transfers to the resulting engine.
+ */
+struct EngineResources {
+    ToolSet                              tools;
+    std::shared_ptr<const GraphRegistry> registry;
 };
 
 /**
@@ -490,6 +505,17 @@ public:
     static std::unique_ptr<GraphEngine> link(CompiledGraph graph, EngineConfig config = {});
 
     /**
+     * @brief Link with owned tools and a per-engine registry overlay.
+     *
+     * For directly compiled graphs, the caller must have used tools.view() in
+     * the NodeContext and the same registry in GraphCompiler::compile(). The
+     * canonical build() overload performs both bindings automatically.
+     */
+    static std::unique_ptr<GraphEngine> link(CompiledGraph   graph,
+                                             EngineConfig    config,
+                                             EngineResources resources);
+
+    /**
      * @brief Build a ready-to-run engine from one construction-time config.
      *
      * New code should prefer this entry point when it needs runtime Store,
@@ -502,6 +528,16 @@ public:
      * @throws std::runtime_error If the graph definition is invalid.
      */
     static std::unique_ptr<GraphEngine> build(const json& definition, EngineConfig config);
+
+    /**
+     * @brief Build with exact tool ownership and a local-first registry.
+     *
+     * resources.tools replaces NodeContext::tools with pointers to the owned
+     * collection. Supplying both forms is rejected as ambiguous.
+     */
+    static std::unique_ptr<GraphEngine> build(const json&     definition,
+                                              EngineConfig    config,
+                                              EngineResources resources);
 
     /**
      * @brief Compile a graph from a JSON definition.

--- a/include/neograph/graph/executor.h
+++ b/include/neograph/graph/executor.h
@@ -60,6 +60,7 @@
 namespace neograph::graph {
 
 class GraphState;
+class GraphRegistry;
 
 /// Per-run metadata carried alongside ``GraphState`` through every
 /// dispatch path. Defined in ``neograph/graph/engine.h``; forward-
@@ -102,6 +103,14 @@ public:
         RetryPolicyLookup retry_policy_for,
         asio::thread_pool* fan_out_pool = nullptr,
         NodeCache* node_cache = nullptr);
+
+    /// @brief Construct with a per-engine registry overlay.
+    NodeExecutor(const std::map<std::string, std::unique_ptr<GraphNode>>& nodes,
+                 const std::vector<ChannelDef>&                           channel_defs,
+                 RetryPolicyLookup                                        retry_policy_for,
+                 std::shared_ptr<const GraphRegistry>                     registry,
+                 asio::thread_pool*                                       fan_out_pool = nullptr,
+                 NodeCache*                                               node_cache   = nullptr);
 
     /**
      * @brief Execute a single node in the current super-step.
@@ -209,6 +218,8 @@ public:
         const RunContext& ctx);
 
 private:
+    friend class GraphEngine;
+
     /// Initialize a clean GraphState using the engine's channel defs.
     /// Used by the multi-send path to build each target's isolated copy.
     void init_state(GraphState& state) const;
@@ -231,6 +242,7 @@ private:
     const std::map<std::string, std::unique_ptr<GraphNode>>& nodes_;
     const std::vector<ChannelDef>& channel_defs_;
     RetryPolicyLookup retry_policy_for_;
+    std::shared_ptr<const GraphRegistry>                     registry_;
     asio::thread_pool* fan_out_pool_ = nullptr;
     NodeCache*         node_cache_   = nullptr;
     mutable std::atomic<bool> warned_serial_fanout_{false};

--- a/include/neograph/graph/loader.h
+++ b/include/neograph/graph/loader.h
@@ -50,10 +50,9 @@ class GraphNode;
 ///     tests; tests must use unique type names or deregister.
 ///   - Pybind users: state survives pytest-case boundaries.
 ///
-/// A future major version (v1.0) is expected to thread per-engine
-/// `Registry` instances through `NodeContext`/`compile()`, with the
-/// global singleton kept as a default-fallback layer. Until then,
-/// avoid duplicate registrations across test cases / embedders.
+/// New code that needs isolation can register an EngineResources
+/// `GraphRegistry`; entries there take precedence and this singleton remains
+/// the built-in/default fallback layer.
 class NEOGRAPH_API ReducerRegistry {
 public:
     /// @brief Get the singleton instance.

--- a/include/neograph/graph/registry.h
+++ b/include/neograph/graph/registry.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/graph/loader.h>
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace neograph::graph {
+
+/**
+ * @brief Per-engine registry overlay with process-global fallback.
+ *
+ * Entries registered here take precedence over the legacy singleton
+ * registries. Missing entries fall back to ReducerRegistry,
+ * ConditionRegistry, and NodeFactory, so built-ins and existing global
+ * registrations remain available. Configure a registry before passing it to
+ * EngineResources; runtime mutation is intentionally unsupported by contract.
+ */
+class NEOGRAPH_API GraphRegistry {
+public:
+    static const GraphRegistry& global();
+
+    void register_reducer(const std::string& name, ReducerFn fn);
+    void register_condition(const std::string& name, ConditionFn fn);
+    void register_condition(const std::string& name, ConditionFn fn, ConditionSpec spec);
+    void register_type(const std::string& type, NodeFactoryFn fn);
+    void register_type(const std::string& type, NodeFactoryFn fn, json config_schema);
+    void register_type(const std::string& type, NodeFactoryFn fn, json config_schema, json effects);
+
+    ReducerFn                    reducer(const std::string& name) const;
+    ConditionFn                  condition(const std::string& name) const;
+    std::optional<ConditionSpec> condition_spec(const std::string& name) const;
+    std::unique_ptr<GraphNode>   create(const std::string& type,
+                                        const std::string& name,
+                                        const json&        config,
+                                        const NodeContext& ctx) const;
+    json                         config_schema(const std::string& type) const;
+    json                         node_effects(const std::string& type) const;
+
+private:
+    std::unordered_map<std::string, ReducerFn>     reducers_;
+    std::unordered_map<std::string, ConditionFn>   conditions_;
+    std::unordered_map<std::string, ConditionSpec> condition_specs_;
+    std::unordered_map<std::string, NodeFactoryFn> node_factories_;
+    std::unordered_map<std::string, json>          node_schemas_;
+    std::unordered_map<std::string, json>          node_effects_;
+};
+
+}  // namespace neograph::graph

--- a/include/neograph/graph/scheduler.h
+++ b/include/neograph/graph/scheduler.h
@@ -22,7 +22,9 @@
 
 #include <neograph/api.h>
 #include <neograph/graph/types.h>
+
 #include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <vector>
@@ -30,6 +32,7 @@
 namespace neograph::graph {
 
 class GraphState;
+class GraphRegistry;
 
 /**
  * @brief Per-node routing signal emitted by this super-step.
@@ -100,6 +103,12 @@ public:
     Scheduler(const std::vector<Edge>& edges,
               const std::vector<ConditionalEdge>& conditional_edges,
               BarrierSpecs barrier_specs = {});
+
+    /// @brief Bind routing to a per-engine registry overlay.
+    Scheduler(const std::vector<Edge>&             edges,
+              const std::vector<ConditionalEdge>&  conditional_edges,
+              BarrierSpecs                         barrier_specs,
+              std::shared_ptr<const GraphRegistry> registry);
 
     /**
      * @brief Resolve the direct successors of a node.
@@ -224,6 +233,7 @@ private:
     const std::vector<Edge>& edges_;
     const std::vector<ConditionalEdge>& conditional_edges_;
     BarrierSpecs barrier_specs_;
+    std::shared_ptr<const GraphRegistry> registry_;
 };
 
 } // namespace neograph::graph

--- a/include/neograph/graph/types.h
+++ b/include/neograph/graph/types.h
@@ -342,10 +342,11 @@ struct NodeContext {
     std::shared_ptr<Provider> provider;    ///< LLM provider for making completions.
     /// Non-owning tool pointers consumed by node factories at compile()
     /// time. **Lifetime contract**: the pointees must outlive the
-    /// GraphEngine. Typical pattern: hand the engine ownership via
-    /// `engine.own_tools(std::move(unique_ptr_vec))` after compile, or
-    /// keep the owning unique_ptrs alive in the caller's scope for at
-    /// least as long as the engine. Constructing NodeContext from a
+    /// GraphEngine. New code should pass an owned ToolSet through
+    /// EngineResources; compatibility code can call
+    /// `engine.own_tools(std::move(unique_ptr_vec))` after compile, or keep the
+    /// owning unique_ptrs alive in the caller's scope for at least as long as
+    /// the engine. Constructing NodeContext from a
     /// throwaway unique_ptr collection that goes out of scope before
     /// `engine->run()` returns leaves these pointers dangling and is UB.
     std::vector<Tool*>        tools;

--- a/include/neograph/graph/validator.h
+++ b/include/neograph/graph/validator.h
@@ -28,6 +28,8 @@
 
 namespace neograph::graph {
 
+class GraphRegistry;
+
 /// One static-analysis finding, with a machine-readable witness
 /// (counterexample) for tooling to highlight.
 struct Diagnostic {
@@ -92,6 +94,9 @@ public:
      * execute anything.
      */
     static ValidationReport validate(const CompiledGraph& cg);
+
+    /// @brief Validate using a local-first registry overlay.
+    static ValidationReport validate(const CompiledGraph& cg, const GraphRegistry& registry);
 };
 
 } // namespace neograph::graph

--- a/include/neograph/neograph.h
+++ b/include/neograph/neograph.h
@@ -16,17 +16,19 @@
 #pragma once
 
 // Foundation types
-#include <neograph/types.h>
-#include <neograph/provider.h>
 #include <neograph/completion_provider.h>
+#include <neograph/provider.h>
 #include <neograph/tool.h>
+#include <neograph/tool_set.h>
+#include <neograph/types.h>
 
 // Graph engine
-#include <neograph/graph/types.h>
-#include <neograph/graph/state.h>
-#include <neograph/graph/node.h>
-#include <neograph/graph/engine.h>
 #include <neograph/graph/checkpoint.h>
+#include <neograph/graph/engine.h>
 #include <neograph/graph/loader.h>
+#include <neograph/graph/node.h>
 #include <neograph/graph/react_graph.h>
+#include <neograph/graph/registry.h>
+#include <neograph/graph/state.h>
 #include <neograph/graph/store.h>
+#include <neograph/graph/types.h>

--- a/include/neograph/tool_set.h
+++ b/include/neograph/tool_set.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <neograph/tool.h>
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace neograph {
+
+/**
+ * @brief Move-only owner for a fixed collection of tools.
+ *
+ * ToolSet closes the lifetime gap of NodeContext::tools: build an owned set,
+ * pass it through EngineResources, and GraphEngine keeps the exact pointees
+ * alive for every run and resume. The collection is immutable after
+ * construction, while the Tool objects retain their normal mutable interface.
+ */
+class ToolSet {
+public:
+    ToolSet() = default;
+
+    explicit ToolSet(std::vector<std::unique_ptr<Tool>> tools) : tools_(std::move(tools)) {}
+
+    ToolSet(const ToolSet&)                = delete;
+    ToolSet& operator=(const ToolSet&)     = delete;
+    ToolSet(ToolSet&&) noexcept            = default;
+    ToolSet& operator=(ToolSet&&) noexcept = default;
+
+    std::vector<Tool*> view() const {
+        std::vector<Tool*> tools;
+        tools.reserve(tools_.size());
+        for (const auto& tool : tools_)
+            tools.push_back(tool.get());
+        return tools;
+    }
+
+    std::size_t size() const noexcept { return tools_.size(); }
+    bool        empty() const noexcept { return size() == 0; }
+
+    std::vector<std::unique_ptr<Tool>> release() && { return std::move(tools_); }
+
+private:
+    std::vector<std::unique_ptr<Tool>> tools_;
+};
+
+}  // namespace neograph

--- a/src/core/graph_compiler.cpp
+++ b/src/core/graph_compiler.cpp
@@ -1,5 +1,7 @@
 #include <neograph/graph/compiler.h>
 #include <neograph/graph/node.h>
+#include <neograph/graph/registry.h>
+
 #include <algorithm>
 #include <cstdio>
 #include <vector>
@@ -136,6 +138,12 @@ json canon_conditional(const json& e) {
 
 CompiledGraph GraphCompiler::compile(const json& definition,
                                      const NodeContext& default_context) {
+    return compile(definition, default_context, GraphRegistry::global());
+}
+
+CompiledGraph GraphCompiler::compile(const json&          definition,
+                                     const NodeContext&   default_context,
+                                     const GraphRegistry& registry) {
     CompiledGraph cg;
     std::vector<std::string> errors;
     std::set<std::string> top_consumed;
@@ -223,7 +231,7 @@ CompiledGraph GraphCompiler::compile(const json& definition,
         top_consumed.insert("nodes");
         for (const auto& [name, node_def] : definition["nodes"].items()) {
             auto type = node_def.value("type", "");
-            auto node = NodeFactory::instance().create(type, name, node_def, default_context);
+            auto node      = registry.create(type, name, node_def, default_context);
             cg.nodes[name] = std::move(node);
 
             std::set<std::string> node_consumed = {"type"};
@@ -267,7 +275,7 @@ CompiledGraph GraphCompiler::compile(const json& definition,
             // registered without a schema stay permissive (the
             // cookbook's custom nodes carry free-form config).
             if (strict) {
-                const json schema = NodeFactory::instance().config_schema(type);
+                const json schema = registry.config_schema(type);
                 bool open = !schema.contains("properties");
                 if (schema.contains("additionalProperties")) {
                     const auto& ap = schema["additionalProperties"];

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -51,7 +51,23 @@ std::unique_ptr<GraphEngine> GraphEngine::compile(
 }
 
 std::unique_ptr<GraphEngine> GraphEngine::build(const json& definition, EngineConfig config) {
-    auto cg = GraphCompiler::compile(definition, config.node_context);
+    return build(definition, std::move(config), {});
+}
+
+std::unique_ptr<GraphEngine> GraphEngine::build(const json&     definition,
+                                                EngineConfig    config,
+                                                EngineResources resources) {
+    if (!resources.tools.empty()) {
+        if (!config.node_context.tools.empty()) {
+            throw std::invalid_argument(
+                "GraphEngine::build received both EngineResources::tools and "
+                "NodeContext::tools; use the owned ToolSet only");
+        }
+        config.node_context.tools = resources.tools.view();
+    }
+
+    const auto& registry = resources.registry ? *resources.registry : GraphRegistry::global();
+    auto        cg       = GraphCompiler::compile(definition, config.node_context, registry);
 
     // Translation validation: assert nothing was silently dropped or
     // rewired between the JSON definition and the compiled graph.
@@ -59,17 +75,24 @@ std::unique_ptr<GraphEngine> GraphEngine::build(const json& definition, EngineCo
     // documents get a stderr warning. Must run before the moves below.
     GraphCompiler::verify_roundtrip(definition, cg);
 
-    return link(std::move(cg), std::move(config));
+    return link(std::move(cg), std::move(config), std::move(resources));
 }
 
 std::unique_ptr<GraphEngine> GraphEngine::link(CompiledGraph cg, EngineConfig config) {
+    return link(std::move(cg), std::move(config), {});
+}
+
+std::unique_ptr<GraphEngine> GraphEngine::link(CompiledGraph   cg,
+                                               EngineConfig    config,
+                                               EngineResources resources) {
     // Static semantic analysis (issue #75 M2). Strict documents:
     // errors throw, warnings go to stderr. Legacy documents: only
     // errors are surfaced (as stderr warnings — they were silent
     // breakage before, e.g. a dangling edge or an empty route map),
     // heuristic lint is suppressed to keep existing graphs quiet.
     {
-        auto report = GraphValidator::validate(cg);
+        const auto& registry = resources.registry ? *resources.registry : GraphRegistry::global();
+        auto        report   = GraphValidator::validate(cg, registry);
         if (cg.schema_version >= 1) {
             if (report.has_errors()) {
                 std::string msg = "graph validation failed (schema_version "
@@ -106,6 +129,7 @@ std::unique_ptr<GraphEngine> GraphEngine::link(CompiledGraph cg, EngineConfig co
     engine->checkpoint_store_    = std::move(config.checkpoint_store);
     engine->store_               = std::move(config.store);
     engine->tool_gate_           = std::move(config.tool_gate);
+    engine->owned_tools_         = std::move(resources.tools).release();
     for (const auto& node_name : config.cached_nodes) {
         engine->node_cache_.set_enabled(node_name, true);
     }
@@ -117,8 +141,17 @@ std::unique_ptr<GraphEngine> GraphEngine::link(CompiledGraph cg, EngineConfig co
     // and deadlock conditional self-loops. Explicitly-declared barriers
     // (via the node's "barrier": {"wait_for": [...]} field) opt back
     // into AND-join semantics for those specific nodes.
-    engine->scheduler_ = std::make_unique<Scheduler>(
-        engine->edges_, engine->conditional_edges_, std::move(cg.barrier_specs));
+    engine->scheduler_ =
+        std::make_unique<Scheduler>(engine->edges_, engine->conditional_edges_,
+                                    std::move(cg.barrier_specs), resources.registry);
+
+    GraphEngine* self         = engine.get();
+    auto         retry_lookup = [self](const std::string& node_name) {
+        return self->get_retry_policy(node_name);
+    };
+    engine->executor_ = std::make_unique<NodeExecutor>(
+        engine->nodes_, engine->channel_defs_, std::move(retry_lookup),
+        std::move(resources.registry), nullptr, &engine->node_cache_);
 
     // NodeExecutor owns retry + fan-out + Send invocation. Bind the
     // retry-policy lookup to this engine's per-node override map so
@@ -201,20 +234,19 @@ void GraphEngine::set_worker_count(std::size_t n) {
     // resizable. Dtor joins the old pool's workers, so callers must
     // not resize across an in-flight run() (documented on declaration).
     GraphEngine* self = this;
+    auto         registry     = executor_ ? executor_->registry_ : nullptr;
     auto retry_lookup = [self](const std::string& node_name) {
         return self->get_retry_policy(node_name);
     };
     if (n == 1) {
         pool_.reset();
-        executor_ = std::make_unique<NodeExecutor>(
-            nodes_, channel_defs_, std::move(retry_lookup),
-            nullptr, &node_cache_);
+        executor_ = std::make_unique<NodeExecutor>(nodes_, channel_defs_, std::move(retry_lookup),
+                                                   std::move(registry), nullptr, &node_cache_);
         return;
     }
     pool_ = std::make_unique<asio::thread_pool>(n);
-    executor_ = std::make_unique<NodeExecutor>(
-        nodes_, channel_defs_, std::move(retry_lookup),
-        pool_.get(), &node_cache_);
+    executor_ = std::make_unique<NodeExecutor>(nodes_, channel_defs_, std::move(retry_lookup),
+                                               std::move(registry), pool_.get(), &node_cache_);
 }
 
 void GraphEngine::set_worker_count_auto() {
@@ -350,14 +382,7 @@ std::string GraphEngine::fork(const std::string& source_thread_id,
 // =========================================================================
 
 void GraphEngine::init_state(GraphState& state) const {
-    for (const auto& cd : channel_defs_) {
-        auto reducer = ReducerRegistry::instance().get(cd.reducer_name);
-        json initial = cd.initial_value;
-        if (cd.type == ReducerType::APPEND && initial.is_null()) {
-            initial = json::array();
-        }
-        state.init_channel(cd.name, cd.type, reducer, initial);
-    }
+    executor_->init_state(state);
 }
 
 void GraphEngine::apply_input(GraphState& state, const json& input) const {

--- a/src/core/graph_executor.cpp
+++ b/src/core/graph_executor.cpp
@@ -1,13 +1,14 @@
-#include <neograph/graph/executor.h>
-#include <neograph/graph/engine.h>   // RunContext (forward-declared in executor.h)
-#include <neograph/graph/state.h>
-#include <neograph/graph/loader.h>
 #include <neograph/graph/cancel.h>
+#include <neograph/graph/engine.h>  // RunContext (forward-declared in executor.h)
+#include <neograph/graph/executor.h>
+#include <neograph/graph/loader.h>
+#include <neograph/graph/registry.h>
+#include <neograph/graph/state.h>
 
 #include <asio/co_spawn.hpp>
 #include <asio/deferred.hpp>
-#include <asio/experimental/parallel_group.hpp>
 #include <asio/error.hpp>
+#include <asio/experimental/parallel_group.hpp>
 #include <asio/steady_timer.hpp>
 #include <asio/system_error.hpp>
 #include <asio/this_coro.hpp>
@@ -15,12 +16,12 @@
 
 #include <algorithm>
 #include <atomic>
-#include <cstdlib>
-#include <cstring>
-#include <random>
 #include <chrono>
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <optional>
+#include <random>
 #include <sstream>
 #include <stdexcept>
 
@@ -69,21 +70,31 @@ inline std::string make_send_task_id(int step, size_t idx,
 // NodeExecutor construction + helpers
 // =========================================================================
 
-NodeExecutor::NodeExecutor(
-    const std::map<std::string, std::unique_ptr<GraphNode>>& nodes,
-    const std::vector<ChannelDef>& channel_defs,
-    RetryPolicyLookup retry_policy_for,
-    asio::thread_pool* fan_out_pool,
-    NodeCache* node_cache)
+NodeExecutor::NodeExecutor(const std::map<std::string, std::unique_ptr<GraphNode>>& nodes,
+                           const std::vector<ChannelDef>&                           channel_defs,
+                           RetryPolicyLookup  retry_policy_for,
+                           asio::thread_pool* fan_out_pool,
+                           NodeCache*         node_cache)
+    : NodeExecutor(
+          nodes, channel_defs, std::move(retry_policy_for), nullptr, fan_out_pool, node_cache) {}
+
+NodeExecutor::NodeExecutor(const std::map<std::string, std::unique_ptr<GraphNode>>& nodes,
+                           const std::vector<ChannelDef>&                           channel_defs,
+                           RetryPolicyLookup                    retry_policy_for,
+                           std::shared_ptr<const GraphRegistry> registry,
+                           asio::thread_pool*                   fan_out_pool,
+                           NodeCache*                           node_cache)
     : nodes_(nodes),
       channel_defs_(channel_defs),
       retry_policy_for_(std::move(retry_policy_for)),
+      registry_(std::move(registry)),
       fan_out_pool_(fan_out_pool),
       node_cache_(node_cache) {}
 
 void NodeExecutor::init_state(GraphState& state) const {
     for (const auto& cd : channel_defs_) {
-        auto reducer = ReducerRegistry::instance().get(cd.reducer_name);
+        auto reducer = registry_ ? registry_->reducer(cd.reducer_name)
+                                 : ReducerRegistry::instance().get(cd.reducer_name);
         json initial = cd.initial_value;
         if (cd.type == ReducerType::APPEND && initial.is_null()) {
             initial = json::array();

--- a/src/core/graph_loader.cpp
+++ b/src/core/graph_loader.cpp
@@ -1,12 +1,14 @@
+#include <neograph/graph/engine.h>
 #include <neograph/graph/loader.h>
 #include <neograph/graph/node.h>
-#include <neograph/graph/engine.h>
+#include <neograph/graph/registry.h>
 #include <neograph/graph/state.h>
+
 #include <algorithm>
-#include <stdexcept>
 #include <fstream>
-#include <vector>
+#include <stdexcept>
 #include <string>
+#include <vector>
 
 // Stamped into export_schema() so external tooling can detect when its
 // cached schema is older than the engine. Defined by CMake
@@ -485,6 +487,96 @@ std::unique_ptr<GraphNode> NodeFactory::create(
             "See docs/troubleshooting.md \"Unknown node type\".");
     }
     return it->second(name, config, ctx);
+}
+
+// =========================================================================
+// GraphRegistry
+// =========================================================================
+
+const GraphRegistry& GraphRegistry::global() {
+    static const GraphRegistry registry;
+    return registry;
+}
+
+void GraphRegistry::register_reducer(const std::string& name, ReducerFn fn) {
+    reducers_[name] = std::move(fn);
+}
+
+void GraphRegistry::register_condition(const std::string& name, ConditionFn fn) {
+    conditions_[name] = std::move(fn);
+    condition_specs_.erase(name);
+}
+
+void GraphRegistry::register_condition(const std::string& name,
+                                       ConditionFn        fn,
+                                       ConditionSpec      spec) {
+    conditions_[name]      = std::move(fn);
+    condition_specs_[name] = std::move(spec);
+}
+
+void GraphRegistry::register_type(const std::string& type, NodeFactoryFn fn) {
+    register_type(type, std::move(fn), json::parse(R"JSON({
+                      "type": "object",
+                      "description": "No declared config schema; any object accepted."
+                  })JSON"));
+}
+
+void GraphRegistry::register_type(const std::string& type, NodeFactoryFn fn, json config_schema) {
+    node_factories_[type] = std::move(fn);
+    node_schemas_[type]   = std::move(config_schema);
+    node_effects_.erase(type);
+}
+
+void GraphRegistry::register_type(const std::string& type,
+                                  NodeFactoryFn      fn,
+                                  json               config_schema,
+                                  json               effects) {
+    node_factories_[type] = std::move(fn);
+    node_schemas_[type]   = std::move(config_schema);
+    node_effects_[type]   = std::move(effects);
+}
+
+ReducerFn GraphRegistry::reducer(const std::string& name) const {
+    auto it = reducers_.find(name);
+    return it != reducers_.end() ? it->second : ReducerRegistry::instance().get(name);
+}
+
+ConditionFn GraphRegistry::condition(const std::string& name) const {
+    auto it = conditions_.find(name);
+    return it != conditions_.end() ? it->second : ConditionRegistry::instance().get(name);
+}
+
+std::optional<ConditionSpec> GraphRegistry::condition_spec(const std::string& name) const {
+    if (conditions_.count(name)) {
+        auto it = condition_specs_.find(name);
+        return it == condition_specs_.end() ? std::nullopt
+                                            : std::optional<ConditionSpec>(it->second);
+    }
+    return ConditionRegistry::instance().condition_spec(name);
+}
+
+std::unique_ptr<GraphNode> GraphRegistry::create(const std::string& type,
+                                                 const std::string& name,
+                                                 const json&        config,
+                                                 const NodeContext& ctx) const {
+    auto it = node_factories_.find(type);
+    return it != node_factories_.end() ? it->second(name, config, ctx)
+                                       : NodeFactory::instance().create(type, name, config, ctx);
+}
+
+json GraphRegistry::config_schema(const std::string& type) const {
+    if (!node_factories_.count(type)) return NodeFactory::instance().config_schema(type);
+    auto it = node_schemas_.find(type);
+    return it != node_schemas_.end()
+               ? it->second
+               : json::parse(
+                     R"JSON({"type":"object","description":"No declared config schema; any object accepted."})JSON");
+}
+
+json GraphRegistry::node_effects(const std::string& type) const {
+    if (!node_factories_.count(type)) return NodeFactory::instance().node_effects(type);
+    auto it = node_effects_.find(type);
+    return it != node_effects_.end() ? it->second : json();
 }
 
 } // namespace neograph::graph

--- a/src/core/graph_validator.cpp
+++ b/src/core/graph_validator.cpp
@@ -1,5 +1,7 @@
-#include <neograph/graph/validator.h>
 #include <neograph/graph/loader.h>
+#include <neograph/graph/registry.h>
+#include <neograph/graph/validator.h>
+
 #include <algorithm>
 #include <map>
 #include <queue>
@@ -20,6 +22,7 @@ json string_set_to_array(const std::set<std::string>& s) {
 
 struct Ctx {
     const CompiledGraph& cg;
+    const GraphRegistry&  registry;
     std::set<std::string> node_names;
     // Static successor map: plain edges + every conditional route
     // target. The scheduler's fallback route is always one of the
@@ -244,7 +247,7 @@ void check_routes(Ctx& c) {
             continue;
         }
 
-        auto spec = ConditionRegistry::instance().condition_spec(ce.condition);
+        auto spec = c.registry.condition_spec(ce.condition);
         if (!spec) continue;   // no declared contract — skip
 
         const std::set<std::string> labels(spec->labels.begin(), spec->labels.end());
@@ -292,7 +295,7 @@ void check_effects(Ctx& c) {
     std::map<std::string, std::pair<std::set<std::string>, std::set<std::string>>>
         node_rw;   // node -> (reads, writes)
     for (const auto& n : c.node_names) {
-        const json eff = NodeFactory::instance().node_effects(c.node_type(n));
+        const json eff = c.registry.node_effects(c.node_type(n));
         if (eff.is_null() || !eff.is_object()) return;   // gate: skip family
         std::set<std::string> reads, writes;
         if (eff.contains("reads"))
@@ -433,7 +436,11 @@ std::string ValidationReport::summary() const {
 }
 
 ValidationReport GraphValidator::validate(const CompiledGraph& cg) {
-    Ctx c{cg, {}, {}, {}};
+    return validate(cg, GraphRegistry::global());
+}
+
+ValidationReport GraphValidator::validate(const CompiledGraph& cg, const GraphRegistry& registry) {
+    Ctx c{cg, registry, {}, {}, {}};
     for (const auto& [name, node] : cg.nodes) {
         (void)node;
         c.node_names.insert(name);

--- a/src/core/scheduler.cpp
+++ b/src/core/scheduler.cpp
@@ -1,6 +1,7 @@
+#include <neograph/graph/loader.h>
+#include <neograph/graph/registry.h>
 #include <neograph/graph/scheduler.h>
 #include <neograph/graph/state.h>
-#include <neograph/graph/loader.h>
 
 #include <algorithm>
 #include <set>
@@ -8,19 +9,27 @@
 
 namespace neograph::graph {
 
-Scheduler::Scheduler(const std::vector<Edge>& edges,
+Scheduler::Scheduler(const std::vector<Edge>&            edges,
                      const std::vector<ConditionalEdge>& conditional_edges,
-                     BarrierSpecs barrier_specs)
+                     BarrierSpecs                        barrier_specs)
+    : Scheduler(edges, conditional_edges, std::move(barrier_specs), nullptr) {}
+
+Scheduler::Scheduler(const std::vector<Edge>&             edges,
+                     const std::vector<ConditionalEdge>&  conditional_edges,
+                     BarrierSpecs                         barrier_specs,
+                     std::shared_ptr<const GraphRegistry> registry)
     : edges_(edges),
       conditional_edges_(conditional_edges),
-      barrier_specs_(std::move(barrier_specs)) {}
+      barrier_specs_(std::move(barrier_specs)),
+      registry_(std::move(registry)) {}
 
 std::vector<std::string> Scheduler::resolve_next_nodes(
     const std::string& current, const GraphState& state) const {
 
     for (const auto& ce : conditional_edges_) {
         if (ce.from == current) {
-            auto cond_fn = ConditionRegistry::instance().get(ce.condition);
+            auto cond_fn = registry_ ? registry_->condition(ce.condition)
+                                     : ConditionRegistry::instance().get(ce.condition);
             auto result  = cond_fn(state);
             auto it = ce.routes.find(result);
             if (it != ce.routes.end()) return {it->second};

--- a/tests/test_engine_config.cpp
+++ b/tests/test_engine_config.cpp
@@ -83,6 +83,108 @@ std::atomic<int> CountingNode::calls{0};
 
 std::atomic<int> link_factory_calls{0};
 
+class OwnedProbeTool final : public Tool {
+public:
+    static std::atomic<int> destructions;
+
+    ~OwnedProbeTool() override { ++destructions; }
+
+    ChatTool get_definition() const override {
+        return {"owned_probe", "ToolSet lifetime probe", json::object()};
+    }
+    std::string execute(const json&) override { return "tool-alive"; }
+    std::string get_name() const override { return "owned_probe"; }
+};
+
+std::atomic<int> OwnedProbeTool::destructions{0};
+
+class ToolProbeNode final : public GraphNode {
+public:
+    explicit ToolProbeNode(Tool* tool) : tool_(tool) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.writes.push_back({"output", tool_->execute(json::object())});
+        co_return out;
+    }
+
+    std::string get_name() const override { return "work"; }
+
+private:
+    Tool* tool_;
+};
+
+class RegistryProbeNode final : public GraphNode {
+public:
+    explicit RegistryProbeNode(std::string name) : name_(std::move(name)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        if (name_ == "seed") {
+            out.writes.push_back({"value", 1});
+        } else {
+            out.writes.push_back({"output", name_});
+        }
+        co_return out;
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+};
+
+json registry_graph() {
+    return {
+        {"schema_version", 1},
+        {"name", "registry_isolation"},
+        {"channels",
+         {
+             {"value", {{"reducer", "engine_local_reducer"}, {"initial", 0}}},
+             {"output", {{"reducer", "overwrite"}}},
+         }},
+        {"nodes",
+         {
+             {"seed", {{"type", "engine_local_node"}}},
+             {"one", {{"type", "engine_local_node"}}},
+             {"eleven", {{"type", "engine_local_node"}}},
+             {"wrong", {{"type", "engine_local_node"}}},
+         }},
+        {"edges", json::array({
+                      {{"from", "__start__"}, {"to", "seed"}},
+                      {{"from", "one"}, {"to", "__end__"}},
+                      {{"from", "eleven"}, {"to", "__end__"}},
+                      {{"from", "wrong"}, {"to", "__end__"}},
+                  })},
+        {"conditional_edges",
+         json::array({
+             {{"from", "seed"},
+              {"condition", "engine_local_condition"},
+              {"routes", {{"one", "one"}, {"eleven", "eleven"}, {"wrong", "wrong"}}}},
+         })},
+    };
+}
+
+std::shared_ptr<GraphRegistry> make_registry(int         reducer_bias,
+                                             int         expected_value,
+                                             std::string route) {
+    auto registry = std::make_shared<GraphRegistry>();
+    registry->register_type("engine_local_node",
+                            [](const std::string& name, const json&, const NodeContext&) {
+                                return std::make_unique<RegistryProbeNode>(name);
+                            });
+    registry->register_reducer("engine_local_reducer",
+                               [reducer_bias](const json& current, const json& incoming) {
+                                   return current.get<int>() + incoming.get<int>() + reducer_bias;
+                               });
+    registry->register_condition(
+        "engine_local_condition",
+        [expected_value, route = std::move(route)](const GraphState& state) {
+            return state.get("value").get<int>() == expected_value ? route : "wrong";
+        });
+    return registry;
+}
+
 void register_node(const std::string& type, NodeFactoryFn factory) {
     NodeFactory::instance().register_type(
         type, std::move(factory), json::parse(R"({"type":"object","properties":{}})"),
@@ -202,4 +304,63 @@ TEST(CompiledGraphLinkTest, AppliesSemanticValidationBeforeRuntimeConstruction) 
     graph.edges.push_back({"missing", "work"});
 
     EXPECT_THROW((void)GraphEngine::link(std::move(graph)), std::runtime_error);
+}
+
+TEST(EngineResourcesTest, KeepsOwnedToolSetAliveForEngineLifetime) {
+    OwnedProbeTool::destructions = 0;
+
+    auto registry = std::make_shared<GraphRegistry>();
+    registry->register_type(
+        "owned_tool_probe", [](const std::string&, const json&, const NodeContext& context) {
+            if (context.tools.size() != 1) {
+                throw std::runtime_error("owned ToolSet was not bound to NodeContext");
+            }
+            return std::make_unique<ToolProbeNode>(context.tools.front());
+        });
+
+    std::vector<std::unique_ptr<Tool>> tools;
+    tools.push_back(std::make_unique<OwnedProbeTool>());
+
+    EngineResources resources;
+    resources.tools    = ToolSet(std::move(tools));
+    resources.registry = registry;
+    auto engine        = GraphEngine::build(one_node_graph("owned_tool_probe"), EngineConfig{},
+                                            std::move(resources));
+
+    EXPECT_EQ(OwnedProbeTool::destructions.load(), 0);
+    RunConfig run;
+    EXPECT_EQ(engine->run(run).channel<std::string>("output"), "tool-alive");
+
+    engine.reset();
+    EXPECT_EQ(OwnedProbeTool::destructions.load(), 1);
+}
+
+TEST(EngineResourcesTest, IsolatesNodeReducerAndConditionRegistrationsPerEngine) {
+    EngineResources first_resources;
+    first_resources.registry = make_registry(0, 1, "one");
+    auto first = GraphEngine::build(registry_graph(), EngineConfig{}, std::move(first_resources));
+
+    EngineResources second_resources;
+    second_resources.registry = make_registry(10, 11, "eleven");
+    auto second = GraphEngine::build(registry_graph(), EngineConfig{}, std::move(second_resources));
+
+    RunConfig run;
+    EXPECT_EQ(first->run(run).channel<std::string>("output"), "one");
+    EXPECT_EQ(second->run(run).channel<std::string>("output"), "eleven");
+    EXPECT_THROW((void)GraphEngine::build(registry_graph(), EngineConfig{}), std::runtime_error);
+}
+
+TEST(EngineResourcesTest, RejectsAmbiguousOwnedAndRawToolBindings) {
+    EngineConfig   config;
+    OwnedProbeTool raw_tool;
+    config.node_context.tools = {&raw_tool};
+
+    std::vector<std::unique_ptr<Tool>> tools;
+    tools.push_back(std::make_unique<OwnedProbeTool>());
+    EngineResources resources;
+    resources.tools = ToolSet(std::move(tools));
+
+    EXPECT_THROW(
+        (void)GraphEngine::build(one_node_graph("unused"), std::move(config), std::move(resources)),
+        std::invalid_argument);
 }


### PR DESCRIPTION
## Summary

- add a move-only `ToolSet` whose ownership transfers into `GraphEngine`
- add a per-engine `GraphRegistry` overlay for node factories, reducers, and conditions
- thread the registry through compile, validation, scheduling, and state initialization
- retain raw `NodeContext::tools`, legacy overloads, and process-global registries as compatibility fallbacks

## Compatibility

- existing exported signatures remain available
- `EngineConfig` and `NodeContext` layouts are unchanged
- legacy build/link paths delegate to the new canonical overloads
- local registry misses fall back to existing process-global registrations

## Verification

- focused engine configuration suite: 8/8 passed
- full build including examples and cookbook targets passed
- serial full test suite: 784/784 passed
- `git clang-format --diff origin/master`: clean
- `git diff --check origin/master...HEAD`: clean

Refs #159