### PR TITLE
feat(graph): add typed run and stream views

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,7 @@ add_library(neograph_core
     src/core/node_cache.cpp
     src/core/scheduler.cpp
     src/core/graph_state.cpp
+    src/core/graph_events.cpp
     src/core/graph_node.cpp
     src/core/tool_dispatch.cpp
     src/core/graph_loader.cpp

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -294,6 +294,33 @@ inline void record_usage(const RunContext& ctx, const ChatCompletion& completion
 }
 
 /**
+ * @brief Typed channel name for RunResult access.
+ *
+ * ChannelKey binds a channel name to its expected C++ value type without
+ * changing the JSON-backed channel model. Keep keys as reusable constants and
+ * pass them to RunResult::channel() or RunResult::try_channel().
+ */
+template <typename T>
+class ChannelKey {
+public:
+    using value_type = T;
+
+    explicit ChannelKey(std::string name) : name_(std::move(name)) {}
+
+    const std::string& name() const noexcept { return name_; }
+
+private:
+    std::string name_;
+};
+
+/// @brief Normal, paused, or step-limited outcome of a successful run call.
+enum class RunStatus {
+    Completed,
+    Interrupted,
+    StepLimit,
+};
+
+/**
  * @brief Result of a graph execution run.
  *
  * ## ``output`` shape (issue #25)
@@ -353,6 +380,13 @@ struct RunResult {
         return yyjson_mut_is_bool(marker) && yyjson_mut_get_bool(marker);
     }
 
+    /// @brief Return a typed outcome without changing the legacy result layout.
+    RunStatus status() const noexcept {
+        if (interrupted) return RunStatus::Interrupted;
+        if (max_steps_exhausted()) return RunStatus::StepLimit;
+        return RunStatus::Completed;
+    }
+
     /// @brief Read a channel value as type ``T`` (issue #25).
     ///
     /// Looks up the value in ``output``. Tries the canonical
@@ -372,6 +406,19 @@ struct RunResult {
     template <typename T>
     T channel(const std::string& name) const {
         return channel_raw(name).get<T>();
+    }
+
+    /// @brief Read a channel using a reusable typed key.
+    template <typename T>
+    T channel(const ChannelKey<T>& key) const {
+        return channel<T>(key.name());
+    }
+
+    /// @brief Read a typed channel when present, preserving conversion errors.
+    template <typename T>
+    std::optional<T> try_channel(const ChannelKey<T>& key) const {
+        if (!has_channel(key.name())) return std::nullopt;
+        return channel(key);
     }
 
     /// @brief Read a channel value as a raw ``json`` node (issue #25).

--- a/include/neograph/graph/types.h
+++ b/include/neograph/graph/types.h
@@ -9,18 +9,21 @@
 #pragma once
 
 #include <neograph/api.h>
-#include <neograph/types.h>
 #include <neograph/provider.h>
 #include <neograph/tool.h>
+#include <neograph/types.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <exception>
 #include <functional>
 #include <map>
 #include <memory>
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <variant>
 #include <vector>
-#include <cstdint>
-#include <exception>
 
 // Windows SDK (pulled in transitively via asio on Win32) defines a
 // bunch of ALL-CAPS macros — notably ERROR (wingdi.h) and DEBUG —
@@ -373,9 +376,107 @@ struct GraphEvent {
     json        data;       ///< Event-specific data payload.
 };
 
+/// Typed view of a node-start event. `data` preserves extension fields.
+struct NodeStartEvent {
+    std::string        node_name;
+    std::optional<int> retry_attempt;
+    json               data;
+};
+
+/// Typed view of a node-end event. `data` preserves extension fields.
+struct NodeEndEvent {
+    std::string                node_name;
+    std::optional<std::string> command_goto;
+    std::size_t                send_count = 0;
+    json                       data;
+};
+
+/// Typed LLM token event.
+struct LlmTokenEvent {
+    std::string node_name;
+    std::string token;
+};
+
+/// Typed channel update event.
+struct ChannelWriteEvent {
+    std::string node_name;
+    std::string channel;
+    json        value;
+};
+
+/// Full serialized state emitted for StreamMode::VALUES.
+struct StateSnapshotEvent {
+    json state;
+};
+
+/// Routing decision emitted for StreamMode::DEBUG.
+struct RoutingEvent {
+    std::optional<std::string> command_goto;
+    std::vector<std::string>   next_nodes;
+    std::optional<int>         step;
+    json                       data;
+};
+
+/// Dynamic Send batch emitted for StreamMode::DEBUG.
+struct SendDispatchEvent {
+    std::vector<Send> sends;
+};
+
+/// Typed HITL interrupt event. `data` remains available for custom metadata.
+struct InterruptEvent {
+    std::string                node_name;
+    std::optional<std::string> phase;
+    std::optional<std::string> checkpoint_id;
+    json                       data;
+};
+
+/// Typed execution error event. `data` preserves retry diagnostics.
+struct ErrorEvent {
+    std::string node_name;
+    std::string message;
+    json        data;
+};
+
+/// Escape hatch for malformed input or payload shapes added by future versions.
+struct RawGraphEvent {
+    GraphEvent event;
+};
+
+using TypedGraphEvent = std::variant<NodeStartEvent,
+                                     NodeEndEvent,
+                                     LlmTokenEvent,
+                                     ChannelWriteEvent,
+                                     StateSnapshotEvent,
+                                     RoutingEvent,
+                                     SendDispatchEvent,
+                                     InterruptEvent,
+                                     ErrorEvent,
+                                     RawGraphEvent>;
+
+/**
+ * @brief Convert the stable GraphEvent wire shape to an owning typed event.
+ *
+ * Existing JSON and callback contracts remain canonical. Sentinel debug events
+ * (`__state__`, `__routing__`, and `__send__`) receive dedicated alternatives;
+ * malformed or unknown payloads are returned as RawGraphEvent instead of
+ * throwing from a streaming callback.
+ */
+NEOGRAPH_API TypedGraphEvent to_typed_event(const GraphEvent& event);
+
 /// Callback for receiving graph execution events.
 /// @param event The graph event to process.
 using GraphStreamCallback = std::function<void(const GraphEvent&)>;
+
+/// Callback for the additive typed event view.
+using TypedGraphStreamCallback = std::function<void(const TypedGraphEvent&)>;
+
+/// @brief Adapt a typed callback to the existing GraphStreamCallback surface.
+inline GraphStreamCallback adapt_typed_stream(TypedGraphStreamCallback callback) {
+    if (!callback) return {};
+    return [callback = std::move(callback)](const GraphEvent& event) {
+        callback(to_typed_event(event));
+    };
+}
 
 /**
  * @brief Extended result returned by node execution.

--- a/src/core/graph_events.cpp
+++ b/src/core/graph_events.cpp
@@ -1,0 +1,125 @@
+#include <neograph/graph/types.h>
+
+namespace neograph::graph {
+
+TypedGraphEvent to_typed_event(const GraphEvent& event) {
+    auto raw = [&event]() -> TypedGraphEvent { return RawGraphEvent{event}; };
+
+    try {
+        if (event.type == GraphEvent::Type::CHANNEL_WRITE && event.node_name == "__state__") {
+            return StateSnapshotEvent{event.data};
+        }
+
+        if (event.type == GraphEvent::Type::NODE_START && event.node_name == "__routing__") {
+            if (!event.data.is_object()) return raw();
+
+            RoutingEvent typed;
+            typed.data = event.data;
+            if (event.data.contains("command_goto")) {
+                const auto value = event.data["command_goto"];
+                if (!value.is_string()) return raw();
+                typed.command_goto = value.get<std::string>();
+            }
+            if (event.data.contains("next_nodes")) {
+                const auto values = event.data["next_nodes"];
+                if (!values.is_array()) return raw();
+                for (const auto& value : values) {
+                    if (!value.is_string()) return raw();
+                    typed.next_nodes.push_back(value.get<std::string>());
+                }
+            }
+            if (event.data.contains("step")) {
+                const auto value = event.data["step"];
+                if (!value.is_number_integer()) return raw();
+                typed.step = value.get<int>();
+            }
+            return typed;
+        }
+
+        if (event.type == GraphEvent::Type::NODE_START && event.node_name == "__send__") {
+            if (!event.data.is_object() || !event.data.contains("sends") ||
+                !event.data["sends"].is_array()) {
+                return raw();
+            }
+
+            SendDispatchEvent typed;
+            for (const auto& item : event.data["sends"]) {
+                if (!item.is_object() || !item.contains("target") || !item["target"].is_string()) {
+                    return raw();
+                }
+                Send send;
+                send.target_node = item["target"].get<std::string>();
+                if (item.contains("input")) send.input = item["input"];
+                typed.sends.push_back(std::move(send));
+            }
+            return typed;
+        }
+
+        switch (event.type) {
+            case GraphEvent::Type::NODE_START: {
+                NodeStartEvent typed{event.node_name, std::nullopt, event.data};
+                if (event.data.is_object() && event.data.contains("retry_attempt")) {
+                    const auto value = event.data["retry_attempt"];
+                    if (!value.is_number_integer()) return raw();
+                    typed.retry_attempt = value.get<int>();
+                }
+                return typed;
+            }
+            case GraphEvent::Type::NODE_END: {
+                NodeEndEvent typed;
+                typed.node_name = event.node_name;
+                typed.data      = event.data;
+                if (event.data.is_object() && event.data.contains("command_goto")) {
+                    const auto value = event.data["command_goto"];
+                    if (!value.is_string()) return raw();
+                    typed.command_goto = value.get<std::string>();
+                }
+                if (event.data.is_object() && event.data.contains("sends")) {
+                    const auto value = event.data["sends"];
+                    if (!value.is_number_integer() || value.get<int>() < 0) return raw();
+                    typed.send_count = static_cast<std::size_t>(value.get<int>());
+                }
+                return typed;
+            }
+            case GraphEvent::Type::LLM_TOKEN:
+                if (!event.data.is_string()) return raw();
+                return LlmTokenEvent{event.node_name, event.data.get<std::string>()};
+            case GraphEvent::Type::CHANNEL_WRITE: {
+                if (!event.data.is_object() || !event.data.contains("channel") ||
+                    !event.data["channel"].is_string() || !event.data.contains("value")) {
+                    return raw();
+                }
+                return ChannelWriteEvent{event.node_name, event.data["channel"].get<std::string>(),
+                                         event.data["value"]};
+            }
+            case GraphEvent::Type::INTERRUPT: {
+                InterruptEvent typed;
+                typed.node_name = event.node_name;
+                typed.data      = event.data;
+                if (event.data.is_object() && event.data.contains("phase")) {
+                    const auto value = event.data["phase"];
+                    if (!value.is_string()) return raw();
+                    typed.phase = value.get<std::string>();
+                }
+                if (event.data.is_object() && event.data.contains("checkpoint_id")) {
+                    const auto value = event.data["checkpoint_id"];
+                    if (!value.is_string()) return raw();
+                    typed.checkpoint_id = value.get<std::string>();
+                }
+                return typed;
+            }
+            case GraphEvent::Type::ERROR:
+                if (!event.data.is_object() || !event.data.contains("error") ||
+                    !event.data["error"].is_string()) {
+                    return raw();
+                }
+                return ErrorEvent{event.node_name, event.data["error"].get<std::string>(),
+                                  event.data};
+        }
+    } catch (const json::exception&) {
+        return raw();
+    }
+    return raw();
+}
+
+}  // namespace neograph::graph

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(neograph_tests
     test_completion_provider.cpp
     test_run_context_store.cpp
     test_run_result_channel.cpp
+    test_typed_events.cpp
     test_error_messages_friendly.cpp
     test_schema_provider_extra_fields_temperature.cpp
     test_openai_provider_async.cpp

--- a/tests/test_run_result_channel.cpp
+++ b/tests/test_run_result_channel.cpp
@@ -15,7 +15,9 @@
 #include <neograph/json.h>
 
 using neograph::json;
+using neograph::graph::ChannelKey;
 using neograph::graph::RunResult;
+using neograph::graph::RunStatus;
 
 namespace {
 
@@ -127,6 +129,24 @@ TEST(RunResultChannel, WrappedWithoutValueKeyFallsThroughToFlatLookup) {
     EXPECT_EQ(r.channel<std::string>("weird"), "from-flat");
 }
 
+TEST(RunResultChannel, TypedKeyReadsAndTriesWithoutStringlyCallSites) {
+    const ChannelKey<int> counter("counter");
+    const ChannelKey<int> missing("missing");
+    auto                  r = make_wrapped("counter", json(42));
+
+    EXPECT_EQ(r.channel(counter), 42);
+    ASSERT_TRUE(r.try_channel(counter).has_value());
+    EXPECT_EQ(*r.try_channel(counter), 42);
+    EXPECT_FALSE(r.try_channel(missing).has_value());
+}
+
+TEST(RunResultChannel, TypedKeyPreservesTypeErrors) {
+    const ChannelKey<int> counter("counter");
+    auto                  r = make_wrapped("counter", json("not a number"));
+
+    EXPECT_THROW((void)r.try_channel(counter), json::type_error);
+}
+
 TEST(RunResultStatus, MaxStepsExhaustedReadsReservedMarker) {
     RunResult r;
     r.output = json{{"_neograph", {{"max_steps_exhausted", true}}}};
@@ -147,4 +167,16 @@ TEST(RunResultStatus, MaxStepsExhaustedRejectsMalformedOrCollidingJson) {
 
     r.output = json{{"_neograph", {{"max_steps_exhausted", false}}}};
     EXPECT_FALSE(r.max_steps_exhausted());
+}
+
+TEST(RunResultStatus, ReportsCompletedInterruptedAndStepLimit) {
+    RunResult result;
+    result.output = json::object();
+    EXPECT_EQ(result.status(), RunStatus::Completed);
+
+    result.output = json{{"_neograph", {{"max_steps_exhausted", true}}}};
+    EXPECT_EQ(result.status(), RunStatus::StepLimit);
+
+    result.interrupted = true;
+    EXPECT_EQ(result.status(), RunStatus::Interrupted);
 }

--- a/tests/test_typed_events.cpp
+++ b/tests/test_typed_events.cpp
@@ -1,0 +1,115 @@
+#include <neograph/graph/types.h>
+
+#include <gtest/gtest.h>
+
+#include <variant>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+TEST(TypedGraphEvent, ConvertsStandardEventPayloads) {
+    auto started = to_typed_event(
+        GraphEvent{GraphEvent::Type::NODE_START, "worker", json{{"retry_attempt", 2}}});
+    ASSERT_TRUE(std::holds_alternative<NodeStartEvent>(started));
+    EXPECT_EQ(std::get<NodeStartEvent>(started).node_name, "worker");
+    EXPECT_EQ(std::get<NodeStartEvent>(started).retry_attempt, 2);
+
+    auto ended = to_typed_event(GraphEvent{GraphEvent::Type::NODE_END, "worker",
+                                           json{{"command_goto", "review"}, {"sends", 2}}});
+    ASSERT_TRUE(std::holds_alternative<NodeEndEvent>(ended));
+    EXPECT_EQ(std::get<NodeEndEvent>(ended).command_goto, "review");
+    EXPECT_EQ(std::get<NodeEndEvent>(ended).send_count, 2u);
+
+    auto token = to_typed_event(GraphEvent{GraphEvent::Type::LLM_TOKEN, "model", json("hello")});
+    ASSERT_TRUE(std::holds_alternative<LlmTokenEvent>(token));
+    EXPECT_EQ(std::get<LlmTokenEvent>(token).token, "hello");
+
+    auto write = to_typed_event(GraphEvent{GraphEvent::Type::CHANNEL_WRITE, "worker",
+                                           json{{"channel", "answer"}, {"value", 42}}});
+    ASSERT_TRUE(std::holds_alternative<ChannelWriteEvent>(write));
+    EXPECT_EQ(std::get<ChannelWriteEvent>(write).channel, "answer");
+    EXPECT_EQ(std::get<ChannelWriteEvent>(write).value.get<int>(), 42);
+
+    auto error = to_typed_event(
+        GraphEvent{GraphEvent::Type::ERROR, "worker", json{{"error", "failed"}, {"attempts", 3}}});
+    ASSERT_TRUE(std::holds_alternative<ErrorEvent>(error));
+    EXPECT_EQ(std::get<ErrorEvent>(error).message, "failed");
+    EXPECT_EQ(std::get<ErrorEvent>(error).data["attempts"].get<int>(), 3);
+
+    auto interrupt =
+        to_typed_event(GraphEvent{GraphEvent::Type::INTERRUPT, "approval",
+                                  json{{"phase", "before"}, {"checkpoint_id", "cp-1"}}});
+    ASSERT_TRUE(std::holds_alternative<InterruptEvent>(interrupt));
+    EXPECT_EQ(std::get<InterruptEvent>(interrupt).phase, "before");
+    EXPECT_EQ(std::get<InterruptEvent>(interrupt).checkpoint_id, "cp-1");
+}
+
+TEST(TypedGraphEvent, ConvertsStateRoutingAndSendSentinels) {
+    auto snapshot = to_typed_event(
+        GraphEvent{GraphEvent::Type::CHANNEL_WRITE, "__state__", json{{"global_version", 4}}});
+    ASSERT_TRUE(std::holds_alternative<StateSnapshotEvent>(snapshot));
+    EXPECT_EQ(std::get<StateSnapshotEvent>(snapshot).state["global_version"].get<int>(), 4);
+
+    auto routing = to_typed_event(
+        GraphEvent{GraphEvent::Type::NODE_START, "__routing__",
+                   json{{"next_nodes", json::array({"left", "right"})}, {"step", 5}}});
+    ASSERT_TRUE(std::holds_alternative<RoutingEvent>(routing));
+    EXPECT_EQ(std::get<RoutingEvent>(routing).next_nodes,
+              (std::vector<std::string>{"left", "right"}));
+    EXPECT_EQ(std::get<RoutingEvent>(routing).step, 5);
+
+    auto command = to_typed_event(
+        GraphEvent{GraphEvent::Type::NODE_START, "__routing__", json{{"command_goto", "review"}}});
+    ASSERT_TRUE(std::holds_alternative<RoutingEvent>(command));
+    EXPECT_EQ(std::get<RoutingEvent>(command).command_goto, "review");
+
+    json sends = json::array();
+    sends.push_back(json{{"target", "worker"}, {"input", {{"task", 7}}}});
+    auto dispatch = to_typed_event(
+        GraphEvent{GraphEvent::Type::NODE_START, "__send__", json{{"sends", sends}}});
+    ASSERT_TRUE(std::holds_alternative<SendDispatchEvent>(dispatch));
+    ASSERT_EQ(std::get<SendDispatchEvent>(dispatch).sends.size(), 1u);
+    EXPECT_EQ(std::get<SendDispatchEvent>(dispatch).sends[0].target_node, "worker");
+    EXPECT_EQ(std::get<SendDispatchEvent>(dispatch).sends[0].input["task"].get<int>(), 7);
+
+    auto empty_dispatch = to_typed_event(
+        GraphEvent{GraphEvent::Type::NODE_START, "__send__", json{{"sends", json::array()}}});
+    ASSERT_TRUE(std::holds_alternative<SendDispatchEvent>(empty_dispatch));
+    EXPECT_TRUE(std::get<SendDispatchEvent>(empty_dispatch).sends.empty());
+
+    json sends_without_input = json::array();
+    sends_without_input.push_back(json{{"target", "worker"}});
+    auto missing_input = to_typed_event(
+        GraphEvent{GraphEvent::Type::NODE_START, "__send__", json{{"sends", sends_without_input}}});
+    ASSERT_TRUE(std::holds_alternative<SendDispatchEvent>(missing_input));
+    ASSERT_EQ(std::get<SendDispatchEvent>(missing_input).sends.size(), 1u);
+    EXPECT_TRUE(std::get<SendDispatchEvent>(missing_input).sends[0].input.is_null());
+}
+
+TEST(TypedGraphEvent, MalformedPayloadFallsBackToRawEvent) {
+    GraphEvent malformed{GraphEvent::Type::CHANNEL_WRITE, "worker", json{{"channel", 12}}};
+    auto       typed = to_typed_event(malformed);
+
+    ASSERT_TRUE(std::holds_alternative<RawGraphEvent>(typed));
+    EXPECT_EQ(std::get<RawGraphEvent>(typed).event.node_name, "worker");
+    EXPECT_EQ(std::get<RawGraphEvent>(typed).event.data["channel"].get<int>(), 12);
+
+    json malformed_sends = json::array();
+    malformed_sends.push_back(json{{"target", 12}});
+    auto malformed_dispatch = to_typed_event(
+        GraphEvent{GraphEvent::Type::NODE_START, "__send__", json{{"sends", malformed_sends}}});
+    EXPECT_TRUE(std::holds_alternative<RawGraphEvent>(malformed_dispatch));
+}
+
+TEST(TypedGraphEvent, AdapterPreservesExistingCallbackSurface) {
+    bool saw_token = false;
+    auto callback  = adapt_typed_stream([&](const TypedGraphEvent& event) {
+        if (const auto* token = std::get_if<LlmTokenEvent>(&event)) {
+            saw_token = token->token == "chunk";
+        }
+    });
+
+    callback(GraphEvent{GraphEvent::Type::LLM_TOKEN, "model", json("chunk")});
+    EXPECT_TRUE(saw_token);
+    EXPECT_FALSE(static_cast<bool>(adapt_typed_stream({})));
+}


### PR DESCRIPTION
## Summary

- add `RunStatus` and `RunResult::status()` without changing the result layout
- add reusable `ChannelKey<T>` reads and missing-aware `try_channel()`
- add event-specific `TypedGraphEvent` variants for node, token, channel, state, routing, Send, interrupt, and error events
- adapt typed callbacks over the unchanged `GraphStreamCallback` and preserve malformed/future payloads as `RawGraphEvent`

## Compatibility

- `RunResult` and `GraphEvent` data layouts are unchanged
- the existing `GraphStreamCallback` signature and JSON payloads remain canonical
- cancellation and failures continue to use their existing exception behavior
- typed event conversion is additive and out-of-line to avoid parser code in every consumer translation unit

## Verification

- focused status/channel/event suite: 18/18 passed
- full build including examples and cookbook targets passed
- serial full test suite: 791/791 passed
- focused API/ABI review found no blocking issue
- `git clang-format --diff origin/master`: clean
- `git diff --check origin/master...HEAD`: clean

Refs #159
Related #158