### PR TITLE
docs(graph): migrate guides and examples to modern APIs

### DIFF
--- a/docs/ASYNC_GUIDE.md
+++ b/docs/ASYNC_GUIDE.md
@@ -19,7 +19,7 @@ Every synchronous I/O point in the engine now has an awaitable peer:
 |---|---|---|
 | Provider | `complete` / `complete_stream` | `complete_async` / `complete_stream_async` |
 | CheckpointStore | `save` / `load_latest` / `load_by_id` / `list` / `delete_thread` / `put_writes` / `get_writes` / `clear_writes` | `*_async` for each |
-| GraphNode | `execute` / `execute_stream` / `execute_full` / `execute_full_stream` | `*_async` for each |
+| GraphNode | — | `run(NodeInput) -> asio::awaitable<NodeOutput>` is the single canonical override |
 | GraphEngine | `run` / `run_stream` / `resume` | `run_async` / `run_stream_async` / `resume_async` |
 | MCPClient | `rpc_call` | `rpc_call_async` |
 | Tool | `execute` (user interface — frozen) | wrap with `AsyncTool` adapter |
@@ -39,7 +39,7 @@ path.
 
 ## 2. The crossover-default pattern
 
-Every sync/async pair on the abstract base classes is connected by a
+Every remaining sync/async pair on Provider and persistence abstractions is connected by a
 pair of default implementations that bridge each direction:
 
 ```cpp
@@ -68,17 +68,17 @@ defaults until the stack overflows. Documented; no runtime guard
 |---|---|
 | Issues real non-blocking I/O (HTTP, MCP, DB, timer) | **async peer** — inherit the sync facade |
 | Pure CPU work, or blocks briefly on a sync library | **sync peer** — inherit the async bridge |
-| Must emit `Command` or `Send` from a coroutine body (graph nodes) | override `execute_full_async` directly |
-| Streaming-aware LLM node that produces writes through a token stream | both `execute_async` (for non-stream paths) and either `execute_stream_async` or `execute_full_stream_async` |
+| Custom `GraphNode` | override `run(NodeInput)`; return writes, `Command`, and `Send` in one `NodeOutput` |
 
 ### Why not a single unified API?
 
-Collapsing sync into async (making every call a coroutine) would
-force every existing Tool, every user-authored GraphNode, every
+Collapsing every public abstraction into async would
+force every existing Tool and every
 CheckpointStore subclass to acknowledge the async machinery —
 including cases where it buys nothing (a tool that adds two
-numbers). The crossover pair is the zero-migration-cost path:
-legacy implementors change nothing.
+numbers). The crossover pair remains the zero-migration-cost path for
+those abstractions. `GraphNode` was intentionally collapsed to one
+coroutine override in v1.0.
 
 ---
 
@@ -170,15 +170,16 @@ halves is a contract violation.
 ```cpp
 class MyNode : public GraphNode {
   public:
-    asio::awaitable<std::vector<ChannelWrite>>
-    execute_async(const GraphState& state) override {
-        CompletionParams params = build_params(state);
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        CompletionParams params = build_params(in.state);
+        params.cancel_token = in.ctx.cancel_token;
         auto completion = co_await provider_->complete_async(params);
 
         neograph::json msg;
         to_json(msg, completion.message);
-        co_return std::vector<ChannelWrite>{
-            ChannelWrite{"messages", json::array({msg})}};
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"messages", json::array({msg})});
+        co_return out;
     }
 
     std::string get_name() const override { return name_; }
@@ -188,10 +189,9 @@ class MyNode : public GraphNode {
 };
 ```
 
-The node's sync `execute()` comes from the `GraphNode` crossover
-default and routes through `run_sync`. For graph users who drive
-everything through `engine->run_async()`, this node participates in
-the io_context overlap without an OS thread per run.
+The engine drives this same coroutine from sync and async entry points. With
+`engine->run_async()`, the node participates in io_context overlap without an
+OS thread per run.
 
 ---
 
@@ -274,31 +274,12 @@ GraphEngine::run_async(const RunConfig& config) {
 }
 ```
 
-### 4.4 `execute_full_stream_async` default re-runs the node
+### 4.4 Streaming from a custom node
 
-The default `execute_full_stream_async` in `GraphNode` runs
-`execute_full_async` first, then if no `Command` or `Send` was
-emitted, replaces the writes with a second call through
-`execute_stream_async`. This is the correct behaviour for LLM nodes
-where the streaming path is what produces the writes (token
-assembly), but for nodes whose `execute_async` already did all the
-work it's a redundant second run — visible as 2× wall-clock cost
-in traces.
-
-Nodes that don't stream should override `execute_full_stream_async`
-directly to short-circuit:
-
-```cpp
-asio::awaitable<NodeResult>
-execute_full_stream_async(const GraphState& state,
-                          const GraphStreamCallback&) override {
-    auto writes = co_await execute_async(state);
-    co_return NodeResult{std::move(writes)};
-}
-```
-
-See `examples/05_parallel_fanout.cpp` for the pattern in a
-real node.
+`GraphNode::run(NodeInput)` executes once per dispatch. Emit events only when
+`in.stream_cb` is non-null, and return the same `NodeOutput` regardless of
+whether the caller used a streaming engine entry point. The legacy
+`execute_full_stream_async` double-execution fallback no longer exists.
 
 ### 4.5 MCP stdio single-session concurrency
 
@@ -349,7 +330,7 @@ and so on.
       or shared event loop?
 - [ ] If shared event loop → migrate call sites to `run_async` /
       `run_stream_async`.
-- [ ] If your custom nodes do real I/O → override `execute_async`.
+- [ ] Custom nodes implement `run(NodeInput)` and `co_await` real I/O directly.
 - [ ] If your tools do real I/O → derive from `AsyncTool`, override
       `execute_async`.
 - [ ] If you use the Postgres checkpoint store → use its `*_async`
@@ -379,28 +360,26 @@ coroutine runtime by removing Taskflow and routing sync entry points
 through `run_sync(execute_graph_async)`. The 2.0 async API shape is
 unchanged — the differences are in the defaults and the new opt-ins.
 
-### 8.1 `execute_full_async` default now bridges through sync `execute_full`
+### 8.1 `GraphNode::run(NodeInput)` replaces the legacy override chain
 
-In 2.0 the default was:
-
-```cpp
-auto writes = co_await execute_async(state);
-co_return NodeResult{std::move(writes)};
-```
-
-Which silently dropped `Command` / `Send` emitted from a sync
-`execute_full` override — never caught in 2.0 because sync `run()`
-bypassed the coroutine path. 3.0 switched the default to:
+v1.0 removed the eight `execute*` virtuals. A custom node now has one
+override for sync and async engine entry points, streaming, and control flow:
 
 ```cpp
-co_return execute_full(state);
+asio::awaitable<NodeOutput> run(NodeInput in) override {
+    NodeOutput out;
+    out.writes.push_back({"answer", co_await fetch_answer(in)});
+    out.command = Command{.goto_node = "review"};
+    if (in.stream_cb) {
+        (*in.stream_cb)({GraphEvent::Type::LLM_TOKEN, get_name(), json("done")});
+    }
+    co_return out;
+}
 ```
 
-So nodes that override **sync** `execute_full` to emit `Command` /
-`Send` now work through every entry point. Nodes that override
-**async** `execute_async` but need non-blocking I/O AND
-`Command` / `Send` must override `execute_full_async` directly (see
-`examples/05_parallel_fanout.cpp` for the shape).
+Code migrating from earlier releases must move its state reads to
+`in.state`, run metadata to `in.ctx`, streaming sink to `in.stream_cb`,
+and writes/`Command`/`Send` values into the returned `NodeOutput`.
 
 ### 8.2 `GraphEngine::set_worker_count(N)` — opt-in CPU parallel fan-out
 
@@ -411,14 +390,18 @@ io_context — I/O-bound branches still overlap via co_await suspension,
 but CPU-bound branches serialize.
 
 ```cpp
-auto engine = GraphEngine::compile(def, ctx, store);
-engine->set_worker_count(std::thread::hardware_concurrency());
+EngineConfig engine_config;
+engine_config.node_context = ctx;
+engine_config.checkpoint_store = store;
+engine_config.worker_count = std::thread::hardware_concurrency();
+auto engine = GraphEngine::build(def, std::move(engine_config));
 // Now run_parallel_async dispatches branches to an engine-owned
 // asio::thread_pool of that size.
 ```
 
-Must be called before any concurrent `run()`; rebuilding the pool
-across in-flight runs is not safe. `run_async` callers who drive a
+Set this before construction when possible. The compatibility setter must be
+called before any concurrent `run()`; rebuilding the pool across in-flight
+runs is not safe. `run_async` callers who drive a
 multi-threaded `asio::thread_pool` themselves don't need this — their
 caller-side executor already parallelizes the branches.
 
@@ -452,101 +435,32 @@ per-request code.
 
 ---
 
-## 9. Override decision guide — which virtual(s) to pick
+## 9. Override decision guide
 
-NeoGraph exposes sync and async peers as **separate public virtuals**
-across every extension point (`GraphNode`, `Provider`,
-`CheckpointStore`). The sync ↔ async bridging happens in the
-base-class defaults (§2), but the user still has to choose **which
-member of each pair to override**. Picking wrong produces subtle
-failure modes — silent `Command` / `Send` drops, frozen event
-loops, or infinite recursion.
-
-This section is the decision table. Headers claim the contract; this
-guide tells you which member of the contract to implement.
+`GraphNode` has one canonical override. Provider and persistence
+interfaces retain separate sync/async peers for compatibility.
 
 ### 9.1 Two-minute version
 
 | You write a… | Override | Inherit as-is |
 |---|---|---|
-| CPU-only `GraphNode`, no `Command` / `Send` | `execute()` | every async peer + both `_full` variants |
-| `GraphNode` that emits `Command` / `Send` | `execute_full()` | every async peer |
-| Async-I/O `GraphNode`, no `Command` / `Send` | `execute_async()` | sync `execute()` + both `_full` variants (but see §9.2.2 pitfall #2) |
-| Async-I/O `GraphNode` that emits `Command` / `Send` | `execute_full_async()` | every other peer |
-| Streaming LLM node (cb-driven token emission) | see §9.2 quadrant table | — |
+| Any custom `GraphNode` | `run(NodeInput)` | `get_name()` is the only other required virtual |
 | New custom LLM backend | inherit `CompletionProvider`, override `do_invoke()` | all existing `Provider` entry points are final adapters |
 | Custom `CheckpointStore`, async-capable backend | all eight `*_async` peers | sync peers bridge via `run_sync` |
 | Custom `CheckpointStore`, sync-only backend | all eight sync peers | async peers bridge via `run_sync` |
 | Custom sync `Tool` | inherit `Tool`, override `execute()` | — |
 | Custom async `Tool` | inherit `AsyncTool`, override `execute_async()` | sync `execute()` is `final`, bridges |
 
-### 9.2 `GraphNode` — the four-quadrant matrix
+### 9.2 `GraphNode`
 
-Two orthogonal axes: **streaming?** and **emits `Command` / `Send`?**.
-Pick the quadrant, then pick sync or async inside it based on
-whether your implementation does blocking work.
+Always override `run(NodeInput)`. CPU-only work can execute directly before
+`co_return`; real asynchronous I/O should be `co_await`ed. The engine invokes
+the same method from `run`, `run_async`, streaming, resume, and Send fan-out,
+so there is no override-selection matrix and no sync/async fallback recursion.
 
-|  | no `Command` / `Send` | emits `Command` / `Send` |
-|---|---|---|
-| **no streaming** | `execute` (sync) or `execute_async` (async) | `execute_full` (sync) or `execute_full_async` (async) |
-| **streaming-aware** (cb-driven tokens) | `execute_stream` (sync) or `execute_stream_async` (async) | `execute_full_stream` (sync) or `execute_full_stream_async` (async) |
-
-Rule of thumb: **if you don't know, override `execute()`**. That
-gives you the widest default-bridge coverage — every other virtual
-has a default that eventually calls back to `execute()`.
-
-#### 9.2.1 How the defaults wire up (3.0)
-
-```
-execute                    → run_sync(execute_async)
-execute_async              → co_return execute()
-execute_stream(state, cb)  → execute(state)        // cb is ignored unless overridden
-execute_stream_async       → co_await execute_async(state)
-execute_full               → NodeResult{execute()}
-execute_full_async         → co_return execute_full()            (3.0 fix)
-execute_full_stream        → execute_full(), replace writes via execute_stream if no Command/Send
-execute_full_stream_async  → co_await execute_full_async(state), replace writes via execute_stream_async
-```
-
-**Golden rule**: as long as you override **at least one of the
-sync/async pair at the level you care about**, you won't
-infinite-recurse. Overriding **neither** `execute` nor `execute_async`
-makes the two defaults call each other forever — the first invocation
-stack-overflows.
-
-#### 9.2.2 Pitfalls
-
-1. **Override `execute_async` only + emit `Command` / `Send` from
-   `execute_full`** → **silently dropped in async path**. The default
-   `execute_full_async` now calls sync `execute_full` (3.0 fix), but
-   sync `execute_full`'s default is `NodeResult{execute()}` which
-   calls your `execute_async` through `run_sync`. The writes come
-   through, but `Command` / `Send` added by overriding
-   `execute_full` (sync) only are lost because the async path
-   actually went through `execute` → `execute_async`, not through
-   your `execute_full`. **Fix**: override `execute_full_async`
-   directly.
-2. **Override `execute()` only + engine driven on a single-thread
-   `io_context`** → **blocks the event loop**. The default
-   `execute_full_async` calls sync `execute_full` → sync `execute`
-   on the current coroutine thread. Other coroutines on that
-   `io_context` freeze for the duration. **Fix**: if `execute()` is
-   fast (< ~100 µs), no action needed. Otherwise port to
-   `execute_async` with coroutine-friendly waits, or drive the
-   engine on an `asio::thread_pool` instead of a single-thread
-   context (via `run_async` on a multi-threaded executor, or
-   `engine->set_worker_count(N)` for sync `run()` callers).
-3. **Override `execute_full_stream_async` for a non-streaming node**
-   → **node runs twice**. The default streams by first calling
-   `execute_full_async` for full NodeResult + directives, then if
-   no `Command` / `Send` was emitted, discards the writes and
-   re-invokes `execute_stream_async` to collect fresh writes via
-   the cb. Correct for token-streaming LLM nodes; wasteful
-   elsewhere. **Fix**: override `execute_full_stream_async` with
-   `{ auto w = co_await execute_async(state); co_return NodeResult{std::move(w)}; }`.
-4. **Override neither `execute` nor `execute_async`** → **infinite
-   recursion**. Both defaults call each other. Compile-time
-   undetectable. **Fix**: override at least one.
+Do not block a shared single-thread `io_context` for long periods. Move blocking
+work to an executor or use coroutine-friendly I/O. `EngineConfig::worker_count`
+controls the engine-owned pool used by sync callers that need parallel fan-out.
 
 ### 9.3 `Provider`
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -367,7 +367,7 @@ planner ─┬─ Send("researcher", {topic: "A"})  ─┐
 
 ### Worker-count tuning
 
-`compile()` defaults to `set_worker_count(1)` — no engine-owned thread
+`build()` defaults to `EngineConfig::worker_count == 1` — no engine-owned thread
 pool, fan-out branches dispatch inline on the coroutine's own
 executor. That's a no-allocate fast path that's cheap for sequential
 graphs and safe for nodes that hold non-thread-safe state.
@@ -660,11 +660,13 @@ warning the first time a multi-Send fan-out runs without an opted-in
 pool — that's a hint, not an error. Python custom nodes see GIL
 contention on small fan-outs, so bench with both 1 and N.
 
-### "RunResult has no .status / .final_state attribute"
+### "Python RunResult has no .status / .final_state attribute"
 
-It doesn't. Use `result.output`, `result.interrupted`,
-`result.execution_trace`. See the table in the README's
-"Reading the output" section.
+The Python binding doesn't expose those attributes. Use `result.output`,
+`result.interrupted`, `result.max_steps_exhausted`, and
+`result.execution_trace`. C++ callers can use `RunResult::status()` for the
+typed `Completed` / `Interrupted` / `StepLimit` view. See the table in the
+README's "Reading the output" section.
 
 ### "Unknown reducer: <name>"
 

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -95,7 +95,10 @@ executor you already use.
 
 ```cpp
 // One engine, many concurrent sessions — no external runtime required.
-auto engine = GraphEngine::compile(def, ctx, std::make_shared<InMemoryCheckpointStore>());
+EngineConfig engine_config;
+engine_config.node_context = ctx;
+engine_config.checkpoint_store = std::make_shared<InMemoryCheckpointStore>();
+auto engine = GraphEngine::build(def, std::move(engine_config));
 
 std::vector<std::future<RunResult>> sessions;
 for (const auto& user : users) {
@@ -113,7 +116,7 @@ Works the same way with an `asio::thread_pool`, a `std::async`-backed
 task system, or your web framework's worker pool — NeoGraph stays out
 of the executor decision. If you need CPU-parallel fan-out *inside*
 a single sync `run()` call (rather than N sync `run()`s on N threads),
-call `engine->set_worker_count(N)` once after `compile()` to install
+set `EngineConfig::worker_count` before `build()` to install
 an engine-owned `asio::thread_pool` that `run_parallel_async` and the
 multi-Send branch dispatch onto.
 
@@ -129,8 +132,10 @@ the built-in lock-free queue — no external executor needed:
 using namespace neograph::util;
 
 RequestQueue pool(16, 1000);           // 16 workers, max 1000 pending sessions
-auto engine = GraphEngine::compile(def, ctx,
-                                   std::make_shared<InMemoryCheckpointStore>());
+EngineConfig engine_config;
+engine_config.node_context = ctx;
+engine_config.checkpoint_store = std::make_shared<InMemoryCheckpointStore>();
+auto engine = GraphEngine::build(def, std::move(engine_config));
 
 std::vector<RunResult>          results(users.size());
 std::vector<std::future<void>>  futs;
@@ -190,7 +195,10 @@ link `neograph::postgres` and swap `InMemoryCheckpointStore` for
 
 auto store = std::make_shared<PostgresCheckpointStore>(
     "postgresql://user:pass@host:5432/dbname");
-auto engine = GraphEngine::compile(def, ctx, store);
+EngineConfig engine_config;
+engine_config.node_context = ctx;
+engine_config.checkpoint_store = store;
+auto engine = GraphEngine::build(def, std::move(engine_config));
 ```
 
 The schema mirrors LangGraph's `PostgresSaver` (three tables prefixed

--- a/docs/doxygen-mainpage.md
+++ b/docs/doxygen-mainpage.md
@@ -59,7 +59,8 @@ int main() {
 
     NodeContext ctx;
     ctx.provider = std::make_shared<llm::MockProvider>();
-    auto engine = GraphEngine::compile(definition, ctx);
+    auto engine = GraphEngine::build(
+        definition, EngineConfig{.node_context = std::move(ctx)});
 
     RunConfig cfg;
     cfg.thread_id = "demo";

--- a/docs/performance-deep-dive.md
+++ b/docs/performance-deep-dive.md
@@ -305,10 +305,9 @@ Linux host with a matching libc and it runs.
 | Dynamic dependencies | `libc.so.6` only |
 
 `example_plan_executor` sleeps 120 ms per Send target to simulate an
-LLM call; the 5-way fan-out runs serially on the default
-single-threaded super-step loop. Call `engine->set_worker_count(N)`
-after `compile()` for multi-threaded fan-out (cuts this demo's wall
-time roughly in half on a 2-core host). Steady-state RSS is unaffected.
+LLM call. The example opts into a hardware-sized fan-out pool through
+`EngineConfig::worker_count` before `GraphEngine::build()`, so the five
+targets execute concurrently. Steady-state RSS is unaffected.
 
 ```bash
 cmake -B build-minsize -S . \

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -90,6 +90,7 @@ before a hand-written tour is worth the maintenance.
   - [IntentClassifierNode](#intentclassifiernode)
   - [SubgraphNode](#subgraphnode)
 - [7. GraphEngine](#7-graphengine)
+  - [EngineConfig and EngineResources](#engineconfig-and-engineresources)
   - [RunConfig](#runconfig)
   - [RunResult](#runresult)
   - [GraphEngine](#graphengine-1)
@@ -729,12 +730,17 @@ LLM provider, tools, and configuration.
 ```cpp
 struct NodeContext {
     std::shared_ptr<Provider> provider;   // LLM provider
-    std::vector<Tool*>        tools;      // Available tools (non-owning; engine owns the unique_ptrs)
+    std::vector<Tool*>        tools;      // Available tools (non-owning)
     std::string               model;      // Model override (empty = provider default)
     std::string               instructions; // System prompt / instructions
     json                      extra_config; // Additional configuration (node-type-specific)
 };
 ```
+
+For new engines, prefer moving a `ToolSet` through `EngineResources` instead
+of managing the pointees separately. `GraphEngine::build()` binds the
+corresponding non-owning view into `NodeContext` and keeps every tool alive for
+the engine's lifetime.
 
 ### GraphEvent
 
@@ -775,6 +781,26 @@ Type alias for the graph event callback used in streaming execution.
 ```cpp
 using GraphStreamCallback = std::function<void(const GraphEvent&)>;
 ```
+
+`GraphEvent` remains the stable callback and JSON-facing shape. Code that wants
+typed payloads can adapt the same stream without changing the engine entry
+point:
+
+```cpp
+using TypedGraphEvent = std::variant<NodeStartEvent, NodeEndEvent,
+    LlmTokenEvent, ChannelWriteEvent, StateSnapshotEvent, RoutingEvent,
+    SendDispatchEvent, InterruptEvent, ErrorEvent, RawGraphEvent>;
+
+auto callback = adapt_typed_stream([](const TypedGraphEvent& event) {
+    std::visit([](const auto& typed) {
+        // Handle NodeStartEvent, LlmTokenEvent, and the other alternatives.
+    }, event);
+});
+```
+
+`to_typed_event()` performs the conversion directly. Malformed payloads and
+payload shapes introduced by future versions become `RawGraphEvent` rather
+than throwing from the streaming callback.
 
 ### NodeResult
 
@@ -953,15 +979,14 @@ public:
 };
 ```
 
-> **Legacy chain (deprecated since v0.4, removed in v1.0).** Pre-v0.4
+> **Legacy chain (removed in v1.0).** Pre-v0.4
 > code overrode one of `execute` / `execute_async` / `execute_full` /
 > `execute_full_async` / `execute_stream` / `execute_stream_async` /
 > `execute_full_stream` / `execute_full_stream_async`. Picking the
 > wrong one silently dropped `Command` / `Send`, froze the event loop,
 > or infinite-recursed — that's the seam `run()` collapses. The 8
-> legacy virtuals are marked `[[deprecated]]`; existing subclasses
-> still compile and forward through the default chain. Migrate to
-> `run(NodeInput)` at your leisure.
+> legacy virtuals are no longer members of `GraphNode`; subclasses
+> migrating from an older release must implement `run(NodeInput)`.
 
 ### LLMCallNode
 
@@ -974,6 +999,7 @@ the run was started via `run_stream` / `run_stream_async`.
 class LLMCallNode : public GraphNode {
 public:
     LLMCallNode(const std::string& name, const NodeContext& ctx);
+    asio::awaitable<NodeOutput> run(NodeInput in) override;
     std::string get_name() const override;
 };
 ```
@@ -998,7 +1024,7 @@ class ToolDispatchNode : public GraphNode {
 public:
     ToolDispatchNode(const std::string& name, const NodeContext& ctx);
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override;
+    asio::awaitable<NodeOutput> run(NodeInput in) override;
     std::string get_name() const override;
 };
 ```
@@ -1021,7 +1047,7 @@ public:
                          const std::string& prompt,
                          std::vector<std::string> valid_routes);
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override;
+    asio::awaitable<NodeOutput> run(NodeInput in) override;
     std::string get_name() const override;
 };
 ```
@@ -1046,10 +1072,7 @@ public:
                  std::shared_ptr<GraphEngine> subgraph,
                  std::map<std::string, std::string> input_map = {},
                  std::map<std::string, std::string> output_map = {});
-
-    std::vector<ChannelWrite> execute(const GraphState& state) override;
-    std::vector<ChannelWrite> execute_stream(
-        const GraphState& state, const GraphStreamCallback& cb) override;
+    asio::awaitable<NodeOutput> run(NodeInput in) override;
     std::string get_name() const override;
 };
 ```
@@ -1072,6 +1095,35 @@ If the maps are empty, channels are mapped by name (identity mapping).
 
 The core execution engine. Compiles graph definitions, manages state transitions,
 and orchestrates node execution through a super-step loop.
+
+### EngineConfig and EngineResources
+
+New code should assemble construction dependencies and policies before creating
+the engine:
+
+```cpp
+struct EngineConfig {
+    NodeContext node_context;
+    std::shared_ptr<CheckpointStore> checkpoint_store;
+    std::shared_ptr<Store> store;
+    std::optional<RetryPolicy> retry_policy;
+    std::map<std::string, RetryPolicy> node_retry_policies;
+    ToolGate tool_gate;
+    std::size_t worker_count = 1;
+    std::set<std::string> cached_nodes;
+};
+
+struct EngineResources {
+    ToolSet tools;
+    std::shared_ptr<const GraphRegistry> registry;
+};
+```
+
+`ToolSet` is a move-only owner for a fixed tool collection. `GraphRegistry` is
+a per-engine reducer, condition, and node-factory overlay; names absent from the
+overlay fall back to the existing process-global registries. Configure both
+before passing them to `build()` or `link()`. Runtime mutation is intentionally
+not part of the local-registry contract.
 
 ### RunConfig
 
@@ -1218,6 +1270,12 @@ struct RunResult {
     std::vector<std::string> execution_trace;    // Ordered list of executed node names
 
     bool max_steps_exhausted() const noexcept;    // Limit stopped runnable work
+    RunStatus status() const noexcept;            // Completed, Interrupted, or StepLimit
+
+    template <typename T> T channel(const std::string& name) const;
+    template <typename T> T channel(const ChannelKey<T>& key) const;
+    template <typename T>
+    std::optional<T> try_channel(const ChannelKey<T>& key) const;
 };
 ```
 
@@ -1234,18 +1292,42 @@ struct RunResult {
 run while runnable work remained. A graph that reaches `__end__` exactly on its
 last permitted step returns `false`.
 
+`status()` returns `RunStatus::Completed`, `RunStatus::Interrupted`, or
+`RunStatus::StepLimit` without changing the public `RunResult` data layout.
+`ChannelKey<T>` binds a reusable channel name to its expected C++ type:
+
+```cpp
+inline const ChannelKey<std::string> Answer{"answer"};
+
+auto answer = result.channel(Answer);
+if (auto optional = result.try_channel(Answer)) {
+    std::cout << *optional << '\n';
+}
+```
+
 ### GraphEngine
 
-The main engine class. Created via the static `compile()` method.
+The main engine class. New code should use `build()` for a JSON definition or
+`link()` for an already inspected or transformed `CompiledGraph`. `compile()`
+and post-construction setters remain compatibility facades.
 
 ```cpp
 class GraphEngine {
 public:
     // ---- Construction ----
 
-    static std::unique_ptr<GraphEngine> compile(
-        const json& definition,
-        const NodeContext& default_context,
+    static std::unique_ptr<GraphEngine> build(
+        const json& definition, EngineConfig config);
+    static std::unique_ptr<GraphEngine> build(
+        const json& definition, EngineConfig config, EngineResources resources);
+
+    static std::unique_ptr<GraphEngine> link(
+        CompiledGraph graph, EngineConfig config = {});
+    static std::unique_ptr<GraphEngine> link(
+        CompiledGraph graph, EngineConfig config, EngineResources resources);
+
+    static std::unique_ptr<GraphEngine> compile( // compatibility facade
+        const json& definition, const NodeContext& default_context,
         std::shared_ptr<CheckpointStore> store = nullptr);
 
     // ---- Execution (sync) ----
@@ -1286,7 +1368,7 @@ public:
                      const std::string& new_thread_id,
                      const std::string& checkpoint_id = "");
 
-    // ---- Configuration ----
+    // ---- Compatibility configuration (prefer EngineConfig/EngineResources) ----
 
     void own_tools(std::vector<std::unique_ptr<Tool>> tools);
     void set_checkpoint_store(std::shared_ptr<CheckpointStore> store);
@@ -1297,16 +1379,15 @@ public:
 
     // Fan-out worker pool. n==1 keeps the engine on the caller's
     // executor (no engine-owned thread_pool); n>=2 installs an
-    // owned `asio::thread_pool` of size n. compile() defaults to
-    // n==1 — call this (or set_worker_count_auto()) to opt into
+    // owned `asio::thread_pool` of size n. build() defaults to
+    // n==1 — prefer EngineConfig::worker_count to opt into
     // real parallel fan-out. Throws `std::logic_error` if called
     // while a run is in flight (Round 3 guard — `active_runs_`
     // counter prevents tasks queued on the old pool from being
     // silently dropped on swap).
     void set_worker_count(std::size_t n);
 
-    // Convenience: set_worker_count(hardware_concurrency()). compile()
-    // does NOT call this — its default is set_worker_count(1).
+    // Compatibility convenience: set_worker_count(hardware_concurrency()).
     void set_worker_count_auto();
 
     // Per-node result caching. Disabled by default; opt in per node.
@@ -1318,7 +1399,36 @@ public:
 };
 ```
 
-#### `compile`
+#### `build` and `link`
+
+```cpp
+EngineConfig config;
+config.node_context.provider = provider;
+config.checkpoint_store = checkpoint_store;
+config.store = store;
+config.worker_count = 4;
+config.cached_nodes.insert("retrieve");
+
+std::vector<std::unique_ptr<Tool>> owned_tools;
+owned_tools.push_back(std::make_unique<SearchTool>());
+auto registry = std::make_shared<GraphRegistry>();
+// Register engine-local reducers, conditions, or node types on registry.
+
+EngineResources resources{
+    .tools = ToolSet(std::move(owned_tools)),
+    .registry = registry,
+};
+
+auto engine = GraphEngine::build(definition, std::move(config),
+                                 std::move(resources));
+```
+
+`build()` compiles, verifies, links, and returns a fully configured engine.
+`link()` consumes a `CompiledGraph` by move and applies runtime configuration;
+callers that compile manually remain responsible for any source-to-IR
+round-trip verification they require.
+
+#### `compile` (compatibility)
 
 ```cpp
 static std::unique_ptr<GraphEngine> compile(
@@ -1328,6 +1438,9 @@ static std::unique_ptr<GraphEngine> compile(
 ```
 
 Compiles a graph from a JSON definition and returns an engine ready for execution.
+This original signature is preserved and delegates to `build()`. Prefer
+`EngineConfig` when new code needs stores, retry policy, worker configuration,
+caching, or a tool gate.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -1545,7 +1658,8 @@ Returns the name of the graph as specified in the definition.
 
 `GraphEngine` is a thin orchestrator that delegates to four purpose-built
 classes. Users typically never touch them directly — they are instantiated
-inside `GraphEngine::compile()` and driven from `execute_graph()` — but
+inside `GraphEngine::build()` (or its `compile()` compatibility facade) and
+driven from `execute_graph()` — but
 they are public so advanced callers can build without JSON, drive custom
 checkpoint flows, or stub pieces in tests.
 
@@ -1595,8 +1709,8 @@ public:
 } // namespace neograph::graph
 ```
 
-`GraphEngine::compile()` calls `GraphCompiler::compile()` then moves
-every field of the result into the engine's runtime home. Parsing
+`GraphEngine::build()` calls `GraphCompiler::compile()`, verifies the result,
+then hands it to `GraphEngine::link()`. Parsing
 failures (malformed edge, unknown node type) surface here before any
 runtime state is built.
 
@@ -2058,9 +2172,10 @@ public:
 **Header:** `<neograph/graph/loader.h>`
 **Namespace:** `neograph::graph`
 
-Singleton registries for reducers, conditions, and node types. These enable
-JSON-driven graph construction: the `GraphEngine::compile()` method looks up
-components by name from these registries.
+Legacy singleton registries for reducers, conditions, and node types. These
+remain the process-global fallback for JSON-driven graph construction. New
+code can pass a `GraphRegistry` through `EngineResources`; its local entries
+take precedence while missing names continue to resolve here.
 
 ### ReducerRegistry
 
@@ -2990,12 +3105,6 @@ int main() {
     tools.push_back(std::make_unique<SearchTool>());
     tools.push_back(std::make_unique<CalculatorTool>());
 
-    // Build tool pointer list for NodeContext
-    std::vector<neograph::Tool*> tool_ptrs;
-    for (auto& t : tools) tool_ptrs.push_back(t.get());
-
-    NodeContext ctx{provider, tool_ptrs, "gpt-4o", "You are a helpful assistant."};
-
     json definition = {
         {"name", "assistant_graph"},
         {"channels", {
@@ -3018,8 +3127,14 @@ int main() {
     };
 
     auto store = std::make_shared<InMemoryCheckpointStore>();
-    auto engine = GraphEngine::compile(definition, ctx, store);
-    engine->own_tools(std::move(tools));
+    EngineConfig engine_config;
+    engine_config.node_context.provider = provider;
+    engine_config.node_context.model = "gpt-4o";
+    engine_config.node_context.instructions = "You are a helpful assistant.";
+    engine_config.checkpoint_store = store;
+    EngineResources resources{.tools = ToolSet(std::move(tools))};
+    auto engine = GraphEngine::build(definition, std::move(engine_config),
+                                     std::move(resources));
 
     RunConfig config;
     config.thread_id = "session-1";
@@ -3042,7 +3157,10 @@ Using interrupts for human approval:
 
 ```cpp
 auto store = std::make_shared<InMemoryCheckpointStore>();
-auto engine = GraphEngine::compile(definition, ctx, store);
+EngineConfig engine_config;
+engine_config.node_context = ctx;
+engine_config.checkpoint_store = store;
+auto engine = GraphEngine::build(definition, std::move(engine_config));
 
 // Configure interrupt after the "tools" node
 // (set "interrupt_after": ["tools"] in the JSON definition)
@@ -3079,17 +3197,16 @@ class FanOutNode : public GraphNode {
 public:
     std::string get_name() const override { return "fan_out"; }
 
-    // Override execute_full to return Send directives
-    NodeResult execute_full(const GraphState& state) override {
-        auto items = state.get("items");
-        NodeResult result;
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto items = in.state.get("items");
+        NodeOutput result;
         for (const auto& item : items) {
             result.sends.push_back(Send{
                 "process_item",       // target node
                 {{"item", item}}      // input for that invocation
             });
         }
-        return result;
+        co_return result;
     }
 };
 ```
@@ -3107,11 +3224,11 @@ class RouterNode : public GraphNode {
 public:
     std::string get_name() const override { return "router"; }
 
-    NodeResult execute_full(const GraphState& state) override {
-        auto messages = state.get_messages();
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto messages = in.state.get_messages();
         auto last = messages.back().content;
 
-        NodeResult result;
+        NodeOutput result;
 
         if (last.find("urgent") != std::string::npos) {
             result.command = Command{
@@ -3125,7 +3242,7 @@ public:
             };
         }
 
-        return result;
+        co_return result;
     }
 };
 ```
@@ -3278,7 +3395,8 @@ edge / single-host deployments.
   coroutine-shaped (HTTP fetch, MCP call). Sync `execute()` is
   `final`-routed through `run_sync`.
 - **`neograph::graph::NodeCache`** — per-node memoization, opt-in
-  via `engine->set_node_cache_enabled(name, true)`.
+  at construction via `EngineConfig::cached_nodes` (the setter remains a
+  compatibility surface).
 - **`neograph::graph::create_deep_research_graph`** —
   open_deep_research-style supervisor + sub-researcher fan-out,
   used by `examples/25_deep_research.cpp`. Round 2 audit added

--- a/docs/reference-ko.md
+++ b/docs/reference-ko.md
@@ -1,8 +1,13 @@
-# NeoGraph API Reference (한국어)
+# NeoGraph API 내러티브 투어 (한국어)
 
 > NeoGraph -- C++ 그래프 에이전트 엔진 라이브러리
 >
 > 버전: 1.0 | 네임스페이스: `neograph`, `neograph::graph`, `neograph::llm`, `neograph::mcp`, `neograph::util`
+
+이 문서는 NeoGraph의 권장 사용 경로를 순서대로 설명하는 투어이며 전체 타입
+목록이 아니다. 모든 public 타입과 멤버의 canonical reference는 public header에서
+매 push마다 생성되는 [Doxygen](https://fox1245.github.io/NeoGraph/)을 사용한다.
+여기서는 실제 agent를 만들 때 자주 만나는 core, graph, LLM, MCP API에 집중한다.
 
 ---
 
@@ -482,23 +487,23 @@ struct Send {
 };
 ```
 
-`Send`는 `NodeResult::sends`에 담아 반환한다. 엔진이 각 Send에 대해
+`Send`는 `NodeOutput::sends`에 담아 반환한다. 엔진이 각 Send에 대해
 대상 노드를 개별적으로 실행하고, 결과를 리듀서를 통해 합산한다.
 
 **사용 예:**
 
 ```cpp
-NodeResult execute_full(const GraphState& state) override {
-    NodeResult nr;
+asio::awaitable<NodeOutput> run(NodeInput in) override {
+    NodeOutput out;
     std::vector<std::string> topics = {"AI", "반도체", "양자컴퓨팅"};
 
     for (const auto& topic : topics) {
-        nr.sends.push_back(Send{
+        out.sends.push_back(Send{
             "researcher",                         // 실행할 노드
             json({{"topic", topic}})              // 각 실행마다 다른 입력
         });
     }
-    return nr;
+    co_return out;
 }
 ```
 
@@ -516,27 +521,27 @@ struct Command {
 };
 ```
 
-`Command`는 `NodeResult::command`에 담아 반환한다.
+`Command`는 `NodeOutput::command`에 담아 반환한다.
 
 **사용 예:**
 
 ```cpp
-NodeResult execute_full(const GraphState& state) override {
-    auto score = state.get("score").get<double>();
-    NodeResult nr;
+asio::awaitable<NodeOutput> run(NodeInput in) override {
+    auto score = in.state.get("score").get<double>();
+    NodeOutput out;
 
     if (score > 0.8) {
-        nr.command = Command{
+        out.command = Command{
             "summarizer",   // 높은 점수 -> 요약 노드로 직행
             {ChannelWrite{"status", json("approved")}}
         };
     } else {
-        nr.command = Command{
+        out.command = Command{
             "researcher",   // 낮은 점수 -> 추가 조사
             {ChannelWrite{"status", json("needs_more_research")}}
         };
     }
-    return nr;
+    co_return out;
 }
 ```
 
@@ -641,7 +646,9 @@ struct NodeContext {
 ```
 
 `tools`는 비소유(non-owning) 포인터다.
-도구의 수명은 `GraphEngine::own_tools()` 또는 호출자가 관리해야 한다.
+새 엔진에서는 `ToolSet`을 `EngineResources`로 이동해 전달하는 방식을 권장한다.
+`GraphEngine::build()`가 `NodeContext`에 비소유 view를 연결하고 엔진 수명 동안
+도구 객체를 소유한다. 기존 `own_tools()`와 호출자 소유 방식도 호환된다.
 
 ---
 
@@ -671,6 +678,20 @@ struct GraphEvent {
 ```cpp
 using GraphStreamCallback = std::function<void(const GraphEvent&)>;
 ```
+
+`GraphEvent`는 안정적인 콜백/JSON 형상으로 유지된다. payload를 타입으로
+처리하려면 같은 실행 API에 `adapt_typed_stream()`을 사용할 수 있다.
+
+```cpp
+auto callback = adapt_typed_stream([](const TypedGraphEvent& event) {
+    std::visit([](const auto& typed) {
+        // NodeStartEvent, LlmTokenEvent 등 각 대안을 처리한다.
+    }, event);
+});
+```
+
+직접 변환은 `to_typed_event()`를 사용한다. 잘못된 payload나 향후 버전이
+추가한 형상은 스트리밍 콜백에서 예외를 던지는 대신 `RawGraphEvent`가 된다.
 
 **특수 노드 이름:**
 
@@ -776,12 +797,9 @@ state.write("messages", json::array({msg2})); // -> [msg1, msg2]
 **헤더:** `neograph/graph/node.h`
 **네임스페이스:** `neograph::graph`
 
-> **커스텀 GraphNode를 작성하신다면?** `execute*` 가상함수가
-> 4개 있고 각각의 async peer까지 총 8개. 잘못 고르면
-> `Command`/`Send`가 조용히 드롭되거나, 이벤트 루프가 얼거나,
-> 무한 재귀. 전체 결정 매트릭스 + 알려진 함정은
-> [`ASYNC_GUIDE.md` §9.2](ASYNC_GUIDE.md#92-graphnode--the-four-quadrant-matrix)
-> 참조.
+> **커스텀 GraphNode를 작성한다면** 단 하나의
+> `run(NodeInput) -> asio::awaitable<NodeOutput>`을 구현한다.
+> v1.0에서 옛 `execute*` 8-virtual chain은 제거되었다.
 
 ### 6.1 GraphNode (추상 클래스)
 
@@ -792,35 +810,14 @@ class GraphNode {
 public:
     virtual ~GraphNode() = default;
 
-    // 기본 실행: 상태를 읽고 채널 쓰기를 반환
-    virtual std::vector<ChannelWrite> execute(const GraphState& state) = 0;
-
-    // 스트리밍 실행 (기본: execute()에 위임)
-    virtual std::vector<ChannelWrite> execute_stream(
-        const GraphState& state, const GraphStreamCallback& cb);
-
-    // 확장 실행: Send/Command를 포함한 NodeResult 반환
-    // 기본 구현은 execute()를 호출하여 writes만 채운 NodeResult를 반환
-    virtual NodeResult execute_full(const GraphState& state);
-
-    // 확장 스트리밍 실행
-    virtual NodeResult execute_full_stream(
-        const GraphState& state, const GraphStreamCallback& cb);
-
-    // 노드 이름
+    virtual asio::awaitable<NodeOutput> run(NodeInput in) = 0;
     virtual std::string get_name() const = 0;
 };
 ```
 
-| 메서드 | 오버라이드 시점 |
-|--------|---------------|
-| `execute()` | 기본 노드. 채널 쓰기만 필요할 때 |
-| `execute_full()` | Send 또는 Command를 사용해야 할 때 |
-| `execute_stream()` | 스트리밍 이벤트를 발생시켜야 할 때 |
-| `execute_full_stream()` | Send/Command + 스트리밍이 모두 필요할 때 |
-
-엔진은 `execute_full()` (또는 스트리밍 시 `execute_full_stream()`)을 호출한다.
-기본 구현이 `execute()`를 래핑하므로, 단순 노드는 `execute()`만 구현하면 된다.
+`in.state`에서 채널을 읽고 `NodeOutput::writes`, `command`, `sends`를 채운다.
+스트리밍이 필요하면 `in.stream_cb`가 null인지 확인한 뒤 `GraphEvent`를 보낸다.
+취소, 현재 step, thread ID, Store는 `in.ctx`에서 접근한다.
 
 ---
 
@@ -834,9 +831,7 @@ class LLMCallNode : public GraphNode {
 public:
     LLMCallNode(const std::string& name, const NodeContext& ctx);
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override;
-    std::vector<ChannelWrite> execute_stream(
-        const GraphState& state, const GraphStreamCallback& cb) override;
+    asio::awaitable<NodeOutput> run(NodeInput in) override;
     std::string get_name() const override;
 };
 ```
@@ -860,7 +855,7 @@ class ToolDispatchNode : public GraphNode {
 public:
     ToolDispatchNode(const std::string& name, const NodeContext& ctx);
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override;
+    asio::awaitable<NodeOutput> run(NodeInput in) override;
     std::string get_name() const override;
 };
 ```
@@ -883,7 +878,7 @@ public:
                          const std::string& prompt,          // 분류 프롬프트
                          std::vector<std::string> valid_routes); // 유효한 경로 목록
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override;
+    asio::awaitable<NodeOutput> run(NodeInput in) override;
     std::string get_name() const override;
 };
 ```
@@ -919,9 +914,7 @@ public:
                  std::map<std::string, std::string> input_map = {},
                  std::map<std::string, std::string> output_map = {});
 
-    std::vector<ChannelWrite> execute(const GraphState& state) override;
-    std::vector<ChannelWrite> execute_stream(
-        const GraphState& state, const GraphStreamCallback& cb) override;
+    asio::awaitable<NodeOutput> run(NodeInput in) override;
     std::string get_name() const override;
 };
 ```
@@ -950,7 +943,34 @@ auto sub = std::make_unique<SubgraphNode>(
 
 NeoGraph의 핵심 실행 엔진. JSON 정의로 그래프를 컴파일하고 super-step 루프로 실행한다.
 
-### 7.1 RunConfig
+### 7.1 EngineConfig와 EngineResources
+
+새 코드는 엔진을 만들기 전에 의존성과 정책을 한 번에 구성한다.
+
+```cpp
+struct EngineConfig {
+    NodeContext node_context;
+    std::shared_ptr<CheckpointStore> checkpoint_store;
+    std::shared_ptr<Store> store;
+    std::optional<RetryPolicy> retry_policy;
+    std::map<std::string, RetryPolicy> node_retry_policies;
+    ToolGate tool_gate;
+    std::size_t worker_count = 1;
+    std::set<std::string> cached_nodes;
+};
+
+struct EngineResources {
+    ToolSet tools;
+    std::shared_ptr<const GraphRegistry> registry;
+};
+```
+
+`ToolSet`은 고정된 도구 집합을 소유하는 move-only 타입이다. `GraphRegistry`는
+엔진별 reducer/condition/node-factory overlay이며, 등록되지 않은 이름은 기존
+process-global registry로 fallback한다. 둘 다 `build()` 또는 `link()`에 넘기기
+전에 구성해야 한다.
+
+### 7.2 RunConfig
 
 실행 설정.
 
@@ -960,12 +980,15 @@ struct RunConfig {
     json        input;                           // 초기 채널 값 (예: {"messages": [...]})
     int         max_steps  = 50;                 // 루프 안전 제한
     StreamMode  stream_mode = StreamMode::ALL;   // 수신할 이벤트 종류
+    std::shared_ptr<CancelToken> cancel_token;    // 협력적 취소
+    std::shared_ptr<UsageAccumulator> usage;      // 선택적 토큰 누적기
+    bool        resume_if_exists = false;         // 기존 checkpoint에서 시작
 };
 ```
 
 ---
 
-### 7.2 RunResult
+### 7.3 RunResult
 
 실행 결과.
 
@@ -979,6 +1002,12 @@ struct RunResult {
     std::vector<std::string> execution_trace;    // 실행된 노드 순서
 
     bool max_steps_exhausted() const noexcept;    // 실행할 작업을 남기고 한도 도달
+    RunStatus status() const noexcept;            // Completed, Interrupted, StepLimit
+
+    template <typename T> T channel(const std::string& name) const;
+    template <typename T> T channel(const ChannelKey<T>& key) const;
+    template <typename T>
+    std::optional<T> try_channel(const ChannelKey<T>& key) const;
 };
 ```
 
@@ -986,16 +1015,36 @@ struct RunResult {
 경우에만 `true`를 반환한다. 마지막 허용 단계에서 정확히 `__end__`에 도달한
 정상 실행은 `false`다.
 
+`status()`는 public `RunResult` data layout을 바꾸지 않고
+`RunStatus::Completed`, `RunStatus::Interrupted`, `RunStatus::StepLimit` 중
+하나를 반환한다. 재사용할 채널 이름과 C++ 타입은 `ChannelKey<T>`로 묶는다.
+
+```cpp
+inline const ChannelKey<std::string> Answer{"answer"};
+auto answer = result.channel(Answer);
+auto optional = result.try_channel(Answer);
+```
+
 ---
 
-### 7.3 GraphEngine 클래스
+### 7.4 GraphEngine 클래스
 
 ```cpp
 class GraphEngine {
 public:
-    // ── 컴파일 ──
+    // ── 생성 ──
 
-    static std::unique_ptr<GraphEngine> compile(
+    static std::unique_ptr<GraphEngine> build(
+        const json& definition, EngineConfig config);
+    static std::unique_ptr<GraphEngine> build(
+        const json& definition, EngineConfig config, EngineResources resources);
+
+    static std::unique_ptr<GraphEngine> link(
+        CompiledGraph graph, EngineConfig config = {});
+    static std::unique_ptr<GraphEngine> link(
+        CompiledGraph graph, EngineConfig config, EngineResources resources);
+
+    static std::unique_ptr<GraphEngine> compile( // 호환 facade
         const json& definition,
         const NodeContext& default_context,
         std::shared_ptr<CheckpointStore> store = nullptr);
@@ -1054,9 +1103,39 @@ public:
 
 ---
 
-### 7.4 compile()
+### 7.5 build() / link()
 
-JSON 정의와 기본 컨텍스트로 그래프를 컴파일한다.
+```cpp
+EngineConfig config;
+config.node_context.provider = provider;
+config.checkpoint_store = checkpoint_store;
+config.store = store;
+config.worker_count = 4;
+config.cached_nodes.insert("retrieve");
+
+std::vector<std::unique_ptr<Tool>> owned_tools;
+owned_tools.push_back(std::make_unique<SearchTool>());
+auto registry = std::make_shared<GraphRegistry>();
+// 엔진 전용 reducer, condition, node type을 registry에 등록한다.
+
+EngineResources resources{
+    .tools = ToolSet(std::move(owned_tools)),
+    .registry = registry,
+};
+
+auto engine = GraphEngine::build(definition, std::move(config),
+                                 std::move(resources));
+```
+
+`build()`는 JSON 정의를 compile, 검증, link하고 완전히 설정된 엔진을 반환한다.
+`link()`는 이미 검사하거나 변환한 `CompiledGraph`를 move로 소비하고 런타임
+설정을 적용한다.
+
+### 7.6 compile() 호환 API
+
+JSON 정의와 기본 컨텍스트로 그래프를 컴파일한다. 기존 signature와 동작을
+보존하며 내부적으로 `build()`에 위임한다. 새 코드에서 store, retry, worker,
+cache, tool gate를 설정할 때는 `EngineConfig`를 권장한다.
 
 ```cpp
 static std::unique_ptr<GraphEngine> compile(
@@ -1124,13 +1203,9 @@ int main() {
     std::vector<std::unique_ptr<Tool>> tools;
     tools.push_back(std::make_unique<MyTool>());
 
-    std::vector<Tool*> tool_ptrs;
-    for (auto& t : tools) tool_ptrs.push_back(t.get());
-
     // 컨텍스트 구성
     NodeContext ctx;
     ctx.provider = provider;
-    ctx.tools = tool_ptrs;
     ctx.instructions = "당신은 유용한 도우미입니다.";
 
     // JSON 정의
@@ -1151,9 +1226,14 @@ int main() {
         })}
     };
 
-    // 컴파일 + 실행
-    auto engine = GraphEngine::compile(definition, ctx);
-    engine->own_tools(std::move(tools));
+    // 생성 + 실행: 도구 소유권도 엔진으로 이동
+    EngineConfig engine_config;
+    engine_config.node_context = ctx;
+    EngineResources resources{
+        .tools = ToolSet(std::move(tools)),
+    };
+    auto engine = GraphEngine::build(definition, std::move(engine_config),
+                                     std::move(resources));
 
     RunConfig config;
     config.input = {{"messages", json::array({
@@ -1172,7 +1252,7 @@ int main() {
 
 ---
 
-### 7.5 run()
+### 7.7 run()
 
 그래프를 동기적으로 실행한다.
 
@@ -1184,7 +1264,7 @@ RunResult run(const RunConfig& config);
 
 ---
 
-### 7.6 run_stream()
+### 7.8 run_stream()
 
 스트리밍 이벤트를 발생시키며 그래프를 실행한다.
 
@@ -1218,7 +1298,7 @@ auto result = engine->run_stream(config,
 
 ---
 
-### 7.7 resume()
+### 7.9 resume()
 
 HITL 인터럽트 후 실행을 재개한다.
 
@@ -1239,7 +1319,10 @@ RunResult resume(const std::string& thread_id,
 ```cpp
 // 1. checkpoint store 준비
 auto store = std::make_shared<InMemoryCheckpointStore>();
-auto engine = GraphEngine::compile(definition, ctx, store);
+EngineConfig engine_config;
+engine_config.node_context = ctx;
+engine_config.checkpoint_store = store;
+auto engine = GraphEngine::build(definition, std::move(engine_config));
 
 // 2. 첫 실행 (tools 노드 전에 인터럽트)
 RunConfig config;
@@ -1262,7 +1345,7 @@ if (result.interrupted) {
 
 ---
 
-### 7.8 get_state() / get_state_history()
+### 7.10 get_state() / get_state_history()
 
 ```cpp
 // 스레드의 최신 상태 조회
@@ -1278,7 +1361,7 @@ std::vector<Checkpoint> get_state_history(const std::string& thread_id,
 
 ---
 
-### 7.9 update_state()
+### 7.11 update_state()
 
 실행 중이 아닌 스레드의 상태를 외부에서 수정한다.
 
@@ -1296,7 +1379,7 @@ void update_state(const std::string& thread_id,
 
 ---
 
-### 7.10 fork()
+### 7.12 fork()
 
 기존 스레드의 checkpoint를 기반으로 새 스레드를 분기한다.
 time-travel 디버깅이나 what-if 분석에 활용한다.
@@ -1317,7 +1400,10 @@ std::string fork(const std::string& source_thread_id,
 
 ---
 
-### 7.11 설정 메서드
+### 7.13 호환 설정 메서드
+
+아래 setter는 기존 코드를 위해 유지된다. 새 엔진은 실행을 시작하기 전에
+`EngineConfig`와 `EngineResources`로 같은 값을 전달하는 방식을 권장한다.
 
 ```cpp
 // 도구 소유권을 엔진에 이전 (수명 관리)
@@ -1341,16 +1427,15 @@ void set_node_retry_policy(const std::string& node_name,
 const std::string& get_graph_name() const;
 ```
 
-**재시도 정책 설정 예:**
+**새 코드의 재시도 정책 설정 예:**
 
 ```cpp
-auto engine = GraphEngine::compile(definition, ctx);
-
 // 전체 기본: 3회 재시도, 200ms 시작, 2배 백오프, 최대 5초
-engine->set_retry_policy({3, 200, 2.0f, 5000});
-
-// LLM 노드만 5회 재시도
-engine->set_node_retry_policy("llm", {5, 500, 2.0f, 10000});
+EngineConfig engine_config;
+engine_config.node_context = ctx;
+engine_config.retry_policy = RetryPolicy{3, 200, 2.0f, 5000};
+engine_config.node_retry_policies["llm"] = RetryPolicy{5, 500, 2.0f, 10000};
+auto engine = GraphEngine::build(definition, std::move(engine_config));
 ```
 
 ---
@@ -1358,8 +1443,8 @@ engine->set_node_retry_policy("llm", {5, 500, 2.0f, 10000});
 ## 7b. 엔진 내부 구성 요소
 
 `GraphEngine`은 얇은 오케스트레이터이며, 실제 일은 네 개의 전용 클래스에 위임한다.
-일반 사용자는 직접 건드릴 일이 없지만(전부 `GraphEngine::compile()`에서 생성되어
-`execute_graph()`에서 구동됨), 공개 헤더로 노출되어 있어 JSON 없이 직접 구성하거나,
+일반 사용자는 직접 건드릴 일이 없지만(전부 `GraphEngine::build()` 또는 호환
+`compile()`에서 생성되어 `execute_graph()`에서 구동됨), 공개 헤더로 노출되어 있어 JSON 없이 직접 구성하거나,
 커스텀 체크포인트 흐름을 만들거나, 테스트에서 특정 부분을 스텁할 수 있다.
 
 | 클래스 | 헤더 | 역할 |
@@ -1407,8 +1492,8 @@ public:
 } // namespace neograph::graph
 ```
 
-`GraphEngine::compile()`은 내부적으로 `GraphCompiler::compile()`을 호출한 뒤
-결과 필드를 엔진의 런타임 슬롯으로 move한다. 잘못된 edge나 등록되지 않은 노드
+`GraphEngine::build()`는 내부적으로 `GraphCompiler::compile()`을 호출하고 결과를
+검증한 뒤 `GraphEngine::link()`에 넘긴다. 잘못된 edge나 등록되지 않은 노드
 타입 같은 파싱 실패는 런타임 상태를 만들기 전에 여기서 터진다.
 
 ### Scheduler
@@ -1713,9 +1798,10 @@ public:
 ```cpp
 auto store = std::make_shared<InMemoryCheckpointStore>();
 
-auto engine = GraphEngine::compile(definition, ctx, store);
-// 또는
-engine->set_checkpoint_store(store);
+EngineConfig engine_config;
+engine_config.node_context = ctx;
+engine_config.checkpoint_store = store;
+auto engine = GraphEngine::build(definition, std::move(engine_config));
 
 // 실행 후 이력 조회
 auto history = store->list("thread-001");
@@ -1811,7 +1897,10 @@ public:
 
 ```cpp
 auto store = std::make_shared<InMemoryStore>();
-engine->set_store(store);
+EngineConfig engine_config;
+engine_config.node_context = ctx;
+engine_config.store = store;
+auto engine = GraphEngine::build(definition, std::move(engine_config));
 
 // 노드 내부에서 Store 접근 (engine->get_store())
 // 사용자 선호도 저장
@@ -1839,7 +1928,9 @@ for (const auto& p : prefs) {
 **네임스페이스:** `neograph::graph`
 
 JSON 정의로 그래프를 컴파일할 때 노드 타입, 리듀서, 조건 함수를
-이름으로 검색하는 싱글턴 레지스트리들.
+이름으로 검색하는 기존 싱글턴 레지스트리들. 새 코드는 `GraphRegistry`를
+`EngineResources`로 전달해 엔진별 overlay를 만들 수 있으며, 로컬에 없는
+이름만 이 process-global registry로 fallback한다.
 
 ### 10.1 ReducerRegistry
 
@@ -2754,9 +2845,9 @@ __start__ -> planner --(Send: researcher x N)--> evaluator --(Command)--> summar
 class PlannerNode : public GraphNode {
     int round_ = 0;
 public:
-    NodeResult execute_full(const GraphState& state) override {
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
         round_++;
-        auto query = state.get("query").get<std::string>();
+        auto query = in.state.get("query").get<std::string>();
 
         std::vector<std::string> topics;
         if (round_ == 1)
@@ -2764,23 +2855,19 @@ public:
         else
             topics = {"risks", "outlook"};
 
-        NodeResult nr;
-        nr.writes.push_back(ChannelWrite{"plan", json({
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"plan", json({
             {"round", round_}, {"topics", topics}
         })});
 
         // 각 주제에 대해 researcher 노드를 개별 실행
         for (const auto& topic : topics) {
-            nr.sends.push_back(Send{
+            out.sends.push_back(Send{
                 "researcher",
                 json({{"topic", topic}})
             });
         }
-        return nr;
-    }
-
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        return execute_full(state).writes;
+        co_return out;
     }
 
     std::string get_name() const override { return "planner"; }
@@ -2789,27 +2876,23 @@ public:
 // EvaluatorNode: 결과를 평가하고 Command로 분기
 class EvaluatorNode : public GraphNode {
 public:
-    NodeResult execute_full(const GraphState& state) override {
-        auto findings = state.get("findings");
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        auto findings = in.state.get("findings");
         int count = findings.is_array() ? (int)findings.size() : 0;
 
-        NodeResult nr;
+        NodeOutput out;
         if (count >= 5) {
-            nr.command = Command{
+            out.command = Command{
                 "summarizer",
                 {ChannelWrite{"status", json("sufficient")}}
             };
         } else {
-            nr.command = Command{
+            out.command = Command{
                 "planner",
                 {ChannelWrite{"status", json("needs_more_data")}}
             };
         }
-        return nr;
-    }
-
-    std::vector<ChannelWrite> execute(const GraphState& state) override {
-        return execute_full(state).writes;
+        co_return out;
     }
 
     std::string get_name() const override { return "evaluator"; }
@@ -2858,7 +2941,7 @@ json definition = {
 };
 
 NodeContext ctx;
-auto engine = GraphEngine::compile(definition, ctx);
+auto engine = GraphEngine::build(definition, EngineConfig{.node_context = ctx});
 
 RunConfig config;
 config.input = {{"query", "AI 반도체 시장 분석"}};

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -259,10 +259,10 @@ pool (CPU-bound bodies, large fan-out widths).
 `re-agent` commits `2a5c5dc` / `5993935` and replicated in NeoGraph
 master.
 
-**Root cause:** pure-write `GraphNode` subclasses (no `Command`, no
-`Send`) ran `execute()` once for the result and once for the stream
-hook. Override `execute_full_stream` (or `execute_full_stream_async`)
-to dedup.
+**Root cause on pre-v1 releases:** pure-write `GraphNode` subclasses (no
+`Command`, no `Send`) could run once for the result and once for the stream
+hook. Upgrade and implement the single `run(NodeInput)` override; v1 invokes
+that method once and exposes the optional stream sink as `in.stream_cb`.
 
 If you're using the `@ng.node` decorator (not subclassing), this is
 already handled.

--- a/examples/04_checkpoint_hitl.cpp
+++ b/examples/04_checkpoint_hitl.cpp
@@ -93,18 +93,16 @@ int main() {
         {"interrupt_before", neograph::json::array({"tools"})}
     };
 
-    // Prepare tool pointers
-    std::vector<neograph::Tool*> tool_ptrs;
-    for (auto& t : tools) tool_ptrs.push_back(t.get());
-
     neograph::graph::NodeContext ctx;
     ctx.provider = provider;
-    ctx.tools = tool_ptrs;
 
     // Checkpoint store (in-memory)
     auto store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
-    auto engine = neograph::graph::GraphEngine::compile(definition, ctx, store);
-    engine->own_tools(std::move(tools));
+    neograph::graph::EngineResources resources;
+    resources.tools = neograph::ToolSet(std::move(tools));
+    auto engine     = neograph::graph::GraphEngine::build(
+        definition, neograph::graph::EngineConfig{.node_context = ctx, .checkpoint_store = store},
+        std::move(resources));
 
     // === First run: up to interrupt ===
     std::cout << "=== Phase 1: Waiting for approval after order analysis ===\n\n";

--- a/examples/05_parallel_fanout.cpp
+++ b/examples/05_parallel_fanout.cpp
@@ -158,7 +158,8 @@ int main() {
     };
 
     neograph::graph::NodeContext ctx;  // Custom nodes, no Provider/Tool needed
-    auto engine = neograph::graph::GraphEngine::compile(definition, ctx);
+    auto                         engine = neograph::graph::GraphEngine::build(
+        definition, neograph::graph::EngineConfig{.node_context = ctx});
 
     std::cout << "=== Parallel Fan-out / Fan-in (async edition) ===\n\n";
 

--- a/examples/06_subgraph.cpp
+++ b/examples/06_subgraph.cpp
@@ -62,12 +62,8 @@ int main() {
     std::vector<std::unique_ptr<neograph::Tool>> tools;
     tools.push_back(std::make_unique<LookupTool>());
 
-    std::vector<neograph::Tool*> tool_ptrs;
-    for (auto& t : tools) tool_ptrs.push_back(t.get());
-
     neograph::graph::NodeContext ctx;
     ctx.provider = provider;
-    ctx.tools = tool_ptrs;
 
     // JSON-based graph definition — subgraph included inline
     neograph::json definition = {
@@ -104,8 +100,10 @@ int main() {
         })}
     };
 
-    auto engine = neograph::graph::GraphEngine::compile(definition, ctx);
-    engine->own_tools(std::move(tools));
+    neograph::graph::EngineResources resources;
+    resources.tools = neograph::ToolSet(std::move(tools));
+    auto engine     = neograph::graph::GraphEngine::build(
+        definition, neograph::graph::EngineConfig{.node_context = ctx}, std::move(resources));
 
     // Execute
     std::cout << "=== Subgraph (Supervisor Pattern) ===\n\n";

--- a/examples/07_intent_routing.cpp
+++ b/examples/07_intent_routing.cpp
@@ -154,7 +154,8 @@ int main() {
         })}
     };
 
-    auto engine = neograph::graph::GraphEngine::compile(definition, ctx);
+    auto engine = neograph::graph::GraphEngine::build(
+        definition, neograph::graph::EngineConfig{.node_context = ctx});
 
     // Run 3 test cases
     struct TestCase {

--- a/examples/08_state_management.cpp
+++ b/examples/08_state_management.cpp
@@ -96,7 +96,8 @@ int main() {
     ctx.provider = provider;
 
     auto store = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
-    auto engine = neograph::graph::GraphEngine::compile(definition, ctx, store);
+    auto engine = neograph::graph::GraphEngine::build(
+        definition, neograph::graph::EngineConfig{.node_context = ctx, .checkpoint_store = store});
 
     // ================================================================
     // 1. Execute → interrupt → get_state

--- a/examples/09_all_features.cpp
+++ b/examples/09_all_features.cpp
@@ -210,7 +210,8 @@ int main() {
 
         NodeContext ctx;
         auto store = std::make_shared<InMemoryCheckpointStore>();
-        auto engine = GraphEngine::compile(def, ctx, store);
+        auto        engine =
+            GraphEngine::build(def, EngineConfig{.node_context = ctx, .checkpoint_store = store});
 
         // Small payment: passes normally
         RunConfig cfg;
@@ -260,15 +261,15 @@ int main() {
         };
 
         NodeContext ctx;
-        auto engine = GraphEngine::compile(def, ctx);
-
-        // Set per-node retry policy
         RetryPolicy retry;
         retry.max_retries = 5;
         retry.initial_delay_ms = 10;   // Short for demo purposes
         retry.backoff_multiplier = 2.0f;
         retry.max_delay_ms = 100;
-        engine->set_node_retry_policy("unstable_api", retry);
+        EngineConfig engine_config;
+        engine_config.node_context                        = ctx;
+        engine_config.node_retry_policies["unstable_api"] = retry;
+        auto engine = GraphEngine::build(def, std::move(engine_config));
 
         RunConfig cfg;
         cfg.stream_mode = StreamMode::EVENTS | StreamMode::DEBUG;
@@ -295,7 +296,7 @@ int main() {
         };
 
         NodeContext ctx;
-        auto engine = GraphEngine::compile(def, ctx);
+        auto        engine = GraphEngine::build(def, EngineConfig{.node_context = ctx});
 
         RunConfig cfg;
         cfg.input = {{"amount", 30000}};
@@ -385,7 +386,7 @@ int main() {
         std::vector<TestCase> cases = {{95, "premium"}, {72, "standard"}, {40, "basic"}};
 
         for (const auto& tc : cases) {
-            auto engine = GraphEngine::compile(def, ctx);
+            auto      engine = GraphEngine::build(def, EngineConfig{.node_context = ctx});
             RunConfig cfg;
             cfg.input = {{"score", tc.score}};
             cfg.stream_mode = StreamMode::EVENTS | StreamMode::UPDATES;
@@ -402,7 +403,7 @@ int main() {
     //
     // NOTE: this block exercises the Store API in isolation in `main()`
     // (put / get / search) and connects an InMemoryStore to a graph via
-    // `engine->set_store(...)`, but does NOT show a node reading from
+    // `EngineConfig::store`, but does NOT show a node reading from
     // Store *during a run*. For the live-node pattern — capturing
     // `shared_ptr<Store>` in a factory closure and reading inside
     // `run()` — see `examples/43_store_personalization.cpp`.
@@ -455,8 +456,7 @@ int main() {
             })}
         };
         NodeContext ctx;
-        auto engine = GraphEngine::compile(def, ctx);
-        engine->set_store(store);
+        auto engine = GraphEngine::build(def, EngineConfig{.node_context = ctx, .store = store});
 
         std::cout << "\n  Engine store connection: "
                   << (engine->get_store() ? "OK" : "FAIL")

--- a/examples/10_send_command.cpp
+++ b/examples/10_send_command.cpp
@@ -198,13 +198,15 @@ int main() {
     };
 
     NodeContext ctx;
-    auto engine = GraphEngine::compile(definition, ctx);
-
     // ResearcherNode 가 sync `std::this_thread::sleep_for` 를 사용하기 때문에
     // 코루틴이 yield 하지 않는다. 워커 풀이 없으면 (v1.0 기본값 = 1) 모든
     // 호출이 io_context 스레드 한 개를 차지해 사실상 순차 실행된다. fan-out
     // 의도를 살리려면 hardware_concurrency 만큼 워커를 풀어줘야 한다.
-    engine->set_worker_count_auto();
+    auto         workers = std::thread::hardware_concurrency();
+    EngineConfig engine_config;
+    engine_config.node_context = ctx;
+    engine_config.worker_count = workers > 0 ? workers : 4u;
+    auto engine                = GraphEngine::build(definition, std::move(engine_config));
 
     // Execute
     std::cout << "=== Send & Command Integration Demo ===\n\n";

--- a/examples/12_rag_agent.cpp
+++ b/examples/12_rag_agent.cpp
@@ -246,71 +246,87 @@ private:
 
 static std::vector<Document> create_knowledge_base() {
     return {
-        {"doc_1", "NeoGraph Overview",
+        {"doc_1",
+         "NeoGraph Overview",
          "NeoGraph is a C++17 graph-based agent orchestration engine. "
          "It brings LangGraph-level capabilities to C++ with zero Python dependency. "
          "Key features include JSON-defined graphs, parallel fan-out via "
          "asio::experimental::make_parallel_group, "
          "checkpointing for time-travel debugging, and HITL support.",
-         "README.md", {}},
+         "README.md",
+         {}},
 
-        {"doc_2", "NeoGraph Architecture",
+        {"doc_2",
+         "NeoGraph Architecture",
          "NeoGraph consists of four modules: neograph::core (graph engine), "
          "neograph::llm (LLM providers for OpenAI, Claude, Gemini), "
          "neograph::mcp (MCP client for JSON-RPC tool discovery), and "
          "neograph::util (lock-free RequestQueue). The core module has zero "
          "network dependencies.",
-         "docs/architecture.md", {}},
+         "docs/architecture.md",
+         {}},
 
-        {"doc_3", "Send and Command",
+        {"doc_3",
+         "Send and Command",
          "Send enables dynamic fan-out: a node can spawn N parallel tasks at runtime "
          "by returning Send objects. Command enables routing override: a node can "
          "simultaneously update state AND control which node executes next, "
          "bypassing normal edge-based routing. Both are processed by the asio "
          "coroutine fan-out runtime (no Taskflow as of 3.0).",
-         "docs/features.md", {}},
+         "docs/features.md",
+         {}},
 
-        {"doc_4", "Checkpointing and HITL",
+        {"doc_4",
+         "Checkpointing and HITL",
          "NeoGraph supports full state snapshots at every super-step via the "
          "CheckpointStore interface. InMemoryCheckpointStore is provided for testing. "
          "Human-in-the-Loop (HITL) is supported through interrupt_before, "
          "interrupt_after, and dynamic NodeInterrupt exceptions. The resume() API "
          "continues execution from the interrupted checkpoint.",
-         "docs/features.md", {}},
+         "docs/features.md",
+         {}},
 
-        {"doc_5", "Performance Comparison",
+        {"doc_5",
+         "Performance Comparison",
          "NeoGraph produces a ~5MB static binary vs ~500MB for Python+LangGraph. "
          "Memory usage is ~10MB vs ~300MB. Cold start is instant vs seconds. "
          "Parallel fan-out of 3 workers completing in 150ms tasks takes ~150ms "
          "(parallel) vs 370ms (sequential). NeoGraph uses asio coroutines on a "
          "shared io_context for cooperative I/O overlap, unlike Python's GIL-"
          "limited asyncio. CPU-parallel fan-out is opt-in via "
-         "engine->set_worker_count(N), which installs an asio::thread_pool.",
-         "README.md", {}},
+         "EngineConfig::worker_count, which installs an asio::thread_pool.",
+         "README.md",
+         {}},
 
-        {"doc_6", "LLM Provider Support",
+        {"doc_6",
+         "LLM Provider Support",
          "NeoGraph supports multiple LLM providers through two mechanisms: "
          "OpenAIProvider for any OpenAI-compatible API (OpenAI, Groq, Together, "
          "vLLM, Ollama), and SchemaProvider which adapts to any LLM API via a "
          "JSON schema. Built-in schemas are provided for OpenAI, Claude, and Gemini. "
          "New providers can be added by creating a JSON schema file.",
-         "docs/providers.md", {}},
+         "docs/providers.md",
+         {}},
 
-        {"doc_7", "Cross-thread Store",
+        {"doc_7",
+         "Cross-thread Store",
          "The Store interface provides namespaced key-value storage that persists "
          "across threads. Use cases include long-term user preferences, shared "
          "knowledge, and agent memory. Namespace is a vector of strings forming a "
          "hierarchical path. InMemoryStore is provided; implement the Store "
          "interface for Redis or a database backend.",
-         "docs/features.md", {}},
+         "docs/features.md",
+         {}},
 
-        {"doc_8", "ReAct Agent Pattern",
+        {"doc_8",
+         "ReAct Agent Pattern",
          "The ReAct (Reasoning + Acting) pattern alternates between LLM calls and "
          "tool execution. NeoGraph provides create_react_graph() which builds a "
          "standard 2-node graph: llm_call -> tool_dispatch -> loop until done. "
          "The Agent class provides a simpler non-graph alternative. Both support "
          "streaming via callbacks.",
-         "docs/patterns.md", {}},
+         "docs/patterns.md",
+         {}},
     };
 }
 

--- a/examples/14_plan_executor.cpp
+++ b/examples/14_plan_executor.cpp
@@ -158,13 +158,15 @@ int main() {
             return std::make_unique<ExecutorNode>();
         });
 
-    auto store  = std::make_shared<InMemoryCheckpointStore>();
-    auto engine = GraphEngine::compile(make_graph(), NodeContext{}, store);
-
+    auto store = std::make_shared<InMemoryCheckpointStore>();
     // ExecutorNode 가 sync sleep_for 120ms 로 LLM 호출을 흉내내기 때문에,
     // 워커 풀 없이 (v1.0 기본 = 1) 돌리면 5 sub-topic 이 600ms 순차로 깎인다.
     // hardware_concurrency 만큼 풀어 진짜 fan-out 으로 동작시킨다.
-    engine->set_worker_count_auto();
+    auto         workers = std::thread::hardware_concurrency();
+    EngineConfig engine_config;
+    engine_config.checkpoint_store = store;
+    engine_config.worker_count     = workers > 0 ? workers : 4u;
+    auto engine                    = GraphEngine::build(make_graph(), std::move(engine_config));
 
     RunConfig cfg;
     cfg.thread_id = "research-42";

--- a/examples/20_mcp_hitl.cpp
+++ b/examples/20_mcp_hitl.cpp
@@ -40,9 +40,6 @@ int main(int argc, char** argv) {
     auto tools = mcp_client.get_tools();
     std::cout << "[*] Discovered " << tools.size() << " MCP tools from " << mcp_url << "\n";
 
-    std::vector<neograph::Tool*> tool_ptrs;
-    for (auto& t : tools) tool_ptrs.push_back(t.get());
-
     // --- LLM ---
     neograph::llm::OpenAIProvider::Config cfg;
     cfg.api_key = api_key;
@@ -69,14 +66,16 @@ int main(int argc, char** argv) {
 
     neograph::graph::NodeContext ctx;
     ctx.provider = provider;
-    ctx.tools = tool_ptrs;
     ctx.instructions =
         "You are a helpful assistant. Always call a tool when the user's "
         "question can be answered by one.";
 
     auto store  = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
-    auto engine = neograph::graph::GraphEngine::compile(definition, ctx, store);
-    engine->own_tools(std::move(tools));
+    neograph::graph::EngineResources resources;
+    resources.tools = neograph::ToolSet(std::move(tools));
+    auto engine     = neograph::graph::GraphEngine::build(
+        definition, neograph::graph::EngineConfig{.node_context = ctx, .checkpoint_store = store},
+        std::move(resources));
 
     // --- Phase 1: run until tool approval gate ---
     std::cout << "\n=== Phase 1 — run until interrupt_before(\"tools\") ===\n";

--- a/examples/21_mcp_fanout.cpp
+++ b/examples/21_mcp_fanout.cpp
@@ -16,13 +16,14 @@
 // weather / calculator) so the demo is deterministic and stays offline
 // for the LLM axis.
 
-#include <neograph/neograph.h>
 #include <neograph/mcp/client.h>
+#include <neograph/neograph.h>
 
 #include <chrono>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <thread>
 
 using namespace neograph;
 using namespace neograph::graph;
@@ -180,13 +181,14 @@ int main(int argc, char** argv) {
     };
 
     NodeContext ctx;
-    auto engine = GraphEngine::compile(definition, ctx);
-
     // 3 MCP 호출을 같은 super-step 에서 동시에 보내려면 워커 수를 늘려야 함.
-    // v1.0 부터 기본 워커 수가 1 이라 (compile() 주석 참조), 명시 안 하면
-    // 세 호출이 순차로 깎여서 wall-time 이 합산된다. set_worker_count_auto()
-    // 는 hardware_concurrency() 만큼 풀어준다.
-    engine->set_worker_count_auto();
+    // v1.0 부터 기본 워커 수가 1 이라 명시 안 하면 세 호출이 순차로 깎여서
+    // wall-time 이 합산된다.
+    auto         workers = std::thread::hardware_concurrency();
+    EngineConfig engine_config;
+    engine_config.node_context = ctx;
+    engine_config.worker_count = workers > 0 ? workers : 4u;
+    auto engine                = GraphEngine::build(definition, std::move(engine_config));
 
     std::cout << "[*] Fanning out 3 MCP tool calls in parallel...\n\n";
 

--- a/examples/24_mcp_feedback.cpp
+++ b/examples/24_mcp_feedback.cpp
@@ -67,8 +67,6 @@ int main(int argc, char** argv) {
 
     neograph::mcp::MCPClient mcp_client(mcp_url);
     auto tools = mcp_client.get_tools();
-    std::vector<neograph::Tool*> tool_ptrs;
-    for (auto& t : tools) tool_ptrs.push_back(t.get());
     std::cout << "[*] " << tools.size()
               << " MCP tools available (agent may or may not call them)\n\n";
 
@@ -95,15 +93,17 @@ int main(int argc, char** argv) {
 
     neograph::graph::NodeContext ctx;
     ctx.provider = provider;
-    ctx.tools    = tool_ptrs;
     ctx.instructions =
         "You are an assistant. Answer from your own knowledge first. "
         "Use the provided tools only if the user explicitly asks for "
         "real-time or external data.";
 
     auto store  = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
-    auto engine = neograph::graph::GraphEngine::compile(definition, ctx, store);
-    engine->own_tools(std::move(tools));
+    neograph::graph::EngineResources resources;
+    resources.tools = neograph::ToolSet(std::move(tools));
+    auto engine     = neograph::graph::GraphEngine::build(
+        definition, neograph::graph::EngineConfig{.node_context = ctx, .checkpoint_store = store},
+        std::move(resources));
 
     // ---------- Round 1 ----------
     std::cout << "User: " << question << "\n\n";

--- a/examples/27_async_concurrent_runs.cpp
+++ b/examples/27_async_concurrent_runs.cpp
@@ -85,8 +85,7 @@ int main() {
                 name, cfg.value("delay_ms", 50));
         });
 
-    auto engine = ng::GraphEngine::compile(one_step_graph("worker"),
-                                           ng::NodeContext{});
+    auto engine = ng::GraphEngine::build(one_step_graph("worker"), ng::EngineConfig{});
 
     asio::io_context io;
     constexpr int N = 3;

--- a/examples/36_classifier_fanout.cpp
+++ b/examples/36_classifier_fanout.cpp
@@ -236,14 +236,14 @@ int main(int argc, char** argv) {
     };
 
     NodeContext ctx;
-    auto engine = GraphEngine::compile(definition, ctx);
     // 5 concurrent classifiers — match the worker pool to the fan-out
     // width. v1.0 부터 기본 워커 수는 1 (engine overhead 최소화) 이므로,
     // 실제 병렬 실행이 필요한 fan-out 예제에서는 명시적으로 풀어줘야 한다.
     // 5 로 고정한 이유는 demo wall time 을 안정적으로 보기 위함 —
     // hardware_concurrency 가 더 큰 머신에서도 wide-fanout 패턴이 일정하게
     // 측정된다.
-    engine->set_worker_count(5);
+    auto engine =
+        GraphEngine::build(definition, EngineConfig{.node_context = ctx, .worker_count = 5});
 
     RunConfig cfg;
     cfg.thread_id = "edge-pipeline";

--- a/examples/37_a2a_client.cpp
+++ b/examples/37_a2a_client.cpp
@@ -126,7 +126,8 @@ int main(int argc, char** argv) {
     };
 
     NodeContext ctx;  // remote agent doesn't need a Provider/Tool
-    auto engine = GraphEngine::compile(definition, ctx);
+    auto        engine =
+        GraphEngine::build(definition, neograph::graph::EngineConfig{.node_context = ctx});
 
     RunConfig cfg;
     cfg.thread_id     = "a2a-graph-1";

--- a/examples/38_a2a_server.cpp
+++ b/examples/38_a2a_server.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<GraphEngine> build_demo_engine() {
         })},
     };
     NodeContext ctx;
-    auto engine = GraphEngine::compile(def, ctx);
+    auto engine = GraphEngine::build(def, neograph::graph::EngineConfig{.node_context = ctx});
     return std::shared_ptr<GraphEngine>(std::move(engine));
 }
 

--- a/examples/39_acp_server.cpp
+++ b/examples/39_acp_server.cpp
@@ -83,7 +83,7 @@ std::shared_ptr<GraphEngine> build_demo_engine() {
         })},
     };
     NodeContext ctx;
-    auto engine = GraphEngine::compile(def, ctx);
+    auto engine = GraphEngine::build(def, neograph::graph::EngineConfig{.node_context = ctx});
     return std::shared_ptr<GraphEngine>(std::move(engine));
 }
 

--- a/examples/40_react_async_streaming.cpp
+++ b/examples/40_react_async_streaming.cpp
@@ -206,9 +206,6 @@ int main() {
 
         std::vector<std::unique_ptr<neograph::Tool>> owned_tools;
         owned_tools.push_back(std::make_unique<CalculatorTool>());
-        std::vector<neograph::Tool*> tool_ptrs;
-        for (auto& t : owned_tools) tool_ptrs.push_back(t.get());
-
         // Standard 2-node ReAct loop: llm → (has_tool_calls?) → tools → llm.
         neograph::json definition = {
             {"name", "react_async_streaming"},
@@ -227,7 +224,6 @@ int main() {
 
         neograph::graph::NodeContext ctx;
         ctx.provider = provider;
-        ctx.tools    = tool_ptrs;
         ctx.instructions =
             "You are a ReAct agent. You MUST use the calculator tool for "
             "every arithmetic operation, even if the answer seems obvious "
@@ -237,8 +233,12 @@ int main() {
             "(no tool call).";
 
         auto store  = std::make_shared<neograph::graph::InMemoryCheckpointStore>();
-        auto engine = neograph::graph::GraphEngine::compile(definition, ctx, store);
-        engine->own_tools(std::move(owned_tools));
+        neograph::graph::EngineResources resources;
+        resources.tools = neograph::ToolSet(std::move(owned_tools));
+        auto engine     = neograph::graph::GraphEngine::build(
+            definition,
+            neograph::graph::EngineConfig{.node_context = ctx, .checkpoint_store = store},
+            std::move(resources));
 
         const std::string question = "What is 15 * 28 + 7?";
 

--- a/examples/41_resume_if_exists_chat.cpp
+++ b/examples/41_resume_if_exists_chat.cpp
@@ -96,7 +96,8 @@ int main() {
     };
 
     auto store  = std::make_shared<InMemoryCheckpointStore>();
-    auto engine = GraphEngine::compile(definition, ctx, store);
+    auto engine = GraphEngine::build(definition,
+                                     EngineConfig{.node_context = ctx, .checkpoint_store = store});
 
     const std::string thread = "session-1";
 

--- a/examples/42_custom_reducer_condition.cpp
+++ b/examples/42_custom_reducer_condition.cpp
@@ -121,7 +121,7 @@ int main() {
     //
     // Channel definition uses `"reducer": "sum"` — the literal string
     // is what gets passed through to ReducerRegistry::get("sum"). If
-    // the registry name is misspelled, compile() throws — try changing
+    // the registry name is misspelled, build() throws — try changing
     // "sum" to "summ" below to see the failure mode.
     json def = {
         {"name", "custom_reducer_demo"},
@@ -150,7 +150,7 @@ int main() {
     };
 
     NodeContext ctx;
-    auto engine = GraphEngine::compile(def, ctx);
+    auto        engine = GraphEngine::build(def, EngineConfig{.node_context = ctx});
 
     RunConfig cfg;
     cfg.thread_id = "t1";

--- a/examples/43_store_personalization.cpp
+++ b/examples/43_store_personalization.cpp
@@ -22,7 +22,7 @@
 //
 // New code should prefer (1) — fewer captures, less boilerplate, and
 // the engine guarantees `in.ctx.store` is the same Store instance
-// `set_store(...)` was called with. This example sticks with (2) so
+// passed through `EngineConfig::store`. This example sticks with (2) so
 // the contrast with example 09 (Store-in-main-only) stays direct.
 //
 // No API key required.
@@ -44,8 +44,8 @@ using namespace neograph::graph;
 //                and `language` from the Store, emits a personalised
 //                greeting on the `reply` channel.
 //
-// The Store is captured in the closure — there is no
-// NodeContext::store. If you forget to set_store() on the engine and
+// The Store is captured in the closure as well as supplied through
+// EngineConfig. If you omit the config value and
 // also forget to capture it, the node silently degrades to defaults.
 class GreetNode : public GraphNode {
     std::shared_ptr<Store> store_;
@@ -154,8 +154,8 @@ int main() {
         });
 
     NodeContext ctx;
-    auto engine = GraphEngine::compile(make_graph(), ctx);
-    engine->set_store(store);  // Engine also holds it for get_store().
+    auto        engine =
+        GraphEngine::build(make_graph(), EngineConfig{.node_context = ctx, .store = store});
 
     // ── Three different user sessions on three different thread_ids ──
     struct Session {

--- a/examples/44_request_queue_backpressure.cpp
+++ b/examples/44_request_queue_backpressure.cpp
@@ -4,7 +4,7 @@
 // shape for multi-tenant servers that want shed-load semantics instead
 // of unbounded memory growth — but there's no runnable example. Most
 // existing examples use `std::async`, `engine->run_async()` on an
-// io_context, or `set_worker_count(N)` for in-run fan-out; none show
+// io_context, or `EngineConfig::worker_count` for in-run fan-out; none show
 // the RequestQueue API.
 //
 // What this example shows:
@@ -78,8 +78,10 @@ int main() {
         });
 
     NodeContext ctx;
-    auto engine = GraphEngine::compile(work_graph(), ctx,
-                                       std::make_shared<InMemoryCheckpointStore>());
+    auto        engine = GraphEngine::build(
+        work_graph(),
+        EngineConfig{.node_context     = ctx,
+                            .checkpoint_store = std::make_shared<InMemoryCheckpointStore>()});
 
     // ── Tiny pool: only 4 workers, only 8 pending allowed ────────────
     //

--- a/examples/46_cancel_token.cpp
+++ b/examples/46_cancel_token.cpp
@@ -76,7 +76,7 @@ int main() {
     };
 
     NodeContext ctx;
-    auto engine = GraphEngine::compile(def, ctx);
+    auto        engine = GraphEngine::build(def, EngineConfig{.node_context = ctx});
 
     RunConfig cfg;
     cfg.input = {{"counter", 0}};

--- a/examples/47_node_cache.cpp
+++ b/examples/47_node_cache.cpp
@@ -56,8 +56,8 @@ int main() {
     };
 
     NodeContext ctx;
-    auto engine = GraphEngine::compile(def, ctx);
-    engine->set_node_cache_enabled("expensive", true);
+    auto        engine =
+        GraphEngine::build(def, EngineConfig{.node_context = ctx, .cached_nodes = {"expensive"}});
 
     // First run — miss.
     RunConfig cfg;

--- a/examples/48_sqlite_checkpoint.cpp
+++ b/examples/48_sqlite_checkpoint.cpp
@@ -61,7 +61,8 @@ int main() {
 
     auto store = std::make_shared<SqliteCheckpointStore>(":memory:");
     NodeContext ctx;
-    auto engine = GraphEngine::compile(def, ctx, store);
+    auto        engine =
+        GraphEngine::build(def, EngineConfig{.node_context = ctx, .checkpoint_store = store});
 
     // RunResult::channel<T>(name) handles both shapes — channels-wrapper
     // (canonical) and flat-key projections (e.g. react_graph's

--- a/examples/49_openinference.cpp
+++ b/examples/49_openinference.cpp
@@ -193,7 +193,7 @@ int main() {
         }},
     };
     NodeContext ctx;
-    auto engine = GraphEngine::compile(def, ctx);
+    auto        engine = GraphEngine::build(def, EngineConfig{.node_context = ctx});
 
     // Use run_stream so the session's cb fires NODE_START/END events.
     RunConfig cfg;

--- a/examples/51_minimal.cpp
+++ b/examples/51_minimal.cpp
@@ -7,7 +7,7 @@
 // 흐름:
 //   1) 그래프를 JSON 으로 기술 — 채널 1개 + 노드 1개 + 엣지
 //   2) 노드 타입을 등록
-//   3) compile → run → 결과를 result.channel<T>(name) 으로 꺼냄
+//   3) build → run → 결과를 result.channel<T>(name) 으로 꺼냄
 //
 // 실행: ./example_minimal     출력: "HELLO"
 
@@ -52,7 +52,7 @@ int main() {
 
     // (3) 컴파일 → 실행 → 결과 꺼냄.
     NodeContext ctx;
-    auto engine = GraphEngine::compile(def, ctx);
+    auto        engine = GraphEngine::build(def, EngineConfig{.node_context = ctx});
 
     RunConfig cfg;
     cfg.input = {{"text", "hello"}};

--- a/examples/52_export_schema.cpp
+++ b/examples/52_export_schema.cpp
@@ -15,7 +15,7 @@
 //
 // `node_types` reflects whatever is registered in NodeFactory at call
 // time, so an embedder's custom node types appear here too — register
-// them before calling, exactly as you would before compile().
+// them before calling, exactly as you would before build().
 //
 // Usage:
 //   ./example_export_schema > schema.json

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,8 +40,8 @@ If this is your first time:
 
 | First | What you learn |
 |---|---|
-| [`51_minimal.cpp`](51_minimal.cpp) | The smallest working program — compile, run, read `result.channel<T>("name")`. No API key. |
-| [`02_custom_graph.cpp`](02_custom_graph.cpp) | Compile a JSON graph definition, run it. No API key. |
+| [`51_minimal.cpp`](51_minimal.cpp) | The smallest working program — build, run, read `result.channel<T>("name")`. No API key. |
+| [`02_custom_graph.cpp`](02_custom_graph.cpp) | Build a JSON graph definition, run it. No API key. |
 | [`05_parallel_fanout.cpp`](05_parallel_fanout.cpp) | Async fan-out with `make_parallel_group`. No API key. |
 | [`10_send_command.cpp`](10_send_command.cpp) | `Send` (dynamic fan-out) + `Command` (routing override). No API key. |
 | [`01_react_agent.cpp`](01_react_agent.cpp) | ReAct loop with a real LLM + a calculator tool. **Needs `OPENAI_API_KEY`.** |
@@ -56,7 +56,7 @@ demonstrate, not by file number.
 
 | # | File | Setup | What it shows |
 |---|------|-------|---------------|
-| 02 | [`02_custom_graph.cpp`](02_custom_graph.cpp) | offline | Compile a JSON graph + run it. The shortest useful program in this repo. |
+| 02 | [`02_custom_graph.cpp`](02_custom_graph.cpp) | offline | Build a JSON graph + run it. The shortest useful program in this repo. |
 | 05 | [`05_parallel_fanout.cpp`](05_parallel_fanout.cpp) | offline | Async fan-out — three "researcher" nodes co-run on one io_context, summarizer fans them in. |
 | 06 | [`06_subgraph.cpp`](06_subgraph.cpp) | offline | Hierarchical composition — outer supervisor graph delegates to an inner ReAct subgraph. |
 | 07 | [`07_intent_routing.cpp`](07_intent_routing.cpp) | offline | Classifier → conditional edge → math / translate / general expert. |
@@ -65,7 +65,7 @@ demonstrate, not by file number.
 | 10 | [`10_send_command.cpp`](10_send_command.cpp) | offline | Planner→Send→researcher→Command(loop|finish) — the canonical Send+Command pattern. |
 | 42 | [`42_custom_reducer_condition.cpp`](42_custom_reducer_condition.cpp) | offline | Register custom channel reducers and edge conditions from C++ — extend the JSON vocabulary without touching the engine. |
 | 43 | [`43_store_personalization.cpp`](43_store_personalization.cpp) | offline | Cross-thread `Store` reached from inside a node via `in.ctx.store` — per-user node behaviour from shared namespaced memory. |
-| 51 | [`51_minimal.cpp`](51_minimal.cpp) | offline | The shortest working program — compile, run, `result.channel<T>("name")`. The fresh-user template. |
+| 51 | [`51_minimal.cpp`](51_minimal.cpp) | offline | The shortest working program — build, run, `result.channel<T>("name")`. The fresh-user template. |
 | 52 | [`52_export_schema.cpp`](52_export_schema.cpp) | offline | `NodeFactory::export_schema()` → topology JSON Schema dump. The version-locked source of truth a codeless visual editor builds its palette from. |
 | 56 | [`56_history_compaction.cpp`](56_history_compaction.cpp) | offline (optional OpenAI) | Bounded message window — when history exceeds the budget the dropped prefix is replaced by an LLM-written summary. Mock provider by default. |
 

--- a/examples/cookbook/ai-assembly/member_server.cpp
+++ b/examples/cookbook/ai-assembly/member_server.cpp
@@ -161,7 +161,8 @@ int main(int argc, char** argv) {
         })},
     };
     NodeContext ctx;
-    auto unique_engine = GraphEngine::compile(def, ctx);
+    auto        unique_engine =
+        GraphEngine::build(def, neograph::graph::EngineConfig{.node_context = ctx});
     auto engine = std::shared_ptr<GraphEngine>(std::move(unique_engine));
 
     // AgentCard advertises this persona to the rest of the assembly.

--- a/examples/cookbook/jarvis/specialists/coder/server.cpp
+++ b/examples/cookbook/jarvis/specialists/coder/server.cpp
@@ -287,7 +287,8 @@ int main(int argc, char** argv) {
     };
 
     NodeContext ctx;
-    auto unique_engine = GraphEngine::compile(def, ctx);
+    auto        unique_engine =
+        GraphEngine::build(def, neograph::graph::EngineConfig{.node_context = ctx});
     auto engine = std::shared_ptr<GraphEngine>(std::move(unique_engine));
 
     // AgentCard — 자비스 라우터가 "coder" 이름으로 찾는다

--- a/examples/cookbook/jarvis/specialists/researcher/server.cpp
+++ b/examples/cookbook/jarvis/specialists/researcher/server.cpp
@@ -250,7 +250,8 @@ std::shared_ptr<GraphEngine> build_engine(std::shared_ptr<Provider> provider,
     };
 
     NodeContext ctx;
-    auto unique_engine = GraphEngine::compile(def, ctx);
+    auto        unique_engine =
+        GraphEngine::build(def, neograph::graph::EngineConfig{.node_context = ctx});
     return std::shared_ptr<GraphEngine>(std::move(unique_engine));
 }
 

--- a/examples/cookbook/jarvis/src/main.cpp
+++ b/examples/cookbook/jarvis/src/main.cpp
@@ -871,11 +871,6 @@ int main(int argc, char** argv) {
         neograph::graph::NodeContext ctx;
         ctx.provider = synth_provider;  // llm_call 노드(response_synth)가 사용
 
-        auto engine_uptr =
-            neograph::graph::GraphEngine::compile(graph_def, ctx);
-        auto engine =
-            std::shared_ptr<neograph::graph::GraphEngine>(engine_uptr.release());
-
         // ── 5.5) 파일 영속 Store 생성 + 엔진에 주입 ─────────────────────────
         // MemoryLookupNode / MemoryCommitNode 가 ctx.store 를 통해 대화 기록을
         // 읽고 쓴다. JsonFileStore 라 프로세스를 재시작해도 기억이 유지됨
@@ -887,7 +882,9 @@ int main(int argc, char** argv) {
                                               : "jarvis_memory.json";
         auto jarvis_store =
             std::make_shared<jarvis::memory::JsonFileStore>(mem_path);
-        engine->set_store(jarvis_store);
+        auto engine_uptr = neograph::graph::GraphEngine::build(
+            graph_def, neograph::graph::EngineConfig{.node_context = ctx, .store = jarvis_store});
+        auto engine = std::shared_ptr<neograph::graph::GraphEngine>(engine_uptr.release());
         std::cerr << "[jarvis] 파일 영속 Store 주입 완료 (" << mem_path << ")\n";
 
         // ── 6) 자비스 A2A self-server 기동 ──────────────────────────────────

--- a/examples/cookbook/multi_tenant_chatbot/README.md
+++ b/examples/cookbook/multi_tenant_chatbot/README.md
@@ -45,7 +45,7 @@ public:
                 return it->second;
             }
         }
-        auto raw = GraphEngine::compile(def, ctx);
+        auto raw = GraphEngine::build(def, EngineConfig{.node_context = ctx});
         std::shared_ptr<GraphEngine> engine(raw.release());
         std::unique_lock lk(mu_);
         cache_.emplace(key, engine);

--- a/examples/cookbook/multi_tenant_chatbot/server.cpp
+++ b/examples/cookbook/multi_tenant_chatbot/server.cpp
@@ -195,7 +195,7 @@ public:
             }
         }
         // Miss — compile (lock 밖에서, 다른 customer 차단 안 함).
-        auto raw = GraphEngine::compile(def, ctx);
+        auto raw = GraphEngine::build(def, EngineConfig{.node_context = ctx});
         std::shared_ptr<GraphEngine> engine(raw.release());
         {
             std::unique_lock lk(mu_);

--- a/examples/cookbook/multi_tenant_chatbot/server_live_llm.cpp
+++ b/examples/cookbook/multi_tenant_chatbot/server_live_llm.cpp
@@ -164,7 +164,7 @@ public:
                 return it->second;
             }
         }
-        auto raw = GraphEngine::compile(def, ctx);
+        auto raw = GraphEngine::build(def, EngineConfig{.node_context = ctx});
         std::shared_ptr<GraphEngine> engine(raw.release());
         {
             std::unique_lock lk(mu_);

--- a/examples/cookbook/self_evolving_chatbot/server.cpp
+++ b/examples/cookbook/self_evolving_chatbot/server.cpp
@@ -137,7 +137,7 @@ public:
             std::shared_lock lk(mu_);
             if (auto it = cache_.find(key); it != cache_.end()) return it->second;
         }
-        auto raw = GraphEngine::compile(def, ctx);
+        auto raw = GraphEngine::build(def, EngineConfig{.node_context = ctx});
         std::shared_ptr<GraphEngine> engine(raw.release());
         std::unique_lock lk(mu_);
         cache_.emplace(key, engine);

--- a/examples/cookbook/self_evolving_chatbot/server_multi.cpp
+++ b/examples/cookbook/self_evolving_chatbot/server_multi.cpp
@@ -138,7 +138,7 @@ public:
             std::shared_lock lk(mu_);
             if (auto it = cache_.find(key); it != cache_.end()) return it->second;
         }
-        auto raw = GraphEngine::compile(def, ctx);
+        auto raw = GraphEngine::build(def, EngineConfig{.node_context = ctx});
         std::shared_ptr<GraphEngine> engine(raw.release());
         std::unique_lock lk(mu_);
         cache_.emplace(key, engine);

--- a/examples/cookbook/the-beast/README.md
+++ b/examples/cookbook/the-beast/README.md
@@ -90,7 +90,7 @@ it, diff it, revert a whole generation.
 ## Act III — roll back (checkpointer time-travel)
 
 The surviving harness is spawned with an `InMemoryCheckpointStore`
-attached (`engine->set_checkpoint_store(store)`). The engine snapshots
+attached through `EngineConfig::checkpoint_store`. The engine snapshots
 state at the end of every super-step. Afterwards:
 
 - `store->list("beast-run")` returns the full timeline — you can *see*

--- a/examples/cookbook/the-beast/the_beast.cpp
+++ b/examples/cookbook/the-beast/the_beast.cpp
@@ -204,8 +204,8 @@ int main() {
     // Spawn a validated harness with a checkpointer; rewind its run.
     std::cout << "── ACT III · spawn + roll back through the checkpointer ──\n";
     auto store = std::make_shared<ng::InMemoryCheckpointStore>();
-    auto engine = ng::GraphEngine::compile(seed_core, ctx);
-    engine->set_checkpoint_store(store);
+    auto engine = ng::GraphEngine::build(
+        seed_core, ng::EngineConfig{.node_context = ctx, .checkpoint_store = store});
 
     ng::RunConfig run_cfg;
     run_cfg.thread_id = "beast-run";

--- a/examples/cookbook/the-beast/the_beast_apex.cpp
+++ b/examples/cookbook/the-beast/the_beast_apex.cpp
@@ -206,8 +206,12 @@ int main(int argc, char** argv) {
     std::cout << "── Spawning the agent it wrote — live, tools bound ──\n";
     std::cout << "  user task: " << task << "\n";
 
-    auto engine = ng::GraphEngine::compile(core, ctx);
-    engine->own_tools(std::move(tools));   // engine owns the tool lifetimes
+    ng::EngineConfig engine_config;
+    engine_config.node_context = ctx;
+    engine_config.node_context.tools.clear();
+    ng::EngineResources resources;
+    resources.tools = neograph::ToolSet(std::move(tools));
+    auto engine     = ng::GraphEngine::build(core, std::move(engine_config), std::move(resources));
 
     ng::RunConfig rc;
     rc.max_steps = 12;                     // bound the ReAct loop

--- a/examples/cookbook/the-beast/the_beast_baldwin.cpp
+++ b/examples/cookbook/the-beast/the_beast_baldwin.cpp
@@ -137,7 +137,7 @@ static Sig sig_fast(const Genome& g) {
 
 // Ground truth: compile the topology and RUN it on one battery input.
 static double run_engine(const json& core, const ng::NodeContext& ctx, double x) {
-    auto engine = ng::GraphEngine::compile(core, ctx);
+    auto          engine = ng::GraphEngine::build(core, ng::EngineConfig{.node_context = ctx});
     ng::RunConfig rc;
     rc.max_steps = N + 4;
     rc.input = {{"acc", x}};

--- a/examples/cookbook/the-beast/the_beast_baldwin_adv.cpp
+++ b/examples/cookbook/the-beast/the_beast_baldwin_adv.cpp
@@ -107,7 +107,7 @@ static Sig sig_fast(const Genome& g) {
     return {f0, f1};
 }
 static double run_engine(const json& core, const ng::NodeContext& ctx, double x) {
-    auto engine = ng::GraphEngine::compile(core, ctx);
+    auto          engine = ng::GraphEngine::build(core, ng::EngineConfig{.node_context = ctx});
     ng::RunConfig rc; rc.max_steps = N + 4; rc.input = {{"acc", x}};
     auto res = engine->run(rc);
     json av = res.has_channel("acc") ? res.channel<json>("acc") : json(0);

--- a/examples/cookbook/the-beast/the_beast_baldwin_llm.cpp
+++ b/examples/cookbook/the-beast/the_beast_baldwin_llm.cpp
@@ -105,7 +105,7 @@ static double run_acc(const Genome& g, const ng::NodeContext& ctx) {
     json core = {{"schema_version", 1}, {"name", "arith"},
                  {"channels", {{"acc", {{"reducer", "overwrite"}, {"initial", 0}}}}},
                  {"nodes", nodes}, {"edges", edges}};
-    auto engine = ng::GraphEngine::compile(core, ctx);
+    auto          engine = ng::GraphEngine::build(core, ng::EngineConfig{.node_context = ctx});
     ng::RunConfig rc; rc.max_steps = N + 4; rc.input = {{"acc", 0}};
     auto res = engine->run(rc);
     json av = res.has_channel("acc") ? res.channel<json>("acc") : json(0);

--- a/examples/cookbook/the-beast/the_beast_evolve.cpp
+++ b/examples/cookbook/the-beast/the_beast_evolve.cpp
@@ -108,7 +108,7 @@ static Fit fitness(const json& core, const ng::NodeContext& ctx) {
         if (ng::GraphValidator::validate(cg).has_errors()) return {};
     } catch (const std::exception&) { return {}; }
     try {
-        auto engine = ng::GraphEngine::compile(core, ctx);
+        auto          engine = ng::GraphEngine::build(core, ng::EngineConfig{.node_context = ctx});
         ng::RunConfig rc; rc.max_steps = 40; rc.input = {{"acc", 0}};
         auto res = engine->run(rc);
         json av = res.has_channel("acc") ? res.channel<json>("acc") : json(0);

--- a/examples/cookbook/the-beast/the_beast_forge.cpp
+++ b/examples/cookbook/the-beast/the_beast_forge.cpp
@@ -219,8 +219,12 @@ int main(int argc, char** argv) {
 
     // ---------- PHASE 5: SPAWN with all tools bound ----------
     std::cout << "── SPAWN · run the agent it wrote, tools bound ──\n";
-    auto engine = ng::GraphEngine::compile(core, ctx);
-    engine->own_tools(std::move(owned));
+    ng::EngineConfig engine_config;
+    engine_config.node_context = ctx;
+    engine_config.node_context.tools.clear();
+    ng::EngineResources resources;
+    resources.tools = neograph::ToolSet(std::move(owned));
+    auto engine     = ng::GraphEngine::build(core, std::move(engine_config), std::move(resources));
     ng::RunConfig rc;
     rc.max_steps = 12;
     rc.input = {{"messages", json::array({{{"role", "user"}, {"content", task}}})}};

--- a/examples/cookbook/the-beast/the_beast_gate_eval.cpp
+++ b/examples/cookbook/the-beast/the_beast_gate_eval.cpp
@@ -81,7 +81,7 @@ enum class Outcome { CLEAN, FAULT, STALL };
 static const char* name(Outcome o) { return o == Outcome::CLEAN ? "CLEAN" : o == Outcome::FAULT ? "FAULT" : "STALL"; }
 static Outcome execute(const json& core, const ng::NodeContext& ctx) {
     try {
-        auto engine = ng::GraphEngine::compile(core, ctx);
+        auto          engine = ng::GraphEngine::build(core, ng::EngineConfig{.node_context = ctx});
         ng::RunConfig rc; rc.max_steps = 8; rc.input = {{"out", 0}};
         auto res = engine->run(rc);
         return (int)res.execution_trace.size() >= rc.max_steps ? Outcome::STALL : Outcome::CLEAN;

--- a/examples/cookbook/the-beast/the_beast_gate_fuzz.cpp
+++ b/examples/cookbook/the-beast/the_beast_gate_fuzz.cpp
@@ -126,7 +126,7 @@ static Verdict validate(const json& core, const ng::NodeContext& ctx) {
 enum class Outcome { CLEAN, FAULT, STALL };
 static Outcome execute(const json& core, const ng::NodeContext& ctx) {
     try {
-        auto engine = ng::GraphEngine::compile(core, ctx);
+        auto          engine = ng::GraphEngine::build(core, ng::EngineConfig{.node_context = ctx});
         ng::RunConfig rc; rc.max_steps = 32; rc.input = {{"out", 0}};
         auto res = engine->run(rc);
         return (int)res.execution_trace.size() >= rc.max_steps ? Outcome::STALL : Outcome::CLEAN;

--- a/examples/cookbook/the-beast/the_beast_live.cpp
+++ b/examples/cookbook/the-beast/the_beast_live.cpp
@@ -215,8 +215,8 @@ int main(int argc, char** argv) {
     // ---- Spawn the model's harness with a checkpointer; run + roll back ----
     std::cout << "── Spawning the model's harness (checkpointed) ──\n";
     auto store = std::make_shared<ng::InMemoryCheckpointStore>();
-    auto engine = ng::GraphEngine::compile(accepted_core, ctx);
-    engine->set_checkpoint_store(store);
+    auto engine = ng::GraphEngine::build(
+        accepted_core, ng::EngineConfig{.node_context = ctx, .checkpoint_store = store});
 
     ng::RunConfig rc;
     rc.thread_id = "beast-live";

--- a/examples/cookbook/the-beast/the_beast_novelist.cpp
+++ b/examples/cookbook/the-beast/the_beast_novelist.cpp
@@ -320,7 +320,7 @@ int main(int argc, char** argv) {
     std::cout << "harness passed the coherence gate. writing";
     std::cout << (g_prov ? " (live — this takes a few minutes)…\n" : " (stub)…\n");
 
-    auto engine = ng::GraphEngine::compile(core, ctx);
+    auto          engine = ng::GraphEngine::build(core, ng::EngineConfig{.node_context = ctx});
     ng::RunConfig rc; rc.max_steps = total + 5;
     auto res = engine->run(rc);
     std::string book = res.has_channel("book") ? res.channel<json>("book").get<std::string>() : "";

--- a/examples/cookbook/the-beast/the_beast_script.cpp
+++ b/examples/cookbook/the-beast/the_beast_script.cpp
@@ -405,7 +405,7 @@ int main(int argc, char** argv) {
 
     // ---- spawn: the loop is driven by model-written goto logic ----
     std::cout << "\n── Spawning — the node's own code drives the loop via goto ──\n";
-    auto engine = ng::GraphEngine::compile(core, ctx);
+    auto          engine = ng::GraphEngine::build(core, ng::EngineConfig{.node_context = ctx});
     ng::RunConfig rc;
     rc.max_steps = 20;
     rc.input = {{"counter", 0}};

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -341,7 +341,7 @@ enum class RunStatus {
  * Use the ``channel<T>(name)`` accessor below to read a channel value
  * without committing to either shape — it checks the channels wrapper
  * first, then falls back to a flat top-level key with the same name.
- * That way the same call site works against ``GraphEngine::compile``-
+ * That way the same call site works against ``GraphEngine::build``-
  * built graphs (channels-wrapped only) and ``react_graph``-built
  * graphs (channels-wrapped + flat-key projections) alike.
  */
@@ -471,7 +471,7 @@ struct RunResult {
  *
  * ## Thread safety
  *
- * After `compile()` returns, the graph definition (nodes, edges, channels)
+ * After `build()` or `link()` returns, the graph definition (nodes, edges, channels)
  * is treated as immutable. A single GraphEngine instance is therefore safe
  * to share across user threads that invoke `run()` / `run_stream()` /
  * `resume()` concurrently with **distinct `thread_id`s** — each call
@@ -505,7 +505,10 @@ struct RunResult {
  *   implementations must be thread-safe.
  *
  * @code
- * auto engine = GraphEngine::compile(graph_json, context, checkpoint_store);
+ * EngineConfig engine_config;
+ * engine_config.node_context = context;
+ * engine_config.checkpoint_store = checkpoint_store;
+ * auto engine = GraphEngine::build(graph_json, std::move(engine_config));
  * RunConfig config;
  * config.thread_id = "session-1";
  * config.input = {{"messages", json::array({{{"role","user"},{"content","Hello"}}})}};
@@ -514,17 +517,12 @@ struct RunResult {
  *
  * @see RunConfig, RunResult, GraphNode
  *
- * @note Public surface size — this class exposes ~23 public methods
- * spanning three concerns: graph execution (run/run_async/run_stream/
+ * @note This class spans three concerns: graph execution (run/run_async/run_stream/
  * resume), state administration (get_state/update_state/fork), and
- * runtime configuration (set_retry_policy/set_worker_count/
- * set_node_cache_enabled/set_checkpoint_store/own_tools). A future
- * major version (v1.0) is expected to split into `GraphEngine` (run
- * + resume only), `GraphAdmin` (state inspection/update/fork), and a
- * `GraphConfigBuilder` consumed at compile time. The current shape
- * is kept so existing examples and downstream consumers don't break;
- * the class-level docs above flag mutator setters as "configuration,
- * not runtime" already.
+ * compatibility configuration setters. New code should pass all construction
+ * policy through EngineConfig and EngineResources. The setters remain so
+ * existing downstream consumers do not break; they are configuration, not
+ * runtime control.
  */
 class NEOGRAPH_API GraphEngine {
 public:

--- a/include/neograph/graph/executor.h
+++ b/include/neograph/graph/executor.h
@@ -141,8 +141,8 @@ public:
         const RunContext& ctx);
 
     /// Inner retry loop with exponential backoff + NodeInterrupt
-    /// short-circuit. Drives node->execute_full_(stream_)async via
-    /// co_await and uses asio::steady_timer.async_wait for backoff so
+    /// short-circuit. Drives node->run(NodeInput) via co_await and uses
+    /// asio::steady_timer.async_wait for backoff so
     /// the executor is not frozen during retry waits. NodeInterrupt +
     /// exception semantics preserved bit-for-bit; GCC-13-safe (catch
     /// block captures the exception via std::optional, co_await

--- a/include/neograph/graph/node.h
+++ b/include/neograph/graph/node.h
@@ -8,17 +8,12 @@
  * - IntentClassifierNode: LLM-based intent routing
  * - SubgraphNode: hierarchical graph composition
  *
- * # v0.4.x migration navigator (external authors)
+ * # Custom node API
  *
- * Writing a custom node subclass in v0.4.x? **Keep using the legacy
- * 8-virtual surface** (`execute` / `execute_async` / `execute_full` /
- * `execute_stream` and their `_async` pairs) — those still work and
- * the engine drives them on every dispatch path. The new unified
- * `run(NodeInput) -> awaitable<NodeOutput>` virtual is additive in
- * v0.4.0 (PR 2 in `ROADMAP_v1.md`): it forwards to the legacy chain
- * by default, so existing subclasses compile unchanged. PR 4 of the
- * same plan will mark the legacy virtuals `[[deprecated]]`; v1.0
- * deletes them.
+ * Custom nodes implement the single coroutine-native
+ * `run(NodeInput) -> awaitable<NodeOutput>` virtual. The pre-v1
+ * `execute*` virtual cross-product has been removed; see
+ * `docs/migration-v0.4-to-v1.0.md` for before/after examples.
  *
  * The engine threads `RunContext` through `NodeInput::ctx`. Nodes can use
  * cancellation, usage accounting, thread/step/stream metadata, Store access,
@@ -30,7 +25,7 @@
  *   - `examples/02_custom_graph.cpp` — custom node subclass
  *   - `examples/05_parallel_fanout.cpp` — Send / Command pattern
  *
- * @see ROADMAP_v1.md for the v0.4 → v1.0 PR sequence
+ * @see docs/migration-v0.4-to-v1.0.md
  */
 #pragma once
 
@@ -52,21 +47,13 @@ namespace neograph::graph {
 struct RunContext;
 
 /**
- * @brief Per-call input bundle for the v0.4 unified ``run()`` virtual.
+ * @brief Per-call input bundle for the unified ``run()`` virtual.
  *
- * Replaces the ``(state[, cb])`` parameter pair that the legacy 8-
- * virtual cross-product passed around. New nodes override
+ * Replaces the old ``(state[, cb])`` parameter pair. Nodes override
  * ``GraphNode::run(NodeInput) -> awaitable<NodeOutput>`` and read
  * everything they need (state, per-run metadata, optional streaming
  * sink) from this struct. Trivially constructed at the dispatch site;
- * cheap to pass by const reference.
- *
- * **PR 2 (v0.4.0)**: ``run()`` is additive — the default body
- * forwards to the legacy 8-virtual chain, so existing C++ subclasses
- * continue to compile and work unchanged. PR 4 marks the legacy
- * virtuals ``[[deprecated]]``; v1.0 deletes them.
- *
- * @see ROADMAP_v1.md "Execution plan" → PR 2
+ * copied into the coroutine frame so its references survive suspension.
  */
 struct NodeInput {
     /// Snapshot of the channel state visible to this node.
@@ -85,35 +72,16 @@ struct NodeInput {
     const GraphStreamCallback* stream_cb = nullptr;
 };
 
-/// Output of the v0.4 unified ``run()`` virtual. Same shape as the
-/// legacy ``NodeResult`` (writes + optional Command + Sends), aliased
-/// here so user code can use either name interchangeably during the
-/// deprecation window. The ROADMAP names it ``NodeOutput`` because the
-/// "input → output" pairing reads more naturally than "input → result"
-/// at the call site; the underlying structure is unchanged.
+/// Output of the unified ``run()`` virtual. Alias for ``NodeResult``:
+/// channel writes plus optional Command and Send directives.
 using NodeOutput = NodeResult;
-
-/// PR 4 (v0.4.0): deprecation marker for the legacy 8-virtual chain.
-/// Centralised so the message stays consistent across every override
-/// point. v0.4.x emits ``-Wdeprecated-declarations`` warnings; v1.0
-/// removes the marked methods entirely. See ROADMAP_v1.md PR 9.
-///
-/// Migration recipe with case-by-case before/after examples:
-/// docs/migration-v0.4-to-v1.0.md
-#define NEOGRAPH_DEPRECATED_VIRTUAL                                  \
-    [[deprecated(                                                    \
-        "v0.4: override run(NodeInput) -> awaitable<NodeOutput> "    \
-        "instead. The legacy 8-virtual chain is preserved for "      \
-        "back-compat through v0.5 and removed in v1.0. "             \
-        "Migration recipe: docs/migration-v0.4-to-v1.0.md")]]
 
 /**
  * @brief Abstract base class for all graph nodes.
  *
  * Nodes are the building blocks of the graph. Each node reads from
  * the graph state and produces channel writes (and optionally Command
- * or Send directives). Override execute() for basic nodes, or
- * execute_full() to use Command/Send.
+ * or Send directives). Override ``run(NodeInput)`` for every node shape.
  *
  * ## Thread safety
  *
@@ -132,8 +100,7 @@ public:
     virtual ~GraphNode() = default;
 
     /**
-     * @brief v0.4 unified dispatch entry — replaces the 8-virtual cross
-     *        product over (sync/async) × (writes/full) × (stream/non-stream).
+     * @brief Unified dispatch entry for sync work, async work, and streaming.
      *
      * **New nodes override THIS method.** Read ``in.state`` for channel
      * inputs, read ``in.ctx`` for available per-run metadata (cancel token,
@@ -142,17 +109,10 @@ public:
      * for ``NodeResult``) populated with channel writes plus optional
      * ``Command`` / ``Send`` directives.
      *
-     * **Legacy nodes that override one of the 8 virtuals** keep
-     * working unchanged: the default body of ``run()`` below forwards
-     * to ``execute_full_async`` / ``execute_full_stream_async``, which
-     * preserves the existing default-fallback chain (and its
-     * ``ExecuteDefaultGuard`` recursion guard).
-     *
      * The engine (``NodeExecutor::execute_node_with_retry_async``)
-     * dispatches via this method as of PR 2. Sync-vs-async is no
-     * longer a user concern — return whatever your body needs to
-     * ``co_return`` (sync work: ``co_return execute(...)``; async work:
-     * ``co_return co_await provider->complete_async(...)``).
+     * dispatches only through this method. Sync-vs-async is no longer
+     * a public virtual cross-product: perform immediate work before
+     * ``co_return``, or ``co_await`` asynchronous dependencies.
      *
      * @code
      * class MyNode : public GraphNode {
@@ -167,8 +127,7 @@ public:
      * };
      * @endcode
      *
-     * @see ROADMAP_v1.md "Execution plan" → PR 2; ``NodeInput`` and
-     * ``NodeOutput`` above.
+     * @see ``NodeInput`` and ``NodeOutput`` above.
      *
      * **Lifetime note**: ``in`` is taken **by value** so the coroutine
      * frame owns its own copy of the struct. The ``state`` / ``ctx``
@@ -204,7 +163,7 @@ public:
      */
     LLMCallNode(const std::string& name, const NodeContext& ctx);
 
-    /// v0.4 PR 9a: unified ``run`` override. Builds completion params,
+    /// Unified ``run`` override. Builds completion params,
     /// calls ``provider_->complete_async`` (or ``complete_stream_async``
     /// when ``in.stream_cb`` is non-null and bridges per-token events
     /// to GraphEvent), writes the assistant message to the
@@ -231,12 +190,9 @@ private:
  * Reads the last assistant message from the "messages" channel,
  * executes each tool call, and writes tool result messages back.
  *
- * Deliberately does NOT override `execute_stream`: tool execution is
- * synchronous work against the user's `Tool` implementations and
- * produces no LLM token stream to emit. The default `execute_stream`
- * inherited from GraphNode falls through to `execute()`, which is the
- * intended behaviour. Emit your own progress events from inside your
- * Tool if you need fine-grained observability.
+ * Tool dispatch does not emit LLM token events because it executes tool calls,
+ * not a model stream. Tools can emit their own progress through application
+ * observability when finer-grained reporting is needed.
  */
 class NEOGRAPH_API ToolDispatchNode : public GraphNode {
 public:
@@ -247,7 +203,7 @@ public:
      */
     ToolDispatchNode(const std::string& name, const NodeContext& ctx);
 
-    /// v0.4 PR 9a: unified ``run`` — finds the latest assistant
+    /// Unified ``run`` — finds the latest assistant
     /// message with tool_calls, dispatches each call to the matching
     /// Tool, writes tool result messages back to the ``messages``
     /// channel.

--- a/include/neograph/llm/agent.h
+++ b/include/neograph/llm/agent.h
@@ -112,7 +112,8 @@ class NEOGRAPH_API Agent {
     /**
      * @brief Intercept every tool call before it runs (issue #89).
      *
-     * The same gate the graph path takes from ``RunConfig::tool_gate``. Both
+     * The same gate the graph path takes from ``EngineConfig::tool_gate`` or
+     * ``GraphEngine::set_tool_gate``. Both
      * route through one dispatcher (issue #87), which is what stops a
      * capability like this from landing in one path and silently missing the
      * other — as concurrency once did.

--- a/include/neograph/tool_dispatch.h
+++ b/include/neograph/tool_dispatch.h
@@ -131,7 +131,8 @@ struct ToolDecision {
  * Awaitable, so a gate may do real work — ask a policy service, hit a database,
  * prompt over a socket — without blocking the executor.
  *
- * Set it on `RunConfig::tool_gate` (graph) or `Agent::set_tool_gate` (standalone).
+ * Set it through `EngineConfig::tool_gate` or `GraphEngine::set_tool_gate`
+ * (graph), or `Agent::set_tool_gate` (standalone).
  * Unset means every call runs, exactly as before this existed.
  */
 using ToolGate =

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -33,12 +33,10 @@ std::size_t default_worker_count() {
 } // namespace
 
 // =========================================================================
-// compile(): JSON definition -> GraphEngine
+// compile(): compatibility facade over the canonical build() path
 //
-// Parsing is delegated to GraphCompiler (pure JSON → CompiledGraph). This
-// function is now just a thin adapter: move every parsed field into the
-// engine's runtime home, then construct the Scheduler from the resulting
-// edge topology + barrier specs.
+// Keep the original signature and behavior while routing construction through
+// EngineConfig so both entry points share one implementation.
 // =========================================================================
 std::unique_ptr<GraphEngine> GraphEngine::compile(
     const json& definition,

--- a/src/core/graph_executor.cpp
+++ b/src/core/graph_executor.cpp
@@ -105,7 +105,7 @@ void NodeExecutor::init_state(GraphState& state) const {
 
 void NodeExecutor::maybe_warn_serial_fanout(std::size_t width) const {
     // Only relevant when the engine has no owned pool — that's the
-    // compile() default (set_worker_count(1)) and the case where a
+    // build() default (EngineConfig::worker_count == 1) and the case where a
     // fan-out of width >= 2 silently runs sequentially. With a pool
     // installed, real parallelism is in effect and nothing to warn
     // about.
@@ -140,11 +140,10 @@ void NodeExecutor::maybe_warn_serial_fanout(std::size_t width) const {
     std::ostringstream oss;
     oss << "[neograph] warning: fan-out of width " << width
         << " is executing serially on a single thread because no "
-        << "engine-owned worker pool is installed (compile() default "
-        << "is set_worker_count(1)).\n"
-        << "    Call engine->set_worker_count_auto() or "
-        << "engine->set_worker_count(N) once after compile() and "
-        << "before run() to enable real parallel fan-out.\n"
+        << "engine-owned worker pool is installed (build() default "
+        << "is EngineConfig::worker_count == 1).\n"
+        << "    Set EngineConfig::worker_count before build() to enable real "
+           "parallel fan-out. Compatibility setters must run before the first run().\n"
         << "    Suppress this warning with the environment variable "
         << "NEOGRAPH_SUPPRESS_FANOUT_WARNING=1.\n";
     std::fputs(oss.str().c_str(), stderr);

--- a/src/core/graph_executor.cpp
+++ b/src/core/graph_executor.cpp
@@ -142,8 +142,9 @@ void NodeExecutor::maybe_warn_serial_fanout(std::size_t width) const {
         << " is executing serially on a single thread because no "
         << "engine-owned worker pool is installed (build() default "
         << "is EngineConfig::worker_count == 1).\n"
-        << "    Set EngineConfig::worker_count before build() to enable real "
-           "parallel fan-out. Compatibility setters must run before the first run().\n"
+        << "    Set EngineConfig::worker_count before build(), or call "
+           "set_worker_count(N) / set_worker_count_auto() before the first run(), "
+           "to enable real parallel fan-out.\n"
         << "    Suppress this warning with the environment variable "
         << "NEOGRAPH_SUPPRESS_FANOUT_WARNING=1.\n";
     std::fputs(oss.str().c_str(), stderr);


### PR DESCRIPTION
## Summary
- make `GraphEngine::build()` with `EngineConfig`/`EngineResources` the primary construction path across C++ examples and cookbooks
- document `ToolSet`, `GraphRegistry`, `RunStatus`, typed channel keys, and typed stream events in the English and Korean API tours
- remove stale `GraphNode::execute*` guidance and update current concurrency, async, troubleshooting, and Doxygen quickstarts
- retain legacy APIs only where they are explicitly documented as compatibility or migration surfaces

## Verification
- `git diff --check`
- `cmake --build build -j2`
- `ctest --test-dir build --output-on-failure -j1` (`791/791` passed; dependency-gated PostgreSQL/live tests skipped)

Closes #159