### PR TITLE
feat(graph): add strict topology APIs

### DIFF
--- a/docs/doxygen-mainpage.md
+++ b/docs/doxygen-mainpage.md
@@ -59,7 +59,7 @@ int main() {
 
     NodeContext ctx;
     ctx.provider = std::make_shared<llm::MockProvider>();
-    auto engine = GraphEngine::build(
+    auto engine = GraphEngine::build_strict(
         definition, EngineConfig{.node_context = std::move(ctx)});
 
     RunConfig cfg;

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -1307,9 +1307,11 @@ if (auto optional = result.try_channel(Answer)) {
 
 ### GraphEngine
 
-The main engine class. New code should use `build()` for a JSON definition or
-`link()` for an already inspected or transformed `CompiledGraph`. `compile()`
-and post-construction setters remain compatibility facades.
+The main engine class. New code should use `build_strict()` for a JSON definition;
+it rejects invalid topology before any node is instantiated. Use `link()` with a
+`ValidatedTopology` when parse, validation, inspection, or transformation must be
+separate steps. The lenient `build()`, `CompiledGraph` link overloads, `compile()`,
+and post-construction setters remain compatibility paths.
 
 ```cpp
 class GraphEngine {
@@ -1320,6 +1322,16 @@ public:
         const json& definition, EngineConfig config);
     static std::unique_ptr<GraphEngine> build(
         const json& definition, EngineConfig config, EngineResources resources);
+
+    static std::unique_ptr<GraphEngine> build_strict(
+        const json& definition, EngineConfig config);
+    static std::unique_ptr<GraphEngine> build_strict(
+        const json& definition, EngineConfig config, EngineResources resources);
+
+    static std::unique_ptr<GraphEngine> link(
+        ValidatedTopology topology, EngineConfig config = {});
+    static std::unique_ptr<GraphEngine> link(
+        ValidatedTopology topology, EngineConfig config, EngineResources resources);
 
     static std::unique_ptr<GraphEngine> link(
         CompiledGraph graph, EngineConfig config = {});
@@ -1354,6 +1366,8 @@ public:
         const GraphStreamCallback& cb = nullptr);
 
     // ---- State Inspection & Manipulation ----
+
+    GraphAdmin admin(); // borrowed facade; must not outlive this engine
 
     std::optional<json> get_state(const std::string& thread_id) const;
 
@@ -1702,6 +1716,9 @@ struct CompiledGraph {
 
 class GraphCompiler {
 public:
+    static TopologySpec parse(const json& definition);
+    static CompiledGraph link(TopologySpec topology,
+                              const NodeContext& default_context);
     static CompiledGraph compile(const json& definition,
                                  const NodeContext& default_context);
 };
@@ -1709,10 +1726,19 @@ public:
 } // namespace neograph::graph
 ```
 
-`GraphEngine::build()` calls `GraphCompiler::compile()`, verifies the result,
-then hands it to `GraphEngine::link()`. Parsing
-failures (malformed edge, unknown node type) surface here before any
-runtime state is built.
+`GraphCompiler::parse()` produces a `TopologySpec` without constructing nodes.
+`GraphValidator::validate()` returns structured diagnostics, while
+`GraphValidator::require_valid()` returns a `ValidatedTopology` or throws
+`std::runtime_error`. Only `GraphCompiler::link()` resolves factories and
+instantiates runtime nodes. `compile()` remains the compatibility composition of
+parse and link, and `GraphEngine::build()` retains its lenient warning behavior.
+New code can enforce the full boundary with `GraphEngine::build_strict()` or:
+
+```cpp
+auto spec = GraphCompiler::parse(definition);
+auto validated = GraphValidator::require_valid(std::move(spec));
+auto engine = GraphEngine::link(std::move(validated), config, resources);
+```
 
 ### Scheduler
 
@@ -1956,10 +1982,9 @@ struct Checkpoint {
 };
 
 // Wire-stable schema version. Bump on layout-incompatible changes.
-// Currently 2 (added `barrier_state`). Typed `uint32_t` (Round 5
-// fix — was a platform-variable `int` round-tripping through JSON,
-// which left an undocumented door for `-1` sentinel values).
-constexpr std::uint32_t CHECKPOINT_SCHEMA_VERSION = 2;
+// v2 added `barrier_state`; v3 records pending-write mode support.
+// Typed `uint32_t`: schema versions are non-negative wire values.
+constexpr std::uint32_t CHECKPOINT_SCHEMA_VERSION = 3;
 ```
 
 | Field | Type | Description |
@@ -1976,19 +2001,19 @@ constexpr std::uint32_t CHECKPOINT_SCHEMA_VERSION = 2;
 | `metadata` | `json` | Arbitrary user-defined data |
 | `step` | `int64_t` | Super-step counter |
 | `timestamp` | `int64_t` | Creation time in Unix epoch milliseconds |
-| `schema_version` | `std::uint32_t` | On-wire layout version (see `CHECKPOINT_SCHEMA_VERSION`, currently `2`). Round 5 widened this from `int` to fixed-width unsigned — schema versions are non-negative and a platform-variable `int` width was wrong for a value persisted to disk and round-tripped through JSON. Persistent `CheckpointStore` implementations should serialize it and treat `0` on a deserialized blob as "pre-versioned" (e.g. the field was absent — migration is the caller's responsibility) |
+| `schema_version` | `std::uint32_t` | On-wire layout version (see `CHECKPOINT_SCHEMA_VERSION`, currently `3`). Round 5 widened this from `int` to fixed-width unsigned — schema versions are non-negative and a platform-variable `int` width was wrong for a value persisted to disk and round-tripped through JSON. Persistent `CheckpointStore` implementations should serialize it and treat `0` on a deserialized blob as "pre-versioned" (e.g. the field was absent — migration is the caller's responsibility) |
 
 ### CheckpointStore
 
 Abstract interface for checkpoint persistence. Implement this to store checkpoints
 in a database, file system, or any other backend.
 
-> **Writing a custom store?** This is a fat interface (5 sync core +
-> 5 async peers + 3 sync pending-writes + 3 async pending-writes =
-> **16 virtuals**). Defaults bridge sync↔async in both directions
-> (sync calls `run_sync(async)`; async calls `execute_in_pool(sync)`)
-> so a backend can override only one side per method — but
-> overriding NEITHER yields infinite mutual recursion at call time.
+> **Writing a custom store?** New implementations should implement the smallest
+> applicable capability: `CheckpointStoreCore`, optionally
+> `AsyncCheckpointStore` and/or `PendingWritesCheckpointStore`, then pass it
+> through `adapt_checkpoint_store()`. The existing `CheckpointStore` interface
+> remains the compatibility contract. Its async defaults invoke the sync methods;
+> a sync-only backend therefore remains valid, but its async calls are blocking.
 > See [`ASYNC_GUIDE.md` §9.4](ASYNC_GUIDE.md#94-checkpointstore).
 
 ```cpp

--- a/docs/reference-ko.md
+++ b/docs/reference-ko.md
@@ -1029,6 +1029,11 @@ auto optional = result.try_channel(Answer);
 
 ### 7.4 GraphEngine 클래스
 
+새 코드는 JSON 정의를 만들 때 `build_strict()`를 사용한다. 이 경로는 노드를
+생성하기 전에 topology 전체를 검증한다. parse, 검증, 검사 또는 변환 단계를
+분리해야 하면 `ValidatedTopology`를 `link()`에 전달한다. 기존 `build()`,
+`CompiledGraph` link overload, `compile()`은 호환성을 위한 lenient 경로다.
+
 ```cpp
 class GraphEngine {
 public:
@@ -1038,6 +1043,16 @@ public:
         const json& definition, EngineConfig config);
     static std::unique_ptr<GraphEngine> build(
         const json& definition, EngineConfig config, EngineResources resources);
+
+    static std::unique_ptr<GraphEngine> build_strict(
+        const json& definition, EngineConfig config);
+    static std::unique_ptr<GraphEngine> build_strict(
+        const json& definition, EngineConfig config, EngineResources resources);
+
+    static std::unique_ptr<GraphEngine> link(
+        ValidatedTopology topology, EngineConfig config = {});
+    static std::unique_ptr<GraphEngine> link(
+        ValidatedTopology topology, EngineConfig config, EngineResources resources);
 
     static std::unique_ptr<GraphEngine> link(
         CompiledGraph graph, EngineConfig config = {});
@@ -1073,6 +1088,8 @@ public:
         const GraphStreamCallback& cb = nullptr);
 
     // ── 상태 조회/조작 ──
+
+    GraphAdmin admin(); // borrowed facade: GraphEngine보다 오래 보관하면 안 됨
 
     std::optional<json> get_state(const std::string& thread_id) const;
 
@@ -1485,6 +1502,9 @@ struct CompiledGraph {
 
 class GraphCompiler {
 public:
+    static TopologySpec parse(const json& definition);
+    static CompiledGraph link(TopologySpec topology,
+                              const NodeContext& default_context);
     static CompiledGraph compile(const json& definition,
                                  const NodeContext& default_context);
 };
@@ -1492,9 +1512,19 @@ public:
 } // namespace neograph::graph
 ```
 
-`GraphEngine::build()`는 내부적으로 `GraphCompiler::compile()`을 호출하고 결과를
-검증한 뒤 `GraphEngine::link()`에 넘긴다. 잘못된 edge나 등록되지 않은 노드
-타입 같은 파싱 실패는 런타임 상태를 만들기 전에 여기서 터진다.
+`GraphCompiler::parse()`는 node를 생성하지 않고 `TopologySpec`을 만든다.
+`GraphValidator::validate()`는 구조화된 진단을 반환하고,
+`GraphValidator::require_valid()`는 `ValidatedTopology`를 반환하거나
+`std::runtime_error`를 던진다. factory 해석과 runtime node 생성은
+`GraphCompiler::link()`에서만 수행한다. `compile()`은 parse와 link를 합친 호환
+helper이고 `GraphEngine::build()`는 기존 lenient warning 동작을 유지한다. 새
+코드는 `GraphEngine::build_strict()` 또는 다음 경로로 전체 경계를 강제한다.
+
+```cpp
+auto spec = GraphCompiler::parse(definition);
+auto validated = GraphValidator::require_valid(std::move(spec));
+auto engine = GraphEngine::link(std::move(validated), config, resources);
+```
 
 ### Scheduler
 
@@ -1724,7 +1754,7 @@ struct Checkpoint {
     json        metadata;         // 사용자 정의 메타데이터
     int64_t     step;             // super-step 번호
     int64_t     timestamp;        // Unix epoch 밀리초
-    int         schema_version = CHECKPOINT_SCHEMA_VERSION;  // 레이아웃 버전 (현재 2)
+    std::uint32_t schema_version = CHECKPOINT_SCHEMA_VERSION;  // 레이아웃 버전 (현재 3)
 
     static std::string generate_id(); // UUID v4 생성
 };
@@ -1738,23 +1768,25 @@ struct Checkpoint {
 | `interrupt_phase` | `CheckpointPhase` enum. `Before` -- interrupt_before, `After` -- interrupt_after, `Completed` -- super-step 정상 종료, `NodeInterrupt` -- 노드 내부에서 `NodeInterrupt` throw, `Updated` -- `update_state()`로 외부 주입. 문자열 인코딩은 `to_string()` / `parse_checkpoint_phase()` |
 | `barrier_state` | barrier 별 누적 upstream 집합. 아직 발사되지 않은 barrier에 대해서만 항목이 존재 — Scheduler가 barrier를 발사할 때 해당 항목을 clear한다. `scheduler.h`의 `BarrierState` 와 동일한 shape. schema v2부터 존재하며, v1 blob은 빈 map으로 로드 (pre-v2 동작과 동등) |
 | `step` | 몇 번째 super-step에서 생성되었는지 |
-| `schema_version` | 현재 `2`. persistent `CheckpointStore` 구현은 이 값을 직렬화해야 하며, `0`은 pre-versioned blob (마이그레이션 책임은 호출자에게) |
+| `schema_version` | 현재 `3`. persistent `CheckpointStore` 구현은 이 값을 직렬화해야 하며, `0`은 pre-versioned blob (마이그레이션 책임은 호출자에게) |
 
 ---
 
-### 8.2 CheckpointStore (추상 클래스)
+### 8.2 Checkpoint capability와 CheckpointStore
 
 checkpoint 영속화 인터페이스. 데이터베이스, 파일 시스템 등으로 구현 가능.
 
-> **커스텀 store를 작성하신다면?** sync 8개, async peer 8개.
-> [`ASYNC_GUIDE.md` §9.4](ASYNC_GUIDE.md#94-checkpointstore) 참조 —
-> 백엔드가 async-capable이면 async 전부 override, blocking이면 sync
-> 전부 override (섞지 말 것).
+> **커스텀 store를 작성한다면?** 새 구현은 필요한 최소 capability인
+> `CheckpointStoreCore`를 구현하고, 필요할 때 `AsyncCheckpointStore` 및
+> `PendingWritesCheckpointStore`를 추가한 뒤 `adapt_checkpoint_store()`로
+> 연결한다. 기존 `CheckpointStore`는 호환 contract로 유지된다. async 기본
+> 구현은 sync 메서드를 호출하므로 sync-only backend도 유효하지만 async 호출은
+> blocking이다. [`ASYNC_GUIDE.md` §9.4](ASYNC_GUIDE.md#94-checkpointstore) 참조.
 
 ```cpp
-class CheckpointStore {
+class CheckpointStoreCore {
 public:
-    virtual ~CheckpointStore() = default;
+    virtual ~CheckpointStoreCore() = default;
 
     virtual void save(const Checkpoint& cp) = 0;
     virtual std::optional<Checkpoint> load_latest(const std::string& thread_id) = 0;
@@ -1763,6 +1795,9 @@ public:
                                           int limit = 100) = 0;
     virtual void delete_thread(const std::string& thread_id) = 0;
 };
+
+std::shared_ptr<CheckpointStore> adapt_checkpoint_store(
+    std::shared_ptr<CheckpointStoreCore> core);
 ```
 
 | 메서드 | 설명 |

--- a/examples/51_minimal.cpp
+++ b/examples/51_minimal.cpp
@@ -19,11 +19,13 @@
 using namespace neograph;
 using namespace neograph::graph;
 
+const ChannelKey<std::string> text_channel{"text"};
+
 // 노드 한 개. 채널 "text" 를 읽어서 대문자로 바꿔 다시 같은 채널에 씀.
 class UpperNode : public GraphNode {
 public:
     asio::awaitable<NodeOutput> run(NodeInput in) override {
-        std::string s = in.state.get("text").get<std::string>();
+        std::string s = in.state.get(text_channel);
         for (auto& c : s) c = static_cast<char>(std::toupper(c));
         NodeOutput out;
         out.writes.push_back(ChannelWrite{"text", json(s)});
@@ -52,12 +54,12 @@ int main() {
 
     // (3) 컴파일 → 실행 → 결과 꺼냄.
     NodeContext ctx;
-    auto        engine = GraphEngine::build(def, EngineConfig{.node_context = ctx});
+    auto        engine = GraphEngine::build_strict(def, EngineConfig{.node_context = ctx});
 
     RunConfig cfg;
     cfg.input = {{"text", "hello"}};
     auto result = engine->run(cfg);
 
-    std::cout << result.channel<std::string>("text") << "\n";   // → HELLO
+    std::cout << result.channel(text_channel) << "\n";   // → HELLO
     return 0;
 }

--- a/include/neograph/graph/admin.h
+++ b/include/neograph/graph/admin.h
@@ -1,0 +1,44 @@
+/**
+ * @file graph/admin.h
+ * @brief Borrowed state-administration facade for GraphEngine.
+ */
+#pragma once
+
+#include <neograph/api.h>
+#include <neograph/graph/checkpoint.h>
+#include <neograph/json.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace neograph::graph {
+
+class GraphEngine;
+
+/**
+ * @brief State inspection and mutation separated from graph execution calls.
+ *
+ * GraphAdmin borrows a GraphEngine and must not outlive it. The corresponding
+ * GraphEngine methods remain supported and are the implementation boundary, so
+ * this facade adds no state to GraphEngine and changes no existing behavior.
+ */
+class NEOGRAPH_API GraphAdmin {
+public:
+    explicit GraphAdmin(GraphEngine& engine) noexcept : engine_(&engine) {}
+
+    std::optional<json> get_state(const std::string& thread_id) const;
+    std::vector<Checkpoint> get_state_history(const std::string& thread_id,
+                                              int limit = 100) const;
+    void update_state(const std::string& thread_id,
+                      const json& channel_writes,
+                      const std::string& as_node = "") const;
+    std::string fork(const std::string& source_thread_id,
+                     const std::string& new_thread_id,
+                     const std::string& checkpoint_id = "") const;
+
+private:
+    GraphEngine* engine_;
+};
+
+} // namespace neograph::graph

--- a/include/neograph/graph/channel_key.h
+++ b/include/neograph/graph/channel_key.h
@@ -1,0 +1,31 @@
+/**
+ * @file graph/channel_key.h
+ * @brief Typed names for JSON-backed graph state channels.
+ */
+#pragma once
+
+#include <string>
+#include <utility>
+
+namespace neograph::graph {
+
+/**
+ * @brief Bind a channel name to its expected C++ value type.
+ *
+ * ChannelKey does not change the JSON-backed channel model. Keep keys as
+ * reusable constants and pass them to GraphState or RunResult accessors.
+ */
+template <typename T>
+class ChannelKey {
+public:
+    using value_type = T;
+
+    explicit ChannelKey(std::string name) : name_(std::move(name)) {}
+
+    const std::string& name() const noexcept { return name_; }
+
+private:
+    std::string name_;
+};
+
+}  // namespace neograph::graph

--- a/include/neograph/graph/checkpoint.h
+++ b/include/neograph/graph/checkpoint.h
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 
+#include <memory>
 #include <optional>
 #include <mutex>
 #include <map>
@@ -153,6 +154,60 @@ struct PendingWrite {
 };
 
 /**
+ * @brief Mandatory synchronous checkpoint persistence capability.
+ *
+ * New backends may implement this small, recursion-free contract and pass it
+ * through adapt_checkpoint_store(). The legacy CheckpointStore remains
+ * unchanged for existing backends and consumers.
+ */
+class NEOGRAPH_API CheckpointStoreCore {
+public:
+    virtual ~CheckpointStoreCore() = default;
+
+    virtual void save(const Checkpoint& cp) = 0;
+    virtual std::optional<Checkpoint> load_latest(const std::string& thread_id) = 0;
+    virtual std::optional<Checkpoint> load_by_id(const std::string& id) = 0;
+    virtual std::vector<Checkpoint> list(const std::string& thread_id,
+                                         int limit = 100) = 0;
+    virtual void delete_thread(const std::string& thread_id) = 0;
+};
+
+/**
+ * @brief Optional coroutine-native checkpoint capability.
+ */
+class NEOGRAPH_API AsyncCheckpointStore {
+public:
+    virtual ~AsyncCheckpointStore() = default;
+
+    virtual asio::awaitable<void> save_async(const Checkpoint& cp) = 0;
+    virtual asio::awaitable<std::optional<Checkpoint>>
+    load_latest_async(const std::string& thread_id) = 0;
+    virtual asio::awaitable<std::optional<Checkpoint>>
+    load_by_id_async(const std::string& id) = 0;
+    virtual asio::awaitable<std::vector<Checkpoint>>
+    list_async(const std::string& thread_id, int limit = 100) = 0;
+    virtual asio::awaitable<void>
+    delete_thread_async(const std::string& thread_id) = 0;
+};
+
+/**
+ * @brief Optional fine-grained pending-writes capability.
+ */
+class NEOGRAPH_API PendingWritesCheckpointStore {
+public:
+    virtual ~PendingWritesCheckpointStore() = default;
+
+    virtual void put_writes(const std::string& thread_id,
+                            const std::string& parent_checkpoint_id,
+                            const PendingWrite& write) = 0;
+    virtual std::vector<PendingWrite> get_writes(
+        const std::string& thread_id,
+        const std::string& parent_checkpoint_id) = 0;
+    virtual void clear_writes(const std::string& thread_id,
+                              const std::string& parent_checkpoint_id) = 0;
+};
+
+/**
  * @brief Abstract interface for checkpoint persistence backends.
  *
  * Implement this to store checkpoints in databases, files, or other
@@ -193,21 +248,13 @@ struct PendingWrite {
  *
  * @see InMemoryCheckpointStore for a reference implementation.
  */
-/// @note Backend authors: this is a "fat" interface (5 sync core +
-///       5 async peers + 3 pending-writes + 1 async pending = 14
-///       virtuals). Defaults bridge sync↔async in both directions
-///       (sync calls run_sync(async); async calls execute_in_pool(sync))
-///       so a backend can override only one side per method — but
-///       overriding NEITHER yields infinite mutual recursion at call
-///       time. The contract is enforced at runtime, not at compile
-///       time. A future major version (v1.0) is expected to split
-///       this into:
-///         - `CheckpointStoreCore`         — 5 sync mandatory virtuals
-///         - `AsyncCheckpointStore`        — async peer mixin (optional)
-///         - `PendingWritesCheckpointStore` — pending-writes mixin
-///       The current monolithic shape is kept for back-compat. New
-///       backends should override at least one of (sync, async) per
-///       method to avoid infinite recursion.
+/// @note Backend authors: this legacy interface remains intentionally unchanged
+///       for ABI compatibility. New backends should implement the mandatory
+///       CheckpointStoreCore and optional AsyncCheckpointStore /
+///       PendingWritesCheckpointStore capabilities, then call
+///       adapt_checkpoint_store(). Existing subclasses should continue to
+///       override at least one of each sync/async pair to avoid the historical
+///       crossover defaults recursing when neither side is implemented.
 class NEOGRAPH_API CheckpointStore {
 public:
     virtual ~CheckpointStore() = default;
@@ -337,6 +384,22 @@ public:
         const std::string& thread_id,
         const std::string& parent_checkpoint_id);
 };
+
+/**
+ * @brief Adapt split checkpoint capabilities to the legacy engine contract.
+ *
+ * The returned object keeps @p core alive. If the same implementation also
+ * derives from AsyncCheckpointStore or PendingWritesCheckpointStore, the
+ * adapter detects and delegates those optional capabilities. If it already
+ * implements CheckpointStore, the original shared object is returned. Without
+ * AsyncCheckpointStore, async calls execute the synchronous core operation on
+ * the caller's coroutine thread, matching the legacy CheckpointStore fallback;
+ * I/O-bound backends should implement the async capability.
+ *
+ * @throws std::invalid_argument If core is null.
+ */
+NEOGRAPH_API std::shared_ptr<CheckpointStore>
+adapt_checkpoint_store(std::shared_ptr<CheckpointStoreCore> core);
 
 /**
  * @brief In-memory checkpoint store for testing and single-process use.

--- a/include/neograph/graph/compiler.h
+++ b/include/neograph/graph/compiler.h
@@ -1,12 +1,11 @@
 /**
  * @file graph/compiler.h
- * @brief Pure JSON-definition → CompiledGraph parser, extracted from GraphEngine.
+ * @brief JSON → declarative topology parsing and runtime node linking.
  *
- * GraphCompiler turns a JSON graph definition into a CompiledGraph — a
- * value-type bundle of channels, nodes, edges, barriers, interrupts, and
- * retry policy. It has NO knowledge of runtime (threading, checkpointing,
- * execution) and NO dependency on GraphEngine; it depends only on
- * NodeFactory (to instantiate GraphNode subclasses).
+ * GraphCompiler first parses JSON into a TopologySpec with no live nodes, then
+ * links that topology into a CompiledGraph by invoking node factories. It has
+ * no knowledge of runtime threading, checkpointing, or execution and no
+ * dependency on GraphEngine.
  *
  * Why a separate stage: parsing failures surface here cleanly
  * (malformed edge, unknown reducer, missing node type) before any
@@ -48,6 +47,28 @@ struct ChannelDef {
     /// key so CompiledGraph::to_json() can re-emit exactly what was
     /// declared (round-trip fidelity).
     bool         has_initial = false;
+};
+
+/**
+ * @brief Declarative graph topology with no live node instances or runtime state.
+ *
+ * This is the inspectable boundary between JSON parsing and runtime linking.
+ * node_defs preserves the exact objects passed to NodeFactory; to_json()
+ * canonicalizes barrier declarations from barrier_specs.
+ */
+struct NEOGRAPH_API TopologySpec {
+    std::string name;
+    std::vector<ChannelDef> channel_defs;
+    std::vector<Edge> edges;
+    std::vector<ConditionalEdge> conditional_edges;
+    BarrierSpecs barrier_specs;
+    std::set<std::string> interrupt_before;
+    std::set<std::string> interrupt_after;
+    std::optional<RetryPolicy> retry_policy;
+    int schema_version = 0;
+    std::map<std::string, json> node_defs;
+
+    json to_json() const;
 };
 
 /**
@@ -105,17 +126,38 @@ struct CompiledGraph {
      * v0.1.0–v0.1.7 conditional_edges regression class.
      */
     json to_json() const;
+
+    /// @brief Copy the declarative portion without live GraphNode instances.
+    TopologySpec topology() const;
 };
 
 /**
- * @brief Stateless JSON → CompiledGraph translator.
+ * @brief Stateless JSON parser and node-instantiation linker.
  *
- * Single static entry point. Separating this stage lets routing /
- * execution tests build a CompiledGraph fixture directly (bypassing
- * JSON) and lets parsing tests run without touching the runtime.
+ * parse() is the pure declarative boundary; link() creates GraphNode instances.
+ * compile() remains the compatibility composition of both operations.
  */
 class NEOGRAPH_API GraphCompiler {
 public:
+    /**
+     * @brief Parse JSON into a declarative topology without creating nodes.
+     */
+    static TopologySpec parse(const json& definition);
+
+    /// @brief Pure parse using a local-first registry for schema metadata.
+    static TopologySpec parse(const json& definition, const GraphRegistry& registry);
+
+    /**
+     * @brief Instantiate runtime nodes from an already parsed topology.
+     */
+    static CompiledGraph link(TopologySpec topology,
+                              const NodeContext& default_context);
+
+    /// @brief Instantiate nodes using a local-first registry overlay.
+    static CompiledGraph link(TopologySpec topology,
+                              const NodeContext& default_context,
+                              const GraphRegistry& registry);
+
     /**
      * @brief Parse a JSON graph definition into a CompiledGraph.
      *
@@ -230,7 +272,11 @@ public:
      * compiling, but silent drops become visible).
      */
     static void verify_roundtrip(const json& definition,
-                                 const CompiledGraph& cg);
+                                  const CompiledGraph& cg);
+
+    /// @brief Translation validation before runtime node instantiation.
+    static void verify_roundtrip(const json& definition,
+                                 const TopologySpec& topology);
 };
 
 } // namespace neograph::graph

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -9,7 +9,9 @@
 #pragma once
 
 #include <neograph/api.h>
+#include <neograph/graph/admin.h>
 #include <neograph/graph/cancel.h>
+#include <neograph/graph/channel_key.h>
 #include <neograph/graph/checkpoint.h>
 #include <neograph/graph/compiler.h>
 #include <neograph/graph/coordinator.h>
@@ -17,6 +19,7 @@
 #include <neograph/graph/node.h>
 #include <neograph/graph/node_cache.h>
 #include <neograph/graph/registry.h>
+#include <neograph/graph/run_context.h>
 #include <neograph/graph/scheduler.h>
 #include <neograph/graph/state.h>
 #include <neograph/graph/store.h>
@@ -38,6 +41,8 @@
 #include <vector>
 
 namespace neograph::graph {
+
+class ValidatedTopology;
 
 /**
  * @brief Construction-time configuration for a GraphEngine.
@@ -150,167 +155,6 @@ struct RunConfig {
      */
     bool resume_if_exists = false;
 
-};
-
-/**
- * @brief Per-run dispatch metadata threaded through the engine and executor.
- *
- * Built from ``RunConfig`` plus engine state (usage accounting and Store) and
- * resume input at the top of ``execute_graph_async``, then carried by reference
- * through every internal dispatch hop
- * (``NodeExecutor::run_one_async`` / ``run_parallel_async`` /
- * ``run_sends_async`` / ``execute_node_with_retry_async``). Replaces the
- * v0.3.x-era smuggling channels — ``GraphState::run_cancel_token_`` and
- * the ``current_cancel_token()`` thread-local — with one explicit
- * argument that survives every Send-fan-out / serialize-restore /
- * thread-hop.
- *
- * ``GraphNode::run(NodeInput)`` consumes it through ``in.ctx``. Cancellation,
- * usage, thread/step/stream metadata, Store, and resume values are active;
- * deadline and trace ID remain reserved extension slots.
- *
- * Workers that need an isolated context copy take it by value; the common
- * path takes it by const reference.
- *
- * @see RunConfig (the primary caller-supplied source) and ROADMAP_v1.md
- * (Candidate 2: "Explicit RunContext for per-run metadata").
- */
-struct RunContext {
-    /// Cooperative cancel handle. This is the operation child forked from
-    /// ``RunConfig::cancel_token``. Null when the caller did not opt in.
-    std::shared_ptr<CancelToken> cancel_token;
-
-    /// Token accounting sink for this run (issue #88). The engine always sets
-    /// it, so a node body can record unconditionally via ``record_usage``.
-    /// A custom node that calls a Provider directly is responsible for doing
-    /// so — the engine only sees completions that pass through its own nodes.
-    std::shared_ptr<UsageAccumulator> usage;
-
-    /// Optional absolute monotonic-clock deadline. Reserved for a future PR
-    /// (RunConfig has no deadline field today); left ``std::nullopt``
-    /// by the engine for now so existing behaviour is unchanged.
-    std::optional<std::chrono::steady_clock::time_point> deadline;
-
-    /// Per-run trace correlator. Reserved for OTel integration; the
-    /// engine does not populate this in PR 1 (callers can fill it via
-    /// a future ``RunConfig::trace_id`` field).
-    std::string trace_id;
-
-    /// Mirrors ``RunConfig::thread_id`` so executor-side logic (e.g.
-    /// future per-thread metric tags) does not have to hold a separate
-    /// ``RunConfig`` reference.
-    std::string thread_id;
-
-    /// Current super-step index. Updated by the engine at the top of
-    /// each super-step iteration so per-step consumers see a consistent
-    /// value without the engine threading ``int step`` separately.
-    int step = 0;
-
-    /// Mirrors ``RunConfig::stream_mode``.
-    StreamMode stream_mode = StreamMode::ALL;
-
-    /**
-     * @brief The value handed to ``GraphEngine::resume()`` — the human's answer.
-     *
-     * Empty on a fresh run, so a node can tell "nobody has answered yet" from
-     * "the answer was no":
-     *
-     * @code
-     * if (!in.ctx.resume_value)
-     *     throw NodeInterrupt("needs approval", payload);    // ask
-     * if (in.ctx.resume_value->value("approved", false))     // act on the reply
-     *     ...
-     * @endcode
-     *
-     * ``std::optional<json>`` rather than a plain ``json``, because a
-     * default-constructed ``json`` allocates a yyjson document — and this
-     * struct is built on every run, including the overwhelming majority that
-     * never interrupt. An empty optional allocates nothing. (Measured: a bare
-     * ``json`` member here cost ~3% of engine overhead per run.)
-     *
-     * The engine also keeps writing ``resume_value`` into a ``messages``
-     * channel when the graph has one, which is how chat-shaped graphs have
-     * always received it. That path is unchanged; this one exists because a
-     * graph without a ``messages`` channel had no way to see the answer at all.
-     */
-    std::optional<json> resume_value;
-
-    /**
-     * @brief Cross-thread shared memory (issue #27).
-     *
-     * Mirrors ``GraphEngine::get_store()``. Populated by the engine
-     * at the top of every run so node bodies can read / write
-     * Store-backed state through ``in.ctx.store`` without a
-     * separate plumbing channel.
-     *
-     * Default ``nullptr``. The engine sets this to whatever the
-     * caller previously passed to ``GraphEngine::set_store(...)``;
-     * if no Store is configured, ``in.ctx.store`` stays ``nullptr``
-     * and node bodies should guard accordingly.
-     *
-     * Before this field existed, the only way for a node body to
-     * reach the Store was to capture a ``shared_ptr<Store>`` in the
-     * ``NodeFactory`` registration closure. That pattern still
-     * works and is left undisturbed during the deprecation window —
-     * use whichever shape fits your code best:
-     *
-     * @code
-     * // New shape (post-#27):
-     * asio::awaitable<NodeOutput> run(NodeInput in) override {
-     *     if (in.ctx.store) {
-     *         auto v = in.ctx.store->get(ns, "user.fact");
-     *     }
-     *     ...
-     * }
-     *
-     * // Legacy factory-closure shape — still supported:
-     * NodeFactory::instance().register_type("my_node",
-     *     [store](const std::string& name, const json&, const NodeContext&) {
-     *         return std::make_unique<MyNode>(name, store);  // ← capture
-     *     });
-     * @endcode
-     */
-    std::shared_ptr<Store> store;
-
-    /// The engine's tool gate (issue #89). Empty when none was set — an empty
-    /// std::function allocates nothing, so the ungated path pays a null check
-    /// and no more.
-    ToolGate tool_gate;
-};
-
-/// @brief Fold a completion's token usage into the run's running total (#88).
-///
-/// One implementation, called from every node that receives a completion. The
-/// alternative — each node incrementing its own counters — is how the two tool
-/// dispatch paths drifted apart in #87, and it would drift the same way here:
-/// a new node type gets written, nobody remembers to count, and the run's token
-/// total silently under-reports. There is nothing in a wrong-but-plausible token
-/// number that tells you it is wrong.
-///
-/// Safe to call with a context whose accumulator is null (a node driven outside
-/// an engine run, as unit tests do).
-inline void record_usage(const RunContext& ctx, const ChatCompletion& completion) {
-    if (ctx.usage) ctx.usage->add(completion.usage);
-}
-
-/**
- * @brief Typed channel name for RunResult access.
- *
- * ChannelKey binds a channel name to its expected C++ value type without
- * changing the JSON-backed channel model. Keep keys as reusable constants and
- * pass them to RunResult::channel() or RunResult::try_channel().
- */
-template <typename T>
-class ChannelKey {
-public:
-    using value_type = T;
-
-    explicit ChannelKey(std::string name) : name_(std::move(name)) {}
-
-    const std::string& name() const noexcept { return name_; }
-
-private:
-    std::string name_;
 };
 
 /// @brief Normal, paused, or step-limited outcome of a successful run call.
@@ -517,12 +361,10 @@ struct RunResult {
  *
  * @see RunConfig, RunResult, GraphNode
  *
- * @note This class spans three concerns: graph execution (run/run_async/run_stream/
- * resume), state administration (get_state/update_state/fork), and
- * compatibility configuration setters. New code should pass all construction
- * policy through EngineConfig and EngineResources. The setters remain so
- * existing downstream consumers do not break; they are configuration, not
- * runtime control.
+ * @note New code can obtain state-administration operations through admin().
+ * The corresponding methods remain on GraphEngine for compatibility. Pass all
+ * construction policy through EngineConfig and EngineResources; setters remain
+ * supported but are configuration, not runtime control.
  */
 class NEOGRAPH_API GraphEngine {
 public:
@@ -561,6 +403,17 @@ public:
                                              EngineResources resources);
 
     /**
+     * @brief Instantiate and link a topology already proven semantically valid.
+     */
+    static std::unique_ptr<GraphEngine> link(ValidatedTopology topology,
+                                             EngineConfig config = {});
+
+    /// @brief Validated topology link with owned resources and local registry.
+    static std::unique_ptr<GraphEngine> link(ValidatedTopology topology,
+                                             EngineConfig config,
+                                             EngineResources resources);
+
+    /**
      * @brief Build a ready-to-run engine from one construction-time config.
      *
      * New code should prefer this entry point when it needs runtime Store,
@@ -581,8 +434,24 @@ public:
      * collection. Supplying both forms is rejected as ambiguous.
      */
     static std::unique_ptr<GraphEngine> build(const json&     definition,
-                                              EngineConfig    config,
-                                              EngineResources resources);
+                                               EngineConfig    config,
+                                               EngineResources resources);
+
+    /**
+     * @brief Build using strict topology validation when schema_version is
+     *        missing or zero.
+     *
+     * The caller's JSON is not mutated. Existing malformed or unsupported
+     * schema_version values are preserved so the compiler reports them rather
+     * than silently replacing them.
+     */
+    static std::unique_ptr<GraphEngine> build_strict(const json& definition,
+                                                      EngineConfig config);
+
+    /// @brief Strict build overload with owned tools and a local registry.
+    static std::unique_ptr<GraphEngine> build_strict(const json&     definition,
+                                                      EngineConfig    config,
+                                                      EngineResources resources);
 
     /**
      * @brief Compile a graph from a JSON definition.
@@ -686,6 +555,9 @@ public:
     asio::awaitable<RunResult> resume_async(RunConfig           config,
                                             json                resume_value = json(),
                                             GraphStreamCallback cb           = nullptr);
+
+    /// @brief Borrow the state-administration facade for this engine.
+    GraphAdmin admin() noexcept;
 
     // ── State inspection & manipulation (LangGraph Checkpointer API) ──
 
@@ -886,6 +758,11 @@ public:
 
 private:
     GraphEngine() = default;
+
+    static std::unique_ptr<GraphEngine> link_impl(CompiledGraph graph,
+                                                   EngineConfig config,
+                                                   EngineResources resources,
+                                                   bool validate);
 
     /// #89 — set_tool_gate(). Lives on the engine rather than RunConfig so it
     /// survives resume(), which builds its own RunConfig internally.

--- a/include/neograph/graph/node.h
+++ b/include/neograph/graph/node.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include <neograph/api.h>
+#include <neograph/graph/run_context.h>
 #include <neograph/graph/types.h>
 #include <neograph/graph/state.h>
 
@@ -38,13 +39,6 @@
 #include <stdexcept>
 
 namespace neograph::graph {
-
-/// Per-run dispatch metadata. Defined in
-/// ``neograph/graph/engine.h``; forward-declared here because
-/// ``node.h`` is below ``engine.h`` in the include order (a full
-/// ``#include`` would loop). The translation unit
-/// (``graph_node.cpp``) pulls in ``engine.h`` to see the layout.
-struct RunContext;
 
 /**
  * @brief Per-call input bundle for the unified ``run()`` virtual.

--- a/include/neograph/graph/run_context.h
+++ b/include/neograph/graph/run_context.h
@@ -1,0 +1,64 @@
+/**
+ * @file graph/run_context.h
+ * @brief Per-run metadata exposed to graph nodes.
+ */
+#pragma once
+
+#include <neograph/graph/cancel.h>
+#include <neograph/graph/store.h>
+#include <neograph/graph/types.h>
+#include <neograph/tool_dispatch.h>
+#include <neograph/types.h>
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+
+namespace neograph::graph {
+
+/**
+ * @brief Per-run dispatch metadata threaded through the engine and executor.
+ *
+ * GraphNode::run(NodeInput) consumes this through NodeInput::ctx. Workers that
+ * need an isolated copy take it by value; the common path takes it by const
+ * reference.
+ */
+struct RunContext {
+    /// Operation-scoped cooperative cancellation handle.
+    std::shared_ptr<CancelToken> cancel_token;
+
+    /// Shared token accounting sink for this run and its subgraphs.
+    std::shared_ptr<UsageAccumulator> usage;
+
+    /// Reserved absolute monotonic-clock deadline.
+    std::optional<std::chrono::steady_clock::time_point> deadline;
+
+    /// Reserved per-run trace correlator.
+    std::string trace_id;
+
+    /// Mirrors RunConfig::thread_id.
+    std::string thread_id;
+
+    /// Current super-step index.
+    int step = 0;
+
+    /// Mirrors RunConfig::stream_mode.
+    StreamMode stream_mode = StreamMode::ALL;
+
+    /// Value supplied to GraphEngine::resume(); empty on a fresh run.
+    std::optional<json> resume_value;
+
+    /// Optional cross-thread shared memory.
+    std::shared_ptr<Store> store;
+
+    /// Engine-wide tool policy, empty when no gate is configured.
+    ToolGate tool_gate;
+};
+
+/// @brief Fold a completion's token usage into the run's running total.
+inline void record_usage(const RunContext& ctx, const ChatCompletion& completion) {
+    if (ctx.usage) ctx.usage->add(completion.usage);
+}
+
+}  // namespace neograph::graph

--- a/include/neograph/graph/state.h
+++ b/include/neograph/graph/state.h
@@ -9,8 +9,10 @@
 #pragma once
 
 #include <neograph/api.h>
+#include <neograph/graph/channel_key.h>
 #include <neograph/graph/types.h>
 #include <mutex>
+#include <optional>
 #include <shared_mutex>
 #include <vector>
 
@@ -43,6 +45,27 @@ public:
      * @return The current value, or null if the channel does not exist.
      */
     json get(const std::string& channel) const;
+
+    /**
+     * @brief Read and convert a channel using a reusable typed key.
+     * @throws json::type_error If the current value cannot be converted to T.
+     */
+    template <typename T>
+    T get(const ChannelKey<T>& channel) const {
+        return get(channel.name()).template get<T>();
+    }
+
+    /**
+     * @brief Read a typed channel when it is declared.
+     *
+     * Missing channels return std::nullopt. Conversion failures remain errors
+     * so a schema/type mismatch is not mistaken for absence.
+     */
+    template <typename T>
+    std::optional<T> try_get(const ChannelKey<T>& channel) const {
+        if (!has_channel(channel.name())) return std::nullopt;
+        return get(channel);
+    }
 
     /**
      * @brief Convenience method to read the "messages" channel as a vector of ChatMessage.

--- a/include/neograph/graph/validator.h
+++ b/include/neograph/graph/validator.h
@@ -1,6 +1,6 @@
 /**
  * @file graph/validator.h
- * @brief Static semantic analysis over a CompiledGraph (issue #75 M2).
+ * @brief Static semantic analysis over declarative or compiled topology.
  *
  * GraphValidator is the pass layer between parsing (GraphCompiler, M1:
  * every key consumed) and execution (GraphEngine): it checks what the
@@ -24,6 +24,7 @@
 #include <neograph/api.h>
 #include <neograph/graph/compiler.h>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace neograph::graph {
@@ -50,8 +51,47 @@ struct NEOGRAPH_API ValidationReport {
     std::string summary() const;
 };
 
+/**
+ * @brief Topology proven free of static semantic errors.
+ *
+ * Construct through GraphValidator::require_valid(). Warnings remain available
+ * for tooling, but the wrapped topology is guaranteed to have no error-level
+ * diagnostics at validation time.
+ */
+class NEOGRAPH_API ValidatedTopology {
+public:
+    const TopologySpec& topology() const noexcept { return topology_; }
+    const ValidationReport& report() const noexcept { return report_; }
+    TopologySpec release() && { return std::move(topology_); }
+
+private:
+    friend class GraphValidator;
+
+    ValidatedTopology(TopologySpec topology, ValidationReport report)
+        : topology_(std::move(topology)), report_(std::move(report)) {}
+
+    TopologySpec topology_;
+    ValidationReport report_;
+};
+
 class NEOGRAPH_API GraphValidator {
 public:
+    /// @brief Validate declarative topology before runtime node creation.
+    static ValidationReport validate(const TopologySpec& topology);
+
+    /// @brief Validate declarative topology with a local registry overlay.
+    static ValidationReport validate(const TopologySpec& topology,
+                                     const GraphRegistry& registry);
+
+    /**
+     * @brief Validate and wrap a topology, throwing when any error is found.
+     */
+    static ValidatedTopology require_valid(TopologySpec topology);
+
+    /// @brief Validate and wrap using a local registry overlay.
+    static ValidatedTopology require_valid(TopologySpec topology,
+                                           const GraphRegistry& registry);
+
     /**
      * @brief Run all static checks against a compiled graph.
      *

--- a/include/neograph/neograph.h
+++ b/include/neograph/neograph.h
@@ -23,12 +23,15 @@
 #include <neograph/types.h>
 
 // Graph engine
+#include <neograph/graph/admin.h>
+#include <neograph/graph/channel_key.h>
 #include <neograph/graph/checkpoint.h>
 #include <neograph/graph/engine.h>
 #include <neograph/graph/loader.h>
 #include <neograph/graph/node.h>
 #include <neograph/graph/react_graph.h>
 #include <neograph/graph/registry.h>
+#include <neograph/graph/run_context.h>
 #include <neograph/graph/state.h>
 #include <neograph/graph/store.h>
 #include <neograph/graph/types.h>

--- a/src/core/graph_checkpoint.cpp
+++ b/src/core/graph_checkpoint.cpp
@@ -9,6 +9,94 @@
 
 namespace neograph::graph {
 
+namespace {
+
+class CapabilityCheckpointStore final : public CheckpointStore {
+public:
+    explicit CapabilityCheckpointStore(std::shared_ptr<CheckpointStoreCore> core)
+        : core_(std::move(core)),
+          async_(std::dynamic_pointer_cast<AsyncCheckpointStore>(core_)),
+          pending_(std::dynamic_pointer_cast<PendingWritesCheckpointStore>(core_)) {}
+
+    void save(const Checkpoint& cp) override { core_->save(cp); }
+    std::optional<Checkpoint> load_latest(const std::string& thread_id) override {
+        return core_->load_latest(thread_id);
+    }
+    std::optional<Checkpoint> load_by_id(const std::string& id) override {
+        return core_->load_by_id(id);
+    }
+    std::vector<Checkpoint> list(const std::string& thread_id, int limit) override {
+        return core_->list(thread_id, limit);
+    }
+    void delete_thread(const std::string& thread_id) override {
+        core_->delete_thread(thread_id);
+    }
+
+    asio::awaitable<void> save_async(const Checkpoint& cp) override {
+        if (async_) {
+            co_await async_->save_async(cp);
+        } else {
+            core_->save(cp);
+        }
+    }
+    asio::awaitable<std::optional<Checkpoint>>
+    load_latest_async(const std::string& thread_id) override {
+        if (async_) co_return co_await async_->load_latest_async(thread_id);
+        co_return core_->load_latest(thread_id);
+    }
+    asio::awaitable<std::optional<Checkpoint>>
+    load_by_id_async(const std::string& id) override {
+        if (async_) co_return co_await async_->load_by_id_async(id);
+        co_return core_->load_by_id(id);
+    }
+    asio::awaitable<std::vector<Checkpoint>>
+    list_async(const std::string& thread_id, int limit) override {
+        if (async_) co_return co_await async_->list_async(thread_id, limit);
+        co_return core_->list(thread_id, limit);
+    }
+    asio::awaitable<void> delete_thread_async(const std::string& thread_id) override {
+        if (async_) {
+            co_await async_->delete_thread_async(thread_id);
+        } else {
+            core_->delete_thread(thread_id);
+        }
+    }
+
+    void put_writes(const std::string& thread_id,
+                    const std::string& parent_checkpoint_id,
+                    const PendingWrite& write) override {
+        if (pending_) pending_->put_writes(thread_id, parent_checkpoint_id, write);
+    }
+    std::vector<PendingWrite> get_writes(
+        const std::string& thread_id,
+        const std::string& parent_checkpoint_id) override {
+        return pending_ ? pending_->get_writes(thread_id, parent_checkpoint_id)
+                        : std::vector<PendingWrite>{};
+    }
+    void clear_writes(const std::string& thread_id,
+                      const std::string& parent_checkpoint_id) override {
+        if (pending_) pending_->clear_writes(thread_id, parent_checkpoint_id);
+    }
+
+private:
+    std::shared_ptr<CheckpointStoreCore> core_;
+    std::shared_ptr<AsyncCheckpointStore> async_;
+    std::shared_ptr<PendingWritesCheckpointStore> pending_;
+};
+
+} // namespace
+
+std::shared_ptr<CheckpointStore>
+adapt_checkpoint_store(std::shared_ptr<CheckpointStoreCore> core) {
+    if (!core) {
+        throw std::invalid_argument("adapt_checkpoint_store requires a non-null core");
+    }
+    if (auto legacy = std::dynamic_pointer_cast<CheckpointStore>(core)) {
+        return legacy;
+    }
+    return std::make_shared<CapabilityCheckpointStore>(std::move(core));
+}
+
 // =========================================================================
 // CheckpointStore — sync ↔ async crossover defaults (Sem 3.1)
 // =========================================================================

--- a/src/core/graph_compiler.cpp
+++ b/src/core/graph_compiler.cpp
@@ -144,7 +144,16 @@ CompiledGraph GraphCompiler::compile(const json& definition,
 CompiledGraph GraphCompiler::compile(const json&          definition,
                                      const NodeContext&   default_context,
                                      const GraphRegistry& registry) {
-    CompiledGraph cg;
+    return link(parse(definition, registry), default_context, registry);
+}
+
+TopologySpec GraphCompiler::parse(const json& definition) {
+    return parse(definition, GraphRegistry::global());
+}
+
+TopologySpec GraphCompiler::parse(const json& definition,
+                                  const GraphRegistry& registry) {
+    TopologySpec topology;
     std::vector<std::string> errors;
     std::set<std::string> top_consumed;
 
@@ -157,16 +166,16 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
                 "topology 'schema_version' must be a non-negative integer, got: "
                 + sv.dump());
         }
-        cg.schema_version = sv.get<int>();
-        if (cg.schema_version > kSupportedSchemaVersion) {
+        topology.schema_version = sv.get<int>();
+        if (topology.schema_version > kSupportedSchemaVersion) {
             throw std::runtime_error(
-                "topology schema_version " + std::to_string(cg.schema_version)
+                "topology schema_version " + std::to_string(topology.schema_version)
                 + " is newer than this engine supports (max "
                 + std::to_string(kSupportedSchemaVersion)
                 + "). Upgrade NeoGraph or re-export the topology.");
         }
     }
-    const bool strict = cg.schema_version >= 1;
+    const bool strict = topology.schema_version >= 1;
 
     auto require_container = [&](const char* field, bool expects_object,
                                  bool legacy_object_allowed = false) {
@@ -193,7 +202,7 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
     require_container("edges", false, true);
     require_container("conditional_edges", false, true);
 
-    cg.name = definition.value("name", "unnamed_graph");
+    topology.name = definition.value("name", "unnamed_graph");
     top_consumed.insert("name");
 
     // --- Channels ---
@@ -222,7 +231,7 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
                 enforce_consumed(ch_def, ch_consumed,
                                  "channels." + name, errors);
             }
-            cg.channel_defs.push_back(std::move(cd));
+            topology.channel_defs.push_back(std::move(cd));
         }
     }
 
@@ -231,8 +240,7 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
         top_consumed.insert("nodes");
         for (const auto& [name, node_def] : definition["nodes"].items()) {
             auto type = node_def.value("type", "");
-            auto node      = registry.create(type, name, node_def, default_context);
-            cg.nodes[name] = std::move(node);
+            topology.node_defs[name] = node_def;
 
             std::set<std::string> node_consumed = {"type"};
 
@@ -251,7 +259,7 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
                     }
                 }
                 if (!wait_for.empty()) {
-                    cg.barrier_specs[name] = std::move(wait_for);
+                    topology.barrier_specs[name] = std::move(wait_for);
                 } else if (strict) {
                     // Historically an empty/missing wait_for was
                     // silently dropped — the node quietly lost its
@@ -291,16 +299,6 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
                 }
             }
 
-            // Verbatim node definition minus "barrier" — barriers are
-            // re-emitted from barrier_specs so translation validation
-            // compares compiled state, not an input echo. (Copy-skip:
-            // the yyjson wrapper has no erase().)
-            json stored = json::object();
-            for (const auto& [k, v] : node_def.items()) {
-                if (k == "barrier") continue;
-                stored[k] = v;
-            }
-            cg.node_defs[name] = std::move(stored);
         }
     }
 
@@ -324,7 +322,7 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
             }
         }
         if (strict) enforce_consumed(edge_def, e_consumed, path, errors);
-        cg.conditional_edges.push_back(std::move(ce));
+        topology.conditional_edges.push_back(std::move(ce));
     };
 
     if (definition.contains("edges")) {
@@ -345,7 +343,7 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
                 e.from = edge_def.at("from").get<std::string>();
                 e.to   = edge_def.at("to").get<std::string>();
                 if (strict) enforce_consumed(edge_def, {"from", "to"}, path, errors);
-                cg.edges.push_back(std::move(e));
+                topology.edges.push_back(std::move(e));
             }
         }
     }
@@ -363,13 +361,13 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
     if (definition.contains("interrupt_before")) {
         top_consumed.insert("interrupt_before");
         for (const auto& n : definition["interrupt_before"]) {
-            cg.interrupt_before.insert(n.get<std::string>());
+            topology.interrupt_before.insert(n.get<std::string>());
         }
     }
     if (definition.contains("interrupt_after")) {
         top_consumed.insert("interrupt_after");
         for (const auto& n : definition["interrupt_after"]) {
-            cg.interrupt_after.insert(n.get<std::string>());
+            topology.interrupt_after.insert(n.get<std::string>());
         }
     }
 
@@ -388,7 +386,7 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
         policy.max_delay_ms       = rp.value("max_delay_ms", 5000);
         rp_consumed.insert("max_delay_ms");
         if (strict) enforce_consumed(rp, rp_consumed, "retry_policy", errors);
-        cg.retry_policy = policy;
+        topology.retry_policy = policy;
     }
 
     if (strict) {
@@ -396,7 +394,7 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
         if (!errors.empty()) {
             std::string msg =
                 "strict topology validation failed (schema_version "
-                + std::to_string(cg.schema_version) + "), "
+                + std::to_string(topology.schema_version) + "), "
                 + std::to_string(errors.size()) + " error(s):";
             for (const auto& e : errors) msg += "\n  - " + e;
             msg += "\nAnnotation keys ('_'/'x-' prefixes) are always allowed. "
@@ -406,6 +404,37 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
         }
     }
 
+    return topology;
+}
+
+CompiledGraph GraphCompiler::link(TopologySpec topology,
+                                  const NodeContext& default_context) {
+    return link(std::move(topology), default_context, GraphRegistry::global());
+}
+
+CompiledGraph GraphCompiler::link(TopologySpec topology,
+                                  const NodeContext& default_context,
+                                  const GraphRegistry& registry) {
+    CompiledGraph cg;
+    cg.name              = std::move(topology.name);
+    cg.channel_defs      = std::move(topology.channel_defs);
+    cg.edges             = std::move(topology.edges);
+    cg.conditional_edges = std::move(topology.conditional_edges);
+    cg.barrier_specs     = std::move(topology.barrier_specs);
+    cg.interrupt_before  = std::move(topology.interrupt_before);
+    cg.interrupt_after   = std::move(topology.interrupt_after);
+    cg.retry_policy      = std::move(topology.retry_policy);
+    cg.schema_version    = topology.schema_version;
+    for (const auto& [name, node_def] : topology.node_defs) {
+        const auto type = node_def.value("type", "");
+        cg.nodes[name] = registry.create(type, name, node_def, default_context);
+
+        json stored = json::object();
+        for (const auto& [key, value] : node_def.items()) {
+            if (key != "barrier") stored[key] = value;
+        }
+        cg.node_defs[name] = std::move(stored);
+    }
     return cg;
 }
 
@@ -413,7 +442,7 @@ CompiledGraph GraphCompiler::compile(const json&          definition,
 // Re-emission + canonicalization + translation validation
 // =========================================================================
 
-json CompiledGraph::to_json() const {
+json TopologySpec::to_json() const {
     json j = json::object();
     if (schema_version > 0) j["schema_version"] = schema_version;
     j["name"] = name;
@@ -432,7 +461,10 @@ json CompiledGraph::to_json() const {
     if (!node_defs.empty()) {
         json nodes = json::object();
         for (const auto& [nname, ndef] : node_defs) {
-            json n = ndef;
+            json n = json::object();
+            for (const auto& [key, value] : ndef.items()) {
+                if (key != "barrier") n[key] = value;
+            }
             auto bit = barrier_specs.find(nname);
             if (bit != barrier_specs.end()) {
                 json wait_for = json::array();
@@ -487,6 +519,33 @@ json CompiledGraph::to_json() const {
     }
 
     return j;
+}
+
+TopologySpec CompiledGraph::topology() const {
+    TopologySpec result;
+    result.name              = name;
+    result.channel_defs      = channel_defs;
+    result.edges             = edges;
+    result.conditional_edges = conditional_edges;
+    result.barrier_specs     = barrier_specs;
+    result.interrupt_before  = interrupt_before;
+    result.interrupt_after   = interrupt_after;
+    result.retry_policy      = retry_policy;
+    result.schema_version    = schema_version;
+    result.node_defs         = node_defs;
+    for (const auto& [name, wait_for_set] : barrier_specs) {
+        auto node = result.node_defs.find(name);
+        if (node == result.node_defs.end()) continue;
+        json wait_for = json::array();
+        for (const auto& upstream : wait_for_set) wait_for.push_back(upstream);
+        node->second["barrier"] =
+            json{{"wait_for", std::move(wait_for)}};
+    }
+    return result;
+}
+
+json CompiledGraph::to_json() const {
+    return topology().to_json();
 }
 
 json GraphCompiler::canon(const json& definition) {
@@ -751,8 +810,13 @@ json GraphCompiler::upgrade_to_latest(const json& definition) {
 
 void GraphCompiler::verify_roundtrip(const json& definition,
                                      const CompiledGraph& cg) {
+    verify_roundtrip(definition, cg.topology());
+}
+
+void GraphCompiler::verify_roundtrip(const json& definition,
+                                     const TopologySpec& topology) {
     const json a = canon(definition);
-    const json b = canon(cg.to_json());
+    const json b = canon(topology.to_json());
     if (a == b) return;
 
     // Structural mismatch report: what compilation lost or rewired.
@@ -763,7 +827,7 @@ void GraphCompiler::verify_roundtrip(const json& definition,
         "to its definition — the compiler dropped or rewired something:";
     for (const auto& m : mismatches) msg += "\n  - " + m;
 
-    if (cg.schema_version >= 1) {
+    if (topology.schema_version >= 1) {
         throw std::runtime_error(msg);
     }
     // Lenient documents keep compiling (historical behavior), but the

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -30,6 +30,27 @@ std::size_t default_worker_count() {
     auto n = std::thread::hardware_concurrency();
     return n > 0 ? static_cast<std::size_t>(n) : 4u;
 }
+
+void report_validation(const ValidationReport& report, int schema_version) {
+    if (schema_version >= 1) {
+        if (report.has_errors()) {
+            throw std::runtime_error(
+                "graph validation failed (schema_version "
+                + std::to_string(schema_version) + "):\n" + report.summary());
+        }
+        for (const auto* warning : report.warnings()) {
+            std::fprintf(stderr, "[neograph] lint [%s] %s: %s\n",
+                         warning->code.c_str(), warning->path.c_str(),
+                         warning->message.c_str());
+        }
+    } else {
+        for (const auto* error : report.errors()) {
+            std::fprintf(stderr, "[neograph] warning: [%s] %s: %s\n",
+                         error->code.c_str(), error->path.c_str(),
+                         error->message.c_str());
+        }
+    }
+}
 } // namespace
 
 // =========================================================================
@@ -53,8 +74,8 @@ std::unique_ptr<GraphEngine> GraphEngine::build(const json& definition, EngineCo
 }
 
 std::unique_ptr<GraphEngine> GraphEngine::build(const json&     definition,
-                                                EngineConfig    config,
-                                                EngineResources resources) {
+                                                 EngineConfig    config,
+                                                 EngineResources resources) {
     if (!resources.tools.empty()) {
         if (!config.node_context.tools.empty()) {
             throw std::invalid_argument(
@@ -65,15 +86,38 @@ std::unique_ptr<GraphEngine> GraphEngine::build(const json&     definition,
     }
 
     const auto& registry = resources.registry ? *resources.registry : GraphRegistry::global();
-    auto        cg       = GraphCompiler::compile(definition, config.node_context, registry);
+    auto topology = GraphCompiler::parse(definition, registry);
 
     // Translation validation: assert nothing was silently dropped or
     // rewired between the JSON definition and the compiled graph.
     // Strict documents (schema_version >= 1) fail hard; legacy
     // documents get a stderr warning. Must run before the moves below.
-    GraphCompiler::verify_roundtrip(definition, cg);
+    GraphCompiler::verify_roundtrip(definition, topology);
 
-    return link(std::move(cg), std::move(config), std::move(resources));
+    // Static semantics operate on the declarative topology before factories
+    // create runtime nodes. Legacy documents keep warning-only behavior.
+    report_validation(GraphValidator::validate(topology, registry),
+                      topology.schema_version);
+
+    auto cg = GraphCompiler::link(std::move(topology), config.node_context, registry);
+    return link_impl(std::move(cg), std::move(config), std::move(resources), false);
+}
+
+std::unique_ptr<GraphEngine> GraphEngine::build_strict(const json& definition,
+                                                        EngineConfig config) {
+    return build_strict(definition, std::move(config), {});
+}
+
+std::unique_ptr<GraphEngine> GraphEngine::build_strict(const json&     definition,
+                                                        EngineConfig    config,
+                                                        EngineResources resources) {
+    json strict_definition = definition;
+    if (!strict_definition.contains("schema_version")
+        || (strict_definition["schema_version"].is_number_integer()
+            && strict_definition["schema_version"].get<int>() == 0)) {
+        strict_definition["schema_version"] = 1;
+    }
+    return build(strict_definition, std::move(config), std::move(resources));
 }
 
 std::unique_ptr<GraphEngine> GraphEngine::link(CompiledGraph cg, EngineConfig config) {
@@ -83,30 +127,45 @@ std::unique_ptr<GraphEngine> GraphEngine::link(CompiledGraph cg, EngineConfig co
 std::unique_ptr<GraphEngine> GraphEngine::link(CompiledGraph   cg,
                                                EngineConfig    config,
                                                EngineResources resources) {
+    return link_impl(std::move(cg), std::move(config), std::move(resources), true);
+}
+
+std::unique_ptr<GraphEngine> GraphEngine::link(ValidatedTopology topology,
+                                               EngineConfig config) {
+    return link(std::move(topology), std::move(config), {});
+}
+
+std::unique_ptr<GraphEngine> GraphEngine::link(ValidatedTopology topology,
+                                               EngineConfig config,
+                                               EngineResources resources) {
+    if (!resources.tools.empty()) {
+        if (!config.node_context.tools.empty()) {
+            throw std::invalid_argument(
+                "GraphEngine::link received both EngineResources::tools and "
+                "NodeContext::tools; use the owned ToolSet only");
+        }
+        config.node_context.tools = resources.tools.view();
+    }
+
+    const auto& registry = resources.registry ? *resources.registry : GraphRegistry::global();
+    report_validation(topology.report(), topology.topology().schema_version);
+    auto cg = GraphCompiler::link(std::move(topology).release(),
+                                  config.node_context, registry);
+    return link_impl(std::move(cg), std::move(config), std::move(resources), false);
+}
+
+std::unique_ptr<GraphEngine> GraphEngine::link_impl(CompiledGraph   cg,
+                                                    EngineConfig    config,
+                                                    EngineResources resources,
+                                                    bool validate) {
     // Static semantic analysis (issue #75 M2). Strict documents:
     // errors throw, warnings go to stderr. Legacy documents: only
     // errors are surfaced (as stderr warnings — they were silent
     // breakage before, e.g. a dangling edge or an empty route map),
     // heuristic lint is suppressed to keep existing graphs quiet.
-    {
+    if (validate) {
         const auto& registry = resources.registry ? *resources.registry : GraphRegistry::global();
-        auto        report   = GraphValidator::validate(cg, registry);
-        if (cg.schema_version >= 1) {
-            if (report.has_errors()) {
-                std::string msg = "graph validation failed (schema_version "
-                    + std::to_string(cg.schema_version) + "):\n" + report.summary();
-                throw std::runtime_error(msg);
-            }
-            for (const auto* w : report.warnings()) {
-                std::fprintf(stderr, "[neograph] lint [%s] %s: %s\n",
-                             w->code.c_str(), w->path.c_str(), w->message.c_str());
-            }
-        } else {
-            for (const auto* e : report.errors()) {
-                std::fprintf(stderr, "[neograph] warning: [%s] %s: %s\n",
-                             e->code.c_str(), e->path.c_str(), e->message.c_str());
-            }
-        }
+        report_validation(GraphValidator::validate(cg, registry), cg.schema_version);
     }
 
     auto engine = std::unique_ptr<GraphEngine>(new GraphEngine());
@@ -269,6 +328,31 @@ RetryPolicy GraphEngine::get_retry_policy(const std::string& node_name) const {
 // =========================================================================
 // get_state / get_state_history / update_state / fork
 // =========================================================================
+
+GraphAdmin GraphEngine::admin() noexcept {
+    return GraphAdmin(*this);
+}
+
+std::optional<json> GraphAdmin::get_state(const std::string& thread_id) const {
+    return engine_->get_state(thread_id);
+}
+
+std::vector<Checkpoint> GraphAdmin::get_state_history(
+    const std::string& thread_id, int limit) const {
+    return engine_->get_state_history(thread_id, limit);
+}
+
+void GraphAdmin::update_state(const std::string& thread_id,
+                              const json& channel_writes,
+                              const std::string& as_node) const {
+    engine_->update_state(thread_id, channel_writes, as_node);
+}
+
+std::string GraphAdmin::fork(const std::string& source_thread_id,
+                             const std::string& new_thread_id,
+                             const std::string& checkpoint_id) const {
+    return engine_->fork(source_thread_id, new_thread_id, checkpoint_id);
+}
 
 std::optional<json> GraphEngine::get_state(const std::string& thread_id) const {
     if (!checkpoint_store_) return std::nullopt;

--- a/src/core/graph_validator.cpp
+++ b/src/core/graph_validator.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include <queue>
 #include <set>
+#include <stdexcept>
 
 namespace neograph::graph {
 
@@ -21,7 +22,7 @@ json string_set_to_array(const std::set<std::string>& s) {
 }
 
 struct Ctx {
-    const CompiledGraph& cg;
+    const TopologySpec& cg;
     const GraphRegistry&  registry;
     std::set<std::string> node_names;
     // Static successor map: plain edges + every conditional route
@@ -436,13 +437,22 @@ std::string ValidationReport::summary() const {
 }
 
 ValidationReport GraphValidator::validate(const CompiledGraph& cg) {
-    return validate(cg, GraphRegistry::global());
+    return validate(cg.topology(), GraphRegistry::global());
 }
 
 ValidationReport GraphValidator::validate(const CompiledGraph& cg, const GraphRegistry& registry) {
-    Ctx c{cg, registry, {}, {}, {}};
-    for (const auto& [name, node] : cg.nodes) {
-        (void)node;
+    return validate(cg.topology(), registry);
+}
+
+ValidationReport GraphValidator::validate(const TopologySpec& topology) {
+    return validate(topology, GraphRegistry::global());
+}
+
+ValidationReport GraphValidator::validate(const TopologySpec& topology,
+                                          const GraphRegistry& registry) {
+    Ctx c{topology, registry, {}, {}, {}};
+    for (const auto& [name, node_def] : topology.node_defs) {
+        (void)node_def;
         c.node_names.insert(name);
     }
 
@@ -457,6 +467,22 @@ ValidationReport GraphValidator::validate(const CompiledGraph& cg, const GraphRe
     check_effects(c);
 
     return ValidationReport{std::move(c.out)};
+}
+
+ValidatedTopology GraphValidator::require_valid(TopologySpec topology) {
+    return require_valid(std::move(topology), GraphRegistry::global());
+}
+
+ValidatedTopology GraphValidator::require_valid(TopologySpec topology,
+                                                 const GraphRegistry& registry) {
+    auto report = validate(topology, registry);
+    if (report.has_errors()) {
+        throw std::runtime_error(
+            "graph validation failed (schema_version "
+            + std::to_string(topology.schema_version) + "):\n"
+            + report.summary());
+    }
+    return ValidatedTopology(std::move(topology), std::move(report));
 }
 
 } // namespace neograph::graph

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(neograph_tests
     test_checkpoint.cpp
     test_store.cpp
     test_node.cpp
+    test_node_header.cpp
     test_loader.cpp
     test_schema_export.cpp
     test_json_path.cpp

--- a/tests/test_admin_api_barrier_preservation.cpp
+++ b/tests/test_admin_api_barrier_preservation.cpp
@@ -122,3 +122,19 @@ TEST(AdminApiBarrierPreservation, ForkCarriesBarrierStateToNewThread) {
     EXPECT_EQ(1u, forked->barrier_state["join"].count("a"));
     EXPECT_EQ(1u, forked->barrier_state["join"].count("c"));
 }
+
+TEST(AdminApiFacade, DelegatesStateHistoryUpdateAndFork) {
+    auto store = seed_cp_with_barrier("admin-facade-src", {});
+    auto engine = compile_minimal_engine(store);
+    auto admin = engine->admin();
+
+    ASSERT_TRUE(admin.get_state("admin-facade-src").has_value());
+    EXPECT_EQ(admin.get_state_history("admin-facade-src").size(), 1u);
+
+    admin.update_state("admin-facade-src", json{{"a_done", true}}, "join");
+    EXPECT_EQ(admin.get_state_history("admin-facade-src").size(), 2u);
+
+    auto forked_id = admin.fork("admin-facade-src", "admin-facade-dst");
+    EXPECT_FALSE(forked_id.empty());
+    EXPECT_TRUE(admin.get_state("admin-facade-dst").has_value());
+}

--- a/tests/test_checkpoint_async_default.cpp
+++ b/tests/test_checkpoint_async_default.cpp
@@ -35,6 +35,100 @@ Checkpoint make_cp(const std::string& thread, int step) {
     return cp;
 }
 
+class CapabilityStore final : public CheckpointStoreCore,
+                              public AsyncCheckpointStore,
+                              public PendingWritesCheckpointStore {
+public:
+    void save(const Checkpoint& cp) override { checkpoints[cp.id] = cp; }
+    std::optional<Checkpoint> load_latest(const std::string& thread_id) override {
+        for (auto it = checkpoints.rbegin(); it != checkpoints.rend(); ++it) {
+            if (it->second.thread_id == thread_id) return it->second;
+        }
+        return std::nullopt;
+    }
+    std::optional<Checkpoint> load_by_id(const std::string& id) override {
+        auto it = checkpoints.find(id);
+        return it == checkpoints.end() ? std::nullopt
+                                       : std::optional<Checkpoint>{it->second};
+    }
+    std::vector<Checkpoint> list(const std::string& thread_id, int limit) override {
+        std::vector<Checkpoint> result;
+        for (auto it = checkpoints.rbegin(); it != checkpoints.rend()
+             && static_cast<int>(result.size()) < limit; ++it) {
+            if (it->second.thread_id == thread_id) result.push_back(it->second);
+        }
+        return result;
+    }
+    void delete_thread(const std::string& thread_id) override {
+        for (auto it = checkpoints.begin(); it != checkpoints.end();) {
+            if (it->second.thread_id == thread_id) it = checkpoints.erase(it);
+            else ++it;
+        }
+    }
+
+    asio::awaitable<void> save_async(const Checkpoint& cp) override {
+        ++async_calls;
+        save(cp);
+        co_return;
+    }
+    asio::awaitable<std::optional<Checkpoint>>
+    load_latest_async(const std::string& thread_id) override {
+        ++async_calls;
+        co_return load_latest(thread_id);
+    }
+    asio::awaitable<std::optional<Checkpoint>>
+    load_by_id_async(const std::string& id) override {
+        ++async_calls;
+        co_return load_by_id(id);
+    }
+    asio::awaitable<std::vector<Checkpoint>>
+    list_async(const std::string& thread_id, int limit) override {
+        ++async_calls;
+        co_return list(thread_id, limit);
+    }
+    asio::awaitable<void> delete_thread_async(const std::string& thread_id) override {
+        ++async_calls;
+        delete_thread(thread_id);
+        co_return;
+    }
+
+    void put_writes(const std::string&, const std::string&,
+                    const PendingWrite& write) override {
+        pending.push_back(write);
+    }
+    std::vector<PendingWrite> get_writes(const std::string&,
+                                         const std::string&) override {
+        return pending;
+    }
+    void clear_writes(const std::string&, const std::string&) override {
+        pending.clear();
+    }
+
+    std::map<std::string, Checkpoint> checkpoints;
+    std::vector<PendingWrite> pending;
+    int async_calls = 0;
+};
+
+class CoreOnlyCapabilityStore final : public CheckpointStoreCore {
+public:
+    void save(const Checkpoint& cp) override { saved = cp; }
+    std::optional<Checkpoint> load_latest(const std::string& thread_id) override {
+        return saved && saved->thread_id == thread_id ? saved : std::nullopt;
+    }
+    std::optional<Checkpoint> load_by_id(const std::string& id) override {
+        return saved && saved->id == id ? saved : std::nullopt;
+    }
+    std::vector<Checkpoint> list(const std::string& thread_id, int limit) override {
+        if (limit > 0 && saved && saved->thread_id == thread_id) return {*saved};
+        return {};
+    }
+    void delete_thread(const std::string& thread_id) override {
+        if (saved && saved->thread_id == thread_id) saved.reset();
+    }
+
+    std::optional<Checkpoint> saved;
+};
+
 } // namespace
 
 TEST(CheckpointAsyncDefault, SaveAndLoadLatestThroughBridge) {
@@ -107,4 +201,41 @@ TEST(CheckpointAsyncDefault, DeleteThreadAsyncRoutesToSync) {
 
     EXPECT_FALSE(store.load_latest("doomed").has_value());
     EXPECT_TRUE(store.load_latest("kept").has_value());
+}
+
+TEST(CheckpointCapabilities, AdapterDelegatesCoreAsyncAndPendingWrites) {
+    auto capabilities = std::make_shared<CapabilityStore>();
+    auto store = adapt_checkpoint_store(capabilities);
+    auto cp = make_cp("capabilities", 1);
+
+    neograph::async::run_sync(store->save_async(cp));
+    auto loaded = neograph::async::run_sync(
+        store->load_latest_async("capabilities"));
+    ASSERT_TRUE(loaded.has_value());
+    EXPECT_EQ(loaded->id, cp.id);
+    EXPECT_EQ(capabilities->async_calls, 2);
+
+    PendingWrite write;
+    write.task_id = "task-capability";
+    store->put_writes("capabilities", cp.id, write);
+    ASSERT_EQ(store->get_writes("capabilities", cp.id).size(), 1u);
+    EXPECT_EQ(store->get_writes("capabilities", cp.id)[0].task_id,
+              "task-capability");
+    store->clear_writes("capabilities", cp.id);
+    EXPECT_TRUE(store->get_writes("capabilities", cp.id).empty());
+}
+
+TEST(CheckpointCapabilities, AdapterRejectsNullCore) {
+    EXPECT_THROW((void)adapt_checkpoint_store(nullptr), std::invalid_argument);
+}
+
+TEST(CheckpointCapabilities, CoreOnlyAdapterProvidesLegacyAsyncFallback) {
+    auto capabilities = std::make_shared<CoreOnlyCapabilityStore>();
+    auto store = adapt_checkpoint_store(capabilities);
+    auto cp = make_cp("core-only", 1);
+
+    neograph::async::run_sync(store->save_async(cp));
+    auto loaded = neograph::async::run_sync(store->load_latest_async("core-only"));
+    ASSERT_TRUE(loaded.has_value());
+    EXPECT_EQ(loaded->id, cp.id);
 }

--- a/tests/test_engine_config.cpp
+++ b/tests/test_engine_config.cpp
@@ -1,4 +1,5 @@
 #include <neograph/neograph.h>
+#include <neograph/graph/validator.h>
 
 #include <gtest/gtest.h>
 
@@ -217,6 +218,37 @@ TEST(EngineConfigTest, LegacyCompileDelegatesWithoutBehaviorChange) {
     EXPECT_EQ(legacy_result.execution_trace, configured_result.execution_trace);
 }
 
+TEST(EngineConfigTest, StrictBuildRejectsUnknownKeysWithoutMutatingDefinition) {
+    register_node("engine_config_strict",
+                  [](const std::string&, const json&, const NodeContext&) {
+                      return std::make_unique<EchoNode>();
+                  });
+
+    auto definition = one_node_graph("engine_config_strict");
+    json legacy = json::object();
+    for (const auto& [key, value] : definition.items()) {
+        if (key != "schema_version") legacy[key] = value;
+    }
+    legacy["conditionnal_edges"] = json::array();
+
+    EXPECT_NO_THROW((void)GraphEngine::build(legacy, EngineConfig{}));
+    EXPECT_THROW((void)GraphEngine::build_strict(legacy, EngineConfig{}),
+                 std::runtime_error);
+    EXPECT_FALSE(legacy.contains("schema_version"));
+}
+
+TEST(EngineConfigTest, StrictBuildPreservesInvalidDeclaredSchemaVersion) {
+    auto definition = one_node_graph("unused");
+    definition["schema_version"] = "1";
+
+    EXPECT_THROW((void)GraphEngine::build_strict(definition, EngineConfig{}),
+                 std::runtime_error);
+
+    definition["schema_version"] = 1.5;
+    EXPECT_THROW((void)GraphEngine::build_strict(definition, EngineConfig{}),
+                 std::runtime_error);
+}
+
 TEST(EngineConfigTest, AppliesRuntimeConfigurationBeforeFirstRun) {
     register_node("engine_config_probe", [](const std::string&, const json&, const NodeContext&) {
         return std::make_unique<ConfigProbeNode>();
@@ -304,6 +336,55 @@ TEST(CompiledGraphLinkTest, AppliesSemanticValidationBeforeRuntimeConstruction) 
     graph.edges.push_back({"missing", "work"});
 
     EXPECT_THROW((void)GraphEngine::link(std::move(graph)), std::runtime_error);
+}
+
+TEST(ValidatedTopologyLinkTest, ParsesAndValidatesBeforeCreatingRuntimeNodes) {
+    link_factory_calls = 0;
+    auto registry = std::make_shared<GraphRegistry>();
+    registry->register_type(
+        "validated_topology_echo",
+        [](const std::string&, const json&, const NodeContext&) {
+            ++link_factory_calls;
+            return std::make_unique<EchoNode>();
+        });
+
+    const auto definition = one_node_graph("validated_topology_echo");
+    auto topology = GraphCompiler::parse(definition, *registry);
+    EXPECT_EQ(link_factory_calls.load(), 0);
+    EXPECT_NO_THROW(GraphCompiler::verify_roundtrip(definition, topology));
+
+    auto validated = GraphValidator::require_valid(std::move(topology), *registry);
+    EXPECT_EQ(link_factory_calls.load(), 0);
+    EXPECT_FALSE(validated.report().has_errors());
+
+    EngineResources resources;
+    resources.registry = registry;
+    auto engine = GraphEngine::link(std::move(validated), EngineConfig{},
+                                    std::move(resources));
+    EXPECT_EQ(link_factory_calls.load(), 1);
+
+    RunConfig run;
+    run.input = {{"input", "validated"}};
+    EXPECT_EQ(engine->run(run).channel<std::string>("output"), "validated");
+}
+
+TEST(ValidatedTopologyLinkTest, RejectsSemanticErrorsBeforeCreatingNodes) {
+    link_factory_calls = 0;
+    auto registry = std::make_shared<GraphRegistry>();
+    registry->register_type(
+        "invalid_validated_topology",
+        [](const std::string&, const json&, const NodeContext&) {
+            ++link_factory_calls;
+            return std::make_unique<EchoNode>();
+        });
+
+    auto definition = one_node_graph("invalid_validated_topology");
+    definition["edges"].push_back({{"from", "work"}, {"to", "missing"}});
+    auto topology = GraphCompiler::parse(definition, *registry);
+
+    EXPECT_THROW((void)GraphValidator::require_valid(std::move(topology), *registry),
+                 std::runtime_error);
+    EXPECT_EQ(link_factory_calls.load(), 0);
 }
 
 TEST(EngineResourcesTest, KeepsOwnedToolSetAliveForEngineLifetime) {

--- a/tests/test_graph_state.cpp
+++ b/tests/test_graph_state.cpp
@@ -145,6 +145,24 @@ TEST(GraphState, GetNonExistent) {
     EXPECT_TRUE(val.is_null());
 }
 
+TEST(GraphState, TypedChannelKeyReadsDeclaredValue) {
+    GraphState state;
+    state.init_channel("count", ReducerType::OVERWRITE, overwrite_fn(), json(7));
+
+    const ChannelKey<int> count{"count"};
+    EXPECT_EQ(state.get(count), 7);
+    ASSERT_TRUE(state.try_get(count).has_value());
+    EXPECT_EQ(*state.try_get(count), 7);
+}
+
+TEST(GraphState, TypedTryGetDistinguishesMissingFromTypeMismatch) {
+    GraphState state;
+    state.init_channel("status", ReducerType::OVERWRITE, overwrite_fn(), json("ready"));
+
+    EXPECT_FALSE(state.try_get(ChannelKey<int>{"missing"}).has_value());
+    EXPECT_THROW((void)state.try_get(ChannelKey<int>{"status"}), json::type_error);
+}
+
 // ── Global Version ──
 
 TEST(GraphState, GlobalVersion) {

--- a/tests/test_node_header.cpp
+++ b/tests/test_node_header.cpp
@@ -1,0 +1,29 @@
+#include <neograph/graph/node.h>
+
+#include <gtest/gtest.h>
+
+using namespace neograph::graph;
+
+namespace {
+
+class HeaderOnlyContextNode final : public GraphNode {
+public:
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        observed_thread_id = in.ctx.thread_id;
+        if (in.ctx.store) {
+            (void)in.ctx.store->get({"header-test"}, "value");
+        }
+        co_return NodeOutput{};
+    }
+
+    std::string get_name() const override { return "header-only-context"; }
+
+    std::string observed_thread_id;
+};
+
+}  // namespace
+
+TEST(NodeHeader, ExposesCompleteRunContextWithoutEngineHeader) {
+    HeaderOnlyContextNode node;
+    EXPECT_EQ(node.get_name(), "header-only-context");
+}


### PR DESCRIPTION
## Summary

- separate declarative topology parsing and validation from runtime node linking
- add strict construction, typed channel access, a borrowed admin facade, and checkpoint capability adapters
- preserve existing signatures, layouts, vtables, wire formats, and lenient build behavior
- update the canonical English/Korean references and minimal example

## Verification

- focused API tests: 11/11 passed
- full CTest suite: 802/802 passed
- `git diff --check` passed