### PR TITLE
fix(cookbook): update JARVIS pybind bench node API

### DIFF
--- a/examples/cookbook/jarvis/bench/pybind/perturn.py
+++ b/examples/cookbook/jarvis/bench/pybind/perturn.py
@@ -16,8 +16,8 @@ if which == "neograph":
         def __init__(self, name, ch):
             super().__init__(); self._n = name; self._ch = ch
         def get_name(self): return self._n
-        def execute(self, state):
-            v = state.get("v") or 0
+        def run(self, input):
+            v = input.state.get("v") or 0
             return [ng.ChannelWrite(self._ch, v + 1)]
 
     for i in range(5):


### PR DESCRIPTION
## Summary
- migrate the JARVIS per-turn pybind benchmark node from the removed `execute(state)` override to `run(NodeInput)`
- read benchmark state through `input.state`

## Testing
- `python3 -m py_compile examples/cookbook/jarvis/bench/pybind/perturn.py`
- `PYTHONPATH=<current build> python3 examples/cookbook/jarvis/bench/pybind/perturn.py neograph 5000`
  - completed 5,000 runs successfully
  - mean: 0.0430 ms/run