### PR TITLE
fix(mcp): expose structured Harness results to text-only hosts

### DIFF
--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -102,6 +102,16 @@ void require_tasks_negotiated(const json& context) {
     }
 }
 
+json structured_text_content(const json& structured, std::string summary) {
+    // MCP 2025-11-25 recommends a serialized JSON TextContent fallback for
+    // clients that do not surface structuredContent.
+    // https://modelcontextprotocol.io/specification/2025-11-25/server/tools#structured-content
+    return json::array({
+        {{"type", "text"}, {"text", std::move(summary)}},
+        {{"type", "text"}, {"text", structured.dump()}},
+    });
+}
+
 json task_from_snapshot(const json& snapshot, bool creation = false) {
     const auto  harness_status = snapshot.value("status", "failed");
     std::string status         = "working";
@@ -150,7 +160,7 @@ json task_from_snapshot(const json& snapshot, bool creation = false) {
         };
     } else if (status == "completed") {
         CallToolResult result;
-        result.content = json::array({{{"type", "text"}, {"text", "Harness run completed"}}});
+        result.content            = structured_text_content(snapshot, "Harness run completed");
         result.structured_content = snapshot;
         task["result"]            = result.to_json();
     } else if (status == "failed") {
@@ -1403,7 +1413,7 @@ void validate_bindings(const json& request,
 
 CallToolResult mcp_result(json structured, std::string text) {
     CallToolResult result;
-    result.content = json::array({{{"type", "text"}, {"text", std::move(text)}}});
+    result.content            = structured_text_content(structured, std::move(text));
     result.structured_content = std::move(structured);
     return result;
 }

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -195,6 +195,16 @@ json wait_terminal(HarnessService&           service,
     return service.get(run_id, "details");
 }
 
+void expect_structured_text_fallback(const json& response) {
+    ASSERT_TRUE(response.contains("result")) << response.dump();
+    const auto& result = response["result"];
+    ASSERT_TRUE(result.contains("structuredContent")) << result.dump();
+    ASSERT_GE(result["content"].size(), 2u) << result.dump();
+    EXPECT_EQ(result["content"][1]["type"], "text");
+    EXPECT_EQ(json::parse(result["content"][1]["text"].get<std::string>()),
+              result["structuredContent"]);
+}
+
 class ScriptedProvider final : public neograph::Provider {
 public:
     std::vector<neograph::ChatCompletion> completions;
@@ -313,6 +323,77 @@ TEST(HarnessServiceTest, ExposesSmallStableMcpToolSurface) {
     EXPECT_NE(invalid_get["result"]["content"][0]["text"].get<std::string>().find(
                   "missing required property run_id"),
               std::string::npos);
+}
+
+TEST(HarnessServiceTest, MirrorsStructuredToolResultsIntoTextContent) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService                 service(std::move(config));
+    neograph::mcp::MCPServerConfig server_config;
+    server_config.server_info = {{"name", "harness-test"}, {"version", "1"}};
+    neograph::mcp::MCPServer server(server_config);
+    ServerResponses          responses;
+    server.set_response_sink(responses.sink());
+    service.register_tools(server);
+
+    server.handle_message({
+        {"jsonrpc", "2.0"},
+        {"id", 1},
+        {"method", "initialize"},
+        {"params",
+         {
+             {"protocolVersion", "2025-11-25"},
+             {"capabilities", json::object()},
+             {"clientInfo", {{"name", "test"}, {"version", "1"}}},
+         }},
+    });
+    server.handle_message({
+        {"jsonrpc", "2.0"},
+        {"method", "notifications/initialized"},
+        {"params", json::object()},
+    });
+    const auto call = [&server, &responses](int id, std::string name, json arguments) {
+        EXPECT_TRUE(
+            server
+                .handle_message({
+                    {"jsonrpc", "2.0"},
+                    {"id", id},
+                    {"method", "tools/call"},
+                    {"params", {{"name", std::move(name)}, {"arguments", std::move(arguments)}}},
+                })
+                .is_null());
+        return responses.wait(id);
+    };
+
+    const auto schema_response = call(2, "neograph_schema", json::object());
+    expect_structured_text_fallback(schema_response);
+    EXPECT_EQ(schema_response["result"]["content"][0]["text"], "NeoGraph Harness M4 schema");
+
+    auto malformed                   = request();
+    malformed["workers"][0]["tools"] = json::array({"missing.tool"});
+    const auto compile_response      = call(3, "neograph_compile", std::move(malformed));
+    expect_structured_text_fallback(compile_response);
+    EXPECT_FALSE(compile_response["result"]["structuredContent"]["ok"].get<bool>());
+    EXPECT_FALSE(compile_response["result"]["structuredContent"]["diagnostics"].empty());
+
+    const auto compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto run_id  = started["run_id"].get<std::string>();
+    ASSERT_EQ(wait_terminal(service, run_id)["status"], "completed");
+
+    const auto details_response =
+        call(4, "neograph_get", {{"run_id", run_id}, {"view", "details"}});
+    expect_structured_text_fallback(details_response);
+    EXPECT_EQ(details_response["result"]["structuredContent"]["result"]["valid_workers"], 1);
+
+    const auto trace_response =
+        call(5, "neograph_get", {{"run_id", run_id}, {"view", "trace"}, {"limit", 10}});
+    expect_structured_text_fallback(trace_response);
+    EXPECT_TRUE(
+        trace_response["result"]["structuredContent"]["result"].contains("execution_trace"));
 }
 
 TEST(HarnessServiceTest, MalformedHarnessCannotProduceExecutableArtifact) {
@@ -774,7 +855,11 @@ TEST(HarnessServiceTest, ExperimentalTasksProfileNegotiatesAndResumesInput) {
         {"params", {{"taskId", task_id}}},
     });
     EXPECT_EQ(completed["result"]["status"], "completed") << completed.dump();
-    EXPECT_EQ(completed["result"]["result"]["structuredContent"]["status"], "completed");
+    const auto& task_result = completed["result"]["result"];
+    EXPECT_EQ(task_result["structuredContent"]["status"], "completed");
+    ASSERT_GE(task_result["content"].size(), 2u);
+    EXPECT_EQ(json::parse(task_result["content"][1]["text"].get<std::string>()),
+              task_result["structuredContent"]);
 }
 
 TEST(HarnessServiceTest, ExperimentalTasksProfileFallsBackWithoutRequestOptIn) {


### PR DESCRIPTION
## Summary

- preserve existing Harness MCP summary text in the first `TextContent` block
- add an exact JSON serialization of `structuredContent` as the second text block, following MCP 2025-11-25 backward-compatibility guidance
- cover schema discovery, rejected compile diagnostics, detailed/trace run views, and completed experimental Tasks results

## Why

OpenCode 1.18.4 currently surfaces Harness tool text but not `structuredContent` to the model. Calls completed successfully, but agents saw only status summaries and could not consume schemas, diagnostics, worker outputs, or traces without a raw MCP workaround.

## Verification

- regression test failed before the implementation and passes after it
- `HarnessServiceTest.*`: 48/48 passed
- full C++ suite: 673 passed, 3 opt-in live tests skipped
- stdio smoke: two text blocks returned and parsed JSON exactly equals `structuredContent`
- independent review found no blocking issues
- changed-line clang-format and `git diff --check` passed

Closes #169