### PR TITLE
fix(harness): recover provider timeouts and versioned base URLs

### DIFF
--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -30,7 +30,12 @@ export NEOGRAPH_HARNESS_MODEL=gpt-4o-mini
 
 `NEOGRAPH_HARNESS_API_KEY` takes precedence over `OPENAI_API_KEY`.
 `NEOGRAPH_HARNESS_BASE_URL` selects any OpenAI-compatible endpoint. The server
-writes protocol messages only to stdout and diagnostics only to stderr.
+accepts both an unversioned base such as `https://openrouter.ai/api` and the
+provider's documented versioned form such as `https://openrouter.ai/api/v1`;
+it adds `/v1` only when missing. The server writes protocol messages only to
+stdout and diagnostics only to stderr. See the
+[OpenRouter quickstart](https://openrouter.ai/docs/quickstart) for its current
+endpoint format.
 
 For host interoperability smoke tests only, set `NEOGRAPH_HARNESS_SMOKE=1`.
 That explicit mode uses a deterministic in-process provider returning a valid

--- a/include/neograph/llm/openai_provider.h
+++ b/include/neograph/llm/openai_provider.h
@@ -40,7 +40,9 @@ class NEOGRAPH_API OpenAIProvider : public Provider {
     /// Configuration for OpenAI-compatible API connections.
     struct Config {
         std::string api_key;                              ///< API key for authentication.
-        std::string base_url = "https://api.openai.com";  ///< Base URL of the API endpoint.
+        /// Base URL of the API endpoint. Both unversioned URLs and URLs ending
+        /// in `/v1` are accepted; the provider adds the missing version path.
+        std::string base_url = "https://api.openai.com";
         std::string default_model = "gpt-4o-mini";        ///< Default model name.
         /// HTTP request timeout in seconds. Note: NeoGraph's public
         /// surface currently uses a mix of `int seconds` (here, in

--- a/src/llm/openai_provider.cpp
+++ b/src/llm/openai_provider.cpp
@@ -95,6 +95,16 @@ static std::pair<std::string, std::string> parse_url(const std::string& base_url
 
 namespace {
 
+std::string chat_completions_path(std::string prefix) {
+    while (!prefix.empty() && prefix.back() == '/') prefix.pop_back();
+    // OpenRouter documents an OpenAI-compatible base URL ending in /api/v1.
+    // Source: https://openrouter.ai/docs/quickstart (fetched 2026-07-23).
+    if (prefix.size() >= 3 && prefix.compare(prefix.size() - 3, 3, "/v1") == 0) {
+        return prefix + "/chat/completions";
+    }
+    return prefix + "/v1/chat/completions";
+}
+
 // Parse Retry-After. Supports the seconds-integer shape only (the
 // HTTP-date shape is rare in practice for LLM endpoints; matching
 // SchemaProvider's behavior). Returns -1 when missing or unparsable.
@@ -130,7 +140,7 @@ OpenAIProvider::complete_async(const CompletionParams& params)
     auto res = co_await conn_pool_->async_post(
         endpoint.host,
         endpoint.port,
-        endpoint.prefix + "/v1/chat/completions",
+        chat_completions_path(endpoint.prefix),
         body_str,
         std::move(headers),
         endpoint.tls,
@@ -202,7 +212,7 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
     std::string error_body;
     httplib::Request request;
     request.method = "POST";
-    request.path = prefix + "/v1/chat/completions";
+    request.path = chat_completions_path(prefix);
     request.headers = headers;
     request.body = body.dump();
     request.set_header("Content-Type", "application/json");

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -1012,8 +1012,7 @@ public:
                 failure_kind = response_kind_name(response.kind);
                 feedback     = response.message.empty() ? failure_kind : response.message;
             }
-            const bool stop_retry = response.kind == HarnessWorkerResponseKind::TIMEOUT ||
-                                    response.kind == HarnessWorkerResponseKind::TOOL_ERROR;
+            const bool stop_retry = response.kind == HarnessWorkerResponseKind::TOOL_ERROR;
             detail::append_harness_journal_event(
                 attempt_context, "worker.attempt.completed",
                 {{"duration_ms", std::chrono::duration_cast<std::chrono::milliseconds>(

--- a/src/mcp/harness_provider.cpp
+++ b/src/mcp/harness_provider.cpp
@@ -4,6 +4,9 @@
 
 #include "harness_journal_internal.h"
 
+#include <asio/error.hpp>
+#include <asio/system_error.hpp>
+
 #include <atomic>
 #include <chrono>
 #include <filesystem>
@@ -168,6 +171,19 @@ HarnessWorkerExecutor make_provider_harness_executor(HarnessProviderExecutorConf
                      {"outcome", "cancelled"}},
                     provider_correlation);
                 return HarnessWorkerResponse::cancelled();
+            } catch (const asio::system_error& error) {
+                const bool timed_out = error.code() == asio::error::timed_out;
+                detail::append_current_harness_journal_event(
+                    "provider.call.completed",
+                    {{"duration_ms",
+                      std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - provider_started)
+                          .count()},
+                     {"error", error.what()},
+                     {"outcome", timed_out ? "timeout" : "error"}},
+                    provider_correlation);
+                if (timed_out) return HarnessWorkerResponse::timeout(error.what());
+                return HarnessWorkerResponse::tool_error(error.what());
             } catch (const std::exception& error) {
                 detail::append_current_harness_journal_event(
                     "provider.call.completed",

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -11,6 +11,9 @@
 #include <neograph/mcp/server.h>
 #include <neograph/provider.h>
 
+#include <asio/error.hpp>
+#include <asio/system_error.hpp>
+
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -219,6 +222,15 @@ public:
     }
 
     std::string get_name() const override { return "scripted-harness-provider"; }
+};
+
+class TimeoutProvider final : public neograph::Provider {
+public:
+    neograph::ChatCompletion complete(const neograph::CompletionParams&) override {
+        throw asio::system_error(asio::error::timed_out);
+    }
+
+    std::string get_name() const override { return "timeout-harness-provider"; }
 };
 
 class StartFailingJournal final : public neograph::mcp::HarnessJournal {
@@ -651,6 +663,34 @@ TEST(HarnessServiceTest, ProviderExecutorRunsDeclaredToolsAndValidatesPaths) {
     ASSERT_EQ(provider->calls[1].messages.size(), 3u);
     EXPECT_EQ(provider->calls[1].messages.back().role, "tool");
     std::filesystem::remove_all(workspace);
+}
+
+TEST(HarnessServiceTest, ProviderExecutorPreservesTransportTimeoutKind) {
+    neograph::mcp::HarnessProviderExecutorConfig config;
+    config.provider = std::make_shared<TimeoutProvider>();
+    auto executor = neograph::mcp::make_provider_harness_executor(std::move(config));
+
+    HarnessWorkerCall call;
+    call.task = {{"objective", "Review"}};
+    call.worker = worker("reviewer");
+    auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
+
+    EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::TIMEOUT);
+    EXPECT_FALSE(response.message.empty());
+}
+
+TEST(HarnessServiceTest, ProviderExecutorKeepsGenericFailuresAsToolErrors) {
+    neograph::mcp::HarnessProviderExecutorConfig config;
+    config.provider = std::make_shared<ScriptedProvider>();
+    auto executor = neograph::mcp::make_provider_harness_executor(std::move(config));
+
+    HarnessWorkerCall call;
+    call.task = {{"objective", "Review"}};
+    call.worker = worker("reviewer");
+    auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
+
+    EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::TOOL_ERROR);
+    EXPECT_EQ(response.message, "no scripted completion");
 }
 
 TEST(HarnessServiceTest, ProviderExecutorRejectsWorkspaceEscapeBeforeToolCall) {
@@ -2146,17 +2186,21 @@ TEST(HarnessServiceTest, RecordedReplayPreservesTerminalWorkerFailure) {
     const auto replayed = wait_terminal(service, replay["run_id"].get<std::string>());
     ASSERT_EQ(replayed["status"], "completed") << replayed.dump();
     EXPECT_EQ(replayed["result"]["workers"], source["result"]["workers"]);
-    EXPECT_EQ(live_calls.load(std::memory_order_relaxed), 1);
+    EXPECT_EQ(live_calls.load(std::memory_order_relaxed), 2);
 
     const auto events               = records->list_events(source_run_id);
+    bool       saw_retry            = false;
     bool       saw_terminal_attempt = false;
     for (const auto& event : events) {
         if (event["event_type"] == "worker.attempt.completed" &&
             event["payload"].value("retry_reason", "") == "timeout") {
-            EXPECT_FALSE(event["payload"]["retry_scheduled"].get<bool>());
-            saw_terminal_attempt = true;
+            if (event["payload"]["retry_scheduled"].get<bool>())
+                saw_retry = true;
+            else
+                saw_terminal_attempt = true;
         }
     }
+    EXPECT_TRUE(saw_retry);
     EXPECT_TRUE(saw_terminal_attempt);
 }
 
@@ -2525,7 +2569,7 @@ TEST(HarnessServiceTest, DistinguishesEmptyResponseAndWorkerTimeout) {
         auto finished = wait_terminal(service, started["run_id"].get<std::string>());
         ASSERT_EQ(finished["status"], "completed") << finished.dump();
         EXPECT_EQ(finished["result"]["workers"][0]["failure_kind"], "timeout");
-        EXPECT_EQ(finished["result"]["workers"][0]["attempts"], 1);
+        EXPECT_EQ(finished["result"]["workers"][0]["attempts"], 2);
     }
 }
 

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -224,13 +224,18 @@ public:
     std::string get_name() const override { return "scripted-harness-provider"; }
 };
 
-class TimeoutProvider final : public neograph::Provider {
+class AsioErrorProvider final : public neograph::Provider {
 public:
+    explicit AsioErrorProvider(asio::error_code error) : error_(error) {}
+
     neograph::ChatCompletion complete(const neograph::CompletionParams&) override {
-        throw asio::system_error(asio::error::timed_out);
+        throw asio::system_error(error_);
     }
 
-    std::string get_name() const override { return "timeout-harness-provider"; }
+    std::string get_name() const override { return "asio-error-harness-provider"; }
+
+private:
+    asio::error_code error_;
 };
 
 class StartFailingJournal final : public neograph::mcp::HarnessJournal {
@@ -667,7 +672,8 @@ TEST(HarnessServiceTest, ProviderExecutorRunsDeclaredToolsAndValidatesPaths) {
 
 TEST(HarnessServiceTest, ProviderExecutorPreservesTransportTimeoutKind) {
     neograph::mcp::HarnessProviderExecutorConfig config;
-    config.provider = std::make_shared<TimeoutProvider>();
+    config.provider = std::make_shared<AsioErrorProvider>(
+        asio::error::make_error_code(asio::error::timed_out));
     auto executor = neograph::mcp::make_provider_harness_executor(std::move(config));
 
     HarnessWorkerCall call;
@@ -676,6 +682,21 @@ TEST(HarnessServiceTest, ProviderExecutorPreservesTransportTimeoutKind) {
     auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
 
     EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::TIMEOUT);
+    EXPECT_FALSE(response.message.empty());
+}
+
+TEST(HarnessServiceTest, ProviderExecutorKeepsOtherAsioFailuresAsToolErrors) {
+    neograph::mcp::HarnessProviderExecutorConfig config;
+    config.provider = std::make_shared<AsioErrorProvider>(
+        asio::error::make_error_code(asio::error::connection_refused));
+    auto executor = neograph::mcp::make_provider_harness_executor(std::move(config));
+
+    HarnessWorkerCall call;
+    call.task = {{"objective", "Review"}};
+    call.worker = worker("reviewer");
+    auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
+
+    EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::TOOL_ERROR);
     EXPECT_FALSE(response.message.empty());
 }
 

--- a/tests/test_openai_provider_async.cpp
+++ b/tests/test_openai_provider_async.cpp
@@ -60,15 +60,16 @@ struct MockServer {
     std::string     retry_after;  // header value when status == 429
 
     MockServer() {
-        svr.Post("/v1/chat/completions",
-                 [this](const httplib::Request&, httplib::Response& res) {
-                     request_count.fetch_add(1, std::memory_order_relaxed);
-                     res.status = status;
-                     if (!retry_after.empty()) {
-                         res.set_header("Retry-After", retry_after);
-                     }
-                     res.set_content(body, "application/json");
-                 });
+        const auto handler = [this](const httplib::Request&, httplib::Response& res) {
+            request_count.fetch_add(1, std::memory_order_relaxed);
+            res.status = status;
+            if (!retry_after.empty()) {
+                res.set_header("Retry-After", retry_after);
+            }
+            res.set_content(body, "application/json");
+        };
+        svr.Post("/v1/chat/completions", handler);
+        svr.Post("/api/v1/chat/completions", handler);
 
         port = svr.bind_to_any_port("127.0.0.1");
         t = std::thread([this] { svr.listen_after_bind(); });
@@ -145,6 +146,24 @@ TEST(OpenAIProviderAsync, SyncCompleteBridgesThroughRunSync) {
     EXPECT_EQ(result.message.content, "pong");
     EXPECT_EQ(result.usage.total_tokens, 9);
     EXPECT_EQ(mock.request_count.load(), 1);
+}
+
+TEST(OpenAIProviderAsync, SyncCompleteAcceptsVersionedAndUnversionedBaseUrls) {
+    MockServer mock;
+    ASSERT_GT(mock.port, 0);
+
+    for (const std::string suffix : {"", "/api", "/api/v1", "/api/v1/"}) {
+        auto config = make_config(mock);
+        config.base_url += suffix;
+        auto provider = llm::OpenAIProvider::create(config);
+        try {
+            EXPECT_EQ(provider->complete(make_params()).message.content, "pong");
+        } catch (const std::exception& error) {
+            ADD_FAILURE() << "base URL suffix " << suffix << " failed: " << error.what();
+        }
+    }
+
+    EXPECT_EQ(mock.request_count.load(), 4);
 }
 
 TEST(OpenAIProviderAsync, RateLimitErrorCarriesRetryAfter) {
@@ -249,6 +268,20 @@ TEST(OpenAIProviderStream, SuccessfulContentAndUsageRemainIntact) {
     EXPECT_EQ(completion.usage.prompt_tokens, 7);
     EXPECT_EQ(completion.usage.completion_tokens, 2);
     EXPECT_EQ(completion.usage.total_tokens, 9);
+}
+
+TEST(OpenAIProviderStream, VersionedBaseUrlDoesNotDuplicateVersionPath) {
+    MockServer mock;
+    mock.body = "data: {\"choices\":[{\"delta\":{\"content\":\"pong\"}}]}\n\n"
+                "data: [DONE]\n\n";
+    auto config = make_config(mock);
+    config.base_url += "/api/v1/";
+
+    auto provider = llm::OpenAIProvider::create(config);
+    auto completion = provider->complete_stream(make_params(), {});
+
+    EXPECT_EQ(completion.message.content, "pong");
+    EXPECT_EQ(mock.request_count.load(), 1);
 }
 
 TEST(OpenAIProviderStream, EmptyChoicesRemainAValidEmptyCompletion) {


### PR DESCRIPTION
## Summary
- preserve Asio transport timeouts as typed Harness timeout failures and retry them within `max_worker_retries`
- keep cancellation and non-timeout provider failures on their existing terminal paths
- accept OpenAI-compatible base URLs with or without a trailing `/v1` across sync, async, and streaming requests
- document the official OpenRouter `/api/v1` form

## Verification
- `ctest --test-dir build-harness-tests --output-on-failure` (808/808 passed; environment-gated integration tests skipped)
- live OpenRouter probe with `https://openrouter.ai/api/v1`, `deepseek/deepseek-v4-flash`: completed in one worker attempt with the expected structured marker
- independent correctness review: no blocking findings

Closes #171
Closes #172