### PR TITLE
fix(harness): suppress exported result lint

### DIFF
--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -48,8 +48,14 @@ namespace {
 
 constexpr const char* kWorkerNodeType = "neograph_harness_worker";
 constexpr const char* kJudgeNodeType = "neograph_harness_judge";
+constexpr const char* kHarnessResultChannel = "final_result";
 constexpr const char* kTasksExtension = "io.modelcontextprotocol/tasks";
 constexpr const char* kHarnessProfile = "harness-m4";
+
+bool is_externally_consumed_harness_result(const graph::Diagnostic& diagnostic) {
+    return diagnostic.code == "E6" && diagnostic.witness.contains("writers") &&
+           diagnostic.witness.value("channel", "") == kHarnessResultChannel;
+}
 
 int64_t unix_millis() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1129,7 +1135,7 @@ public:
             {"failed_workers", failed},
         };
         graph::NodeOutput output;
-        output.writes.push_back({"final_result", std::move(result)});
+        output.writes.push_back({kHarnessResultChannel, std::move(result)});
         co_return output;
     }
 
@@ -1178,7 +1184,7 @@ json preset_fanout_judge(const json& request, const std::string& preset) {
          {
              {"task", {{"reducer", "overwrite"}, {"initial", json::object()}}},
              {"worker_results", {{"reducer", "append"}, {"initial", json::array()}}},
-             {"final_result", {{"reducer", "overwrite"}, {"initial", nullptr}}},
+             {kHarnessResultChannel, {{"reducer", "overwrite"}, {"initial", nullptr}}},
          }},
         {"nodes", json::object()},
         {"edges", json::array()},
@@ -1883,6 +1889,9 @@ struct HarnessService::Impl {
                 graph::GraphCompiler::verify_roundtrip(core, compiled);
                 auto report = graph::GraphValidator::validate(compiled);
                 for (const auto& diagnostic : report.diagnostics) {
+                    // HarnessService consumes this channel after graph execution,
+                    // so an in-graph write-only warning is not actionable here.
+                    if (is_externally_consumed_harness_result(diagnostic)) continue;
                     diagnostics.push_back(make_diagnostic("static", diagnostic.code,
                                                           diagnostic.severity, diagnostic.path,
                                                           diagnostic.message, diagnostic.witness));
@@ -2097,7 +2106,7 @@ struct HarnessService::Impl {
                 } else {
                     run->status = "completed";
                     run->pending                    = nullptr;
-                    run->details = graph_result.channel_raw("final_result");
+                    run->details = graph_result.channel_raw(kHarnessResultChannel);
                     run->details["execution_trace"] = graph_result.execution_trace;
                     const auto base_uri = "neograph://runs/" + run->id;
                     run->result                     = {

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -536,6 +536,17 @@ TEST(HarnessServiceTest, PresetAndEquivalentDslCompileToCanonicalCore) {
     auto preset = service.compile(preset_request);
     ASSERT_TRUE(preset["ok"].get<bool>()) << preset.dump();
 
+    const auto has_final_result_e6 = [](const json& diagnostics) {
+        for (const auto& diagnostic : diagnostics) {
+            if (diagnostic["code"] == "E6" &&
+                diagnostic["path"] == "channels.final_result") {
+                return true;
+            }
+        }
+        return false;
+    };
+    EXPECT_FALSE(has_final_result_e6(preset["diagnostics"])) << preset.dump();
+
     auto dsl_request = preset_request;
     dsl_request["harness"] = {
         {"mode", "dsl"},
@@ -543,6 +554,8 @@ TEST(HarnessServiceTest, PresetAndEquivalentDslCompileToCanonicalCore) {
     };
     auto dsl = service.compile(dsl_request);
     ASSERT_TRUE(dsl["ok"].get<bool>()) << dsl.dump();
+    EXPECT_FALSE(has_final_result_e6(dsl["diagnostics"])) << dsl.dump();
+    EXPECT_EQ(preset["diagnostics"], dsl["diagnostics"]);
 
     EXPECT_EQ(
         neograph::graph::GraphCompiler::canon(preset["artifacts"]["core_lockfile"]["content"]),

--- a/tests/test_validator.cpp
+++ b/tests/test_validator.cpp
@@ -318,6 +318,20 @@ TEST(Validator, E6_DeadChannelWarns) {
     EXPECT_EQ(e6[0]->witness["channel"].get<std::string>(), "unused");
 }
 
+TEST(Validator, E6_WriteOnlyChannelWarns) {
+    json def = {
+        {"channels", {{"out", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"w", {{"type", "vfx_writer"}}}}},
+        {"edges", json::array({{{"from", "__start__"}, {"to", "w"}}})},
+    };
+    auto r = validate_def(def);
+    auto e6 = by_code(r, "E6");
+    ASSERT_EQ(e6.size(), 1u) << r.summary();
+    EXPECT_EQ(e6[0]->witness["channel"].get<std::string>(), "out");
+    ASSERT_TRUE(e6[0]->witness.contains("writers"));
+    EXPECT_EQ(e6[0]->witness["writers"].size(), 1u);
+}
+
 TEST(Validator, E5_OverwriteRaceBetweenFanOutSiblingsWarns) {
     json def = {
         {"channels", {{"out", {{"reducer", "overwrite"}}}}},


### PR DESCRIPTION
## Summary
- treat the produced Harness `final_result` as externally consumed when translating GraphValidator diagnostics
- retain generic E6 warnings for unrelated write-only channels
- keep preset and equivalent DSL diagnostics aligned without changing public graph ABI

## Verification
- regression test failed on `origin/master` and passes with the fix
- `ctest --test-dir build-issue-173 --output-on-failure` (809/809 passed; environment-gated integrations skipped)
- independent review found no blocking issues

Closes #173