### PR TITLE
fix(bench): preserve sub-millisecond timing precision

### DIFF
--- a/benchmarks/bench_neograph.cpp
+++ b/benchmarks/bench_neograph.cpp
@@ -135,7 +135,7 @@ static json par_graph() {
 }
 
 struct BenchResult {
-    long total_ms;
+    double total_ms;
     double per_iter_us;
 };
 
@@ -146,7 +146,7 @@ static BenchResult bench(GraphEngine* engine, int iters) {
     for (int i = 0; i < iters; ++i) {
         (void)engine->run(cfg);
     }
-    auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+    const auto total_ms = std::chrono::duration<double, std::milli>(
         std::chrono::steady_clock::now() - t0).count();
 
     return {total_ms, (total_ms * 1000.0) / iters};
@@ -161,7 +161,7 @@ static BenchResult bench_stream(GraphEngine* engine, int iters, StreamMode mode)
     for (int i = 0; i < iters; ++i) {
         (void)engine->run_stream(cfg, discard);
     }
-    auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+    const auto total_ms = std::chrono::duration<double, std::milli>(
         std::chrono::steady_clock::now() - t0).count();
 
     return {total_ms, (total_ms * 1000.0) / iters};


### PR DESCRIPTION
## Summary

- retain fractional milliseconds in the C++ benchmark elapsed-time result
- derive `per_iter_us` from the full-precision elapsed duration for both normal and streaming workloads
- preserve the existing TSV field order and CI parsing contract

## Verification

```bash
cmake --build build --parallel 18 --target bench_neograph
NEOGRAPH_SUPPRESS_FANOUT_WARNING=1 ./build/bench_neograph 1 1 1 | awk -F "\t" ...
```

The benchmark builds successfully, and a one-iteration run now emits positive fractional `total_ms` and `per_iter_us` values rather than truncating sub-millisecond work to zero.

## Context

Related to #179. The existing milliseconds-to-microseconds conversion is dimensionally correct; this change removes its integer-millisecond precision loss. The benchmark-platform record remains open as a baseline.