### PR TITLE
fix(harness): model exported result channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Harness exported result lint (issue #173).** Node effect contracts may now
+  declare written channels in an optional `exports` array when callers consume
+  them after graph execution. Both Harness compilation and `GraphEngine`
+  runtime validation therefore keep E6 for truly write-only channels without
+  falsely warning on `final_result`.
 - **MCP 2025-11-25 tool-client contract modernization (issue #147 M0).**
   Initialization is now idempotent and retains negotiated server metadata;
   HTTP tools reuse the discovery session; `/mcp` endpoint construction is

--- a/include/neograph/graph/loader.h
+++ b/include/neograph/graph/loader.h
@@ -235,8 +235,13 @@ public:
     /**
      * @brief Register a custom node type with a declared config schema
      *        AND a declared channel-effect contract.
-     * @param effects `{"reads": ["ch", ...], "writes": ["ch", ...]}` —
-     *        the channels instances of this type touch at runtime.
+     * @param effects `{"reads": ["ch", ...], "writes": ["ch", ...],
+     *        "exports": ["result", ...]}` — the channels instances of
+     *        this type touch at runtime. Optional `exports` marks written
+     *        channels that a caller consumes after graph execution, so
+     *        they are not reported as write-only by E6. Only exported
+     *        channels that are also declared in `writes` suppress E6;
+     *        the graph must still declare the channel itself.
      *        Enables static effect checking (GraphValidator E4/E5/E6:
      *        writes to undeclared channels, overwrite races, dead
      *        channels). Effect analysis only runs on graphs where
@@ -248,8 +253,8 @@ public:
 
     /**
      * @brief Declared channel effects for a node type.
-     * @return `{"reads":[...],"writes":[...]}`, or null json for types
-     *         registered without an effect contract.
+     * @return `{"reads":[...],"writes":[...],"exports":[...]}`, or null
+     *         json for types registered without an effect contract.
      */
     json node_effects(const std::string& type) const;
 
@@ -299,8 +304,12 @@ public:
      *   "$schema": "https://json-schema.org/draft/2020-12/schema",
      *   "topology": { ...JSON Schema for the top-level envelope... },
      *   "node_types": { "<type>": { ...config JSON Schema... }, ... },
+     *   "node_effects": {
+     *     "<type>": { "reads": [...], "writes": [...], "exports": [...] }
+     *   },
      *   "reducers":   ["append", "overwrite", ...],
-     *   "conditions": ["has_tool_calls", "route_channel", ...]
+     *   "conditions": ["has_tool_calls", "route_channel", ...],
+     *   "condition_specs": { ... }
      * }
      * @endcode
      *
@@ -309,6 +318,7 @@ public:
      * fragment is fixed (defined by the graph compiler); per-type
      * config schemas come from register_type's 3-arg overload, or
      * default to a permissive object for types registered without one.
+     * `node_effects` preserves each declared effect contract verbatim.
      *
      * @return The schema document as json.
      */

--- a/include/neograph/graph/validator.h
+++ b/include/neograph/graph/validator.h
@@ -128,7 +128,9 @@ public:
      *        E5 overwrite-reducer channel written by two direct
      *        fan-out siblings (warning: racy last-writer-wins);
      *        E6 dead channel — declared but never read nor written,
-     *        read-only without initial value (warnings).
+     *        write-only unless declared as externally consumed through
+     *        an effect contract's optional `exports`, or read-only
+     *        without an initial value (warnings).
      *
      * Pure function of the CompiledGraph + registries; does not
      * execute anything.

--- a/src/core/graph_loader.cpp
+++ b/src/core/graph_loader.cpp
@@ -439,6 +439,7 @@ json NodeFactory::export_schema() const {
     }
 
     // Per-type channel-effect contracts (only types that declared one).
+    // Preserve optional fields such as exports for external tooling.
     json node_effects = json::object();
     for (const auto& kv : registry_) {
         auto eit = effects_.find(kv.first);

--- a/src/core/graph_validator.cpp
+++ b/src/core/graph_validator.cpp
@@ -295,6 +295,7 @@ void check_effects(Ctx& c) {
     // whole family (an unknown type could touch anything).
     std::map<std::string, std::pair<std::set<std::string>, std::set<std::string>>>
         node_rw;   // node -> (reads, writes)
+    std::set<std::string> exported;
     for (const auto& n : c.node_names) {
         const json eff = c.registry.node_effects(c.node_type(n));
         if (eff.is_null() || !eff.is_object()) return;   // gate: skip family
@@ -303,6 +304,12 @@ void check_effects(Ctx& c) {
             for (const auto& ch : eff["reads"]) reads.insert(ch.get<std::string>());
         if (eff.contains("writes"))
             for (const auto& ch : eff["writes"]) writes.insert(ch.get<std::string>());
+        if (eff.contains("exports")) {
+            for (const auto& ch : eff["exports"]) {
+                const auto name = ch.get<std::string>();
+                if (writes.count(name)) exported.insert(name);
+            }
+        }
         node_rw[n] = {std::move(reads), std::move(writes)};
     }
 
@@ -353,7 +360,7 @@ void check_effects(Ctx& c) {
                    "channel '" + ch + "' is declared but no node reads or "
                    "writes it (dead channel)",
                    json{{"channel", ch}});
-        } else if (!r && w && !engine_channel) {
+        } else if (!r && w && !engine_channel && !exported.count(ch)) {
             c.warn("E6", "channels." + ch,
                    "channel '" + ch + "' is written but never read",
                    json{{"channel", ch},

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -52,11 +52,6 @@ constexpr const char* kHarnessResultChannel = "final_result";
 constexpr const char* kTasksExtension = "io.modelcontextprotocol/tasks";
 constexpr const char* kHarnessProfile = "harness-m4";
 
-bool is_externally_consumed_harness_result(const graph::Diagnostic& diagnostic) {
-    return diagnostic.code == "E6" && diagnostic.witness.contains("writers") &&
-           diagnostic.witness.value("channel", "") == kHarnessResultChannel;
-}
-
 int64_t unix_millis() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(
                std::chrono::system_clock::now().time_since_epoch())
@@ -1172,7 +1167,9 @@ void register_harness_node_types() {
             },
             json::parse(
                 R"JSON({"type":"object","properties":{},"additionalProperties":false})JSON"),
-            json::parse(R"JSON({"reads":["worker_results"],"writes":["final_result"]})JSON"));
+            json{{"reads", json::array({"worker_results"})},
+                 {"writes", json::array({kHarnessResultChannel})},
+                 {"exports", json::array({kHarnessResultChannel})}});
     });
 }
 
@@ -1889,9 +1886,6 @@ struct HarnessService::Impl {
                 graph::GraphCompiler::verify_roundtrip(core, compiled);
                 auto report = graph::GraphValidator::validate(compiled);
                 for (const auto& diagnostic : report.diagnostics) {
-                    // HarnessService consumes this channel after graph execution,
-                    // so an in-graph write-only warning is not actionable here.
-                    if (is_externally_consumed_harness_result(diagnostic)) continue;
                     diagnostics.push_back(make_diagnostic("static", diagnostic.code,
                                                           diagnostic.severity, diagnostic.path,
                                                           diagnostic.message, diagnostic.witness));

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -562,6 +562,27 @@ TEST(HarnessServiceTest, PresetAndEquivalentDslCompileToCanonicalCore) {
         neograph::graph::GraphCompiler::canon(dsl["artifacts"]["core_lockfile"]["content"]));
 }
 
+#if GTEST_HAS_STREAM_REDIRECTION
+TEST(HarnessServiceTest, RuntimeValidationHonorsExportedFinalResult) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall&, const auto&) {
+        return HarnessWorkerResponse::success(
+            {{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+    const auto compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+
+    testing::internal::CaptureStderr();
+    const auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    const auto terminal = wait_terminal(service, started["run_id"].get<std::string>());
+    const auto errors = testing::internal::GetCapturedStderr();
+
+    ASSERT_EQ(terminal["status"], "completed") << terminal.dump();
+    EXPECT_EQ(errors.find("[E6] channels.final_result"), std::string::npos) << errors;
+}
+#endif
+
 TEST(HarnessServiceTest, ShipsReviewTriageAndResearchPresets) {
     HarnessService service;
     auto schema = service.schema();

--- a/tests/test_schema_evolution.cpp
+++ b/tests/test_schema_evolution.cpp
@@ -118,6 +118,11 @@ TEST(SchemaEvolution, CurrentSchemaIsBackwardCompatibleWithSnapshot) {
                   string_set(cur["node_effects"][type]["reads"])) << type;
         EXPECT_EQ(string_set(snap_eff["writes"]),
                   string_set(cur["node_effects"][type]["writes"])) << type;
+        if (snap_eff.contains("exports")) {
+            ASSERT_TRUE(cur["node_effects"][type].contains("exports")) << type;
+            EXPECT_EQ(string_set(snap_eff["exports"]),
+                      string_set(cur["node_effects"][type]["exports"])) << type;
+        }
     }
 
     // Topology envelope: properties must not disappear.

--- a/tests/test_validator.cpp
+++ b/tests/test_validator.cpp
@@ -49,6 +49,28 @@ void ensure_vtypes_registered() {
         },
         json::parse(R"({"type":"object"})"),
         json::parse(R"({"reads":["out"],"writes":[]})"));
+    NodeFactory::instance().register_type(
+        "vfx_exporter",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<VNoopNode>(name);
+        },
+        json::parse(R"({"type":"object"})"),
+        json::parse(R"({"reads":[],"writes":["out"],"exports":["out"]})"));
+    NodeFactory::instance().register_type(
+        "vfx_export_only",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<VNoopNode>(name);
+        },
+        json::parse(R"({"type":"object"})"),
+        json::parse(R"({"reads":[],"writes":[],"exports":["out"]})"));
+    NodeFactory::instance().register_type(
+        "vfx_mixed_exporter",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<VNoopNode>(name);
+        },
+        json::parse(R"({"type":"object"})"),
+        json::parse(
+            R"({"reads":[],"writes":["out","internal"],"exports":["out"]})"));
     // closed two-label condition for E10 tests.
     ConditionRegistry::instance().register_condition(
         "vcond_binary",
@@ -330,6 +352,43 @@ TEST(Validator, E6_WriteOnlyChannelWarns) {
     EXPECT_EQ(e6[0]->witness["channel"].get<std::string>(), "out");
     ASSERT_TRUE(e6[0]->witness.contains("writers"));
     EXPECT_EQ(e6[0]->witness["writers"].size(), 1u);
+}
+
+TEST(Validator, E6_ExportedWriteOnlyChannelIsExternallyConsumed) {
+    json def = {
+        {"channels", {{"out", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"w", {{"type", "vfx_exporter"}}}}},
+        {"edges", json::array({{{"from", "__start__"}, {"to", "w"}}})},
+    };
+    auto r = validate_def(def);
+    EXPECT_TRUE(by_code(r, "E6").empty()) << r.summary();
+}
+
+TEST(Validator, E6_ExportWithoutMatchingWriteDoesNotSuppressWarning) {
+    json def = {
+        {"channels", {{"out", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"w", {{"type", "vfx_writer"}}},
+                   {"e", {{"type", "vfx_export_only"}}}}},
+        {"edges", json::array({{{"from", "__start__"}, {"to", "w"}},
+                               {{"from", "w"}, {"to", "e"}}})},
+    };
+    auto r = validate_def(def);
+    auto e6 = by_code(r, "E6");
+    ASSERT_EQ(e6.size(), 1u) << r.summary();
+    EXPECT_EQ(e6[0]->witness["channel"].get<std::string>(), "out");
+}
+
+TEST(Validator, E6_MixedExportsStillWarnForInternalWriteOnlyChannel) {
+    json def = {
+        {"channels", {{"out", {{"reducer", "overwrite"}}},
+                      {"internal", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"w", {{"type", "vfx_mixed_exporter"}}}}},
+        {"edges", json::array({{{"from", "__start__"}, {"to", "w"}}})},
+    };
+    auto r = validate_def(def);
+    auto e6 = by_code(r, "E6");
+    ASSERT_EQ(e6.size(), 1u) << r.summary();
+    EXPECT_EQ(e6[0]->witness["channel"].get<std::string>(), "internal");
 }
 
 TEST(Validator, E5_OverwriteRaceBetweenFanOutSiblingsWarns) {


### PR DESCRIPTION
## Summary
- add optional `exports` entries to node effect contracts for channels consumed after graph execution
- mark Harness `final_result` as exported and remove the Harness-only diagnostic filter
- cover generic E6 behavior, mismatched and mixed exports, preset/DSL parity, and runtime stderr

## Why this follow-up
PR #178 removed E6 from Harness compile diagnostics, but `GraphEngine` validates the topology again at execution time and still printed the warning. This makes both paths use the same semantic declaration.

## Verification
- `ctest --test-dir build-issue-173 --output-on-failure -j2`
- 813/813 passed; 34 environment-dependent PostgreSQL/live WebSocket tests skipped
- independent review: no blocking findings

Closes #173