### PR TITLE
fix(harness): retain aggregate finding provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **Harness aggregate finding provenance (issue #174).** Details now include a
+  `finding_sources` array aligned with the existing flat `findings` array.
+  Every entry records its aggregate index, source worker ID, and worker-local
+  index without changing schema-validated worker output or the established
+  `findings` shape.
 - **Harness exported result lint (issue #173).** Node effect contracts may now
   declare written channels in an optional `exports` array when callers consume
   them after graph execution. Both Harness compilation and `GraphEngine`

--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -383,6 +383,15 @@ The host should follow this sequence:
    returned `neograph://runs/...` URI as `uri`. Do not pull traces into context
    by default.
 
+### Finding Provenance
+
+The details artifact preserves each schema-validated worker response in
+`workers` and keeps the established flat `findings` array for existing clients.
+`finding_sources` is a same-length parallel array: each entry contains the
+aggregate `finding_index`, source `worker_id`, and that worker's `local_index`.
+Use it to identify the source of duplicate local IDs such as `F1`; do not add
+provenance fields to the worker's declared finding object.
+
 ## Host-Brokered Resume
 
 Use `executor.kind: "host_brokered"` when the MCP host, rather than the worker

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -1086,6 +1086,7 @@ public:
 
         json normalized = json::array();
         json findings = json::array();
+        json finding_sources = json::array();
         int valid = 0;
         int failed = 0;
         bool partial = false;
@@ -1108,7 +1109,13 @@ public:
             if (!output.contains("findings") || !output["findings"].is_array()) {
                 findings_contract = false;
             } else {
+                const auto worker_id = worker.value("worker_id", "");
+                std::size_t local_index = 0;
                 for (const auto& finding : output["findings"]) {
+                    finding_sources.push_back(
+                        {{"finding_index", findings.size()},
+                         {"worker_id", worker_id},
+                         {"local_index", local_index++}});
                     findings.push_back(finding);
                 }
             }
@@ -1126,6 +1133,7 @@ public:
             {"outcome", outcome},
             {"workers", std::move(normalized)},
             {"findings", std::move(findings)},
+            {"finding_sources", std::move(finding_sources)},
             {"valid_workers", valid},
             {"failed_workers", failed},
         };

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -1958,6 +1958,10 @@ TEST(HarnessServiceTest, CompatibleForkResumesExactCheckpointWithTargetArtifact)
     EXPECT_EQ(finished["source_checkpoint_id"], source_checkpoint_id);
     ASSERT_EQ(finished["result"]["findings"].size(), 1u);
     EXPECT_EQ(finished["result"]["findings"][0]["evidence"], "source checkpoint");
+    EXPECT_EQ(finished["result"]["finding_sources"],
+              json::array({{{"finding_index", 0},
+                            {"worker_id", "reviewer"},
+                            {"local_index", 0}}}));
     EXPECT_EQ(live_calls.load(std::memory_order_relaxed), 1)
         << "forking after the worker checkpoint must not execute the worker again";
 
@@ -2170,6 +2174,9 @@ TEST(HarnessServiceTest, RecordedReplaySurvivesReconnectWithoutCallingLiveExecut
     EXPECT_EQ(replayed["execution_mode"], "recorded_replay");
     EXPECT_EQ(replayed["source_run_id"], source_run_id);
     EXPECT_EQ(replayed["result"]["workers"], source_workers);
+    EXPECT_EQ(replayed["result"]["finding_sources"],
+              json::array({{{"finding_index", 0}, {"worker_id", "a"}, {"local_index", 0}},
+                           {{"finding_index", 1}, {"worker_id", "b"}, {"local_index", 0}}}));
     EXPECT_EQ(live_calls.load(std::memory_order_relaxed), 3)
         << "recorded replay must not invoke provider/tool execution";
 
@@ -2185,6 +2192,9 @@ TEST(HarnessServiceTest, RecordedReplaySurvivesReconnectWithoutCallingLiveExecut
     ASSERT_EQ(live_result["result"]["findings"].size(), 2u);
     EXPECT_EQ(live_result["result"]["findings"][0]["evidence"], "live a");
     EXPECT_EQ(live_result["result"]["findings"][1]["evidence"], "live b");
+    EXPECT_EQ(live_result["result"]["finding_sources"],
+              json::array({{{"finding_index", 0}, {"worker_id", "a"}, {"local_index", 0}},
+                           {{"finding_index", 1}, {"worker_id", "b"}, {"local_index", 0}}}));
 }
 
 TEST(HarnessServiceTest, RecordedReplayRejectsRedactedWorkerOutputs) {
@@ -2565,6 +2575,39 @@ TEST(HarnessServiceTest, PreservesPartialWorkerOutcome) {
     auto finished = wait_terminal(service, started["run_id"].get<std::string>());
     ASSERT_EQ(finished["status"], "completed") << finished.dump();
     EXPECT_EQ(finished["result"]["outcome"], "partial");
+}
+
+TEST(HarnessServiceTest, AggregatedFindingsRetainWorkerProvenance) {
+    HarnessServiceConfig config;
+    config.worker_executor = [](const HarnessWorkerCall& call, const auto&) {
+        return HarnessWorkerResponse::success({
+            {"status", "ok"},
+            {"findings",
+             json::array({{{"id", "F1"}, {"evidence", call.worker["id"]}},
+                          {{"id", "F2"}, {"evidence", call.worker["id"]}}})},
+        });
+    };
+    HarnessService service(std::move(config));
+    auto compiled = service.compile(request(json::array({worker("b"), worker("a")})));
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    auto finished = wait_terminal(service, started["run_id"].get<std::string>());
+    ASSERT_EQ(finished["status"], "completed") << finished.dump();
+
+    ASSERT_EQ(finished["result"]["findings"].size(), 4u);
+    EXPECT_EQ(finished["result"]["findings"][0]["id"], "F1");
+    EXPECT_EQ(finished["result"]["findings"][2]["id"], "F1");
+    ASSERT_EQ(finished["result"]["finding_sources"].size(), 4u);
+    EXPECT_EQ(finished["result"]["finding_sources"][0],
+              json({{"finding_index", 0}, {"worker_id", "a"}, {"local_index", 0}}));
+    EXPECT_EQ(finished["result"]["finding_sources"][1],
+              json({{"finding_index", 1}, {"worker_id", "a"}, {"local_index", 1}}));
+    EXPECT_EQ(finished["result"]["finding_sources"][2],
+              json({{"finding_index", 2}, {"worker_id", "b"}, {"local_index", 0}}));
+    EXPECT_EQ(finished["result"]["finding_sources"][3],
+              json({{"finding_index", 3}, {"worker_id", "b"}, {"local_index", 1}}));
+    EXPECT_FALSE(finished["result"]["workers"][0]["output"]["findings"][0]
+                     .contains("worker_id"));
 }
 
 TEST(HarnessServiceTest, ReturnsCompactResultAndUriLinkedDetails) {


### PR DESCRIPTION
## Summary
- add an additive `finding_sources` projection parallel to Harness result `findings`
- preserve the established flat findings array and schema-validated worker outputs
- document source mapping and cover deterministic ordering, recorded/live replay, and compatible forks

## Why
Worker-local IDs such as `F1` collide in multi-worker aggregation. The old flat result retained no way to attribute them.

## Verification
- `ctest --test-dir build-issue-174 --output-on-failure -j2`
- 814/814 passed; 34 environment-dependent PostgreSQL/live WebSocket tests skipped
- independent review: no blocking findings

Closes #174