### PR TITLE
feat(harness): add provider budgets

### DIFF
--- a/docs/HARNESS_MCP.md
+++ b/docs/HARNESS_MCP.md
@@ -365,7 +365,9 @@ the Harness tools. A suitable request is:
     "max_steps": 10,
     "timeout_seconds": 600,
     "max_parallel_workers": 2,
-    "max_worker_retries": 1
+    "max_worker_retries": 1,
+    "provider_timeout_seconds": 60,
+    "max_output_tokens": 4096
   },
   "policy": {
     "read_only": true,
@@ -373,6 +375,19 @@ the Harness tools. A suitable request is:
   }
 }
 ```
+
+### Provider Budgets
+
+`budgets.provider_timeout_seconds` limits one provider completion attempt to
+1--600 seconds. `budgets.max_output_tokens` limits one completion to 1--128000
+generated tokens. Both are optional: omitting either preserves the previous
+behavior, with no Harness deadline and the provider's existing output limit.
+
+A worker may set either field to a smaller value. A worker value above the
+Harness-wide value is rejected at compile time. On a deadline, Harness cancels
+only the child cancellation token supplied to that provider call; it does not
+cancel sibling workers or the enclosing run. The provider must honor the token,
+so a provider that cannot be interrupted may return after its deadline.
 
 The host should follow this sequence:
 

--- a/src/mcp/harness.cpp
+++ b/src/mcp/harness.cpp
@@ -52,6 +52,8 @@ constexpr const char* kHarnessResultChannel = "final_result";
 constexpr const char* kTasksExtension = "io.modelcontextprotocol/tasks";
 constexpr const char* kHarnessProfile = "harness-m4";
 
+json effective_provider_budget(const json& request, const json& worker);
+
 int64_t unix_millis() {
     return std::chrono::duration_cast<std::chrono::milliseconds>(
                std::chrono::system_clock::now().time_since_epoch())
@@ -192,6 +194,8 @@ json harness_request_schema() {
                 "id":{"type":"string"},
                 "instructions":{"type":"string"},
                 "tools":{"type":"array","items":{"type":"string"}},
+                "provider_timeout_seconds":{"type":"integer"},
+                "max_output_tokens":{"type":"integer"},
                 "output_schema":{"type":"object"}
             },"additionalProperties":false}},
             "tool_catalog":{"type":"array","items":{"type":"object","required":["id","description","input_schema","executor"],"properties":{
@@ -213,7 +217,9 @@ json harness_request_schema() {
                 "max_steps":{"type":"integer"},
                 "timeout_seconds":{"type":"integer"},
                 "max_parallel_workers":{"type":"integer"},
-                "max_worker_retries":{"type":"integer"}
+                "max_worker_retries":{"type":"integer"},
+                "provider_timeout_seconds":{"type":"integer"},
+                "max_output_tokens":{"type":"integer"}
             },"additionalProperties":false},
             "policy":{"type":"object","properties":{
                 "read_only":{"type":"boolean"},
@@ -925,6 +931,8 @@ public:
             HarnessWorkerCall call;
             call.task = task;
             call.worker = worker_it->second;
+            call.worker["_harness_provider_budget"] = effective_provider_budget(
+                request_, worker_it->second);
             call.tool_catalog = selected_tools;
             call.policy = request_.value("policy", json::object());
             call.attempt = static_cast<std::size_t>(attempt + 1);
@@ -1229,6 +1237,16 @@ void validate_range(const json& budgets,
                 std::to_string(maximum),
             {{"value", value}, {"minimum", minimum}, {"maximum", maximum}}));
     }
+}
+
+json effective_provider_budget(const json& request, const json& worker) {
+    const auto budgets = request.value("budgets", json::object());
+    return {
+        {"provider_timeout_seconds",
+         worker.value("provider_timeout_seconds", budgets.value("provider_timeout_seconds", 0))},
+        {"max_output_tokens",
+         worker.value("max_output_tokens", budgets.value("max_output_tokens", -1))},
+    };
 }
 
 void validate_bindings(const json& request,
@@ -1861,6 +1879,33 @@ struct HarnessService::Impl {
             validate_range(budgets, "timeout_seconds", 1, 86400, 600, diagnostics);
             validate_range(budgets, "max_parallel_workers", 1, 64, 4, diagnostics);
             validate_range(budgets, "max_worker_retries", 0, 5, 1, diagnostics);
+            if (budgets.contains("provider_timeout_seconds")) {
+                validate_range(budgets, "provider_timeout_seconds", 1, 600, 1, diagnostics);
+            }
+            if (budgets.contains("max_output_tokens")) {
+                validate_range(budgets, "max_output_tokens", 1, 128000, 1, diagnostics);
+            }
+            const int provider_timeout = budgets.value("provider_timeout_seconds", 600);
+            const int max_output_tokens = budgets.value("max_output_tokens", 128000);
+            std::size_t worker_index = 0;
+            for (const auto& worker : request["workers"]) {
+                const auto path = "$.workers[" + std::to_string(worker_index++) + "]";
+                for (const auto& [name, maximum] :
+                     std::initializer_list<std::pair<const char*, int>>{
+                         {"provider_timeout_seconds", provider_timeout},
+                         {"max_output_tokens", max_output_tokens}}) {
+                    if (!worker.contains(name)) continue;
+                    const int value = worker[name].get<int>();
+                    if (value < 1 || value > maximum) {
+                        diagnostics.push_back(make_diagnostic(
+                            "request", "H_WORKER_BUDGET", "error", path + "." + name,
+                            std::string(name) + " must be between 1 and " +
+                                std::to_string(maximum) +
+                                " and must not exceed the Harness-wide limit",
+                            {{"value", value}, {"maximum", maximum}}));
+                    }
+                }
+            }
         }
 
         if (!diagnostics_have_errors(diagnostics)) {

--- a/src/mcp/harness_provider.cpp
+++ b/src/mcp/harness_provider.cpp
@@ -9,11 +9,15 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <filesystem>
 #include <map>
+#include <memory>
+#include <mutex>
 #include <random>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -120,6 +124,40 @@ std::string host_call_id() {
     return out.str();
 }
 
+class ProviderDeadline {
+public:
+    ProviderDeadline(std::shared_ptr<graph::CancelToken> cancel, int timeout_seconds)
+        : cancel_(std::move(cancel)) {
+        timer_ = std::thread([this, timeout_seconds] {
+            std::unique_lock lock(mutex_);
+            if (!cv_.wait_for(lock, std::chrono::seconds(timeout_seconds),
+                              [this] { return finished_; })) {
+                expired_.store(true, std::memory_order_release);
+                cancel_->cancel();
+            }
+        });
+    }
+
+    ~ProviderDeadline() {
+        {
+            std::lock_guard lock(mutex_);
+            finished_ = true;
+        }
+        cv_.notify_one();
+        timer_.join();
+    }
+
+    bool expired() const { return expired_.load(std::memory_order_acquire); }
+
+private:
+    std::shared_ptr<graph::CancelToken> cancel_;
+    std::atomic<bool> expired_{false};
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    bool finished_ = false;
+    std::thread timer_;
+};
+
 } // namespace
 
 HarnessWorkerExecutor make_provider_harness_executor(HarnessProviderExecutorConfig config) {
@@ -140,7 +178,11 @@ HarnessWorkerExecutor make_provider_harness_executor(HarnessProviderExecutorConf
         CompletionParams params;
         params.model = config.model;
         params.temperature = 0.0f;
-        params.cancel_token = cancel;
+        const auto budget = call.worker.value("_harness_provider_budget", json::object());
+        const int provider_timeout = budget.value("provider_timeout_seconds", 0);
+        const int max_output_tokens = budget.value("max_output_tokens", -1);
+        params.max_tokens = max_output_tokens;
+        params.cancel_token = cancel->fork();
         params.tools = chat_tools(call.tool_catalog);
         ChatMessage initial;
         initial.role = "user";
@@ -155,24 +197,51 @@ HarnessWorkerExecutor make_provider_harness_executor(HarnessProviderExecutorConf
             detail::append_current_harness_journal_event(
                 "provider.call.started",
                 {{"message_count", params.messages.size()},
+                 {"max_output_tokens",
+                  max_output_tokens < 0 ? json(nullptr) : json(max_output_tokens)},
                  {"model", params.model},
+                 {"provider_timeout_seconds",
+                  provider_timeout == 0 ? json(nullptr) : json(provider_timeout)},
                  {"round", round + 1},
                  {"tool_count", params.tools.size()}},
                 provider_correlation);
+            std::unique_ptr<ProviderDeadline> deadline;
+            if (provider_timeout > 0) {
+                deadline = std::make_unique<ProviderDeadline>(params.cancel_token, provider_timeout);
+            }
+            const auto deadline_expired = [&deadline] {
+                return deadline && deadline->expired();
+            };
             try {
                 completion = config.provider->complete(params);
+                if (deadline_expired()) {
+                    detail::append_current_harness_journal_event(
+                        "provider.call.completed",
+                        {{"duration_ms",
+                          std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::steady_clock::now() - provider_started)
+                              .count()},
+                         {"outcome", "timeout"}},
+                        provider_correlation);
+                    return HarnessWorkerResponse::timeout("provider request exceeded its timeout");
+                }
             } catch (const graph::CancelledException&) {
+                const bool timed_out = deadline_expired();
                 detail::append_current_harness_journal_event(
                     "provider.call.completed",
                     {{"duration_ms",
                       std::chrono::duration_cast<std::chrono::milliseconds>(
                           std::chrono::steady_clock::now() - provider_started)
                           .count()},
-                     {"outcome", "cancelled"}},
+                     {"outcome", timed_out ? "timeout" : "cancelled"}},
                     provider_correlation);
+                if (timed_out) {
+                    return HarnessWorkerResponse::timeout("provider request exceeded its timeout");
+                }
                 return HarnessWorkerResponse::cancelled();
             } catch (const asio::system_error& error) {
-                const bool timed_out = error.code() == asio::error::timed_out;
+                const bool timed_out = error.code() == asio::error::timed_out ||
+                                       deadline_expired();
                 detail::append_current_harness_journal_event(
                     "provider.call.completed",
                     {{"duration_ms",
@@ -185,6 +254,18 @@ HarnessWorkerExecutor make_provider_harness_executor(HarnessProviderExecutorConf
                 if (timed_out) return HarnessWorkerResponse::timeout(error.what());
                 return HarnessWorkerResponse::tool_error(error.what());
             } catch (const std::exception& error) {
+                if (deadline_expired()) {
+                    detail::append_current_harness_journal_event(
+                        "provider.call.completed",
+                        {{"duration_ms",
+                          std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::steady_clock::now() - provider_started)
+                              .count()},
+                         {"error", error.what()},
+                         {"outcome", "timeout"}},
+                        provider_correlation);
+                    return HarnessWorkerResponse::timeout("provider request exceeded its timeout");
+                }
                 detail::append_current_harness_journal_event(
                     "provider.call.completed",
                     {{"duration_ms",

--- a/tests/test_harness_service.cpp
+++ b/tests/test_harness_service.cpp
@@ -238,6 +238,18 @@ private:
     asio::error_code error_;
 };
 
+class CancellationAwareProvider final : public neograph::Provider {
+public:
+    neograph::ChatCompletion complete(const neograph::CompletionParams& params) override {
+        while (!params.cancel_token->is_cancelled()) {
+            std::this_thread::sleep_for(1ms);
+        }
+        throw neograph::graph::CancelledException("provider cancellation observed");
+    }
+
+    std::string get_name() const override { return "cancellation-aware-harness-provider"; }
+};
+
 class StartFailingJournal final : public neograph::mcp::HarnessJournal {
 public:
     void append_event(const json& event) override {
@@ -717,6 +729,124 @@ TEST(HarnessServiceTest, ProviderExecutorPreservesTransportTimeoutKind) {
 
     EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::TIMEOUT);
     EXPECT_FALSE(response.message.empty());
+}
+
+TEST(HarnessServiceTest, ProviderExecutorAppliesEffectiveOutputBudget) {
+    auto provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion completion;
+    completion.message.content = R"({"status":"ok","findings":[]})";
+    provider->completions = {completion};
+    neograph::mcp::HarnessProviderExecutorConfig config;
+    config.provider = provider;
+    auto executor = neograph::mcp::make_provider_harness_executor(std::move(config));
+
+    HarnessWorkerCall call;
+    call.task = {{"objective", "Review"}};
+    call.worker = worker("reviewer");
+    call.worker["_harness_provider_budget"] = {
+        {"provider_timeout_seconds", 5}, {"max_output_tokens", 37}};
+    auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
+
+    ASSERT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::VALUE);
+    ASSERT_EQ(provider->calls.size(), 1u);
+    EXPECT_EQ(provider->calls[0].max_tokens, 37);
+}
+
+TEST(HarnessServiceTest, ProviderExecutorPreservesUnboundedDefaults) {
+    auto provider = std::make_shared<ScriptedProvider>();
+    neograph::ChatCompletion completion;
+    completion.message.content = R"({"status":"ok","findings":[]})";
+    provider->completions = {completion};
+    neograph::mcp::HarnessProviderExecutorConfig config;
+    config.provider = provider;
+    auto executor = neograph::mcp::make_provider_harness_executor(std::move(config));
+
+    HarnessWorkerCall call;
+    call.task = {{"objective", "Review"}};
+    call.worker = worker("reviewer");
+    const auto response = executor(call, std::make_shared<neograph::graph::CancelToken>());
+
+    ASSERT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::VALUE);
+    ASSERT_EQ(provider->calls.size(), 1u);
+    EXPECT_EQ(provider->calls[0].max_tokens, -1);
+}
+
+TEST(HarnessServiceTest, ProviderExecutorDeadlineCancelsOnlyProviderChild) {
+    neograph::mcp::HarnessProviderExecutorConfig config;
+    config.provider = std::make_shared<CancellationAwareProvider>();
+    auto executor = neograph::mcp::make_provider_harness_executor(std::move(config));
+
+    HarnessWorkerCall call;
+    call.task = {{"objective", "Review"}};
+    call.worker = worker("reviewer");
+    call.worker["_harness_provider_budget"] = {
+        {"provider_timeout_seconds", 1}, {"max_output_tokens", 10}};
+    auto parent = std::make_shared<neograph::graph::CancelToken>();
+    auto sibling = parent->fork();
+
+    const auto response = executor(call, parent);
+
+    EXPECT_EQ(response.kind, neograph::mcp::HarnessWorkerResponseKind::TIMEOUT);
+    EXPECT_FALSE(parent->is_cancelled());
+    EXPECT_FALSE(sibling->is_cancelled());
+}
+
+TEST(HarnessServiceTest, RejectsWorkerBudgetAboveHarnessMaximum) {
+    HarnessService service;
+    auto value = request();
+    value["budgets"]["provider_timeout_seconds"] = 10;
+    value["budgets"]["max_output_tokens"] = 100;
+    value["workers"][0]["provider_timeout_seconds"] = 11;
+    value["workers"][0]["max_output_tokens"] = 101;
+    const auto compiled = service.compile(value);
+    ASSERT_FALSE(compiled["ok"].get<bool>());
+    int budget_errors = 0;
+    for (const auto& diagnostic : compiled["diagnostics"])
+        if (diagnostic["code"] == "H_WORKER_BUDGET") ++budget_errors;
+    EXPECT_EQ(budget_errors, 2) << compiled.dump();
+}
+
+TEST(HarnessServiceTest, SuppliesEffectiveProviderBudgetsToWorker) {
+    json observed;
+    HarnessServiceConfig config;
+    config.worker_executor = [&observed](const HarnessWorkerCall& call, const auto&) {
+        observed = call.worker["_harness_provider_budget"];
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+    auto value = request();
+    value["budgets"]["provider_timeout_seconds"] = 30;
+    value["budgets"]["max_output_tokens"] = 100;
+    value["workers"][0]["provider_timeout_seconds"] = 5;
+    value["workers"][0]["max_output_tokens"] = 25;
+    const auto compiled = service.compile(value);
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    ASSERT_TRUE(started["started"].get<bool>()) << started.dump();
+    const auto terminal = wait_terminal(service, started["run_id"].get<std::string>());
+
+    EXPECT_EQ(terminal["status"], "completed") << terminal.dump();
+    EXPECT_EQ(observed["provider_timeout_seconds"], 5);
+    EXPECT_EQ(observed["max_output_tokens"], 25);
+}
+
+TEST(HarnessServiceTest, SuppliesUnboundedProviderBudgetByDefault) {
+    json observed;
+    HarnessServiceConfig config;
+    config.worker_executor = [&observed](const HarnessWorkerCall& call, const auto&) {
+        observed = call.worker["_harness_provider_budget"];
+        return HarnessWorkerResponse::success({{"status", "ok"}, {"findings", json::array()}});
+    };
+    HarnessService service(std::move(config));
+    const auto compiled = service.compile(request());
+    ASSERT_TRUE(compiled["ok"].get<bool>()) << compiled.dump();
+    const auto started = service.start({{"artifact_id", compiled["artifact_id"]}});
+    ASSERT_TRUE(started["started"].get<bool>()) << started.dump();
+    const auto terminal = wait_terminal(service, started["run_id"].get<std::string>());
+
+    EXPECT_EQ(terminal["status"], "completed") << terminal.dump();
+    EXPECT_EQ(observed["provider_timeout_seconds"], 0);
+    EXPECT_EQ(observed["max_output_tokens"], -1);
 }
 
 TEST(HarnessServiceTest, ProviderExecutorKeepsOtherAsioFailuresAsToolErrors) {


### PR DESCRIPTION
## Summary
- add optional Harness and worker provider output-token and deadline budgets
- preserve prior unbounded behavior when budgets are omitted
- cancel only a timed-out provider call's child token and journal effective limits

## Validation
- ctest: 820 passed; 34 environment-dependent PostgreSQL/live-provider tests skipped
- one live OpenAI-compatible gpt-4o-mini Harness call completed with a 32-token output limit and 15-second provider deadline
- independent review found no blocking issues

Closes #175