### PR TITLE
feat(provider): expose normalized completion stop reasons

### DIFF
--- a/bindings/python/src/bind_provider.cpp
+++ b/bindings/python/src/bind_provider.cpp
@@ -287,6 +287,7 @@ void init_provider(py::module_& m) {
     chat_completion
         .def(py::init<>())
         .def_readwrite("message", &neograph::ChatCompletion::message)
+        .def_readwrite("stop_reason", &neograph::ChatCompletion::stop_reason)
         .def_readwrite("usage",   &neograph::ChatCompletion::usage);
 
     py::class_<neograph::ChatCompletion::Usage>(chat_completion, "Usage",

--- a/bindings/python/tests/test_llm_call_contract.py
+++ b/bindings/python/tests/test_llm_call_contract.py
@@ -65,6 +65,14 @@ class _CapturingProvider(ng.Provider):
         return "capturing"
 
 
+def test_chat_completion_exposes_normalized_stop_reason():
+    completion = ng.ChatCompletion()
+
+    assert completion.stop_reason == "unknown"
+    completion.stop_reason = "max_tokens"
+    assert completion.stop_reason == "max_tokens"
+
+
 def _definition(node):
     return {
         "name": "llm-call-contract",

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -210,6 +210,7 @@ Result of a single LLM completion call.
 ```cpp
 struct ChatCompletion {
     ChatMessage message;   // The assistant's response message
+    std::string stop_reason = "unknown";
     struct Usage {
         int prompt_tokens = 0;      // Tokens in the prompt
         int completion_tokens = 0;  // Tokens in the completion
@@ -221,9 +222,14 @@ struct ChatCompletion {
 | Field | Type | Description |
 |-------|------|-------------|
 | `message` | `ChatMessage` | The assistant's response (may include tool calls) |
+| `stop_reason` | `std::string` | Normalized provider completion reason: `end_turn`, `max_tokens`, `stop_sequence`, `tool_use`, `content_filter`, `refusal`, or `unknown` |
 | `usage.prompt_tokens` | `int` | Number of tokens in the input prompt |
 | `usage.completion_tokens` | `int` | Number of tokens in the generated completion |
 | `usage.total_tokens` | `int` | Total tokens consumed (prompt + completion) |
+
+`stop_reason` was added to the public C++ struct. Recompile applications and
+shared-library consumers when upgrading to this release because the struct's
+binary layout changed.
 
 ### Helper Functions
 

--- a/docs/reference-ko.md
+++ b/docs/reference-ko.md
@@ -139,6 +139,7 @@ LLM 호출 결과. 응답 메시지와 토큰 사용량을 포함한다.
 ```cpp
 struct ChatCompletion {
     ChatMessage message;          // 응답 메시지
+    std::string stop_reason = "unknown"; // 정규화한 종료 사유
     struct Usage {
         int prompt_tokens = 0;    // 입력 토큰 수
         int completion_tokens = 0; // 출력 토큰 수
@@ -146,6 +147,13 @@ struct ChatCompletion {
     } usage;
 };
 ```
+
+`stop_reason`은 Provider가 응답을 끝낸 이유를 공통 값으로 바꿔 담는다.
+값은 `end_turn`, `max_tokens`, `stop_sequence`, `tool_use`,
+`content_filter`, `refusal`, `unknown` 중 하나다. 이 필드가 추가되어
+`ChatCompletion`의 C++ 바이너리 구조가 바뀌었으므로, 이 버전으로
+업그레이드할 때는 이를 사용하는 애플리케이션과 공유 라이브러리를 다시
+빌드해야 한다.
 
 ---
 

--- a/include/neograph/llm/schema_provider.h
+++ b/include/neograph/llm/schema_provider.h
@@ -293,6 +293,11 @@ class NEOGRAPH_API SchemaProvider : public Provider {
         std::string prompt_tokens_field;
         std::string completion_tokens_field;
         std::string total_tokens_field;
+        std::string stop_reason_path;
+        std::map<std::string, std::string> stop_reason_map;
+        std::string stop_reason_status_path;
+        std::map<std::string, std::string> stop_reason_status_map;
+        std::string default_stop_reason = "unknown";
     };
 
     struct StreamConfig {
@@ -312,6 +317,8 @@ class NEOGRAPH_API SchemaProvider : public Provider {
         std::string delta_function_call_field;
         std::string delta_tool_call_name_field;
         std::string delta_tool_call_args_field;
+        std::string stop_reason_path;
+        std::string stop_reason_status_path;
         json events_config;
     };
 
@@ -395,6 +402,8 @@ class NEOGRAPH_API SchemaProvider : public Provider {
 
     ChatMessage parse_response(const json& resp_json) const;
     ChatCompletion::Usage parse_usage(const json& resp_json) const;
+    std::string parse_stop_reason(const json& resp_json) const;
+    std::string parse_stream_stop_reason(const json& event_json) const;
 
     std::string build_endpoint(const std::string& model, bool streaming) const;
     std::map<std::string, std::string> build_headers() const;

--- a/include/neograph/types.h
+++ b/include/neograph/types.h
@@ -61,6 +61,11 @@ struct ChatTool {
 struct ChatCompletion {
     ChatMessage message;  ///< The response message from the LLM.
 
+    /// Normalized reason the provider stopped: `end_turn`, `max_tokens`,
+    /// `stop_sequence`, `tool_use`, `content_filter`, `refusal`, or `unknown`.
+    /// Adding this field changes the C++ ABI; recompile consumers with this release.
+    std::string stop_reason = "unknown";
+
     /// Token usage statistics for the completion.
     struct Usage {
         int prompt_tokens = 0;      ///< Number of tokens in the prompt.

--- a/schemas/claude.json
+++ b/schemas/claude.json
@@ -94,7 +94,16 @@
     "usage_path": "usage",
     "prompt_tokens_field": "input_tokens",
     "completion_tokens_field": "output_tokens",
-    "total_tokens_field": ""
+    "total_tokens_field": "",
+    "stop_reason_path": "stop_reason",
+    "stop_reason_map": {
+      "end_turn": "end_turn",
+      "max_tokens": "max_tokens",
+      "stop_sequence": "stop_sequence",
+      "tool_use": "tool_use",
+      "refusal": "refusal"
+    },
+    "default_stop_reason": "end_turn"
   },
   "streaming": {
     "format": "sse_events",
@@ -127,6 +136,7 @@
       "message_stop": {
         "action": "done"
       }
-    }
+    },
+    "stop_reason_path": "delta.stop_reason"
   }
 }

--- a/schemas/gemini.json
+++ b/schemas/gemini.json
@@ -94,7 +94,18 @@
     "usage_path": "usageMetadata",
     "prompt_tokens_field": "promptTokenCount",
     "completion_tokens_field": "candidatesTokenCount",
-    "total_tokens_field": "totalTokenCount"
+    "total_tokens_field": "totalTokenCount",
+    "stop_reason_path": "candidates.0.finishReason",
+    "stop_reason_map": {
+      "STOP": "end_turn",
+      "MAX_TOKENS": "max_tokens",
+      "SAFETY": "content_filter",
+      "RECITATION": "content_filter",
+      "BLOCKLIST": "content_filter",
+      "PROHIBITED_CONTENT": "content_filter",
+      "SPII": "content_filter"
+    },
+    "default_stop_reason": "end_turn"
   },
   "streaming": {
     "format": "sse_data",
@@ -105,6 +116,7 @@
     "text_field": "text",
     "function_call_field": "functionCall",
     "tool_call_name_field": "name",
-    "tool_call_args_field": "args"
+    "tool_call_args_field": "args",
+    "stop_reason_path": "candidates.0.finishReason"
   }
 }

--- a/schemas/openai.json
+++ b/schemas/openai.json
@@ -87,7 +87,16 @@
     "usage_path": "usage",
     "prompt_tokens_field": "prompt_tokens",
     "completion_tokens_field": "completion_tokens",
-    "total_tokens_field": "total_tokens"
+    "total_tokens_field": "total_tokens",
+    "stop_reason_path": "choices.0.finish_reason",
+    "stop_reason_map": {
+      "stop": "end_turn",
+      "length": "max_tokens",
+      "tool_calls": "tool_use",
+      "function_call": "tool_use",
+      "content_filter": "content_filter"
+    },
+    "default_stop_reason": "end_turn"
   },
   "streaming": {
     "format": "sse_data",
@@ -99,6 +108,7 @@
     "tool_call_index_field": "index",
     "tool_call_id_field": "id",
     "tool_call_name_path": "function.name",
-    "tool_call_args_path": "function.arguments"
+    "tool_call_args_path": "function.arguments",
+    "stop_reason_path": "choices.0.finish_reason"
   }
 }

--- a/schemas/openai_responses.json
+++ b/schemas/openai_responses.json
@@ -87,7 +87,17 @@
     "usage_path": "usage",
     "prompt_tokens_field": "input_tokens",
     "completion_tokens_field": "output_tokens",
-    "total_tokens_field": "total_tokens"
+    "total_tokens_field": "total_tokens",
+    "stop_reason_path": "incomplete_details.reason",
+    "stop_reason_status_path": "status",
+    "stop_reason_map": {
+      "max_output_tokens": "max_tokens",
+      "content_filter": "content_filter"
+    },
+    "stop_reason_status_map": {
+      "incomplete": "unknown"
+    },
+    "default_stop_reason": "end_turn"
   },
   "streaming": {
     "format": "sse_events",
@@ -132,7 +142,12 @@
       },
       "response.completed": {
         "action": "done"
+      },
+      "response.incomplete": {
+        "action": "done"
       }
-    }
+    },
+    "stop_reason_path": "response.incomplete_details.reason",
+    "stop_reason_status_path": "response.status"
   }
 }

--- a/src/llm/openai_provider.cpp
+++ b/src/llm/openai_provider.cpp
@@ -118,6 +118,18 @@ int parse_retry_after_seconds(std::string_view raw) {
     return seconds;
 }
 
+std::string normalize_finish_reason(const json& choice) {
+    if (!choice.contains("finish_reason") || choice["finish_reason"].is_null()) {
+        return {};
+    }
+    const auto reason = choice.value("finish_reason", "");
+    if (reason == "stop") return "end_turn";
+    if (reason == "length") return "max_tokens";
+    if (reason == "tool_calls" || reason == "function_call") return "tool_use";
+    if (reason == "content_filter") return "content_filter";
+    return "unknown";
+}
+
 } // namespace
 
 asio::awaitable<ChatCompletion>
@@ -162,6 +174,10 @@ OpenAIProvider::complete_async(const CompletionParams& params)
 
     ChatCompletion completion;
     completion.message = parse_response_message(choice);
+    completion.stop_reason = normalize_finish_reason(choice);
+    if (completion.stop_reason.empty()) {
+        completion.stop_reason = completion.message.tool_calls.empty() ? "end_turn" : "tool_use";
+    }
 
     if (resp_json.contains("usage")) {
         auto u = resp_json["usage"];
@@ -207,6 +223,7 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
     // Buffer for partial SSE lines across chunk boundaries
     std::string line_buffer;
     std::exception_ptr stream_error;
+    std::string observed_stop_reason;
 
     int response_status = 0;
     std::string error_body;
@@ -276,6 +293,10 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
 
                     if (!j.contains("choices") || !j["choices"].is_array()
                         || j["choices"].empty()) continue;
+                    if (const auto reason = normalize_finish_reason(j["choices"][0]);
+                        !reason.empty()) {
+                        observed_stop_reason = reason;
+                    }
                     auto delta = j["choices"][0]["delta"];
 
                     // Content token
@@ -338,6 +359,9 @@ OpenAIProvider::complete_stream(const CompletionParams& params,
     for (auto& [idx, tc] : tc_map) {
         completion.message.tool_calls.push_back(tc);
     }
+    completion.stop_reason = observed_stop_reason.empty()
+        ? (completion.message.tool_calls.empty() ? "end_turn" : "tool_use")
+        : observed_stop_reason;
 
     return completion;
 }

--- a/src/llm/schema_provider.cpp
+++ b/src/llm/schema_provider.cpp
@@ -311,6 +311,23 @@ void SchemaProvider::parse_schema()
     resp_.prompt_tokens_field = resp.value("prompt_tokens_field", "prompt_tokens");
     resp_.completion_tokens_field = resp.value("completion_tokens_field", "completion_tokens");
     resp_.total_tokens_field = resp.value("total_tokens_field", "total_tokens");
+    resp_.stop_reason_path = resp.value("stop_reason_path", "");
+    if (resp.contains("stop_reason_map") && resp["stop_reason_map"].is_object()) {
+        for (const auto& [raw, normalized] : resp["stop_reason_map"].items()) {
+            if (normalized.is_string()) {
+                resp_.stop_reason_map[raw] = normalized.get<std::string>();
+            }
+        }
+    }
+    resp_.stop_reason_status_path = resp.value("stop_reason_status_path", "");
+    if (resp.contains("stop_reason_status_map") && resp["stop_reason_status_map"].is_object()) {
+        for (const auto& [raw, normalized] : resp["stop_reason_status_map"].items()) {
+            if (normalized.is_string()) {
+                resp_.stop_reason_status_map[raw] = normalized.get<std::string>();
+            }
+        }
+    }
+    resp_.default_stop_reason = resp.value("default_stop_reason", "unknown");
 
     // --- Streaming ---
     auto st = schema_["streaming"];
@@ -335,6 +352,8 @@ void SchemaProvider::parse_schema()
     stream_.delta_function_call_field = st.value("function_call_field", "functionCall");
     stream_.delta_tool_call_name_field = st.value("tool_call_name_field", "name");
     stream_.delta_tool_call_args_field = st.value("tool_call_args_field", "args");
+    stream_.stop_reason_path = st.value("stop_reason_path", "");
+    stream_.stop_reason_status_path = st.value("stop_reason_status_path", "");
     if (st.contains("events")) {
         stream_.events_config = st["events"];
     }
@@ -1173,6 +1192,58 @@ ChatCompletion::Usage SchemaProvider::parse_usage(const json& resp_json) const {
     return usage;
 }
 
+std::string SchemaProvider::parse_stop_reason(const json& resp_json) const {
+    auto map_reason = [](const json& value,
+                         const std::map<std::string, std::string>& mapping,
+                         bool unknown_when_unmapped) {
+        if (!value.is_string()) return std::string{};
+        const auto raw = value.get<std::string>();
+        const auto it = mapping.find(raw);
+        if (it != mapping.end()) return it->second;
+        return unknown_when_unmapped ? std::string("unknown") : std::string{};
+    };
+
+    if (!resp_.stop_reason_path.empty()) {
+        if (const auto value = json_path::at_path(resp_json, resp_.stop_reason_path)) {
+            if (const auto mapped = map_reason(*value, resp_.stop_reason_map, true); !mapped.empty()) {
+                return mapped;
+            }
+        }
+    }
+    if (!resp_.stop_reason_status_path.empty()) {
+        if (const auto value = json_path::at_path(resp_json, resp_.stop_reason_status_path)) {
+            return map_reason(*value, resp_.stop_reason_status_map, false);
+        }
+    }
+    return {};
+}
+
+std::string SchemaProvider::parse_stream_stop_reason(const json& event_json) const {
+    auto map_reason = [](const json& value,
+                         const std::map<std::string, std::string>& mapping,
+                         bool unknown_when_unmapped) {
+        if (!value.is_string()) return std::string{};
+        const auto raw = value.get<std::string>();
+        const auto it = mapping.find(raw);
+        if (it != mapping.end()) return it->second;
+        return unknown_when_unmapped ? std::string("unknown") : std::string{};
+    };
+
+    if (!stream_.stop_reason_path.empty()) {
+        if (const auto value = json_path::at_path(event_json, stream_.stop_reason_path)) {
+            if (const auto mapped = map_reason(*value, resp_.stop_reason_map, true); !mapped.empty()) {
+                return mapped;
+            }
+        }
+    }
+    if (!stream_.stop_reason_status_path.empty()) {
+        if (const auto value = json_path::at_path(event_json, stream_.stop_reason_status_path)) {
+            return map_reason(*value, resp_.stop_reason_status_map, false);
+        }
+    }
+    return {};
+}
+
 // ============================================================================
 // HTTP: complete()
 // ============================================================================
@@ -1266,6 +1337,12 @@ SchemaProvider::complete_async(const CompletionParams& params)
         std::lock_guard<std::mutex> lock(schema_mutex_);
         completion.message = parse_response(resp_json);
         completion.usage = parse_usage(resp_json);
+        completion.stop_reason = parse_stop_reason(resp_json);
+        if (completion.stop_reason.empty()) {
+            completion.stop_reason = completion.message.tool_calls.empty()
+                ? resp_.default_stop_reason
+                : "tool_use";
+        }
     }
 
     co_return completion;
@@ -1329,6 +1406,7 @@ ChatCompletion SchemaProvider::complete_stream(const CompletionParams& params,
     std::string full_content;
     std::map<int, ToolCall> tc_map;
     std::string line_buffer;
+    std::string observed_stop_reason;
 
     // SSE_EVENTS: track current block/item (used by Claude and OpenAI Responses)
     struct EventBlock {
@@ -1370,6 +1448,9 @@ ChatCompletion SchemaProvider::complete_stream(const CompletionParams& params,
 
                     try {
                         auto j = json::parse(payload);
+                        if (const auto reason = parse_stream_stop_reason(j); !reason.empty()) {
+                            observed_stop_reason = reason;
+                        }
 
                         // Usage capture: OpenAI-compatible endpoints emit
                         // `usage` on the FINAL chunk (with empty choices,
@@ -1464,6 +1545,9 @@ ChatCompletion SchemaProvider::complete_stream(const CompletionParams& params,
 
                     try {
                         auto j = json::parse(payload);
+                        if (const auto reason = parse_stream_stop_reason(j); !reason.empty()) {
+                            observed_stop_reason = reason;
+                        }
 
                         if (!stream_.events_config.contains(current_event_type)) continue;
                         auto event_cfg = stream_.events_config[current_event_type];
@@ -1620,6 +1704,9 @@ ChatCompletion SchemaProvider::complete_stream(const CompletionParams& params,
     for (auto& [idx, tc] : tc_map) {
         completion.message.tool_calls.push_back(tc);
     }
+    completion.stop_reason = observed_stop_reason.empty()
+        ? (completion.message.tool_calls.empty() ? resp_.default_stop_reason : "tool_use")
+        : observed_stop_reason;
 
     return completion;
 }
@@ -1829,6 +1916,7 @@ SchemaProvider::complete_stream_ws_responses(const CompletionParams& params,
     completion.message.role = "assistant";
     std::string full_content;
     std::map<int, ToolCall> tc_map;
+    std::string observed_stop_reason;
 
     struct EventBlock {
         std::string type;
@@ -1919,6 +2007,9 @@ SchemaProvider::complete_stream_ws_responses(const CompletionParams& params,
 
         std::string event_type = j.value("type", "");
         if (event_type.empty()) continue;
+        if (const auto reason = parse_stream_stop_reason(j); !reason.empty()) {
+            observed_stop_reason = reason;
+        }
 
         // Server-side error frames terminate the stream with detail.
         if (event_type == "error") {
@@ -2014,6 +2105,9 @@ SchemaProvider::complete_stream_ws_responses(const CompletionParams& params,
     for (auto& [_, tc] : tc_map) {
         completion.message.tool_calls.push_back(tc);
     }
+    completion.stop_reason = observed_stop_reason.empty()
+        ? (completion.message.tool_calls.empty() ? resp_.default_stop_reason : "tool_use")
+        : observed_stop_reason;
     co_return completion;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(neograph_tests
     test_schema_provider_concurrent.cpp
     test_schema_provider_stream_usage.cpp
     test_schema_provider_responses_stream.cpp
+    test_schema_provider_stop_reason.cpp
     test_rate_limited_provider.cpp
     test_admin_api_barrier_preservation.cpp
     test_intent_classifier_streaming.cpp

--- a/tests/test_openai_provider_async.cpp
+++ b/tests/test_openai_provider_async.cpp
@@ -131,6 +131,7 @@ TEST(OpenAIProviderAsync, CompleteAsyncReturnsParsedCompletion) {
     EXPECT_EQ(result.usage.prompt_tokens, 7);
     EXPECT_EQ(result.usage.completion_tokens, 2);
     EXPECT_EQ(result.usage.total_tokens, 9);
+    EXPECT_EQ(result.stop_reason, "end_turn");
     EXPECT_EQ(mock.request_count.load(), 1);
 }
 
@@ -268,6 +269,7 @@ TEST(OpenAIProviderStream, SuccessfulContentAndUsageRemainIntact) {
     EXPECT_EQ(completion.usage.prompt_tokens, 7);
     EXPECT_EQ(completion.usage.completion_tokens, 2);
     EXPECT_EQ(completion.usage.total_tokens, 9);
+    EXPECT_EQ(completion.stop_reason, "end_turn");
 }
 
 TEST(OpenAIProviderStream, VersionedBaseUrlDoesNotDuplicateVersionPath) {

--- a/tests/test_schema_provider_responses_stream.cpp
+++ b/tests/test_schema_provider_responses_stream.cpp
@@ -120,6 +120,7 @@ TEST(SchemaProviderResponsesStream, TextDeltasAccumulateAndUsageCaptured) {
     EXPECT_EQ(42, r.usage.prompt_tokens);
     EXPECT_EQ(18, r.usage.completion_tokens);
     EXPECT_EQ(60, r.usage.total_tokens);
+    EXPECT_EQ("end_turn", r.stop_reason);
 }
 
 TEST(SchemaProviderResponsesStream,

--- a/tests/test_schema_provider_stop_reason.cpp
+++ b/tests/test_schema_provider_stop_reason.cpp
@@ -1,0 +1,112 @@
+// Provider schemas carry vendor-specific completion reasons. This pins their
+// normalized public contract without contacting an external provider.
+
+#include <gtest/gtest.h>
+#include <neograph/llm/schema_provider.h>
+
+#define CPPHTTPLIB_OPENSSL_SUPPORT
+#include <httplib.h>
+
+#include <chrono>
+#include <string>
+#include <thread>
+
+using namespace neograph;
+
+namespace {
+
+struct StopReasonMock {
+    httplib::Server svr;
+    std::thread t;
+    int port = 0;
+
+    StopReasonMock() {
+        svr.Post("/v1/chat/completions",
+            [](const httplib::Request& req, httplib::Response& res) {
+                if (req.body.find("gpt-tool") != std::string::npos) {
+                    res.set_content(R"({"choices":[{"message":{"role":"assistant","content":"done","tool_calls":[{"id":"call_1","function":{"name":"lookup","arguments":"{}"}}]},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}})", "application/json");
+                    return;
+                }
+                res.set_content(R"({"choices":[{"message":{"role":"assistant","content":"done"},"finish_reason":"length"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}})", "application/json");
+            });
+        svr.Post("/v1/messages",
+            [](const httplib::Request& req, httplib::Response& res) {
+                if (req.body.find("claude-refusal") != std::string::npos) {
+                    res.set_content(R"({"content":[{"type":"text","text":"done"}],"stop_reason":"refusal","usage":{"input_tokens":1,"output_tokens":2}})", "application/json");
+                    return;
+                }
+                res.set_content(R"({"content":[{"type":"text","text":"done"}],"stop_reason":"stop_sequence","usage":{"input_tokens":1,"output_tokens":2}})", "application/json");
+            });
+        svr.Post("/v1beta/models/gemini-test:generateContent",
+            [](const httplib::Request&, httplib::Response& res) {
+                res.set_content(R"({"candidates":[{"content":{"parts":[{"text":"done"}]},"finishReason":"SAFETY"}],"usageMetadata":{"promptTokenCount":1,"candidatesTokenCount":2,"totalTokenCount":3}})", "application/json");
+            });
+        svr.Post("/v1/responses",
+            [](const httplib::Request& req, httplib::Response& res) {
+                if (req.body.find("gpt-complete") != std::string::npos) {
+                    res.set_content(R"({"status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}})", "application/json");
+                    return;
+                }
+                res.set_content(R"({"status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"output":[{"type":"message","content":[{"type":"output_text","text":"done"}]}],"usage":{"input_tokens":1,"output_tokens":2,"total_tokens":3}})", "application/json");
+            });
+
+        port = svr.bind_to_any_port("127.0.0.1");
+        t = std::thread([this] { svr.listen_after_bind(); });
+        for (int i = 0; i < 200 && !svr.is_running(); ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+    }
+
+    ~StopReasonMock() {
+        svr.stop();
+        if (t.joinable()) t.join();
+    }
+};
+
+llm::SchemaProvider::Config config_for(const std::string& schema, int port,
+                                       const std::string& model) {
+    llm::SchemaProvider::Config cfg;
+    cfg.schema_path = schema;
+    cfg.api_key = "test-key";
+    cfg.default_model = model;
+    cfg.timeout_seconds = 10;
+    cfg.base_url_override = "http://127.0.0.1:" + std::to_string(port);
+    return cfg;
+}
+
+CompletionParams params_for(const std::string& model) {
+    CompletionParams params;
+    params.model = model;
+    params.messages.push_back({"user", "hello"});
+    return params;
+}
+
+} // namespace
+
+TEST(SchemaProviderStopReason, BundledSchemasNormalizeProviderReasons) {
+    StopReasonMock mock;
+    ASSERT_GT(mock.port, 0);
+
+    struct Case {
+        const char* schema;
+        const char* model;
+        const char* expected_reason;
+    };
+    const Case cases[] = {
+        {"openai", "gpt-test", "max_tokens"},
+        {"openai", "gpt-tool", "tool_use"},
+        {"claude", "claude-test", "stop_sequence"},
+        {"claude", "claude-refusal", "refusal"},
+        {"gemini", "gemini-test", "content_filter"},
+        {"openai_responses", "gpt-test", "max_tokens"},
+        {"openai_responses", "gpt-complete", "end_turn"},
+    };
+
+    for (const auto& test : cases) {
+        auto provider = llm::SchemaProvider::create(
+            config_for(test.schema, mock.port, test.model));
+        const auto completion = provider->complete(params_for(test.model));
+        EXPECT_EQ(completion.stop_reason, test.expected_reason) << test.schema;
+        EXPECT_EQ(completion.message.content, "done") << test.schema;
+    }
+}

--- a/tests/test_schema_provider_stream_usage.cpp
+++ b/tests/test_schema_provider_stream_usage.cpp
@@ -63,7 +63,7 @@ struct ClaudeStreamMock {
                     "data: {\"type\":\"content_block_stop\",\"index\":0}\n"
                     "\n"
                     "event: message_delta\n"
-                    "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"output_tokens\":7}}\n"
+                     "data: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"stop_sequence\"},\"usage\":{\"output_tokens\":7}}\n"
                     "\n"
                     "event: message_stop\n"
                     "data: {\"type\":\"message_stop\"}\n"
@@ -99,7 +99,7 @@ struct OpenAIStreamMock {
                     "\n"
                     "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\" there\"},\"finish_reason\":null}]}\n"
                     "\n"
-                    "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n"
+                     "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"length\"}]}\n"
                     "\n"
                     "data: {\"id\":\"c1\",\"object\":\"chat.completion.chunk\",\"choices\":[],\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":3,\"total_tokens\":15}}\n"
                     "\n"
@@ -152,6 +152,7 @@ TEST(SchemaProviderStreamUsage, ClaudeStreamingPopulatesUsage) {
         << "message_start's input_tokens lost — pre-audit regression";
     EXPECT_EQ(7, result.usage.completion_tokens)
         << "message_delta's output_tokens lost — pre-audit regression";
+    EXPECT_EQ("stop_sequence", result.stop_reason);
 }
 
 TEST(SchemaProviderStreamUsage, OpenAIStreamingPopulatesUsage) {
@@ -183,4 +184,5 @@ TEST(SchemaProviderStreamUsage, OpenAIStreamingPopulatesUsage) {
     EXPECT_EQ(12, result.usage.prompt_tokens);
     EXPECT_EQ(3,  result.usage.completion_tokens);
     EXPECT_EQ(15, result.usage.total_tokens);
+    EXPECT_EQ("max_tokens", result.stop_reason);
 }

--- a/tests/test_schema_provider_ws_responses.cpp
+++ b/tests/test_schema_provider_ws_responses.cpp
@@ -79,6 +79,8 @@ TEST(SchemaProviderWs, LiveRoundTripIfEnabled) {
         << "response.completed should populate prompt_tokens";
     EXPECT_GT(completion.usage.completion_tokens, 0)
         << "response.completed should populate completion_tokens";
+    EXPECT_EQ(completion.stop_reason, "end_turn")
+        << "response.completed should normalize to end_turn";
 }
 
 TEST(SchemaProviderWs, LiveToolCallIfEnabled) {


### PR DESCRIPTION
## Summary
- Add ChatCompletion::stop_reason with normalized provider outcomes.
- Map OpenAI, Claude, Gemini, and OpenAI Responses finish reasons across non-streaming and streaming transports.
- Expose the field to Python and document the C++ ABI rebuild requirement.

## Validation
- ctest --output-on-failure: 821 passed; 34 environment-gated tests skipped.
- Python binding test: 6 passed.
- Live OpenAI WebSocket test: one gpt-4o-mini request passed.

Closes #183.