### PR TITLE
Harden deferred async input ownership and track API v1 work

### DIFF
--- a/include/neograph/async/conn_pool.h
+++ b/include/neograph/async/conn_pool.h
@@ -73,6 +73,7 @@ public:
     /// reaching into another bucket from a pooled request hides
     /// too much for the library to do behind the caller's back.
     /// Use the free async_post for redirect-following.
+    /// Request inputs are copied before the returned awaitable is exposed.
     asio::awaitable<HttpResponse> async_post(
         std::string_view host,
         std::string_view port,
@@ -88,6 +89,15 @@ public:
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;
+
+    asio::awaitable<HttpResponse> async_post_owned(
+        std::string host,
+        std::string port,
+        std::string path,
+        std::string body,
+        std::vector<std::pair<std::string, std::string>> headers,
+        bool tls,
+        RequestOptions opts);
 };
 
 } // namespace neograph::async

--- a/include/neograph/async/http_client.h
+++ b/include/neograph/async/http_client.h
@@ -96,6 +96,9 @@ struct RequestOptions {
 /// @param tls     When true, wrap the socket in asio::ssl::stream, do
 ///                TLS handshake with SNI=host, and verify the peer
 ///                certificate against the system trust store.
+///
+/// All request inputs are copied before this function returns, so the
+/// returned awaitable does not borrow the caller's strings or header vector.
 NEOGRAPH_API asio::awaitable<HttpResponse> async_post(
     asio::any_io_executor ex,
     std::string_view host,
@@ -110,6 +113,7 @@ NEOGRAPH_API asio::awaitable<HttpResponse> async_post(
 /// request with an empty body and no Content-Length / Content-Type
 /// headers — used for resources like the A2A `/.well-known/agent-card.json`
 /// discovery endpoint.
+/// Request inputs are copied before the returned awaitable is exposed.
 NEOGRAPH_API asio::awaitable<HttpResponse> async_get(
     asio::any_io_executor ex,
     std::string_view host,
@@ -144,6 +148,8 @@ struct HttpStreamResponse {
 ///
 /// The bytes passed to `on_chunk` are only valid for the duration
 /// of the callback invocation; copy them out if you need to retain.
+/// The callback object and request inputs are copied before this function
+/// returns. Objects referenced by the callback's captures remain caller-owned.
 NEOGRAPH_API asio::awaitable<HttpStreamResponse> async_post_stream(
     asio::any_io_executor ex,
     std::string_view host,

--- a/include/neograph/async/ws_client.h
+++ b/include/neograph/async/ws_client.h
@@ -82,10 +82,12 @@ class NEOGRAPH_API WsClient {
 
     /// Send a text frame (FIN=1, no fragmentation). Payload must be
     /// valid UTF-8 per RFC 6455 §5.6 — this client does NOT validate;
-    /// the caller is responsible. Masked per §5.3.
+    /// the caller is responsible. Masked per §5.3. The payload is copied
+    /// before the returned awaitable is exposed.
     asio::awaitable<void> send_text(std::string_view payload);
 
-    /// Send a binary frame (FIN=1). Masked per §5.3.
+    /// Send a binary frame (FIN=1). Masked per §5.3. The payload is copied
+    /// before the returned awaitable is exposed.
     asio::awaitable<void> send_binary(std::string_view payload);
 
     /// Send a close frame with the given status code and optional
@@ -121,6 +123,18 @@ class NEOGRAPH_API WsClient {
     std::unique_ptr<Impl> impl_;
 
     explicit WsClient(std::unique_ptr<Impl>);
+
+    asio::awaitable<void> send_frame_owned(WsOpcode opcode,
+                                           std::string payload);
+    asio::awaitable<void> send_close_owned(std::uint16_t code,
+                                           std::string reason);
+    static asio::awaitable<std::unique_ptr<WsClient>> connect_owned(
+        asio::any_io_executor ex,
+        std::string host,
+        std::string port,
+        std::string path,
+        std::vector<std::pair<std::string, std::string>> headers,
+        bool tls);
 };
 
 /// Establish a WebSocket connection.
@@ -138,6 +152,7 @@ class NEOGRAPH_API WsClient {
 ///
 /// Throws asio::system_error on transport failure, std::runtime_error
 /// if the server refuses the upgrade (non-101 status or bad Accept).
+/// Request inputs are copied before the returned awaitable is exposed.
 NEOGRAPH_API asio::awaitable<std::unique_ptr<WsClient>> ws_connect(
     asio::any_io_executor ex,
     std::string_view host,

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -546,6 +546,9 @@ public:
                      const GraphStreamCallback& cb           = nullptr);
 
     /// Async peer of resume — non-blocking coroutine surface.
+    /// All arguments are copied before this function returns, so the returned
+    /// awaitable does not borrow the caller's strings, JSON, or callback object.
+    /// Objects referenced by the callback's captures remain caller-owned.
     asio::awaitable<RunResult> resume_async(
         const std::string& thread_id,
         const json& resume_value = json(),
@@ -770,6 +773,11 @@ private:
 
     void init_state(GraphState& state) const;
     void apply_input(GraphState& state, const json& input) const;
+
+    asio::awaitable<RunResult> resume_async_owned(
+        std::string thread_id,
+        json resume_value,
+        GraphStreamCallback cb);
 
     /// Super-step loop (coroutine). Owns: state init, interrupt
     /// gates, resume load, super-step commit, routing via Scheduler.

--- a/spec/issue-187-api-v1-tracker.sdd.yaml
+++ b/spec/issue-187-api-v1-tracker.sdd.yaml
@@ -1,0 +1,105 @@
+# NeoGraph v1 public API and runtime-contract umbrella specification.
+spec:
+  id: issue-187-api-v1-tracker
+  issue: 187
+  revision: 1
+  created: "2026-07-25"
+  owner: fox1245
+  status: proposed
+  visibility: private-local-only
+  methodology: [SDD, TDD, EDD]
+
+objective: >-
+  Finish the v1 public extension contracts without losing any correctness,
+  ownership, protocol, or migration work discovered by the issue-187 audit.
+
+principles:
+  - One canonical virtual dispatch direction per extension point.
+  - Coroutine entry points own all data needed after call return.
+  - Missing implementations, capabilities, targets, and routes fail explicitly.
+  - Run identity, cancellation, Store, ToolGate, usage, tracing, and checkpoint
+    policy cross execution boundaries deliberately.
+  - Protocol hosts share graph invocation, not transport or session internals.
+  - Exported virtual changes require an explicit ABI and SOVERSION boundary.
+  - Each child issue lands and verifies independently; no umbrella mega-PR.
+
+workstreams:
+  public_contracts: [192, 193, 194, 195, 221]
+  p0_correctness: [196, 197, 198, 199, 200, 201, 203]
+  concurrency_and_failure: [202, 204, 205, 206, 207, 208]
+  schema_routing_cache: [209, 210, 211, 212, 213]
+  protocol_boundary: [214, 215]
+  long_term_decomposition: [216, 217, 218, 219, 220]
+
+child_specs:
+  192: spec/issue-192-provider-single-dispatch.sdd.yaml
+  193: spec/issue-193-checkpoint-async-contract.sdd.yaml
+  194: spec/issue-194-v1-abi-policy.sdd.yaml
+  195: spec/issue-195-graphnode-doc-contract.sdd.yaml
+  196: spec/issue-196-subgraph-context.sdd.yaml
+  197: spec/issue-197-a2a-cancellation.sdd.yaml
+  198: spec/issue-198-acp-cancellation.sdd.yaml
+  199: spec/issue-199-async-http-ownership.sdd.yaml
+  200: spec/issue-200-resume-async-ownership.sdd.yaml
+  201: spec/issue-201-python-update-mode.sdd.yaml
+  202: spec/issue-202-send-target-validation.sdd.yaml
+  203: spec/issue-203-store-structured-key.sdd.yaml
+  204: spec/issue-204-a2a-client-thread-safety.sdd.yaml
+  205: spec/issue-205-a2a-task-single-flight.sdd.yaml
+  206: spec/issue-206-a2a-message-id.sdd.yaml
+  207: spec/issue-207-request-queue-admission.sdd.yaml
+  208: spec/issue-208-request-queue-lifecycle.sdd.yaml
+  209: spec/issue-209-schema-keyword-validation.sdd.yaml
+  210: spec/issue-210-cache-context-identity.sdd.yaml
+  211: spec/issue-211-cache-bounds.sdd.yaml
+  212: spec/issue-212-routing-default-policy.sdd.yaml
+  213: spec/issue-213-strict-mode-migration.sdd.yaml
+  214: spec/issue-214-run-invocation-boundary.sdd.yaml
+  215: spec/issue-215-protocol-contract-tests.sdd.yaml
+  216: spec/issue-216-graph-engine-responsibilities.sdd.yaml
+  217: spec/issue-217-nodecontext-tool-ownership.sdd.yaml
+  218: spec/issue-218-engine-scoped-registries.sdd.yaml
+  219: spec/issue-219-mcp-transport-separation.sdd.yaml
+  220: spec/issue-220-schema-provider-decomposition.sdd.yaml
+  221: spec/issue-221-sync-node-ergonomics.sdd.yaml
+
+execution_order:
+  - phase: facts_and_release_boundary
+    issues: [195, 194]
+  - phase: independent_correctness
+    issues: [199, 200, 201, 202, 203, 207, 208]
+  - phase: canonical_extension_contracts
+    issues: [192, 193, 221]
+  - phase: context_and_protocol_runtime
+    issues: [196, 197, 198, 204, 205, 206]
+  - phase: explicit_policy
+    issues: [209, 210, 211, 212, 213]
+  - phase: shared_invocation_boundary
+    issues: [214, 215]
+  - phase: optional_decomposition
+    issues: [216, 217, 218, 219, 220]
+
+global_invariants:
+  - No public sync/async virtual pair mutually recurses by default.
+  - No accepted coroutine retains unowned request data past API return.
+  - Cancellation reaches in-flight graph, provider, and cooperative tool work.
+  - Nested execution cannot weaken the parent ToolGate or tenant boundary.
+  - Unknown dynamic control-flow input never becomes silent partial success.
+  - Existing lightweight and disabled-feature fast paths remain measurable.
+
+global_gates:
+  required:
+    - Fresh default C++ build and complete available ctest pass.
+    - Python binding build and complete available pytest pass.
+    - ASan, UBSan, TSan, and shared-library jobs pass for touched surfaces.
+    - Installed shared-library consumer smoke passes after ABI changes.
+    - Protocol contract suite passes for A2A, ACP, gRPC, and mock host.
+  performance:
+    baseline: "Record a fresh-worktree baseline before hot-path changes."
+    threshold: "No unexplained engine-overhead regression above 5 percent."
+
+completion:
+  - Every child issue is closed or rejected with a recorded reason.
+  - Every child spec has observed red evidence before implementation.
+  - Public docs describe only the final supported contracts.
+  - Migration and binary rebuild boundaries are explicit.

--- a/spec/issue-192-provider-single-dispatch.sdd.yaml
+++ b/spec/issue-192-provider-single-dispatch.sdd.yaml
@@ -1,0 +1,48 @@
+spec:
+  id: issue-192-provider-single-dispatch
+  issue: 192
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: breaking-api
+  depends_on: [194]
+
+problem:
+  statement: >-
+    Provider advertises invoke as the sole new override, but deprecated
+    complete and complete_async defaults call each other. An invoke-only
+    provider therefore recurses when reached through a legacy caller.
+  evidence:
+    - "include/neograph/provider.h:127-311"
+    - "src/core/provider.cpp:40-50,156-162"
+
+contract:
+  canonical: "invoke(CompletionParams, StreamCallback)"
+  modes:
+    non_streaming: "Empty callback returns one fully assembled completion."
+    streaming: "Callback receives ordered chunks and return value is fully assembled."
+  invariants:
+    - invoke is the only provider behavior virtual after the migration boundary.
+    - Retained facades forward one way to invoke and cannot be overridden.
+    - Final content, tool calls, finish state, and usage are identical by mode.
+    - Cancellation reaches the selected transport.
+
+red_tests:
+  - id: invoke-only-through-every-facade
+    assertion: "No facade recurses and each reaches invoke exactly once."
+  - id: streaming-contract
+    assertion: "Chunks are ordered and returned ChatCompletion is complete."
+  - id: override-matrix
+    assertion: "Legacy-only, invoke-only, mixed, and missing implementations are explicit."
+
+implementation:
+  - Freeze the compatibility matrix before changing virtual declarations.
+  - Migrate native providers and decorators to one invoke implementation.
+  - Replace or remove legacy virtual facades at the ABI boundary.
+  - Update C++, Python, examples, references, and migration notes together.
+
+acceptance:
+  - No bidirectional Provider fallback remains.
+  - Invoke-only streaming and non-streaming paths pass contract tests.
+  - Legacy behavior is either preserved by an explicit adapter or rejected clearly.
+  - Full provider, graph, Agent, Python, and live opt-in tests pass.

--- a/spec/issue-193-checkpoint-async-contract.sdd.yaml
+++ b/spec/issue-193-checkpoint-async-contract.sdd.yaml
@@ -1,0 +1,46 @@
+spec:
+  id: issue-193-checkpoint-async-contract
+  issue: 193
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: breaking-api
+  depends_on: [194]
+
+problem:
+  statement: >-
+    CheckpointStore has mutually recursive sync/async defaults and its async
+    defaults call sync backends inline, potentially blocking the graph executor.
+  evidence:
+    - "include/neograph/graph/checkpoint.h:196-338"
+    - "src/core/graph_checkpoint.cpp:21-81"
+
+contract:
+  canonical: "Engine-facing checkpoint operations are asynchronous."
+  sync_backends: "Use an explicit adapter with a bounded blocking executor."
+  pending_writes: "Expose as an explicit optional durability capability."
+  invariants:
+    - Missing mandatory operations fail before runtime recursion.
+    - Async engine paths never unknowingly block on backend I/O.
+    - Pending-write absence has one documented full-step replay behavior.
+    - Per-call atomicity remains required for every backend.
+
+red_tests:
+  - id: empty-backend-contract
+    assertion: "An incomplete backend cannot instantiate or fails explicitly."
+  - id: sync-adapter-does-not-block-io
+    assertion: "A timer progresses while a sync-only store operation waits."
+  - id: async-native-overlap
+    assertion: "Independent PostgreSQL operations overlap across pool slots."
+
+implementation:
+  - Inventory every engine, admin, Python, gRPC, and backend call site.
+  - Define async core and sync-only adapter ownership/lifecycle.
+  - Separate pending-write capability from snapshot CRUD.
+  - Migrate InMemory, SQLite, PostgreSQL, gRPC, and bindings independently.
+
+acceptance:
+  - No CheckpointStore method pair mutually recurses.
+  - Sync-only and async-native conformance suites pass.
+  - Resume and pending-write replay semantics remain deterministic.
+  - Blocking behavior is measured and documented.

--- a/spec/issue-194-v1-abi-policy.sdd.yaml
+++ b/spec/issue-194-v1-abi-policy.sdd.yaml
@@ -1,0 +1,41 @@
+spec:
+  id: issue-194-v1-abi-policy
+  issue: 194
+  parent: 187
+  status: proposed
+  priority: P0
+  kind: release-contract
+  depends_on: []
+
+problem:
+  statement: >-
+    GraphNode, Provider, and CheckpointStore are exported polymorphic classes.
+    Virtual removal or reordering breaks existing shared-library binaries.
+  evidence:
+    - "include/neograph/graph/node.h:132"
+    - "include/neograph/provider.h:127"
+    - "include/neograph/graph/checkpoint.h:211"
+    - "CMakeLists.txt:143-203"
+
+decisions_required:
+  - Define whether all pre-v1 binaries must rebuild.
+  - Freeze the release that establishes final v1 vtable layouts.
+  - Define library VERSION, SOVERSION, and installed filenames.
+  - Define supported source and binary compatibility windows after v1.
+
+red_tests:
+  - id: installed-shared-consumer
+    assertion: "A separately built consumer loads and executes installed libraries."
+  - id: soname-inspection
+    assertion: "ELF and Mach-O metadata match the declared policy."
+
+implementation:
+  - Record ABI policy before issues 192 and 193 remove virtuals.
+  - Add CMake version properties and package metadata.
+  - Add old-consumer/new-library and new-consumer/new-library CI cases as applicable.
+  - Publish mandatory rebuild and migration notes.
+
+acceptance:
+  - VERSION and SOVERSION are deliberate and test-covered.
+  - Release notes identify every binary-incompatible boundary.
+  - Shared and static installed-consumer smoke tests pass.

--- a/spec/issue-195-graphnode-doc-contract.sdd.yaml
+++ b/spec/issue-195-graphnode-doc-contract.sdd.yaml
@@ -1,0 +1,42 @@
+spec:
+  id: issue-195-graphnode-doc-contract
+  issue: 195
+  parent: 187
+  status: proposed
+  priority: P0
+  kind: documentation-correctness
+  depends_on: []
+
+problem:
+  statement: >-
+    GraphNode has only pure virtual run(NodeInput), while public headers,
+    references, diagnostics, and test prose still recommend removed methods.
+  evidence:
+    - "include/neograph/graph/node.h:11-34,65-68,98-118,147-151"
+    - "src/core/graph_executor.cpp:155-177,218-224"
+    - "docs/concepts.md and docs/reference-{en,ko}.md"
+
+scope:
+  in:
+    - Public headers and Doxygen comments.
+    - English and Korean references and concepts guide.
+    - Python diagnostics, dead helpers, and test descriptions.
+  out:
+    - Another GraphNode dispatch redesign.
+    - Historical changelog and explicitly labeled migration archaeology.
+
+red_tests:
+  - id: documented-minimal-node
+    assertion: "The documented custom node compiles and runs unchanged."
+  - id: stale-symbol-scan
+    assertion: "Legacy names appear only in approved historical files."
+
+implementation:
+  - Replace false fallback prose with the current pure run contract.
+  - Remove unused legacy macro and helper code after reference checks.
+  - Align C++ and Python examples and errors.
+
+acceptance:
+  - No active documentation tells users to override removed methods.
+  - Documentation snippets are compiled or executed in CI.
+  - Custom-node C++ and Python suites pass.

--- a/spec/issue-196-subgraph-context.sdd.yaml
+++ b/spec/issue-196-subgraph-context.sdd.yaml
@@ -1,0 +1,42 @@
+spec:
+  id: issue-196-subgraph-context
+  issue: 196
+  parent: 187
+  status: proposed
+  priority: P0
+  kind: correctness-security
+  depends_on: []
+
+problem:
+  statement: >-
+    SubgraphNode forwards input, cancellation, usage, and events but omits
+    parent execution identity, Store, ToolGate, trace, and checkpoint policy.
+  evidence:
+    - "src/core/graph_node.cpp:311-329"
+    - "include/neograph/graph/engine.h:126-227"
+
+contract:
+  identity: "Child IDs are deterministic, collision-free derivatives of parent context."
+  policy: "A child may narrow but never silently weaken parent ToolGate policy."
+  state: "Store and checkpoint inheritance/override precedence is explicit."
+  propagation: [cancel_token, usage, deadline, trace_id, stream_mode]
+
+red_tests:
+  - id: nested-tool-gate
+    assertion: "A parent-denied tool cannot execute inside a child graph."
+  - id: nested-store
+    assertion: "Child reads the intended parent Store namespace."
+  - id: sibling-checkpoint-isolation
+    assertion: "Sibling subgraphs cannot collide in checkpoint identity."
+  - id: multi-level-cancel
+    assertion: "Parent cancellation reaches a grandchild provider/tool."
+
+implementation:
+  - Define a child-run context derivation function before wiring fields.
+  - Pass policy through a supported engine execution boundary, not ad-hoc setters.
+  - Add one-level and multi-level contract tests.
+
+acceptance:
+  - All context fields have documented inherit, derive, override, or omit semantics.
+  - Nested policy cannot be weaker by accident.
+  - Checkpoint, HITL, Store, usage, trace, and cancellation tests pass.

--- a/spec/issue-197-a2a-cancellation.sdd.yaml
+++ b/spec/issue-197-a2a-cancellation.sdd.yaml
@@ -1,0 +1,40 @@
+spec:
+  id: issue-197-a2a-cancellation
+  issue: 197
+  parent: 187
+  status: proposed
+  priority: P0
+  kind: correctness
+  depends_on: []
+
+problem:
+  statement: >-
+    A2A tasks/cancel flips a local flag but does not cancel the graph run, so
+    provider and tool work continue until normal completion.
+  evidence:
+    - "src/a2a/server.cpp:289-347"
+    - "src/a2a/server.cpp:480-501"
+
+contract:
+  - Each active task owns one CancelToken for exactly one graph run.
+  - tasks/cancel is idempotent and triggers that token immediately.
+  - Exactly one terminal A2A status sequence is emitted.
+  - Task and token entries are removed only by their owning generation.
+
+red_tests:
+  - id: cancel-inflight-provider
+    assertion: "Socket-level provider work aborts before its normal deadline."
+  - id: repeated-cancel
+    assertion: "Repeated cancellation emits no duplicate terminal result."
+  - id: cancel-race-matrix
+    assertion: "Before, during, and after completion states are deterministic."
+
+implementation:
+  - Replace or pair the atomic flag with a per-task CancelToken.
+  - Put the token into RunConfig before engine execution.
+  - Make map cleanup generation-safe and coordinate with issue 205.
+
+acceptance:
+  - In-flight graph/provider/cooperative-tool work observes cancellation.
+  - A2A status, events, task lookup, and cleanup remain consistent.
+  - Cancellation tests require no live provider.

--- a/spec/issue-198-acp-cancellation.sdd.yaml
+++ b/spec/issue-198-acp-cancellation.sdd.yaml
@@ -1,0 +1,40 @@
+spec:
+  id: issue-198-acp-cancellation
+  issue: 198
+  parent: 187
+  status: proposed
+  priority: P0
+  kind: correctness
+  depends_on: []
+
+problem:
+  statement: >-
+    ACP session cancellation is consumed after engine.run returns and therefore
+    changes only the reported StopReason, not in-flight work or cost.
+  evidence:
+    - "src/acp/server.cpp:317-350"
+    - "src/acp/server.cpp:388-409"
+
+contract:
+  - Each in-flight session prompt owns one CancelToken.
+  - session/cancel immediately signals the active token.
+  - Cancel-before-prompt behavior is explicit and consumed once.
+  - Worker completion releases single-flight state exactly once.
+
+red_tests:
+  - id: cancel-inflight-prompt
+    assertion: "A cancellable node exits before its normal completion."
+  - id: sticky-pre-cancel
+    assertion: "The documented next-prompt cancellation rule is deterministic."
+  - id: shutdown-cancel-race
+    assertion: "Server destruction and cancel cannot leak or double-complete."
+
+implementation:
+  - Store a token with each session generation.
+  - Assign it to RunConfig before the worker starts graph execution.
+  - Preserve the existing worker drain and notify-under-lock invariant.
+
+acceptance:
+  - ACP cancellation reaches provider and cooperative tool work.
+  - StopReason and session/update terminal messages are emitted once.
+  - Session single-flight and teardown tests remain sanitizer-clean.

--- a/spec/issue-199-async-http-ownership.sdd.yaml
+++ b/spec/issue-199-async-http-ownership.sdd.yaml
@@ -1,0 +1,128 @@
+spec:
+  id: issue-199-async-http-ownership
+  issue: 199
+  parent: 187
+  status: completed
+  priority: P0
+  kind: memory-safety
+  depends_on: []
+
+problem:
+  statement: >-
+    Public HTTP coroutine APIs borrow string_view and request data, then copy
+    only after first resume. Deferred awaitables can outlive temporary inputs.
+  evidence:
+    - "include/neograph/async/http_client.h:99-120"
+    - "src/async/http_client.cpp:303-316"
+    - "src/async/conn_pool.cpp:273-284"
+
+invariants:
+  - Every value read after initial suspend is owned by the coroutine frame.
+  - Streaming callbacks and cancellation targets outlive all scheduled work.
+  - Ownership fixes do not introduce one copy per retry or redirect hop.
+
+red_tests:
+  - id: delayed-spawn-temporaries
+    assertion: "Temporary URL, body, and headers survive delayed co_spawn."
+  - id: stored-awaitable
+    assertion: "An awaitable created in one scope runs safely in another."
+  - id: stream-callback-lifetime
+    assertion: "Chunks never target a destroyed callback capture."
+
+implementation:
+  - Change public coroutine boundaries to take owned values where required.
+  - Move owned data into the coroutine frame at call construction.
+  - Audit redirects, retries, ConnPool, SSE, and WebSocket call chains.
+
+acceptance:
+  - ASan and delayed-resume regressions pass for every public HTTP entry point.
+  - Cancellation, headers, redirects, pooling, and streaming behavior are unchanged.
+  - Copy/allocation impact is measured.
+
+observed:
+  root_cause: >-
+    async_post, async_get, async_post_stream, ConnPool::async_post,
+    ws_connect, and the WsClient send methods were lazy coroutine functions
+    with string_view parameters. Their frames copied the views at call time but
+    did not copy the referenced bytes until first resume, so mutating or
+    destroying caller storage changed the eventual request or caused undefined
+    behavior.
+  red_evidence:
+    - >-
+      Before the fix, all four HTTP ownership regressions failed: POST and GET
+      observed the mutated path, streaming delivered the mutated-path response,
+      and ConnPool sent the mutated path.
+    - >-
+      The WebSocket delayed-send regression echoed truncated mutated text,
+      binary, and close-reason payloads instead of the values present when each
+      awaitable was created.
+
+resolution:
+  design: >-
+    Preserve every public signature as a non-coroutine facade. Each facade
+    synchronously constructs owned strings and moves them, along with already
+    by-value headers and callbacks, into a private by-value coroutine frame.
+  changed_files:
+    - include/neograph/async/http_client.h
+    - include/neograph/async/conn_pool.h
+    - include/neograph/async/ws_client.h
+    - src/async/http_client.cpp
+    - src/async/conn_pool.cpp
+    - src/async/ws_client.cpp
+    - tests/test_async_get.cpp
+    - tests/test_async_http_stream.cpp
+    - tests/test_async_conn_pool.cpp
+    - tests/test_async_ws_loopback.cpp
+  compatibility:
+    - Public function signatures and ConnPool/WsClient object layouts are unchanged.
+    - Timeout, redirect, pooling, SSE chunk, and WebSocket wire behavior are unchanged.
+    - Callback wrapper objects are owned; objects referenced by their captures remain caller-owned.
+  audit:
+    - CurlH2Pool was already safe because URL and body parameters are owned strings.
+    - SseEventParser::feed is synchronous and does not retain its string_view input.
+    - Internal string_view/reference helpers are immediately awaited by frames that own their sources.
+    - ConnPool and WsClient instances must still outlive operations invoked on them.
+  copy_cost: >-
+    Static allocation accounting adds exactly one string construction per
+    borrowed public string_view: at most four for POST/stream/pool calls, three
+    for GET/ws_connect, and one for each WebSocket send. SSO may avoid heap
+    allocation for short values. Header vectors and callback wrappers retain
+    their prior by-value copy behavior and are moved into the owned frame.
+    Redirect and stale-connection retry loops receive the same frame-owned
+    values, so the fix adds no copy per hop or retry.
+
+verification:
+  targeted:
+    command: >-
+      ./build/tests/neograph_tests
+      --gtest_filter=AsyncHttpOwnership.*:WsLoopback.DelayedOperationsOwnEndpointAndPayloads
+    result: "6 passed, 0 failed"
+  behavior_matrix:
+    command: >-
+      ./build/tests/neograph_tests
+      --gtest_filter=AsyncHttpOwnership.*:RequestOptions.*:HttpResponseHeaders.*:AsyncPostStream.*:AsyncPost.*:AsyncPostUnchanged.*:AsyncGet.*:ConnPool.*:WsLoopback.*:WsCodec.*
+    result: "37 passed, 0 failed before the explicit temporary-input case was added"
+  sanitizer:
+    configuration: >-
+      Debug; -fsanitize=address,undefined; ASAN_OPTIONS
+      detect_stack_use_after_return=1.
+    command: >-
+      ./build-asan/tests/neograph_tests
+      --gtest_filter=AsyncHttpOwnership.*:WsLoopback.DelayedOperationsOwnEndpointAndPayloads
+    result: "6 passed, 0 failed"
+  cpp_full:
+    configuration: "Release; PostgreSQL/SQLite/A2A/ACP/MCP ON."
+    command: "ctest --test-dir build --output-on-failure -j2"
+    result: "614 passed, 30 skipped, 0 failed (644 discovered)"
+    skips: >-
+      27 PostgreSQL tests skipped because NEOGRAPH_TEST_POSTGRES_URL was unset;
+      one live cancellation test skipped because NEOGRAPH_LIVE_LLM and an
+      OpenAI key were not enabled; two live WebSocket tests skipped because
+      NEOGRAPH_LIVE_OPENAI was not enabled.
+  python_full:
+    configuration: >-
+      Release Python binding; PostgreSQL/SQLite/A2A/ACP ON; MCP OFF.
+    command: >-
+      PYTHONPATH=build_pybind:bindings/python python3 -m pytest
+      bindings/python/tests/ -q -rs
+    result: "149 passed, 6 skipped, 0 failed"

--- a/spec/issue-200-resume-async-ownership.sdd.yaml
+++ b/spec/issue-200-resume-async-ownership.sdd.yaml
@@ -1,0 +1,105 @@
+spec:
+  id: issue-200-resume-async-ownership
+  issue: 200
+  parent: 187
+  status: completed
+  priority: P0
+  kind: memory-safety
+  depends_on: []
+
+problem:
+  statement: >-
+    resume_async still accepts caller-owned references even though a lazy
+    coroutine may not read them until after the caller scope is gone.
+  evidence:
+    - "include/neograph/graph/engine.h:500-504"
+    - "src/core/graph_engine.cpp:388-414"
+
+invariants:
+  - Thread ID, resume JSON, callback, and config needed after suspend are owned.
+  - Sync resume and Python behavior retain their current semantics.
+  - No coroutine frame holds a reference to a temporary public argument.
+
+red_tests:
+  - id: temporary-resume-input
+    assertion: "Temporary thread ID and JSON survive delayed co_spawn."
+  - id: callback-scope
+    assertion: "A stored resume awaitable cannot call a destroyed callback."
+  - id: resume-behavior-parity
+    assertion: "Owned-argument async and sync resume produce identical results."
+
+implementation:
+  - Make the public boundary own arguments before initial suspend.
+  - Audit internal helper references independently from public ownership.
+  - Update C++ and binding signatures and migration notes as needed.
+
+acceptance:
+  - Delayed-resume ASan tests pass.
+  - HITL, pending writes, barrier state, streaming, and Python resume tests pass.
+
+observed:
+  root_cause: >-
+    resume_async was itself a lazy coroutine with const-reference parameters.
+    Calling it created a frame that retained references to caller-owned thread
+    ID, JSON, and std::function storage, but its body did not read those values
+    until the awaitable was first resumed.
+  red_evidence:
+    - >-
+      ResumeAsyncSnapshotsThreadIdBeforeFirstResume failed with
+      "No checkpoint found for thread: different-thread-id" after the source
+      string was changed between awaitable creation and co_spawn.
+    - >-
+      The initial combined delayed-resume case threw std::bad_alloc after a
+      temporary thread ID expired before co_spawn, demonstrating ordinary
+      undefined behavior rather than a stable semantic failure.
+
+resolution:
+  design: >-
+    Preserve the public signature as a non-coroutine facade that copies all
+    three inputs synchronously, then return a private by-value coroutine.
+  changed_files:
+    - include/neograph/graph/engine.h
+    - src/core/graph_engine.cpp
+    - tests/test_graph_engine_async_api.cpp
+    - spec/issue-200-resume-async-ownership.sdd.yaml
+  compatibility:
+    - The public resume_async signature and GraphEngine object layout are unchanged.
+    - Sync resume still drives the same async implementation.
+    - Python's existing heap-pinned call path remains behaviorally unchanged.
+
+verification:
+  targeted:
+    command: >-
+      ./build/tests/neograph_tests
+      --gtest_filter=GraphEngineAsyncApi.*:DynamicInterrupt.*:PendingWritesTest.*:BarrierPersistence.*:MultiNodeResume.*
+    result: "28 passed, 0 failed"
+  sanitizer:
+    configuration: >-
+      Debug; -fsanitize=address,undefined; PostgreSQL OFF; SQLite OFF;
+      A2A/ACP/MCP ON; ASAN_OPTIONS detect_stack_use_after_return=1.
+    command: >-
+      ./build-asan/tests/neograph_tests
+      --gtest_filter=GraphEngineAsyncApi.ResumeAsync*
+    result: "4 passed, 0 failed"
+  cpp_full:
+    configuration: >-
+      Release; PostgreSQL/SQLite/A2A/ACP/MCP ON.
+    command: "ctest --test-dir build --output-on-failure -j2"
+    result: "608 passed, 30 skipped, 0 failed (638 discovered)"
+    skips: >-
+      27 PostgreSQL tests skipped because NEOGRAPH_TEST_POSTGRES_URL was unset;
+      one live cancellation test skipped because NEOGRAPH_LIVE_LLM and an
+      OpenAI key were not enabled; two live WebSocket tests skipped because
+      NEOGRAPH_LIVE_OPENAI was not enabled.
+  python_full:
+    configuration: >-
+      Release Python binding; PostgreSQL/SQLite/A2A/ACP ON; MCP OFF.
+    command: >-
+      PYTHONPATH=build_pybind:bindings/python python3 -m pytest
+      bindings/python/tests/ -q -rs
+    result: "149 passed, 6 skipped, 0 failed"
+    skips: >-
+      one MCP test skipped because MCP was compiled OFF; two live OpenAI tests
+      skipped because NEOGRAPH_LIVE_LLM and OPENAI_API_KEY were not enabled;
+      two Groq usage tests skipped because GROQ_API_KEY was unset; one Anthropic
+      usage test skipped because ANTHROPIC_API_KEY was unset.

--- a/spec/issue-201-python-update-mode.sdd.yaml
+++ b/spec/issue-201-python-update-mode.sdd.yaml
@@ -1,0 +1,40 @@
+spec:
+  id: issue-201-python-update-mode
+  issue: 201
+  parent: 187
+  status: proposed
+  priority: P0
+  kind: correctness-parity
+  depends_on: []
+
+problem:
+  statement: >-
+    Python update_state list form flattens ChannelWrite into a dictionary and
+    loses its reducer-versus-overwrite mode.
+  evidence:
+    - "bindings/python/src/bind_graph.cpp:703-730"
+    - "include/neograph/graph/types.h:85-100"
+
+contract:
+  list_form: "Preserves each ChannelWrite value and mode in order."
+  dict_form: "Keeps its separately documented reducer semantics."
+  invariants:
+    - Administrative updates remain checkpointed and versioned.
+    - Mode behavior matches C++ GraphState writes.
+
+red_tests:
+  - id: overwrite-append-channel
+    assertion: "Explicit overwrite replaces accumulated messages."
+  - id: reduce-append-channel
+    assertion: "Default reduce still appends."
+  - id: mixed-write-order
+    assertion: "Reduce and overwrite writes are applied in list order."
+
+implementation:
+  - Route list form through a mode-preserving C++ update path.
+  - Keep dictionary conversion only for dictionary input.
+  - Update Python docs and type hints.
+
+acceptance:
+  - C++ and Python update_state mode matrices agree.
+  - Checkpoint, fork, version, and resume tests remain correct.

--- a/spec/issue-202-send-target-validation.sdd.yaml
+++ b/spec/issue-202-send-target-validation.sdd.yaml
@@ -1,0 +1,38 @@
+spec:
+  id: issue-202-send-target-validation
+  issue: 202
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: correctness
+  depends_on: []
+
+problem:
+  statement: >-
+    Dynamic Send silently returns an empty result for an unknown target while
+    normal node dispatch throws. A typo can therefore look like partial success.
+  evidence:
+    - "src/core/graph_executor.cpp:665-670,721-725"
+
+contract:
+  - Every Send target must resolve before its work is considered accepted.
+  - Single and multi-Send paths use the same error type and diagnostic fields.
+  - A mixed valid/invalid fan-out has deterministic pending-write semantics.
+  - Statically knowable targets are validated before execution when possible.
+
+red_tests:
+  - id: unknown-single-send
+    assertion: "Run fails with source and target names."
+  - id: mixed-multi-send
+    assertion: "Failure and successful-sibling replay behavior are deterministic."
+  - id: resume-after-invalid-send
+    assertion: "No invalid task is recorded as completed."
+
+implementation:
+  - Centralize Send target resolution before single/multi dispatch diverge.
+  - Preserve node exception and pending-write accounting.
+  - Surface the same diagnostic through streaming and Python.
+
+acceptance:
+  - Unknown Send never becomes silent success.
+  - Existing valid Send, retry, interrupt, and resume tests pass.

--- a/spec/issue-203-store-structured-key.sdd.yaml
+++ b/spec/issue-203-store-structured-key.sdd.yaml
@@ -1,0 +1,42 @@
+spec:
+  id: issue-203-store-structured-key
+  issue: 203
+  parent: 187
+  status: proposed
+  priority: P0
+  kind: data-correctness
+  depends_on: []
+
+problem:
+  statement: >-
+    InMemoryStore joins namespace and key with slash, causing identity collisions
+    and component-prefix search errors.
+  evidence:
+    - "src/core/store.cpp:7-18,49-58"
+
+contract:
+  identity: "Namespace components plus key have an injective representation."
+  search: "Prefix means a prefix of complete namespace components."
+  supported_values:
+    - Empty namespace and empty component.
+    - Slash and arbitrary UTF-8 bytes in components and keys.
+  invariants:
+    - Put, get, delete, search, and namespace listing agree on identity.
+    - Existing timestamp and limit behavior is preserved.
+
+red_tests:
+  - id: delimiter-collision
+    assertion: "[a,b]+c and [a]+b/c remain distinct."
+  - id: component-prefix
+    assertion: "[user] does not match [user2]."
+  - id: encoded-edge-cases
+    assertion: "Empty and slash-containing components round-trip."
+
+implementation:
+  - Replace flattened string keys with tuple/structured keys or length encoding.
+  - Implement component-wise prefix comparison.
+  - Audit Python conversion and deterministic namespace ordering.
+
+acceptance:
+  - Collision and prefix red tests pass.
+  - Store C++ and Python suites pass without behavior ambiguity.

--- a/spec/issue-204-a2a-client-thread-safety.sdd.yaml
+++ b/spec/issue-204-a2a-client-thread-safety.sdd.yaml
@@ -1,0 +1,39 @@
+spec:
+  id: issue-204-a2a-client-thread-safety
+  issue: 204
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: concurrency
+  depends_on: []
+
+problem:
+  statement: >-
+    A2AClient claims thread safety while request IDs, cached card state, and
+    mutable configuration are accessed without synchronization.
+  evidence:
+    - "include/neograph/a2a/client.h:30-35,134-140"
+    - "src/a2a/client.cpp:56-63,185-224"
+
+decision:
+  options:
+    - Make all documented concurrent operations race-free.
+    - Narrow the API to externally synchronized single-owner use.
+  rule: "Choose one model; do not retain a false thread-safe claim."
+
+red_tests:
+  - id: concurrent-request-ids
+    assertion: "IDs are unique and responses correlate under contention."
+  - id: card-cache-single-init
+    assertion: "Concurrent first reads perform one coherent initialization."
+  - id: config-race
+    assertion: "Timeout/config access follows the selected ownership model."
+
+implementation:
+  - Inventory mutable state and public methods.
+  - Use atomics, immutable config, or scoped locks with no network I/O under lock.
+  - Add TSAN stress tests.
+
+acceptance:
+  - Documentation and implementation expose the same concurrency contract.
+  - TSAN reports no client-state race.

--- a/spec/issue-205-a2a-task-single-flight.sdd.yaml
+++ b/spec/issue-205-a2a-task-single-flight.sdd.yaml
@@ -1,0 +1,39 @@
+spec:
+  id: issue-205-a2a-task-single-flight
+  issue: 205
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: concurrency
+  depends_on: [197]
+
+problem:
+  statement: >-
+    Two requests with one A2A task ID may execute concurrently, sharing a
+    checkpoint thread and replacing task/cancel map ownership.
+  evidence:
+    - "src/a2a/server.cpp:298-347"
+    - "src/acp/server.cpp:283-309"
+
+contract:
+  - One task ID has at most one active graph generation.
+  - A duplicate request receives an explicit error or documented join behavior.
+  - Cleanup from an old generation cannot erase a newer generation.
+  - Global admission is bounded separately from per-task single-flight.
+
+red_tests:
+  - id: same-task-concurrent
+    assertion: "Only one graph body begins."
+  - id: different-task-concurrent
+    assertion: "Distinct tasks may overlap within the global limit."
+  - id: cancel-replace-race
+    assertion: "Cancellation always targets the owning generation."
+
+implementation:
+  - Reserve task generation atomically before publishing Working state.
+  - Associate Task, CancelToken, and worker ownership in one record.
+  - Release reservation with generation checks on every terminal path.
+
+acceptance:
+  - Same-task races cannot corrupt checkpoints or task state.
+  - Cancellation, reconnect, lookup, and eviction tests pass.

--- a/spec/issue-206-a2a-message-id.sdd.yaml
+++ b/spec/issue-206-a2a-message-id.sdd.yaml
@@ -1,0 +1,37 @@
+spec:
+  id: issue-206-a2a-message-id
+  issue: 206
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: protocol-correctness
+  depends_on: []
+
+problem:
+  statement: >-
+    A2ACallerNode derives message IDs from low object-address bits, so calls
+    repeat IDs and unrelated nodes may collide.
+  evidence:
+    - "src/a2a/a2a_caller_node.cpp:40-43"
+
+contract:
+  - Message identity is generated per call, not per object.
+  - Concurrent calls in one process do not collide.
+  - Production IDs expose no memory address information.
+  - Tests may inject a deterministic generator without changing production policy.
+
+red_tests:
+  - id: repeated-node-calls
+    assertion: "One node emits a different ID on every call."
+  - id: concurrent-callers
+    assertion: "A large concurrent set contains no duplicate."
+  - id: propagation
+    assertion: "The generated ID survives request and response history."
+
+implementation:
+  - Reuse the project UUID facility or a monotonic process-safe generator.
+  - Add an optional generator dependency only if deterministic tests require it.
+
+acceptance:
+  - No address-derived ID code remains.
+  - A2A caller and wire round-trip tests pass.

--- a/spec/issue-207-request-queue-admission.sdd.yaml
+++ b/spec/issue-207-request-queue-admission.sdd.yaml
@@ -1,0 +1,38 @@
+spec:
+  id: issue-207-request-queue-admission
+  issue: 207
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: concurrency
+  depends_on: []
+
+problem:
+  statement: >-
+    RequestQueue checks capacity and increments pending separately, allowing
+    concurrent submitters to exceed the bound. Enqueue failure is ignored.
+  evidence:
+    - "include/neograph/util/request_queue.h:89-99"
+
+contract:
+  - Admission reserves capacity atomically before enqueue.
+  - Failed enqueue rolls back the reservation.
+  - Every rejected submission receives one stable error outcome.
+  - pending never exceeds configured capacity.
+
+red_tests:
+  - id: barriered-contention
+    assertion: "Simultaneous submitters admit no more than capacity."
+  - id: enqueue-failure
+    assertion: "Reservation rolls back and future becomes exceptional."
+  - id: pending-accounting
+    assertion: "Accepted plus completed accounting never underflows or leaks."
+
+implementation:
+  - Use a CAS reservation loop or one lock covering check and reservation.
+  - Handle enqueue return before exposing successful submission.
+  - Keep completion decrement exception-safe.
+
+acceptance:
+  - Contention stress and TSAN pass.
+  - Capacity and error behavior are documented.

--- a/spec/issue-208-request-queue-lifecycle.sdd.yaml
+++ b/spec/issue-208-request-queue-lifecycle.sdd.yaml
@@ -1,0 +1,44 @@
+spec:
+  id: issue-208-request-queue-lifecycle
+  issue: 208
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: lifecycle
+  depends_on: [207]
+
+problem:
+  statement: >-
+    RequestQueue accepts zero workers and shutdown may leave accepted queued
+    promises unresolved because no explicit drain-or-cancel contract exists.
+  evidence:
+    - "include/neograph/util/request_queue.h:52-71,129-146"
+
+decision:
+  required: "Select reject, drain, or cancel semantics for close and destruction."
+  recommended: >-
+    Reject zero workers, reject new work after close, and explicitly complete
+    every accepted task by execution or cancellation.
+
+invariants:
+  - Every accepted future reaches value, exception, or cancellation.
+  - close is idempotent.
+  - Submit racing close has one linearizable outcome.
+  - Destruction performs no callback into destroyed owner state.
+
+red_tests:
+  - id: zero-workers
+    assertion: "Construction rejects an unusable queue."
+  - id: queued-on-close
+    assertion: "Every queued future becomes ready under the chosen policy."
+  - id: submit-close-race
+    assertion: "No accepted task is lost and no rejected task runs."
+
+implementation:
+  - Add explicit lifecycle state and close operation.
+  - Coordinate worker exit with queue drain/cancel policy.
+  - Make destructor call only the defined idempotent close path.
+
+acceptance:
+  - No lifecycle test can wait indefinitely.
+  - ASan, TSan, and repeated teardown stress pass.

--- a/spec/issue-209-schema-keyword-validation.sdd.yaml
+++ b/spec/issue-209-schema-keyword-validation.sdd.yaml
@@ -1,0 +1,45 @@
+spec:
+  id: issue-209-schema-keyword-validation
+  issue: 209
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: compiler-correctness
+  depends_on: []
+
+problem:
+  statement: >-
+    Strict compilation uses node-schema properties for unknown-key checks but
+    does not enforce exported required, type, or enum constraints.
+  evidence:
+    - "src/core/graph_compiler.cpp:143-161,238-258"
+    - "src/core/graph_loader.cpp:220-235"
+
+contract:
+  supported_subset: [required, type, enum]
+  diagnostics:
+    - Aggregate deterministic violations instead of first-error exit.
+    - Include source coordinate, node name/type, keyword, expected, and actual.
+  invariants:
+    - Built-in and custom node schemas use the same validator.
+    - Exported schema and compiler claim exactly the same supported subset.
+    - Unsupported schema keywords are explicit, not silently enforced partially.
+
+red_tests:
+  - id: required-missing
+    assertion: "Missing intent_classifier routes fails strict compilation."
+  - id: wrong-type
+    assertion: "A property of the wrong JSON type fails at compile time."
+  - id: enum-mismatch
+    assertion: "Unknown enumerated value reports allowed values."
+  - id: multi-error-order
+    assertion: "Several violations are returned in stable order."
+
+implementation:
+  - Define a small value-level schema validator independent of NodeFactory parsing.
+  - Run it before node construction for strict documents.
+  - Extend corpus, mutation, and schema-evolution tests.
+
+acceptance:
+  - All supported keywords reject invalid documents before execution.
+  - Translation-validation and existing valid corpus remain green.

--- a/spec/issue-210-cache-context-identity.sdd.yaml
+++ b/spec/issue-210-cache-context-identity.sdd.yaml
@@ -1,0 +1,41 @@
+spec:
+  id: issue-210-cache-context-identity
+  issue: 210
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: tenant-correctness
+  depends_on: [196]
+
+problem:
+  statement: >-
+    NodeCache keys only node name and serialized state although node output may
+    depend on thread, Store, ToolGate, resume value, provider, model, or policy.
+  evidence:
+    - "src/core/node_cache.cpp:19-26"
+    - "tests/test_node_cache.cpp:82-103"
+
+contract:
+  default_scope: "No reuse across execution or tenant policy boundaries."
+  explicit_scope: "Safe cross-thread reuse requires a declared cache-key policy."
+  key_requirements:
+    - Deterministic and inspectable.
+    - Includes all declared state and context dependencies.
+    - Does not serialize secrets into logs or public metrics.
+
+red_tests:
+  - id: same-state-different-tenant
+    assertion: "Default cache does not reuse the first tenant result."
+  - id: tool-gate-context
+    assertion: "A result produced under one policy is not reused under another."
+  - id: explicit-global-scope
+    assertion: "A pure node may opt into safe cross-thread reuse."
+
+implementation:
+  - Define cache scope and optional key-provider API.
+  - Include stable context identity or isolate caches by scope.
+  - Update cache enablement and diagnostics.
+
+acceptance:
+  - Default behavior cannot leak Store- or policy-dependent output.
+  - Explicit pure-node reuse remains available and measured.

--- a/spec/issue-211-cache-bounds.sdd.yaml
+++ b/spec/issue-211-cache-bounds.sdd.yaml
@@ -1,0 +1,43 @@
+spec:
+  id: issue-211-cache-bounds
+  issue: 211
+  parent: 187
+  status: proposed
+  priority: P2
+  kind: resource-control
+  depends_on: [210]
+
+problem:
+  statement: >-
+    NodeCache retains every distinct key until clear and has no entry, memory,
+    or age bound for long-running services.
+  evidence:
+    - "src/core/node_cache.cpp:42-58"
+    - "include/neograph/graph/node_cache.h:69-78"
+
+contract:
+  defaults: "Disabled cache keeps the existing allocation-free fast path."
+  controls:
+    - Configurable maximum entries or measured memory budget.
+    - Deterministic documented eviction, initially LRU unless evidence rejects it.
+    - Optional TTL only if monotonic-clock behavior is testable.
+  observability: [hits, misses, entries, evictions]
+
+red_tests:
+  - id: entry-bound
+    assertion: "Inserting beyond capacity never exceeds the configured count."
+  - id: eviction-order
+    assertion: "Access order produces deterministic victim selection."
+  - id: concurrent-eviction
+    assertion: "Lookup and insert remain race-free under eviction."
+  - id: bounded-stress
+    assertion: "Resident cache state remains bounded across diverse inputs."
+
+implementation:
+  - Add policy/config without affecting disabled engines.
+  - Make accounting and eviction atomic under the selected synchronization model.
+  - Expose metrics without leaking cache key payloads.
+
+acceptance:
+  - Capacity and eviction tests pass under TSan.
+  - Disabled and small-cache overhead is measured.

--- a/spec/issue-212-routing-default-policy.sdd.yaml
+++ b/spec/issue-212-routing-default-policy.sdd.yaml
@@ -1,0 +1,41 @@
+spec:
+  id: issue-212-routing-default-policy
+  issue: 212
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: control-flow-contract
+  depends_on: [209]
+
+problem:
+  statement: >-
+    An unknown condition label currently selects the lexicographically last
+    route, making typos and new model output take an ordering-dependent path.
+  evidence:
+    - "src/core/scheduler.cpp:21-31"
+    - "tests/test_scheduler.cpp:83-101"
+
+contract:
+  closed_conditions: "All declared labels must be covered; unknown output is an error."
+  open_conditions: "Graph declares an explicit default target or fail policy."
+  invariants:
+    - Route map ordering never affects behavior.
+    - Diagnostics identify source node, condition, returned label, and known labels.
+    - Command.goto semantics remain higher priority than edge routing.
+
+red_tests:
+  - id: unknown-label-fails
+    assertion: "No route is selected by lexical order."
+  - id: explicit-default
+    assertion: "An open condition reaches only its declared default."
+  - id: closed-completeness
+    assertion: "Missing labels fail strict compilation."
+
+implementation:
+  - Extend graph schema and compiled edge representation with explicit policy.
+  - Remove scheduler last-route fallback.
+  - Provide an upgrader rule only when old intent can be inferred explicitly.
+
+acceptance:
+  - Unknown labels follow only declared error/default behavior.
+  - Scheduler, validator, schema export, corpus, and migration tests pass.

--- a/spec/issue-213-strict-mode-migration.sdd.yaml
+++ b/spec/issue-213-strict-mode-migration.sdd.yaml
@@ -1,0 +1,44 @@
+spec:
+  id: issue-213-strict-mode-migration
+  issue: 213
+  parent: 187
+  status: proposed
+  priority: P2
+  kind: schema-migration
+  depends_on: [209, 212]
+
+problem:
+  statement: >-
+    Strict compilation is opt-in through schema_version while canonical examples
+    omit a version and teach permissive legacy behavior to new users.
+  evidence:
+    - "src/core/graph_compiler.cpp:143-161"
+    - "examples/51_minimal.cpp:43"
+
+decisions_required:
+  - Define behavior for unversioned documents in v0.x and v1.
+  - Define warning and removal timeline for permissive compilation.
+  - Define upgrader, lockfile, comments, and source-map preservation rules.
+  - Define which examples and generated assets must declare the latest version.
+
+invariants:
+  - Existing legacy input never changes semantics silently.
+  - A default flip occurs only at a documented breaking boundary.
+  - Upgrade output strict-compiles to canonically equivalent IR.
+
+red_tests:
+  - id: canonical-example-is-strict
+    assertion: "Minimal and generated examples declare current schema version."
+  - id: legacy-warning
+    assertion: "Unversioned input follows the declared compatibility policy."
+  - id: upgrade-equivalence
+    assertion: "Legacy IR equals upgraded strict IR modulo version annotations."
+
+implementation:
+  - Publish migration policy before changing defaults.
+  - Version all recommended examples, templates, and generated definitions.
+  - Extend corpus coverage for legacy/current/upgraded triplets.
+
+acceptance:
+  - New users enter strict mode through every recommended path.
+  - Legacy behavior and end date are explicit and tested.

--- a/spec/issue-214-run-invocation-boundary.sdd.yaml
+++ b/spec/issue-214-run-invocation-boundary.sdd.yaml
@@ -1,0 +1,55 @@
+spec:
+  id: issue-214-run-invocation-boundary
+  issue: 214
+  parent: 187
+  status: design-required
+  priority: P1
+  kind: architecture
+  depends_on: [196, 197, 198]
+
+problem:
+  statement: >-
+    Protocol hosts currently assemble graph execution and cancellation separately,
+    allowing policy and terminal-state behavior to drift across A2A, ACP, and gRPC.
+
+goal: >-
+  Add a narrow concrete graph invocation boundary that owns RunConfig, execution
+  identity, CancelToken, event delivery, and terminal outcome without absorbing
+  protocol transport or session internals.
+
+functional_blocks:
+  - id: request
+    responsibility: "Own validated RunConfig and execution identity."
+  - id: cancellation
+    responsibility: "Own and expose one CancelToken for the invocation lifetime."
+  - id: events
+    responsibility: "Deliver ordered GraphEvents under a stated backpressure contract."
+  - id: terminal
+    responsibility: "Represent success, interrupt, error, max-steps, and cancellation distinctly."
+  - id: policy
+    responsibility: "Carry Store, ToolGate, checkpoint, usage, trace, and retry inputs."
+
+protocol_specific_non_goals:
+  - Request and response wire encoding.
+  - Authentication, reverse RPC, and protocol error vocabularies.
+  - Task/session persistence, reconnect, and transport streaming.
+  - Host admission limits and shutdown policy.
+
+red_tests:
+  - id: mock-protocol-no-core-change
+    assertion: "A mock host invokes a graph without protocol types in src/core."
+  - id: terminal-state-matrix
+    assertion: "All five terminal outcomes remain distinguishable."
+  - id: policy-through-boundary
+    assertion: "CancelToken, ToolGate, Store, and checkpoint identity reach the graph."
+
+implementation_phases:
+  - Approve an ownership and concurrency design document.
+  - Implement the boundary as concrete composition, not a fat virtual interface.
+  - Migrate one protocol and prove parity before migrating the others.
+  - Remove duplicate run assembly only after shared contract tests exist.
+
+acceptance:
+  - A2A, ACP, gRPC, and a mock host use one graph invocation contract.
+  - Adding a protocol requires no GraphEngine or core protocol-type change.
+  - Protocol-specific lifecycle remains outside the shared boundary.

--- a/spec/issue-215-protocol-contract-tests.sdd.yaml
+++ b/spec/issue-215-protocol-contract-tests.sdd.yaml
@@ -1,0 +1,42 @@
+spec:
+  id: issue-215-protocol-contract-tests
+  issue: 215
+  parent: 187
+  status: proposed
+  priority: P1
+  kind: test-infrastructure
+  depends_on: [214]
+
+objective: >-
+  Define a reusable graph-boundary conformance suite for every protocol host
+  while leaving wire-format and host-lifecycle tests protocol-specific.
+
+contract_cases:
+  - Identity maps to the expected RunConfig and checkpoint thread.
+  - Cancellation reaches an in-flight node, provider, and cooperative tool.
+  - GraphEvent order and terminal result are consistent.
+  - ToolGate, Store, usage, and nested execution policy propagate.
+  - Success, error, interrupt, max-steps, and cancellation remain distinct.
+  - Overload rejection does not start graph work.
+  - Host shutdown follows the protocol-specific declared policy.
+
+test_design:
+  fixtures:
+    - Deterministic blocking/cancellable node.
+    - Mock provider and side-effect-counting tool.
+    - In-memory checkpoint and Store.
+    - Event recorder with bounded sink behavior.
+  mutation_checks:
+    - Remove CancelToken wiring and require suite failure.
+    - Drop ToolGate propagation and require suite failure.
+    - Collapse cancel and error terminal states and require suite failure.
+
+implementation:
+  - Define a host test adapter only for fixture control, not production behavior.
+  - Run the same cases against A2A, ACP, gRPC, and mock host.
+  - Keep protocol payload assertions in existing protocol suites.
+
+acceptance:
+  - Every shipping protocol passes the shared suite offline.
+  - A deliberately broken host fails at least one targeted mutation check.
+  - Future protocol documentation names this suite as a release gate.

--- a/spec/issue-216-graph-engine-responsibilities.sdd.yaml
+++ b/spec/issue-216-graph-engine-responsibilities.sdd.yaml
@@ -1,0 +1,40 @@
+spec:
+  id: issue-216-graph-engine-responsibilities
+  issue: 216
+  parent: 187
+  status: design-required
+  priority: P2
+  kind: architecture
+  depends_on: [214]
+
+problem:
+  statement: >-
+    GraphEngine combines execution, resume, state administration, fork/update,
+    Store/cache/ToolGate setup, worker tuning, tracing, and lifecycle controls.
+
+precondition:
+  - Inventory every public GraphEngine method and current external call site.
+  - Record thread-safety, mutability, and lifetime for each method.
+  - Identify actual coupling pressure before introducing interfaces.
+
+candidate_boundaries:
+  execution: [run, run_async, run_stream, resume]
+  administration: [get_state, history, update_state, fork, delete]
+  runtime_policy: [store, tool_gate, cache, workers, tracing]
+
+invariants:
+  - Existing facade can remain during migration.
+  - Protocol hosts depend only on execution capabilities.
+  - Admin operations have an explicit race policy with active runs.
+  - No allocation or indirect call is added to the common run fast path without measurement.
+
+red_tests:
+  - id: capability-compile-boundary
+    assertion: "Protocol host compiles with execution capability only."
+  - id: admin-run-race-policy
+    assertion: "Same-thread update/fork during a run follows declared behavior."
+
+acceptance:
+  - Every method has one responsibility owner and documented concurrency contract.
+  - Compatibility and removal timeline are explicit.
+  - Engine overhead remains within the measured gate.

--- a/spec/issue-217-nodecontext-tool-ownership.sdd.yaml
+++ b/spec/issue-217-nodecontext-tool-ownership.sdd.yaml
@@ -1,0 +1,38 @@
+spec:
+  id: issue-217-nodecontext-tool-ownership
+  issue: 217
+  parent: 187
+  status: design-required
+  priority: P2
+  kind: ownership-api
+  depends_on: [194]
+
+problem:
+  statement: >-
+    NodeContext exposes raw Tool pointers while ownership may be transferred later,
+    making safe lifetime depend on call ordering and hidden owner storage.
+
+contract:
+  - Borrowed and owned tool input are distinguishable in types.
+  - A compiled engine cannot retain a dangling Tool pointer.
+  - C++, Python trampoline, and MCP-discovered tools share one lifetime model.
+  - Compile-time ownership transfer performs no per-dispatch ownership work.
+
+red_tests:
+  - id: temporary-tool-owner
+    assertion: "A tool supplied by the supported owning path survives graph lifetime."
+  - id: borrowed-expiry
+    assertion: "Unsafe borrowed lifetime cannot compile or fails before engine retention."
+  - id: replacement-release
+    assertion: "Replacing context tools releases only superseded ownership."
+  - id: cross-language-lifetime
+    assertion: "Python and MCP tool wrappers remain alive exactly as long as required."
+
+implementation_phases:
+  - Inventory aggregate initialization and ownership call sites.
+  - Choose shared ownership, unique transfer, or explicit borrowed view.
+  - Migrate compile boundary and bindings before deprecating old fields.
+
+acceptance:
+  - No raw pointer is retained without a statically visible owner contract.
+  - ASan, Python GC, MCP session, and concurrent tool tests pass.

--- a/spec/issue-218-engine-scoped-registries.sdd.yaml
+++ b/spec/issue-218-engine-scoped-registries.sdd.yaml
@@ -1,0 +1,37 @@
+spec:
+  id: issue-218-engine-scoped-registries
+  issue: 218
+  parent: 187
+  status: design-required
+  priority: P2
+  kind: isolation-api
+  depends_on: [216]
+
+problem:
+  statement: >-
+    Process-wide registries allow unrelated engines, tenants, plugins, and tests
+    to replace each others node, reducer, and condition definitions.
+
+contract:
+  - Compilation receives an explicit registry set with stable lifetime.
+  - Built-ins are supplied by default without process-global mutation.
+  - Two engines may bind the same name to different implementations.
+  - Schema export reflects the registry set used for compilation.
+  - Concurrent registration/compilation behavior is explicit.
+
+red_tests:
+  - id: same-name-two-engines
+    assertion: "Each engine executes its own registration."
+  - id: test-isolation
+    assertion: "One Python or C++ test cannot alter a later engine by leakage."
+  - id: schema-export-scope
+    assertion: "Each registry exports only its selected extensions plus built-ins."
+
+implementation_phases:
+  - Introduce clonable/default registry values.
+  - Thread the registry through compiler and context construction.
+  - Preserve global convenience only as an explicit compatibility adapter.
+
+acceptance:
+  - Engine-scoped isolation tests pass under concurrency.
+  - Existing custom registration has a documented migration path.

--- a/spec/issue-219-mcp-transport-separation.sdd.yaml
+++ b/spec/issue-219-mcp-transport-separation.sdd.yaml
@@ -1,0 +1,41 @@
+spec:
+  id: issue-219-mcp-transport-separation
+  issue: 219
+  parent: 187
+  status: design-required
+  priority: P2
+  kind: architecture
+  depends_on: []
+
+problem:
+  statement: >-
+    MCP JSON-RPC/session behavior, tool adaptation, HTTP state, stdio process
+    lifetime, correlation, and concurrency are coupled across client code.
+
+functional_blocks:
+  - id: protocol-session
+    responsibility: "Initialize, negotiate capabilities, correlate RPC, and expose tools."
+  - id: http-transport
+    responsibility: "URL, headers, session ID, timeout, cancellation, and HTTP framing."
+  - id: stdio-transport
+    responsibility: "Process, pipes, framed writes, reader lifecycle, EOF, and shutdown."
+  - id: tool-adapter
+    responsibility: "Map discovered tools to NeoGraph Tool without transport knowledge."
+
+invariants:
+  - Protocol method names and result/error parsing have one implementation.
+  - Correlation IDs preserve concurrent calls on capable transports.
+  - Transport shutdown completes every in-flight call with value or error.
+  - Adding a transport does not modify graph tool dispatch.
+
+red_tests:
+  - id: transport-parity
+    assertion: "HTTP and stdio pass one protocol/session contract suite."
+  - id: concurrent-correlation
+    assertion: "Out-of-order responses reach the correct caller."
+  - id: shutdown-inflight
+    assertion: "EOF/cancel completes all waiters without UAF or hang."
+
+acceptance:
+  - HTTP and stdio ownership and lifecycle are independently testable.
+  - Existing MCP graph, Python, and concurrent stdio tests pass.

--- a/spec/issue-220-schema-provider-decomposition.sdd.yaml
+++ b/spec/issue-220-schema-provider-decomposition.sdd.yaml
@@ -1,0 +1,46 @@
+spec:
+  id: issue-220-schema-provider-decomposition
+  issue: 220
+  parent: 187
+  status: design-required
+  priority: P2
+  kind: architecture
+  depends_on: [192, 199]
+
+problem:
+  statement: >-
+    SchemaProvider combines schema interpretation, request construction,
+    transport selection, stream parsing, response extraction, and usage mapping.
+
+functional_blocks:
+  - id: request-mapper
+    responsibility: "Map CompletionParams plus schema to an owned request value."
+  - id: transport
+    responsibility: "Execute HTTP, SSE, WebSocket, or libcurl with cancellation."
+  - id: event-parser
+    responsibility: "Turn transport frames into typed deltas and terminal events."
+  - id: response-assembler
+    responsibility: "Build ChatCompletion content, tool calls, finish state, and usage."
+
+invariants:
+  - Provider-facing API remains canonical invoke.
+  - Request and response mapping are testable without network I/O.
+  - Callback execution and cancellation obey Provider contract.
+  - Data-driven custom schemas remain possible.
+
+red_tests:
+  - id: request-fixture-matrix
+    assertion: "OpenAI Responses, Claude, Gemini, and custom schemas map deterministically."
+  - id: stream-fixture-matrix
+    assertion: "SSE and WebSocket fixtures assemble identical semantic completions."
+  - id: transport-substitution
+    assertion: "A fake transport tests provider behavior without sockets."
+
+implementation_phases:
+  - Freeze value-level mapper contracts and fixtures.
+  - Extract parsing/assembly before transport strategies.
+  - Migrate one transport at a time with parity tests.
+
+acceptance:
+  - Mapping, parsing, and transport have independent unit suites.
+  - Existing provider, live opt-in, usage, tool-call, and streaming tests pass.

--- a/spec/issue-221-sync-node-ergonomics.sdd.yaml
+++ b/spec/issue-221-sync-node-ergonomics.sdd.yaml
@@ -1,0 +1,44 @@
+spec:
+  id: issue-221-sync-node-ergonomics
+  issue: 221
+  parent: 187
+  status: design-required
+  priority: P2
+  kind: additive-api
+  depends_on: [195]
+
+problem:
+  statement: >-
+    The single coroutine GraphNode contract is correct but simple synchronous
+    nodes require avoidable coroutine syntax. Restoring a sync virtual would
+    recreate the dispatch ambiguity removed by the v1 work.
+
+constraints:
+  - GraphNode keeps one virtual run(NodeInput) entry.
+  - The helper is additive and non-virtual or implements run finally.
+  - Send, Command, RunContext, and optional stream sink remain available.
+  - Blocking I/O is not disguised as asynchronous work.
+
+candidate_shapes:
+  - "SyncGraphNode adapter with one synchronous body method and final run lift."
+  - "NodeFactory callable wrapper from NodeInputView to NodeOutput."
+  - "Free make_node helper owning a callable."
+
+red_tests:
+  - id: minimal-sync-node
+    assertion: "A complete synchronous node needs no manual co_return boilerplate."
+  - id: full-output
+    assertion: "The helper emits writes, Send, and Command without loss."
+  - id: streaming-context
+    assertion: "The helper can inspect context and optional stream sink."
+  - id: no-recursion
+    assertion: "No sync/async fallback pair is introduced."
+
+measurement:
+  - Compare wrapper dispatch with a direct run override in the engine benchmark.
+  - Reject unexplained overhead above the established noise floor.
+
+acceptance:
+  - One concise C++ example demonstrates the selected helper.
+  - Canonical run dispatch and async-native nodes remain unchanged.
+  - Documentation warns that blocking I/O requires an async node or explicit pool.

--- a/src/async/conn_pool.cpp
+++ b/src/async/conn_pool.cpp
@@ -278,10 +278,23 @@ asio::awaitable<HttpResponse> ConnPool::async_post(
     std::vector<std::pair<std::string, std::string>> headers,
     bool tls,
     RequestOptions opts) {
+    return async_post_owned(
+        std::string(host), std::string(port), std::string(path),
+        std::string(body), std::move(headers), tls, opts);
+}
 
-    Key key{ std::string(host), std::string(port), tls };
+asio::awaitable<HttpResponse> ConnPool::async_post_owned(
+    std::string host,
+    std::string port,
+    std::string path,
+    std::string body,
+    std::vector<std::pair<std::string, std::string>> headers,
+    bool tls,
+    RequestOptions opts) {
+
     std::string req = detail::build_request(
         host, path, body, headers, detail::ConnDirective::keep_alive);
+    Key key{ std::move(host), std::move(port), tls };
 
     if (opts.timeout.count() <= 0) {
         co_return co_await impl_->dispatch(std::move(key), req);

--- a/src/async/http_client.cpp
+++ b/src/async/http_client.cpp
@@ -300,20 +300,20 @@ asio::awaitable<HttpStreamResponse> async_post_stream_once_timed(
 
 // ── Public API ────────────────────────────────────────────────────
 
-asio::awaitable<HttpResponse> async_post(
+static asio::awaitable<HttpResponse> async_post_owned(
     asio::any_io_executor ex,
-    std::string_view host,
-    std::string_view port,
-    std::string_view path,
-    std::string_view body,
+    std::string host,
+    std::string port,
+    std::string path,
+    std::string body,
     std::vector<std::pair<std::string, std::string>> headers,
     bool tls,
     RequestOptions opts) {
 
     Target cur{
-        std::string(host), std::string(port), std::string(path), tls
+        std::move(host), std::move(port), std::move(path), tls
     };
-    std::string req_body(body);
+    std::string req_body(std::move(body));
     int hops = 0;
     for (;;) {
         auto resp = co_await async_post_once_timed(
@@ -334,6 +334,20 @@ asio::awaitable<HttpResponse> async_post(
         cur = parse_location(cur, resp.location);
         // Loop: next hop uses the new cur.
     }
+}
+
+asio::awaitable<HttpResponse> async_post(
+    asio::any_io_executor ex,
+    std::string_view host,
+    std::string_view port,
+    std::string_view path,
+    std::string_view body,
+    std::vector<std::pair<std::string, std::string>> headers,
+    bool tls,
+    RequestOptions opts) {
+    return async_post_owned(
+        std::move(ex), std::string(host), std::string(port),
+        std::string(path), std::string(body), std::move(headers), tls, opts);
 }
 
 // ── Async GET ─────────────────────────────────────────────────────
@@ -417,6 +431,20 @@ asio::awaitable<HttpResponse> async_get_once_timed(
     co_return std::get<0>(std::move(res));
 }
 
+static asio::awaitable<HttpResponse> async_get_owned(
+    asio::any_io_executor ex,
+    std::string host,
+    std::string port,
+    std::string path,
+    std::vector<std::pair<std::string, std::string>> headers,
+    bool tls,
+    RequestOptions opts) {
+
+    co_return co_await async_get_once_timed(
+        ex, std::move(host), std::move(port), std::move(path),
+        std::move(headers), tls, opts.timeout);
+}
+
 asio::awaitable<HttpResponse> async_get(
     asio::any_io_executor ex,
     std::string_view host,
@@ -425,18 +453,17 @@ asio::awaitable<HttpResponse> async_get(
     std::vector<std::pair<std::string, std::string>> headers,
     bool tls,
     RequestOptions opts) {
-
-    co_return co_await async_get_once_timed(
-        ex, std::string(host), std::string(port), std::string(path),
-        std::move(headers), tls, opts.timeout);
+    return async_get_owned(
+        std::move(ex), std::string(host), std::string(port),
+        std::string(path), std::move(headers), tls, opts);
 }
 
-asio::awaitable<HttpStreamResponse> async_post_stream(
+static asio::awaitable<HttpStreamResponse> async_post_stream_owned(
     asio::any_io_executor ex,
-    std::string_view host,
-    std::string_view port,
-    std::string_view path,
-    std::string_view body,
+    std::string host,
+    std::string port,
+    std::string path,
+    std::string body,
     std::vector<std::pair<std::string, std::string>> headers,
     bool tls,
     std::function<void(std::string_view chunk)> on_chunk,
@@ -449,9 +476,9 @@ asio::awaitable<HttpStreamResponse> async_post_stream(
     // redirect occurs. In practice, streaming endpoints always return
     // 200 or a fixed-body error, so this loop usually runs once.
     Target cur{
-        std::string(host), std::string(port), std::string(path), tls
+        std::move(host), std::move(port), std::move(path), tls
     };
-    std::string req_body(body);
+    std::string req_body(std::move(body));
     int hops = 0;
     for (;;) {
         auto resp = co_await async_post_stream_once_timed(
@@ -471,6 +498,22 @@ asio::awaitable<HttpStreamResponse> async_post_stream(
         // rather than guess a target.
         co_return resp;
     }
+}
+
+asio::awaitable<HttpStreamResponse> async_post_stream(
+    asio::any_io_executor ex,
+    std::string_view host,
+    std::string_view port,
+    std::string_view path,
+    std::string_view body,
+    std::vector<std::pair<std::string, std::string>> headers,
+    bool tls,
+    std::function<void(std::string_view chunk)> on_chunk,
+    RequestOptions opts) {
+    return async_post_stream_owned(
+        std::move(ex), std::string(host), std::string(port),
+        std::string(path), std::string(body), std::move(headers), tls,
+        std::move(on_chunk), opts);
 }
 
 } // namespace neograph::async

--- a/src/async/ws_client.cpp
+++ b/src/async/ws_client.cpp
@@ -265,17 +265,26 @@ WsClient& WsClient::operator=(WsClient&&) noexcept = default;
 // ── Frame send/recv ───────────────────────────────────────────────
 
 asio::awaitable<void> WsClient::send_text(std::string_view payload) {
-    co_await impl_->write_frame(WsOpcode::Text, true, payload);
-    co_return;
+    return send_frame_owned(WsOpcode::Text, std::string(payload));
 }
 
 asio::awaitable<void> WsClient::send_binary(std::string_view payload) {
-    co_await impl_->write_frame(WsOpcode::Binary, true, payload);
+    return send_frame_owned(WsOpcode::Binary, std::string(payload));
+}
+
+asio::awaitable<void> WsClient::send_frame_owned(
+    WsOpcode opcode, std::string payload) {
+    co_await impl_->write_frame(opcode, true, payload);
     co_return;
 }
 
 asio::awaitable<void> WsClient::send_close(
     std::uint16_t code, std::string_view reason) {
+    return send_close_owned(code, std::string(reason));
+}
+
+asio::awaitable<void> WsClient::send_close_owned(
+    std::uint16_t code, std::string reason) {
     if (impl_->close_sent) co_return;
     std::string payload;
     payload.reserve(2 + reason.size());
@@ -519,11 +528,11 @@ std::string build_upgrade_request(
 
 }  // namespace
 
-asio::awaitable<std::unique_ptr<WsClient>> ws_connect(
+asio::awaitable<std::unique_ptr<WsClient>> WsClient::connect_owned(
     asio::any_io_executor ex,
-    std::string_view host,
-    std::string_view port,
-    std::string_view path,
+    std::string host,
+    std::string port,
+    std::string path,
     std::vector<std::pair<std::string, std::string>> headers,
     bool tls) {
 
@@ -531,7 +540,7 @@ asio::awaitable<std::unique_ptr<WsClient>> ws_connect(
 
     asio::ip::tcp::resolver resolver{ex};
     auto endpoints = co_await resolver.async_resolve(
-        std::string(host), std::string(port), asio::use_awaitable);
+        host, port, asio::use_awaitable);
     co_await asio::async_connect(impl->socket, endpoints, asio::use_awaitable);
 
     if (tls) {
@@ -542,16 +551,15 @@ asio::awaitable<std::unique_ptr<WsClient>> ws_connect(
 
         impl->tls_stream = std::make_unique<
             asio::ssl::stream<asio::ip::tcp::socket&>>(impl->socket, *impl->ssl_ctx);
-        std::string host_str(host);
         if (!SSL_set_tlsext_host_name(
-                impl->tls_stream->native_handle(), host_str.c_str())) {
+                impl->tls_stream->native_handle(), host.c_str())) {
             throw asio::system_error{
                 asio::error_code{static_cast<int>(::ERR_get_error()),
                                  asio::error::get_ssl_category()},
                 "ws: SNI setup"};
         }
         impl->tls_stream->set_verify_callback(
-            asio::ssl::host_name_verification{host_str});
+            asio::ssl::host_name_verification{host});
         co_await impl->tls_stream->async_handshake(
             asio::ssl::stream_base::client, asio::use_awaitable);
     }
@@ -617,6 +625,18 @@ asio::awaitable<std::unique_ptr<WsClient>> ws_connect(
     impl->read_buf.erase(0, parsed->consumed);
 
     co_return std::unique_ptr<WsClient>(new WsClient(std::move(impl)));
+}
+
+asio::awaitable<std::unique_ptr<WsClient>> ws_connect(
+    asio::any_io_executor ex,
+    std::string_view host,
+    std::string_view port,
+    std::string_view path,
+    std::vector<std::pair<std::string, std::string>> headers,
+    bool tls) {
+    return WsClient::connect_owned(
+        std::move(ex), std::string(host), std::string(port),
+        std::string(path), std::move(headers), tls);
 }
 
 }  // namespace neograph::async

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -597,7 +597,8 @@ asio::awaitable<RunResult> GraphEngine::resume_async(const std::string&         
                                                      const GraphStreamCallback& cb) {
     RunConfig config;
     config.thread_id = thread_id;
-    co_return co_await resume_async(std::move(config), resume_value, cb);
+    return resume_async(
+        std::move(config), json(resume_value), GraphStreamCallback(cb));
 }
 
 asio::awaitable<RunResult> GraphEngine::resume_async(RunConfig           config,

--- a/tests/test_async_conn_pool.cpp
+++ b/tests/test_async_conn_pool.cpp
@@ -27,6 +27,7 @@
 #include <asio/redirect_error.hpp>
 #include <asio/streambuf.hpp>
 #include <asio/use_awaitable.hpp>
+#include <asio/use_future.hpp>
 #include <asio/write.hpp>
 
 #include <gtest/gtest.h>
@@ -82,9 +83,17 @@ struct MockServer {
 
                 std::istream is(&buf);
                 std::string line;
+                std::string request_path;
                 long content_length = 0;
                 bool client_keepalive = true;
                 std::getline(is, line);  // request line
+                {
+                    auto sp1 = line.find(' ');
+                    auto sp2 = line.find(' ', sp1 == std::string::npos ? 0 : sp1 + 1);
+                    if (sp1 != std::string::npos && sp2 != std::string::npos) {
+                        request_path = line.substr(sp1 + 1, sp2 - sp1 - 1);
+                    }
+                }
                 while (std::getline(is, line)) {
                     if (!line.empty() && line.back() == '\r') line.pop_back();
                     if (line.empty()) break;
@@ -120,7 +129,9 @@ struct MockServer {
 
                 ++requests;
 
-                const std::string body = R"({"ok":true})";
+                const std::string body = request_path == "/x"
+                    ? R"({"ok":true})"
+                    : R"({"ok":false})";
                 const bool send_close = force_close.load() || !client_keepalive;
                 std::string resp;
                 resp.reserve(160 + body.size());
@@ -277,6 +288,26 @@ TEST(ConnPool, ParallelConverges) {
     EXPECT_LE(srv.accepted.load(), M);    // ≤ one socket per coro
     EXPECT_LE(pool.idle_count(), 4u);
     EXPECT_GT(pool.idle_count(), 0u);     // at least some reuse retained
+}
+
+TEST(AsyncHttpOwnership, ConnPoolSnapshotsRequestBeforeFirstResume) {
+    MockServer srv;
+    asio::io_context io;
+    neograph::async::ConnPool pool(io.get_executor());
+    std::string host = "127.0.0.1";
+    std::string port = std::to_string(srv.port);
+    std::string path = "/x";
+    std::string body = "{}";
+
+    auto operation = pool.async_post(host, port, path, body);
+    path = "/mutated";
+
+    auto future = asio::co_spawn(io, std::move(operation), asio::use_future);
+    io.run();
+    auto resp = future.get();
+
+    EXPECT_EQ(resp.status, 200);
+    EXPECT_EQ(resp.body, R"({"ok":true})");
 }
 
 }  // namespace

--- a/tests/test_async_get.cpp
+++ b/tests/test_async_get.cpp
@@ -16,7 +16,10 @@
 #include <httplib.h>
 
 #include <asio/awaitable.hpp>
+#include <asio/co_spawn.hpp>
+#include <asio/io_context.hpp>
 #include <asio/this_coro.hpp>
+#include <asio/use_future.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -47,6 +50,27 @@ struct CapturingServer {
             record(req, "POST");
             res.status = 200;
             res.set_content(R"({"got":"bar"})", "application/json");
+        });
+        svr.Get("/snapshot", [this](const httplib::Request& req, httplib::Response& res) {
+            record(req, "GET");
+            res.status = 200;
+            res.set_content("snapshot", "text/plain");
+        });
+        svr.Get("/mutated", [this](const httplib::Request& req, httplib::Response& res) {
+            record(req, "GET");
+            res.status = 200;
+            res.set_content("mutated", "text/plain");
+        });
+        svr.Post("/snapshot", [this](const httplib::Request& req, httplib::Response& res) {
+            record(req, "POST");
+            res.status = 200;
+            res.set_content(req.body + "|" + req.get_header_value("X-Ownership"),
+                            "text/plain");
+        });
+        svr.Post("/mutated", [this](const httplib::Request& req, httplib::Response& res) {
+            record(req, "POST");
+            res.status = 200;
+            res.set_content("mutated", "text/plain");
         });
         port = svr.bind_to_any_port("127.0.0.1");
         t = std::thread([this] { svr.listen_after_bind(); });
@@ -164,6 +188,69 @@ TEST(AsyncGet, SurfacesNon200Status) {
 
     svr.stop();
     if (t.joinable()) t.join();
+}
+
+TEST(AsyncHttpOwnership, PostSnapshotsInputsBeforeFirstResume) {
+    CapturingServer srv;
+    asio::io_context io;
+    std::string host = "127.0.0.1";
+    std::string port = std::to_string(srv.port);
+    std::string path = "/snapshot";
+    std::string body = "original-body";
+    std::vector<std::pair<std::string, std::string>> headers = {
+        {"X-Ownership", "original-header"},
+    };
+
+    auto operation = async::async_post(
+        io.get_executor(), host, port, path, body, headers);
+    path = "/mutated";
+    body = "mutated-body";
+    headers[0].second = "mutated-header";
+
+    auto future = asio::co_spawn(io, std::move(operation), asio::use_future);
+    io.run();
+    auto resp = future.get();
+
+    EXPECT_EQ(resp.status, 200);
+    EXPECT_EQ(resp.body, "original-body|original-header");
+}
+
+TEST(AsyncHttpOwnership, GetSnapshotsEndpointBeforeFirstResume) {
+    CapturingServer srv;
+    asio::io_context io;
+    std::string host = "127.0.0.1";
+    std::string port = std::to_string(srv.port);
+    std::string path = "/snapshot";
+
+    auto operation = async::async_get(io.get_executor(), host, port, path);
+    path = "/mutated";
+
+    auto future = asio::co_spawn(io, std::move(operation), asio::use_future);
+    io.run();
+    auto resp = future.get();
+
+    EXPECT_EQ(resp.status, 200);
+    EXPECT_EQ(resp.body, "snapshot");
+}
+
+TEST(AsyncHttpOwnership, PostOwnsTemporariesUntilDelayedSpawn) {
+    CapturingServer srv;
+    asio::io_context io;
+
+    auto operation = async::async_post(
+        io.get_executor(),
+        std::string("127.0.0.1"),
+        std::to_string(srv.port),
+        std::string("/snapshot"),
+        std::string("temporary-body"),
+        {{"X-Ownership", "temporary-header"}});
+
+    auto future = asio::co_spawn(io, std::move(operation), asio::use_future);
+    io.run();
+    auto resp = future.get();
+
+    EXPECT_EQ(resp.status, 200);
+    EXPECT_EQ(resp.body, "temporary-body|temporary-header");
 }
 
 }  // namespace

--- a/tests/test_async_http_stream.cpp
+++ b/tests/test_async_http_stream.cpp
@@ -19,6 +19,7 @@
 #include <asio/redirect_error.hpp>
 #include <asio/streambuf.hpp>
 #include <asio/use_awaitable.hpp>
+#include <asio/use_future.hpp>
 #include <asio/write.hpp>
 
 #include <gtest/gtest.h>
@@ -26,6 +27,7 @@
 #include <atomic>
 #include <chrono>
 #include <exception>
+#include <istream>
 #include <string>
 #include <thread>
 #include <utility>
@@ -41,9 +43,12 @@ struct ChunkedMockServer {
     asio::ip::tcp::acceptor acceptor{io};
     std::thread             worker;
     std::vector<std::string> chunks;
+    std::string             expected_path;
     unsigned short          port = 0;
 
-    ChunkedMockServer(std::vector<std::string> chs) : chunks(std::move(chs)) {
+    ChunkedMockServer(std::vector<std::string> chs,
+                      std::string expected = {})
+        : chunks(std::move(chs)), expected_path(std::move(expected)) {
         acceptor.open(asio::ip::tcp::v4());
         acceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true));
         acceptor.bind(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), 0));
@@ -66,6 +71,16 @@ struct ChunkedMockServer {
             asio::streambuf buf;
             co_await asio::async_read_until(
                 sock, buf, "\r\n\r\n", asio::use_awaitable);
+            std::istream is(&buf);
+            std::string request_line;
+            std::getline(is, request_line);
+            std::string request_path;
+            auto sp1 = request_line.find(' ');
+            auto sp2 = request_line.find(
+                ' ', sp1 == std::string::npos ? 0 : sp1 + 1);
+            if (sp1 != std::string::npos && sp2 != std::string::npos) {
+                request_path = request_line.substr(sp1 + 1, sp2 - sp1 - 1);
+            }
             // (Body ignored for this mock.)
 
             // Write response headers.
@@ -78,7 +93,12 @@ struct ChunkedMockServer {
                                        asio::use_awaitable);
 
             // Emit each configured chunk.
-            for (const auto& c : chunks) {
+            const std::vector<std::string> mutated_chunks = {"mutated"};
+            const auto& response_chunks =
+                expected_path.empty() || request_path == expected_path
+                    ? chunks
+                    : mutated_chunks;
+            for (const auto& c : response_chunks) {
                 std::string frame;
                 frame.reserve(16 + c.size());
                 // Hex size, \r\n, payload, \r\n
@@ -278,6 +298,30 @@ TEST(AsyncPostStream, ServerErrorStatusStillDelivered) {
 
     EXPECT_EQ(status, 500);
     EXPECT_EQ(got, "oops nope");
+}
+
+TEST(AsyncHttpOwnership, StreamSnapshotsEndpointAndCallbackBeforeFirstResume) {
+    ChunkedMockServer srv({"owned"}, "/v1/stream");
+    asio::io_context io;
+    std::string host = "127.0.0.1";
+    std::string port = std::to_string(srv.port);
+    std::string path = "/v1/stream";
+    std::string body = "{}";
+    std::string received;
+    std::function<void(std::string_view)> callback =
+        [&](std::string_view chunk) { received.append(chunk); };
+
+    auto operation = neograph::async::async_post_stream(
+        io.get_executor(), host, port, path, body, {}, false, callback);
+    path = "/mutated";
+    callback = nullptr;
+
+    auto future = asio::co_spawn(io, std::move(operation), asio::use_future);
+    io.run();
+    auto resp = future.get();
+
+    EXPECT_EQ(resp.status, 200);
+    EXPECT_EQ(received, "owned");
 }
 
 }  // namespace

--- a/tests/test_async_ws_loopback.cpp
+++ b/tests/test_async_ws_loopback.cpp
@@ -57,6 +57,13 @@ asio::awaitable<void> serve_one(asio::ip::tcp::socket sock) {
         hdr_end = buf.find("\r\n\r\n");
     }
     auto head = buf.substr(0, hdr_end);
+    if (head.rfind("GET / HTTP/1.1\r\n", 0) != 0 &&
+        head.rfind("GET /owned HTTP/1.1\r\n", 0) != 0) {
+        const std::string bad =
+            "HTTP/1.1 400 Bad Request\r\nContent-Length: 0\r\n\r\n";
+        co_await asio::async_write(sock, asio::buffer(bad), asio::use_awaitable);
+        co_return;
+    }
     std::string key;
     {
         auto pos = head.find("Sec-WebSocket-Key:");
@@ -220,4 +227,67 @@ TEST_F(WsLoopback, LargeBinaryEcho) {
     auto echoed = fut.get();
     EXPECT_EQ(echoed.size(), big.size());
     EXPECT_EQ(echoed, big);
+}
+
+TEST_F(WsLoopback, DelayedOperationsOwnEndpointAndPayloads) {
+    asio::io_context client_ioc;
+    std::string host = "127.0.0.1";
+    std::string port = std::to_string(port_);
+    std::string path = "/owned";
+
+    auto connect_operation = ws_connect(
+        client_ioc.get_executor(), host, port, path, {}, /*tls=*/false);
+    path = "/change";
+    auto connect_future = asio::co_spawn(
+        client_ioc, std::move(connect_operation), asio::use_future);
+    client_ioc.run();
+    auto ws = connect_future.get();
+
+    client_ioc.restart();
+    std::string text = "owned-text";
+    auto text_operation = ws->send_text(text);
+    text = "mutated-text";
+    auto text_future = asio::co_spawn(
+        client_ioc, std::move(text_operation), asio::use_future);
+    client_ioc.run();
+    text_future.get();
+
+    client_ioc.restart();
+    auto text_recv_future = asio::co_spawn(
+        client_ioc, ws->recv(), asio::use_future);
+    client_ioc.run();
+    EXPECT_EQ(text_recv_future.get().payload, "owned-text");
+
+    client_ioc.restart();
+    std::string binary = "owned-binary";
+    auto binary_operation = ws->send_binary(binary);
+    binary = "mutated-binary";
+    auto binary_future = asio::co_spawn(
+        client_ioc, std::move(binary_operation), asio::use_future);
+    client_ioc.run();
+    binary_future.get();
+
+    client_ioc.restart();
+    auto binary_recv_future = asio::co_spawn(
+        client_ioc, ws->recv(), asio::use_future);
+    client_ioc.run();
+    EXPECT_EQ(binary_recv_future.get().payload, "owned-binary");
+
+    client_ioc.restart();
+    std::string reason = "owned-close";
+    auto close_operation = ws->send_close(1000, reason);
+    reason = "mutated-close";
+    auto close_future = asio::co_spawn(
+        client_ioc, std::move(close_operation), asio::use_future);
+    client_ioc.run();
+    close_future.get();
+
+    client_ioc.restart();
+    auto close_recv_future = asio::co_spawn(
+        client_ioc, ws->recv(), asio::use_future);
+    client_ioc.run();
+    auto close = close_recv_future.get();
+    ASSERT_EQ(close.op, WsOpcode::Close);
+    ASSERT_GE(close.payload.size(), 2u);
+    EXPECT_EQ(close.payload.substr(2), "owned-close");
 }

--- a/tests/test_graph_engine_async_api.cpp
+++ b/tests/test_graph_engine_async_api.cpp
@@ -30,10 +30,12 @@
 #include <asio/streambuf.hpp>
 #include <asio/this_coro.hpp>
 #include <asio/use_awaitable.hpp>
+#include <asio/use_future.hpp>
 #include <asio/write.hpp>
 
 #include <atomic>
 #include <chrono>
+#include <memory>
 #include <mutex>
 #include <stdexcept>
 #include <thread>
@@ -222,6 +224,52 @@ private:
     std::atomic<CancelToken*>* seen_;
 };
 
+class ResumeApprovalNode : public GraphNode {
+public:
+    explicit ResumeApprovalNode(std::string name) : name_(std::move(name)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        if (!in.ctx.resume_value) {
+            throw NodeInterrupt("approval required");
+        }
+
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{
+            "result", in.ctx.resume_value->at("decision")});
+        co_return out;
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+};
+
+json resume_graph() {
+    return {
+        {"name", "async_resume_ownership"},
+        {"channels", {{"result", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"approval", {{"type", "async_resume_approval"}}}}},
+        {"edges", {
+            {{"from", "__start__"}, {"to", "approval"}},
+            {{"from", "approval"}, {"to", "__end__"}},
+        }},
+    };
+}
+
+void register_resume_approval() {
+    NodeFactory::instance().register_type("async_resume_approval",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<ResumeApprovalNode>(name);
+        });
+}
+
+void seed_interrupted_run(GraphEngine& engine, const std::string& thread_id) {
+    RunConfig cfg;
+    cfg.thread_id = thread_id;
+    ASSERT_TRUE(engine.run(cfg).interrupted);
+}
+
 } // namespace
 
 TEST(GraphEngineAsyncApi, RunAsyncMatchesSyncResult) {
@@ -340,31 +388,101 @@ TEST(GraphEngineAsyncApi, SubgraphFailureStillHonorsOuterRetry) {
 }
 
 TEST(GraphEngineAsyncApi, ResumeAsyncMatchesSyncResume) {
-    // resume_async needs a checkpoint store + a thread that has a
-    // checkpoint to resume from. Run once first to seed it, then drive
-    // resume_async.
-    register_writer("v");
+    register_resume_approval();
     auto store = std::make_shared<InMemoryCheckpointStore>();
-    auto engine = GraphEngine::compile(minimal_graph("worker"), NodeContext{}, store);
+    auto engine = GraphEngine::compile(resume_graph(), NodeContext{}, store);
+    seed_interrupted_run(*engine, "t-resume-sync");
+    seed_interrupted_run(*engine, "t-resume-async");
 
-    RunConfig cfg;
-    cfg.thread_id = "t-resume";
-    auto first = engine->run(cfg);
-    ASSERT_FALSE(first.checkpoint_id.empty());
+    json decision{{"decision", "approved"}};
+    auto sync_result = engine->resume("t-resume-sync", decision);
 
     asio::io_context io;
     RunResult resumed;
     asio::co_spawn(
         io,
         [&]() -> asio::awaitable<void> {
-            resumed = co_await engine->resume_async("t-resume");
+            resumed = co_await engine->resume_async(
+                "t-resume-async", decision);
         },
         asio::detached);
     io.run();
 
-    // Run that has already completed to END returns interrupted=false
-    // with no further work — match the sync resume() contract.
-    EXPECT_FALSE(resumed.interrupted);
+    EXPECT_EQ(resumed.output, sync_result.output);
+    EXPECT_EQ(resumed.interrupted, sync_result.interrupted);
+}
+
+TEST(GraphEngineAsyncApi, ResumeAsyncSnapshotsThreadIdBeforeFirstResume) {
+    register_resume_approval();
+    auto store = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(resume_graph(), NodeContext{}, store);
+    seed_interrupted_run(*engine, "owned-thread-id");
+
+    std::string thread_id = "owned-thread-id";
+    auto operation = engine->resume_async(
+        thread_id, json{{"decision", "approved"}});
+
+    // asio::awaitable is lazy. Changing the caller's source after the API
+    // returns must not change which checkpoint the eventual coroutine loads.
+    thread_id = "different-thread-id";
+
+    asio::io_context io;
+    auto future = asio::co_spawn(io, std::move(operation), asio::use_future);
+    io.run();
+
+    ASSERT_NO_THROW({
+        auto result = future.get();
+        EXPECT_EQ(result.output["channels"]["result"]["value"], "approved");
+    });
+}
+
+TEST(GraphEngineAsyncApi, ResumeAsyncSnapshotsValueAndCallbackBeforeFirstResume) {
+    register_resume_approval();
+    auto store = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(resume_graph(), NodeContext{}, store);
+    seed_interrupted_run(*engine, "owned-value-callback");
+
+    json decision{{"decision", "approved"}};
+    int event_count = 0;
+    const std::string thread_id = "owned-value-callback";
+    GraphStreamCallback callback =
+        [&](const GraphEvent&) { ++event_count; };
+    auto operation = engine->resume_async(
+        thread_id, decision, callback);
+
+    decision["decision"] = "mutated";
+    callback = nullptr;
+
+    asio::io_context io;
+    auto future = asio::co_spawn(io, std::move(operation), asio::use_future);
+    io.run();
+    auto result = future.get();
+
+    EXPECT_EQ(result.output["channels"]["result"]["value"], "approved");
+    EXPECT_GT(event_count, 0);
+}
+
+TEST(GraphEngineAsyncApi, ResumeAsyncOwnsTemporaryArgumentsUntilDelayedSpawn) {
+    register_resume_approval();
+    auto store = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(resume_graph(), NodeContext{}, store);
+    seed_interrupted_run(*engine, "temporary-resume-input");
+
+    auto event_count = std::make_shared<std::atomic<int>>(0);
+    auto operation = engine->resume_async(
+        std::string("temporary-resume-input"),
+        json{{"decision", "approved"}},
+        GraphStreamCallback([event_count](const GraphEvent&) {
+            event_count->fetch_add(1, std::memory_order_relaxed);
+        }));
+
+    asio::io_context io;
+    auto future = asio::co_spawn(io, std::move(operation), asio::use_future);
+    io.run();
+    auto result = future.get();
+
+    EXPECT_EQ(result.output["channels"]["result"]["value"], "approved");
+    EXPECT_GT(event_count->load(std::memory_order_relaxed), 0);
 }
 
 TEST(GraphEngineAsyncApi, ConcurrentRunAsyncOnSharedIoContext) {


### PR DESCRIPTION
## Summary

- make graph resume operations own deferred input values
- make HTTP, WebSocket, and connection-pool operations retain deferred inputs safely
- add the API v1 hardening tracker and follow-up issue specifications

## Validation

- CI will validate the full matrix
- `git diff --check origin/master...HEAD`