### PR TITLE
fix(store): preserve structured key identity

### DIFF
--- a/bindings/python/tests/test_parity.py
+++ b/bindings/python/tests/test_parity.py
@@ -80,6 +80,36 @@ def test_delete_and_list_namespaces():
     assert store.get(["users", "u1"], "a") is None
 
 
+def test_store_identity_preserves_components_and_slashes():
+    store = ng.InMemoryStore()
+    store.put(["a", "b"], "c", {"kind": "nested"})
+    store.put(["a"], "b/c", {"kind": "slash-key"})
+    store.put([], "root", {"kind": "empty-namespace"})
+    store.put([""], "root", {"kind": "empty-component"})
+
+    assert len(store) == 4
+    assert store.get(["a", "b"], "c").value == {"kind": "nested"}
+    assert store.get(["a"], "b/c").value == {"kind": "slash-key"}
+    assert store.get([], "root").value == {"kind": "empty-namespace"}
+    assert store.get([""], "root").value == {"kind": "empty-component"}
+
+
+def test_store_prefix_matches_complete_namespace_components():
+    store = ng.InMemoryStore()
+    store.put(["user", "one"], "key", 1)
+    store.put(["user", "two"], "key", 2)
+    store.put(["user2", "three"], "key", 3)
+
+    assert sorted(item.ns for item in store.search(["user"])) == [
+        ["user", "one"],
+        ["user", "two"],
+    ]
+    assert sorted(store.list_namespaces(["user"])) == [
+        ["user", "one"],
+        ["user", "two"],
+    ]
+
+
 def test_a_node_can_reach_the_store_through_its_context():
     """The point of the subsystem: a node remembering something across runs.
 

--- a/include/neograph/graph/store.h
+++ b/include/neograph/graph/store.h
@@ -92,8 +92,8 @@ public:
 /**
  * @brief In-memory store implementation for testing and single-process use.
  *
- * Thread-safe via mutex. Items are stored in a std::map keyed by
- * a composite string of namespace + key.
+ * Thread-safe via mutex. Items are stored in a std::map keyed by a
+ * collision-free length encoding of namespace components and item key.
  */
 class NEOGRAPH_API InMemoryStore : public Store {
 public:

--- a/spec/issue-203-store-structured-key.sdd.yaml
+++ b/spec/issue-203-store-structured-key.sdd.yaml
@@ -2,7 +2,7 @@ spec:
   id: issue-203-store-structured-key
   issue: 203
   parent: 187
-  status: proposed
+  status: completed
   priority: P0
   kind: data-correctness
   depends_on: []
@@ -40,3 +40,76 @@ implementation:
 acceptance:
   - Collision and prefix red tests pass.
   - Store C++ and Python suites pass without behavior ambiguity.
+
+observed:
+  root_cause: >-
+    InMemoryStore flattened namespace components and the item key with slash.
+    The representation was not injective, and search/list_namespaces compared
+    flattened namespace strings rather than complete components.
+  red_evidence:
+    - >-
+      StoreTest.StructuredIdentityAvoidsDelimiterCollisions stored only one
+      item for [a,b]+c and [a]+b/c, returned slash-key through both identities,
+      and deleting one identity removed the shared entry.
+    - >-
+      The Python structured-identity test stored four distinct identities but
+      len(store) was 2.
+    - >-
+      C++ and Python component-prefix tests returned the user2 namespace for a
+      user prefix.
+
+resolution:
+  design: >-
+    Keep the existing public API, InMemoryStore object layout, and
+    std::map<string, StoreItem>. Replace slash flattening with a self-delimiting
+    component-count and length encoding, and compare Namespace vectors directly
+    for prefix search and namespace listing.
+  changed_files:
+    - include/neograph/graph/store.h
+    - src/core/store.cpp
+    - tests/test_store.cpp
+    - bindings/python/tests/test_parity.py
+    - spec/issue-203-store-structured-key.sdd.yaml
+  compatibility:
+    - Store and InMemoryStore public signatures are unchanged.
+    - InMemoryStore is process-local, so no persisted key migration is required.
+    - Existing timestamps, limits, deletion, and Python conversion are unchanged.
+
+verification:
+  targeted_cpp:
+    command: >-
+      ./build/tests/neograph_tests --gtest_filter=StoreTest.*
+    result: "13 passed, 0 failed"
+  targeted_python:
+    command: >-
+      PYTHONPATH=build_pybind:bindings/python python3 -m pytest
+      bindings/python/tests/test_parity.py -q -k store
+    result: "4 passed, 12 deselected, 0 failed"
+  sanitizer:
+    configuration: >-
+      Debug; -fsanitize=address,undefined; PostgreSQL OFF; SQLite OFF;
+      A2A/ACP/MCP ON.
+    command: >-
+      ASAN_OPTIONS=strict_string_checks=1:check_initialization_order=1
+      ./build-asan/tests/neograph_tests --gtest_filter=StoreTest.*
+    result: "13 passed, 0 failed"
+  cpp_full:
+    configuration: "Release; PostgreSQL/SQLite/A2A/ACP/MCP ON."
+    command: "ctest --test-dir build --output-on-failure -j2"
+    result: "805 passed, 30 skipped, 0 failed (835 discovered)"
+    skips: >-
+      27 PostgreSQL tests skipped because NEOGRAPH_TEST_POSTGRES_URL was unset;
+      one live cancellation test skipped because NEOGRAPH_LIVE_LLM and an
+      OpenAI key were not enabled; two live WebSocket tests skipped because
+      NEOGRAPH_LIVE_OPENAI was not enabled.
+  python_full:
+    configuration: >-
+      Release Python binding; PostgreSQL/SQLite/A2A/ACP ON; MCP OFF.
+    command: >-
+      PYTHONPATH=build_pybind:bindings/python python3 -m pytest
+      bindings/python/tests/ -q -rs
+    result: "251 passed, 4 skipped, 0 failed"
+    skips: >-
+      one MCP test skipped because MCP was compiled OFF; one A2A test skipped
+      because the Python a2a SDK was unavailable; two live OpenAI tests skipped
+      because NEOGRAPH_LIVE_LLM and OPENAI_API_KEY were not enabled.

--- a/src/core/store.cpp
+++ b/src/core/store.cpp
@@ -4,15 +4,29 @@
 
 namespace neograph::graph {
 
+namespace {
+
+bool namespace_has_prefix(const Namespace& ns, const Namespace& prefix) {
+    return ns.size() >= prefix.size() &&
+           std::equal(prefix.begin(), prefix.end(), ns.begin());
+}
+
+} // namespace
+
 std::string InMemoryStore::make_key(const Namespace& ns, const std::string& key) {
-    return ns_to_string(ns) + "/" + key;
+    auto result = ns_to_string(ns);
+    result += std::to_string(key.size());
+    result += ":";
+    result += key;
+    return result;
 }
 
 std::string InMemoryStore::ns_to_string(const Namespace& ns) {
-    std::string result;
-    for (size_t i = 0; i < ns.size(); ++i) {
-        if (i > 0) result += "/";
-        result += ns[i];
+    std::string result = std::to_string(ns.size()) + ":";
+    for (const auto& component : ns) {
+        result += std::to_string(component.size());
+        result += ":";
+        result += component;
     }
     return result;
 }
@@ -48,11 +62,10 @@ std::optional<StoreItem> InMemoryStore::get(const Namespace& ns, const std::stri
 
 std::vector<StoreItem> InMemoryStore::search(const Namespace& ns_prefix, int limit) const {
     std::lock_guard lock(mutex_);
-    std::string prefix = ns_to_string(ns_prefix);
 
     std::vector<StoreItem> results;
     for (const auto& [composite, item] : items_) {
-        if (starts_with(ns_to_string(item.ns), prefix)) {
+        if (namespace_has_prefix(item.ns, ns_prefix)) {
             results.push_back(item);
             if (static_cast<int>(results.size()) >= limit) break;
         }
@@ -67,15 +80,12 @@ void InMemoryStore::delete_item(const Namespace& ns, const std::string& key) {
 
 std::vector<Namespace> InMemoryStore::list_namespaces(const Namespace& prefix) const {
     std::lock_guard lock(mutex_);
-    std::string prefix_str = ns_to_string(prefix);
 
-    std::set<std::string> seen;
+    std::set<Namespace> seen;
     std::vector<Namespace> results;
 
     for (const auto& [composite, item] : items_) {
-        auto ns_str = ns_to_string(item.ns);
-        if (starts_with(ns_str, prefix_str) && seen.find(ns_str) == seen.end()) {
-            seen.insert(ns_str);
+        if (namespace_has_prefix(item.ns, prefix) && seen.insert(item.ns).second) {
             results.push_back(item.ns);
         }
     }

--- a/tests/test_store.cpp
+++ b/tests/test_store.cpp
@@ -91,3 +91,62 @@ TEST_F(StoreTest, EmptyNamespace) {
     ASSERT_TRUE(item.has_value());
     EXPECT_EQ(item->value, "root_val");
 }
+
+TEST_F(StoreTest, StructuredIdentityAvoidsDelimiterCollisions) {
+    store.put({"a", "b"}, "c", json("nested"));
+    store.put({"a"}, "b/c", json("slash-key"));
+
+    EXPECT_EQ(store.size(), 2u);
+    ASSERT_TRUE(store.get({"a", "b"}, "c").has_value());
+    ASSERT_TRUE(store.get({"a"}, "b/c").has_value());
+    EXPECT_EQ(store.get({"a", "b"}, "c")->value, "nested");
+    EXPECT_EQ(store.get({"a"}, "b/c")->value, "slash-key");
+
+    store.delete_item({"a", "b"}, "c");
+    EXPECT_FALSE(store.get({"a", "b"}, "c").has_value());
+    auto survivor = store.get({"a"}, "b/c");
+    ASSERT_TRUE(survivor.has_value());
+    EXPECT_EQ(survivor->value, "slash-key");
+}
+
+TEST_F(StoreTest, NamespacePrefixMatchesWholeComponents) {
+    store.put({"user", "one"}, "key", json(1));
+    store.put({"user", "two"}, "key", json(2));
+    store.put({"user2", "three"}, "key", json(3));
+
+    auto items = store.search({"user"});
+    ASSERT_EQ(items.size(), 2u);
+    for (const auto& item : items) {
+        ASSERT_FALSE(item.ns.empty());
+        EXPECT_EQ(item.ns.front(), "user");
+    }
+
+    auto namespaces = store.list_namespaces({"user"});
+    ASSERT_EQ(namespaces.size(), 2u);
+    for (const auto& ns : namespaces) {
+        ASSERT_FALSE(ns.empty());
+        EXPECT_EQ(ns.front(), "user");
+    }
+}
+
+TEST_F(StoreTest, EmptySlashAndUtf8ComponentsRemainDistinct) {
+    const std::string snowman = "\xE2\x98\x83";
+    store.put({}, "root", json("empty-namespace"));
+    store.put({""}, "root", json("empty-component"));
+    store.put({"", "a/b", snowman}, "k/x", json("slash-component"));
+    store.put({"", "a", "b", snowman}, "k/x", json("split-components"));
+
+    EXPECT_EQ(store.size(), 4u);
+    auto empty_ns = store.get({}, "root");
+    auto empty_component = store.get({""}, "root");
+    auto slash_component = store.get({"", "a/b", snowman}, "k/x");
+    auto split_components = store.get({"", "a", "b", snowman}, "k/x");
+    ASSERT_TRUE(empty_ns.has_value());
+    ASSERT_TRUE(empty_component.has_value());
+    ASSERT_TRUE(slash_component.has_value());
+    ASSERT_TRUE(split_components.has_value());
+    EXPECT_EQ(empty_ns->value, "empty-namespace");
+    EXPECT_EQ(empty_component->value, "empty-component");
+    EXPECT_EQ(slash_component->value, "slash-component");
+    EXPECT_EQ(split_components->value, "split-components");
+}


### PR DESCRIPTION
## Summary
- encode namespace components and item keys with a collision-free length format
- compare namespace prefixes component-by-component
- add C++ and Python regressions for delimiter collisions, empty components, UTF-8, and textual-prefix false matches

## Verification
- C++ Store tests: 13 passed
- ASan/UBSan Store tests: 13 passed
- Full C++ suite: 805 passed, 30 skipped, 0 failed
- Full Python suite: 251 passed, 4 skipped, 0 failed
- Targeted Python Store tests: 4 passed

Closes #203