### PR TITLE
fix(graph): reject unknown Send targets

### DIFF
--- a/include/neograph/graph/types.h
+++ b/include/neograph/graph/types.h
@@ -237,6 +237,9 @@ private:
 struct Send {
     std::string target_node;  ///< Node to dispatch.
     json        input;        ///< Channel writes for that invocation.
+    // Filled by GraphEngine when it collects a node's output. User-created
+    // Sends leave this empty until they are returned from a node.
+    std::string source_node;
 };
 
 /**

--- a/spec/issue-202-send-target-validation.sdd.yaml
+++ b/spec/issue-202-send-target-validation.sdd.yaml
@@ -2,7 +2,7 @@ spec:
   id: issue-202-send-target-validation
   issue: 202
   parent: 187
-  status: proposed
+  status: implemented
   priority: P1
   kind: correctness
   depends_on: []
@@ -30,6 +30,8 @@ red_tests:
 
 implementation:
   - Centralize Send target resolution before single/multi dispatch diverge.
+  - Reject the complete Send batch before any sibling can execute or record a
+    pending write.
   - Preserve node exception and pending-write accounting.
   - Surface the same diagnostic through streaming and Python.
 

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -902,8 +902,10 @@ GraphEngine::execute_graph_async(const RunConfig& config,
         }
 
         // --- Collect Send requests ---
-        for (auto& nr : step_results) {
+        for (std::size_t i = 0; i < step_results.size(); ++i) {
+            auto& nr = step_results[i];
             for (auto& s : nr.sends) {
+                s.source_node = ready[i];
                 pending_sends.push_back(std::move(s));
             }
         }

--- a/src/core/graph_executor.cpp
+++ b/src/core/graph_executor.cpp
@@ -676,6 +676,18 @@ asio::awaitable<std::vector<StepRouting>> NodeExecutor::run_sends_async(
     std::vector<StepRouting> routings;
     if (sends.empty()) co_return routings;
 
+    // Validate the whole batch before any Send can run or record a pending
+    // write. This keeps single- and multi-Send failures identical and makes a
+    // mixed batch all-or-nothing at the dispatch boundary.
+    for (std::size_t si = 0; si < sends.size(); ++si) {
+        if (nodes_.find(sends[si].target_node) == nodes_.end()) {
+            throw std::runtime_error(
+                "Send from '" + sends[si].source_node
+                + "' targets unknown node '" + sends[si].target_node
+                + "' (Send invocation index " + std::to_string(si) + ")");
+        }
+    }
+
     if (cb && has_mode(stream_mode, StreamMode::DEBUG)) {
         json send_info = json::array();
         for (const auto& s : sends) {
@@ -693,8 +705,6 @@ asio::awaitable<std::vector<StepRouting>> NodeExecutor::run_sends_async(
     // --- Single Send: sequential on shared state, with retry. ---
     if (sends.size() == 1) {
         const auto& s = sends[0];
-        auto node_it = nodes_.find(s.target_node);
-        if (node_it == nodes_.end()) co_return routings;
 
         const std::string task_id = make_send_task_id(
             step, 0, s.target_node, s.input);
@@ -748,10 +758,6 @@ asio::awaitable<std::vector<StepRouting>> NodeExecutor::run_sends_async(
 
     auto worker = [&, this](std::size_t si) -> asio::awaitable<NodeResult> {
         const auto& s = sends[si];
-        auto node_it = nodes_.find(s.target_node);
-        if (node_it == nodes_.end()) {
-            co_return NodeResult{};  // silently skip missing target
-        }
 
         const std::string task_id = make_send_task_id(
             step, si, s.target_node, s.input);

--- a/tests/test_multi_send_routing.cpp
+++ b/tests/test_multi_send_routing.cpp
@@ -20,7 +20,10 @@
 #include <gtest/gtest.h>
 #include <neograph/neograph.h>
 
+#include <atomic>
+#include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <vector>
 
 using namespace neograph;
@@ -107,6 +110,41 @@ public:
         co_return out;
     }
     std::string get_name() const override { return "bridge"; }
+};
+
+class SendTargetPlannerNode : public GraphNode {
+public:
+    explicit SendTargetPlannerNode(std::vector<std::string> targets)
+        : targets_(std::move(targets)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        for (const auto& target : targets_) {
+            out.sends.push_back(Send{target, json::object()});
+        }
+        co_return out;
+    }
+
+    std::string get_name() const override { return "planner"; }
+
+private:
+    std::vector<std::string> targets_;
+};
+
+class CountingWorkerNode : public GraphNode {
+public:
+    explicit CountingWorkerNode(std::shared_ptr<std::atomic<int>> calls)
+        : calls_(std::move(calls)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        calls_->fetch_add(1, std::memory_order_relaxed);
+        co_return NodeOutput{};
+    }
+
+    std::string get_name() const override { return "worker"; }
+
+private:
+    std::shared_ptr<std::atomic<int>> calls_;
 };
 
 void register_finalize_and_bridge_once() {
@@ -285,4 +323,68 @@ TEST(MultiSendRouting, MultiSendDefaultOutgoingEdgeFollows) {
     ASSERT_TRUE(result.output["channels"].contains("finalized"))
         << "finalize node never ran — Send-spawned default edge dropped";
     EXPECT_TRUE(result.output["channels"]["finalized"]["value"].get<bool>());
+}
+
+TEST(MultiSendRouting, UnknownSingleSendReportsTargetAndInvocation) {
+    NodeFactory::instance().register_type("__rt_planner_unknown_single",
+        [](const std::string&, const json&, const NodeContext&)
+            -> std::unique_ptr<GraphNode> {
+            return std::make_unique<SendTargetPlannerNode>(
+                std::vector<std::string>{"missing_worker"});
+        });
+
+    json def = {
+        {"name", "unknown_single_send"},
+        {"channels", json::object()},
+        {"nodes", {{"planner", {{"type", "__rt_planner_unknown_single"}}}}},
+        {"edges", json::array({{{"from", "__start__"}, {"to", "planner"}}})}
+    };
+
+    auto engine = GraphEngine::compile(def, NodeContext{});
+    try {
+        engine->run({});
+        FAIL() << "unknown Send target was accepted";
+    } catch (const std::runtime_error& error) {
+        const std::string message = error.what();
+        EXPECT_NE(std::string::npos, message.find("planner"));
+        EXPECT_NE(std::string::npos, message.find("missing_worker"));
+        EXPECT_NE(std::string::npos, message.find("Send invocation index 0"));
+    }
+}
+
+TEST(MultiSendRouting, MixedMultiSendRejectsBatchBeforeValidSiblingRuns) {
+    auto worker_calls = std::make_shared<std::atomic<int>>(0);
+    NodeFactory::instance().register_type("__rt_planner_mixed_targets",
+        [](const std::string&, const json&, const NodeContext&)
+            -> std::unique_ptr<GraphNode> {
+            return std::make_unique<SendTargetPlannerNode>(
+                std::vector<std::string>{"worker", "missing_worker"});
+        });
+    NodeFactory::instance().register_type("__rt_counting_worker",
+        [worker_calls](const std::string&, const json&, const NodeContext&)
+            -> std::unique_ptr<GraphNode> {
+            return std::make_unique<CountingWorkerNode>(worker_calls);
+        });
+
+    json def = {
+        {"name", "mixed_send_targets"},
+        {"channels", json::object()},
+        {"nodes", {
+            {"planner", {{"type", "__rt_planner_mixed_targets"}}},
+            {"worker", {{"type", "__rt_counting_worker"}}}
+        }},
+        {"edges", json::array({{{"from", "__start__"}, {"to", "planner"}}})}
+    };
+
+    auto engine = GraphEngine::compile(def, NodeContext{});
+    try {
+        engine->run({});
+        FAIL() << "mixed Send batch with an unknown target was accepted";
+    } catch (const std::runtime_error& error) {
+        const std::string message = error.what();
+        EXPECT_NE(std::string::npos, message.find("planner"));
+        EXPECT_NE(std::string::npos, message.find("missing_worker"));
+        EXPECT_NE(std::string::npos, message.find("Send invocation index 1"));
+    }
+    EXPECT_EQ(0, worker_calls->load(std::memory_order_relaxed));
 }


### PR DESCRIPTION
## Summary
- Validate every dynamic Send target before dispatch.
- Include the emitting node, target, and Send index in invalid-target diagnostics.
- Reject mixed fan-out batches before any sibling can run or record pending writes.

## Verification
- `ctest --output-on-failure`: 838 runnable tests passed; 35 environment-gated skips.
- `./tests/neograph_tests --gtest_filter='MultiSendRouting.*'`.
- The same focused suite under ASan.

Python binding tests were not rerun: the existing `build-py` cache fails during its vendored pybind11 FetchContent update before compiling project code.