### PR TITLE
fix(a2a): propagate task cancellation to graph runs

### DIFF
--- a/spec/issue-197-a2a-cancellation.sdd.yaml
+++ b/spec/issue-197-a2a-cancellation.sdd.yaml
@@ -2,7 +2,7 @@ spec:
   id: issue-197-a2a-cancellation
   issue: 197
   parent: 187
-  status: proposed
+  status: implemented
   priority: P0
   kind: correctness
   depends_on: []
@@ -32,7 +32,8 @@ red_tests:
 implementation:
   - Replace or pair the atomic flag with a per-task CancelToken.
   - Put the token into RunConfig before engine execution.
-  - Make map cleanup generation-safe and coordinate with issue 205.
+  - Make map cleanup generation-safe; duplicate task admission remains scoped
+    to issue 205.
 
 acceptance:
   - In-flight graph/provider/cooperative-tool work observes cancellation.

--- a/src/a2a/server.cpp
+++ b/src/a2a/server.cpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
+#include <cstdint>
 #include <cstdlib>
 #include <list>
 #include <map>
@@ -172,6 +173,12 @@ Task build_failure_task(const std::string& task_id,
     return t;
 }
 
+bool is_terminal(TaskState state) {
+    return state == TaskState::Completed || state == TaskState::Canceled
+        || state == TaskState::Failed || state == TaskState::Rejected
+        || state == TaskState::AuthRequired;
+}
+
 neograph::json jsonrpc_error(int code, std::string msg, const neograph::json& id) {
     neograph::json env;
     env["jsonrpc"] = "2.0";
@@ -215,16 +222,17 @@ struct A2AServer::Impl {
     /// the id to the back. On insert that would exceed the cap, we
     /// evict from the front.
     ///
-    /// `cancel_flags` holds atomics behind shared_ptrs so a worker
-    /// thread can capture the pointer at dispatch time (under the
-    /// lock) and read/write the flag thereafter without re-traversing
-    /// the map — `std::map<…, std::atomic<bool>>` would otherwise
-    /// invite concurrent-rebalance UB when a parallel insert from
-    /// `tasks/cancel` rotates a tree node the worker is reading.
+    struct ActiveRun {
+        std::shared_ptr<neograph::graph::CancelToken> cancel_token;
+        std::uint64_t                                  generation;
+    };
+
+    /// Active runs remain separately addressable until their owning
+    /// generation publishes its terminal task state.
     std::mutex                                                tasks_mu;
     std::unordered_map<std::string, Task>                     tasks;
-    std::unordered_map<std::string, std::shared_ptr<std::atomic<bool>>>
-                                                              cancel_flags;
+    std::unordered_map<std::string, ActiveRun>                active_runs;
+    std::uint64_t                                              next_generation = 1;
     std::list<std::string>                                    task_lru;
     std::unordered_map<std::string, std::list<std::string>::iterator>
                                                               task_lru_pos;
@@ -244,12 +252,17 @@ struct A2AServer::Impl {
     /// Evict LRU entries until tasks.size() <= max_tasks. Caller must
     /// hold tasks_mu.
     void evict_lru_unlocked() {
-        while (tasks.size() > max_tasks && !task_lru.empty()) {
+        auto remaining = task_lru.size();
+        while (tasks.size() > max_tasks && remaining-- > 0 && !task_lru.empty()) {
             auto victim = task_lru.front();
             task_lru.pop_front();
+            if (active_runs.contains(victim)) {
+                task_lru.push_back(victim);
+                task_lru_pos[victim] = std::prev(task_lru.end());
+                continue;
+            }
             task_lru_pos.erase(victim);
             tasks.erase(victim);
-            cancel_flags.erase(victim);
         }
     }
 
@@ -342,10 +355,8 @@ Task A2AServer::Impl::run_graph(
     cfg.thread_id = task_id;
     cfg.input     = a.build_initial_state(user_text);
 
-    // Capture the cancel-flag shared_ptr while holding the mutex so the
-    // worker can read/write it later without re-traversing the map (see
-    // tasks_mu / cancel_flags doc comment for the rationale).
-    std::shared_ptr<std::atomic<bool>> my_cancel;
+    std::shared_ptr<neograph::graph::CancelToken> task_cancel;
+    std::uint64_t generation = 0;
     {
         std::lock_guard lk(tasks_mu);
         Task working;
@@ -353,11 +364,13 @@ Task A2AServer::Impl::run_graph(
         working.context_id    = context_id;
         working.status.state  = TaskState::Working;
         tasks[task_id]        = working;
-        my_cancel             = std::make_shared<std::atomic<bool>>(false);
-        cancel_flags[task_id] = my_cancel;
+        task_cancel = std::make_shared<neograph::graph::CancelToken>();
+        generation = next_generation++;
+        active_runs[task_id] = ActiveRun{task_cancel, generation};
         touch_task_unlocked(task_id);
         evict_lru_unlocked();
     }
+    cfg.cancel_token = task_cancel;
 
     if (on_event) {
         TaskStatusUpdateEvent ev;
@@ -371,7 +384,7 @@ Task A2AServer::Impl::run_graph(
     Task result;
     try {
         auto rr = engine->run(cfg);
-        if (my_cancel->load(std::memory_order_acquire)) {
+        if (task_cancel->is_cancelled()) {
             result = build_failure_task(task_id, context_id, "(canceled)");
             result.status.state = TaskState::Canceled;
         } else {
@@ -379,6 +392,9 @@ Task A2AServer::Impl::run_graph(
             result = build_response_task(task_id, context_id, agent_text,
                                          a.build_output_artifact(rr.output, task_id));
         }
+    } catch (const neograph::graph::CancelledException&) {
+        result = build_failure_task(task_id, context_id, "(canceled)");
+        result.status.state = TaskState::Canceled;
     } catch (const std::exception& e) {
         result = build_failure_task(
             task_id, context_id,
@@ -387,8 +403,14 @@ Task A2AServer::Impl::run_graph(
 
     {
         std::lock_guard lk(tasks_mu);
-        tasks[task_id] = result;
-        touch_task_unlocked(task_id);
+        auto run_it = active_runs.find(task_id);
+        if (run_it != active_runs.end()
+            && run_it->second.generation == generation
+            && run_it->second.cancel_token == task_cancel) {
+            tasks[task_id] = result;
+            touch_task_unlocked(task_id);
+            active_runs.erase(run_it);
+        }
     }
 
     if (on_event) {
@@ -527,18 +549,18 @@ void A2AServer::Impl::handle_tasks_cancel(const neograph::json& params,
     auto task_id = params.value("id", std::string());
     Task t;
     bool found = false;
+    std::shared_ptr<neograph::graph::CancelToken> cancel_token;
     {
         std::lock_guard lk(tasks_mu);
         auto it = tasks.find(task_id);
         if (it != tasks.end()) {
             t = it->second;
             found = true;
-            auto cf_it = cancel_flags.find(task_id);
-            if (cf_it != cancel_flags.end() && cf_it->second) {
-                cf_it->second->store(true, std::memory_order_release);
-            }
-            if (t.status.state == TaskState::Working
-                || t.status.state == TaskState::Submitted) {
+            if (!is_terminal(t.status.state)) {
+                if (auto run_it = active_runs.find(task_id);
+                    run_it != active_runs.end()) {
+                    cancel_token = run_it->second.cancel_token;
+                }
                 t.status.state = TaskState::Canceled;
                 tasks[task_id] = t;
                 touch_task_unlocked(task_id);
@@ -551,6 +573,7 @@ void A2AServer::Impl::handle_tasks_cancel(const neograph::json& params,
                         "application/json");
         return;
     }
+    if (cancel_token) cancel_token->cancel();
     neograph::json tj;
     to_json(tj, t);
     res.status = 200;

--- a/tests/test_a2a_server.cpp
+++ b/tests/test_a2a_server.cpp
@@ -12,11 +12,13 @@
 #include <neograph/a2a/client.h>
 #include <neograph/a2a/types.h>
 #include <neograph/graph/engine.h>
+#include <neograph/graph/cancel.h>
 #include <neograph/graph/loader.h>
 #include <neograph/graph/node.h>
 
 #include <atomic>
 #include <chrono>
+#include <future>
 #include <memory>
 #include <string>
 #include <thread>
@@ -34,6 +36,8 @@ using neograph::graph::NodeInput;
 using neograph::graph::NodeOutput;
 
 namespace {
+
+using namespace std::chrono_literals;
 
 class EchoNode : public GraphNode {
   public:
@@ -65,6 +69,38 @@ class JsonSiteNode : public GraphNode {
     std::string name_;
 };
 
+struct CancelProbe {
+    std::atomic<bool> entered{false};
+    std::atomic<bool> normal_completion{false};
+};
+
+class CancelAwareNode : public GraphNode {
+  public:
+    CancelAwareNode(std::string name, std::shared_ptr<CancelProbe> probe)
+        : name_(std::move(name)), probe_(std::move(probe)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        probe_->entered.store(true, std::memory_order_release);
+        const auto deadline = std::chrono::steady_clock::now() + 1s;
+        while (std::chrono::steady_clock::now() < deadline) {
+            if (in.ctx.cancel_token && in.ctx.cancel_token->is_cancelled()) {
+                throw neograph::graph::CancelledException();
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        probe_->normal_completion.store(true, std::memory_order_release);
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"response", json("completed")});
+        co_return out;
+    }
+
+    std::string get_name() const override { return name_; }
+
+  private:
+    std::string                  name_;
+    std::shared_ptr<CancelProbe> probe_;
+};
+
 std::shared_ptr<GraphEngine> build_echo_engine() {
     auto& factory = NodeFactory::instance();
     factory.register_type("echo",
@@ -87,6 +123,28 @@ std::shared_ptr<GraphEngine> build_echo_engine() {
     };
     NodeContext ctx;
     auto unique = GraphEngine::compile(def, ctx);
+    return std::shared_ptr<GraphEngine>(std::move(unique));
+}
+
+std::shared_ptr<GraphEngine> build_cancel_aware_engine(
+    const std::shared_ptr<CancelProbe>& probe) {
+    NodeFactory::instance().register_type("a2a_cancel_probe",
+        [probe](const std::string& name, const neograph::json&, const NodeContext&) {
+            return std::make_unique<CancelAwareNode>(name, probe);
+        });
+    neograph::json def = {
+        {"name", "a2a-cancel-graph"},
+        {"channels", {
+            {"prompt", { {"reducer", "overwrite"} }},
+            {"response", { {"reducer", "overwrite"} }},
+        }},
+        {"nodes", {{"worker", {{"type", "a2a_cancel_probe"}}}}},
+        {"edges", neograph::json::array({
+            neograph::json{{"from", "__start__"}, {"to", "worker"}},
+            neograph::json{{"from", "worker"}, {"to", "__end__"}},
+        })},
+    };
+    auto unique = GraphEngine::compile(def, NodeContext{});
     return std::shared_ptr<GraphEngine>(std::move(unique));
 }
 
@@ -253,6 +311,43 @@ TEST(A2AServer, StaysUpAcrossIndependentClients) {
     // Server still healthy after all those round-trips — only an explicit
     // stop() (or a signal in the example) tears it down.
     EXPECT_TRUE(srv.server->is_running());
+}
+
+TEST(A2AServer, CancelTaskAbortsInflightGraphAndIsIdempotent) {
+    auto probe = std::make_shared<CancelProbe>();
+    A2AServer server(build_cancel_aware_engine(probe), build_card(0));
+    ASSERT_TRUE(server.start_async("127.0.0.1", 0));
+    const std::string url = "http://127.0.0.1:" + std::to_string(server.port());
+    const std::string task_id = "a2a-cancel-inflight";
+
+    std::promise<Task> completion;
+    auto done = completion.get_future();
+    std::thread runner([&] {
+        try {
+            A2AClient client(url);
+            completion.set_value(client.send_message_sync("cancel me", task_id));
+        } catch (...) {
+            completion.set_exception(std::current_exception());
+        }
+    });
+
+    for (int i = 0; i < 200 && !probe->entered.load(std::memory_order_acquire); ++i) {
+        std::this_thread::sleep_for(5ms);
+    }
+    ASSERT_TRUE(probe->entered.load(std::memory_order_acquire));
+
+    A2AClient canceller(url);
+    const auto start = std::chrono::steady_clock::now();
+    EXPECT_EQ(canceller.cancel_task(task_id).status.state, TaskState::Canceled);
+    EXPECT_EQ(canceller.cancel_task(task_id).status.state, TaskState::Canceled);
+    ASSERT_EQ(done.wait_for(500ms), std::future_status::ready);
+    const auto task = done.get();
+    runner.join();
+    server.stop();
+
+    EXPECT_EQ(task.status.state, TaskState::Canceled);
+    EXPECT_FALSE(probe->normal_completion.load(std::memory_order_acquire));
+    EXPECT_LT(std::chrono::steady_clock::now() - start, 500ms);
 }
 
 TEST(A2AServer, MethodNotFoundReturnsCorrectCode) {


### PR DESCRIPTION
## Summary
- Associate each active A2A task with a graph `CancelToken`.
- Signal that token immediately from `tasks/cancel` outside the task-store lock.
- Publish and clean active runs only from their owning generation.

## Verification
- `ctest --output-on-failure`: 839 runnable tests passed; 35 environment-gated skips.
- `./tests/neograph_tests --gtest_filter='A2AServer.*'`.
- The same focused suite under ASan.