### PR TITLE
fix(graph): propagate subgraph runtime context

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,7 @@ add_library(neograph_core
     src/core/provider.cpp
     src/core/completion_provider.cpp
     src/core/tool.cpp
+    src/core/run_context_runtime.cpp
     src/core/graph_engine.cpp
     src/core/graph_compiler.cpp
     src/core/graph_validator.cpp

--- a/bindings/python/src/bind_node.cpp
+++ b/bindings/python/src/bind_node.cpp
@@ -521,8 +521,8 @@ void init_node(py::module_& m) {
     // cancel_token (so they can pass it explicitly to
     // provider.complete instead of relying on the smuggling thread-local),
     // step (super-step counter), thread_id (RunConfig.thread_id), and
-    // stream_mode, store, and resume_value. ``deadline`` and ``trace_id`` are
-    // reserved for future RunConfig fields and stay default-constructed for now.
+    // stream_mode, store, and resume_value. C++ RunMetadata can also supply
+    // deadline and trace_id; those remain intentionally unbound in Python.
     py::class_<RunContext>(m, "RunContext",
         "Per-run dispatch metadata threaded by the engine. New nodes "
         "read this from ``input.ctx`` inside their ``run(input)`` "

--- a/docs/concepts.ja.md
+++ b/docs/concepts.ja.md
@@ -202,10 +202,10 @@ class Researcher(ng.GraphNode):
         )
 ```
 
-Python は `cancel_token`、`thread_id`、`step`、`stream_mode`、`store` を公開します。
-および `input.ctx` の `resume_value`。 C++ `deadline` および `trace_id` スロットは、
-将来の `RunConfig` フィールド用に予約されています。エンジンはそれらを設定しません。
-Python はまだそれらを公開していません。
+Python は `input.ctx` で `cancel_token`、`thread_id`、`step`、`stream_mode`、
+`store`、`resume_value` を公開します。C++ 呼び出し元は `RunMetadata` に
+`deadline` と `trace_id` を設定でき、エンジンはそれらをネストした subgraph
+まで伝播します。この 2 フィールドはまだ Python バインディングには公開されません。
 
 必要ない場合は、裸の `list[ChannelWrite]` を返却することもできます。
 `Send` または `Command` — バインディングにより `NodeResult` に持ち上げられます。

--- a/docs/concepts.ko.md
+++ b/docs/concepts.ko.md
@@ -203,10 +203,10 @@ class Researcher(ng.GraphNode):
         )
 ```
 
-Python은 `cancel_token`, `thread_id`, `step`, `stream_mode`, `store`를 노출합니다.
-및 `input.ctx`의 `resume_value`. C++ `deadline` 및 `trace_id` 슬롯은 다음과 같습니다.
-향후 `RunConfig` 필드를 위해 예약되었습니다. 엔진은 그것들을 채우지 않으며
-Python은 아직 이를 노출하지 않습니다.
+Python은 `input.ctx`에서 `cancel_token`, `thread_id`, `step`, `stream_mode`,
+`store`, `resume_value`를 노출합니다. C++ 호출자는 `RunMetadata`의 `deadline`과
+`trace_id`를 설정할 수 있고, 엔진은 이를 중첩 subgraph까지 전파합니다. 이 두
+필드는 아직 Python 바인딩에 노출되지 않습니다.
 
 필요하지 않은 경우 기본 `list[ChannelWrite]`를 반환할 수도 있습니다.
 `Send` 또는 `Command` - 바인딩이 `NodeResult`로 들어갑니다.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -199,9 +199,9 @@ class Researcher(ng.GraphNode):
 ```
 
 Python exposes `cancel_token`, `thread_id`, `step`, `stream_mode`, `store`,
-and `resume_value` on `input.ctx`. The C++ `deadline` and `trace_id` slots are
-reserved for future `RunConfig` fields; the engine does not populate them and
-Python does not expose them yet.
+and `resume_value` on `input.ctx`. C++ callers may set `deadline` and
+`trace_id` on `RunMetadata`; the engine propagates them through nested subgraphs.
+Those two fields are not exposed by the Python binding yet.
 
 You can also return a bare `list[ChannelWrite]` when you don't need
 `Send` or `Command` — the binding lifts it into a `NodeResult`

--- a/docs/concepts.zh-CN.md
+++ b/docs/concepts.zh-CN.md
@@ -183,7 +183,9 @@ class Researcher(ng.GraphNode):
         )
 ```
 
-Python 暴露`cancel_token`, `thread_id`, `step`, `stream_mode`, `store`， 和`resume_value`在`input.ctx`。 C++`deadline`和`trace_id`预留插槽以供将来使用`RunConfig`领域；引擎不会填充它们，Python 也不会公开它们。
+Python 在 `input.ctx` 上暴露 `cancel_token`、`thread_id`、`step`、`stream_mode`、
+`store` 和 `resume_value`。C++ 调用方可以在 `RunMetadata` 中设置 `deadline` 和
+`trace_id`，引擎会将它们传播到嵌套 subgraph。这两个字段目前仍未暴露给 Python 绑定。
 
 你也可以返回裸 `list[ChannelWrite]`当你不需要的时候`Send`或者`Command`— 绑定将其提升到`NodeResult`自动地。
 

--- a/docs/migration-v0.4-to-v1.0.ja.md
+++ b/docs/migration-v0.4-to-v1.0.ja.md
@@ -246,9 +246,11 @@ asio::awaitable<NodeOutput> run(NodeInput in) override {
 ```
 
 ノードが利用可能な `in.ctx` のフィールド: `cancel_token`、`usage`、
-`thread_id`、`step`、`stream_mode`、`store`、`resume_value`。`deadline` と
-`trace_id` は将来の `RunConfig` 拡張用の予約スロットであり、現在のエンジンは
-これらに値を設定せず、Python にも公開していません。
+`thread_id`、`step`、`stream_mode`、`store`、`resume_value`、`deadline`、
+`trace_id`。最後の 2 つは `RunMetadata` で設定し、エンジンはネストした
+subgraph まで保持します。チェックポイントの経路はエンジン内部であり、公開
+`RunContext` フィールドではありません。Python は `deadline` と `trace_id` を
+まだ公開していません。
 
 ### `_full` 仮想メソッドの移行 — 1 行で `co_return out;` で終了
 

--- a/docs/migration-v0.4-to-v1.0.ko.md
+++ b/docs/migration-v0.4-to-v1.0.ko.md
@@ -221,7 +221,11 @@ asio::awaitable<NodeOutput> run(NodeInput in) override {
 }
 ```
 
-노드에서 사용 가능한 `in.ctx` 필드: `cancel_token`, `usage`, `thread_id`, `step`, `stream_mode`, `store`, `resume_value`. `deadline`과 `trace_id`는 미래 `RunConfig` 확장을 위한 예약 슬롯이며, 현재 엔진은 이들을 채우지 않고 Python에도 노출하지 않는다.
+C++ 노드에서 사용 가능한 `in.ctx` 필드: `cancel_token`, `usage`, `thread_id`,
+`step`, `stream_mode`, `store`, `resume_value`, `deadline`, `trace_id`. 마지막 두
+필드는 `RunMetadata`에서 설정하며 엔진은 중첩 subgraph까지 보존한다. 체크포인트
+라우팅은 엔진 내부 구현이며 공개 `RunContext` 필드가 아니다. Python은 아직
+`deadline`, `trace_id`를 노출하지 않는다.
 
 ### `_full` 가상 함수 이전 — `co_return out;` 한 줄로 마무리
 

--- a/docs/migration-v0.4-to-v1.0.md
+++ b/docs/migration-v0.4-to-v1.0.md
@@ -242,10 +242,12 @@ asio::awaitable<NodeOutput> run(NodeInput in) override {
 }
 ```
 
-Fields of `in.ctx` available to nodes are: `cancel_token`, `usage`,
-`thread_id`, `step`, `stream_mode`, `store`, and `resume_value`. `deadline` and
-`trace_id` are reserved slots for future `RunConfig` extensions; the current
-engine does not populate them and does not expose them to Python.
+Fields of `in.ctx` available to C++ nodes are: `cancel_token`, `usage`,
+`thread_id`, `step`, `stream_mode`, `store`, `resume_value`, `deadline`, and
+`trace_id`. Set the latter two on `RunMetadata`; the engine preserves them
+through nested subgraphs. Checkpoint routing remains internal to the engine,
+not a public `RunContext` field. Python does not expose `deadline` or `trace_id`
+yet.
 
 ### Migrating `_full` virtuals — finish with `co_return out;` in one line
 

--- a/docs/migration-v0.4-to-v1.0.zh-CN.md
+++ b/docs/migration-v0.4-to-v1.0.zh-CN.md
@@ -236,10 +236,11 @@ asio::awaitable<NodeOutput> run(NodeInput in) override {
 }
 ```
 
-节点可用的 `in.ctx` 字段包括：`cancel_token`、`usage`、
-`thread_id`、`step`、`stream_mode`、`store` 和 `resume_value`。
-`deadline` 和 `trace_id` 是为未来 `RunConfig` 扩展保留的字段；当前
-引擎不填充它们，也不向 Python 暴露。
+C++ 节点可用的 `in.ctx` 字段包括：`cancel_token`、`usage`、`thread_id`、
+`step`、`stream_mode`、`store`、`resume_value`、`deadline` 和 `trace_id`。
+后两个字段由 `RunMetadata` 设置，且引擎会在嵌套 subgraph 中保留它们。检查点
+路由是引擎内部实现，不是公开的 `RunContext` 字段。Python 目前仍不暴露
+`deadline` 或 `trace_id`。
 
 ### 迁移 `_full` 虚函数 — 在一行内以 `co_return out;` 结束
 

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -1094,6 +1094,21 @@ public:
 
 If the maps are empty, channels are mapped by name (identity mapping).
 
+#### Runtime-context propagation
+
+`SubgraphNode` derives a child execution context at the engine boundary. It
+does not change the public `RunContext` layout.
+
+| Context value | Child semantics |
+|---------------|-----------------|
+| `cancel_token` | A descendant operation token is created, so parent cancellation reaches every child and grandchild. |
+| `usage`, `deadline`, `trace_id`, `stream_mode` | Inherited. `deadline` and `trace_id` originate from `RunMetadata`; a child cannot widen the parent's stream mode. |
+| `thread_id` | When the parent thread ID is non-empty, deterministically derived from it, the subgraph node name, super-step, and invocation identity. Sibling `Send` invocations therefore receive distinct checkpoint identities. An empty parent thread ID keeps the child unscoped and checkpointing disabled. |
+| `step` | Local to the child execution; it starts from the child checkpoint or zero. |
+| `store` | The parent Store is inherited when present; otherwise the child engine retains its configured Store. |
+| Tool policy | Parent `ToolGate` runs before the child's gate. A child may further restrict or rewrite an allowed call, but cannot bypass a parent deny or interrupt. |
+| Checkpoint backend and resume value | The parent backend is inherited when present; otherwise the child keeps its own backend. A parent resume follows a child checkpoint only when the child's derived checkpoint identity exists, forwarding a non-null resume value. Checkpoint routing is internal, not a public `RunContext` field. |
+
 ---
 
 ## 7. GraphEngine
@@ -1162,21 +1177,22 @@ struct RunConfig {
 ### RunContext (v0.4 PR 1, exposed to nodes via `NodeInput.ctx`)
 
 Per-run dispatch metadata threaded by the engine. Constructed from `RunConfig`
-(with a new usage accumulator when none was supplied), the engine's Store,
-and an optional resume value. Nodes consume it inside a
+(with a new usage accumulator when none was supplied), `RunMetadata`, the
+effective Store, and an optional resume value. Nodes consume it inside a
 `run(NodeInput) -> NodeOutput` override via `in.ctx`.
 
 ```cpp
 struct RunContext {
     std::shared_ptr<CancelToken>  cancel_token;
     std::shared_ptr<UsageAccumulator> usage;
-    std::optional<std::chrono::steady_clock::time_point> deadline; // reserved
-    std::string                   trace_id;     // reserved
+    std::optional<std::chrono::steady_clock::time_point> deadline;
+    std::string                   trace_id;
     std::string                   thread_id;
     int                           step;
     StreamMode                    stream_mode;
     std::optional<json>           resume_value;
     std::shared_ptr<Store>        store;
+    ToolGate                      tool_gate;
 };
 ```
 
@@ -1184,13 +1200,14 @@ struct RunContext {
 |-------|-------------|
 | `cancel_token` | The active token. Pass to `provider.complete(params)` so an LLM HTTP socket aborts on cancel, or poll `is_cancelled()` for your own loops |
 | `usage` | Shared token-accounting sink populated by the engine |
-| `deadline` | Reserved (no `RunConfig.deadline` field yet) |
-| `trace_id` | Reserved for OTel integration |
+| `deadline` | Optional absolute deadline from C++ `RunMetadata` |
+| `trace_id` | Optional trace correlator from C++ `RunMetadata` |
 | `thread_id` | Mirror of `RunConfig.thread_id` |
 | `step` | Current super-step index, updated each iteration |
 | `stream_mode` | Mirror of `RunConfig.stream_mode` |
 | `resume_value` | Value supplied to `GraphEngine::resume()`, or empty on a fresh run |
 | `store` | Store installed on the engine, or `nullptr` when none is configured |
+| `tool_gate` | Effective policy for this invocation, including any inherited parent policy |
 
 ### CancelToken
 

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -157,6 +157,17 @@ struct RunConfig {
 
 };
 
+/**
+ * @brief Optional per-run metadata without changing the stable RunConfig ABI.
+ *
+ * The engine copies this metadata into RunContext and preserves it through
+ * subgraphs. Python does not expose this C++-only extension yet.
+ */
+struct RunMetadata {
+    std::optional<std::chrono::steady_clock::time_point> deadline;
+    std::string trace_id;
+};
+
 /// @brief Normal, paused, or step-limited outcome of a successful run call.
 enum class RunStatus {
     Completed,
@@ -485,6 +496,10 @@ public:
      */
     RunResult run(const RunConfig& config);
 
+    /// Execute with optional C++ deadline and trace metadata. RunMetadata is
+    /// separate from RunConfig to preserve the latter's stable ABI.
+    RunResult run(const RunConfig& config, const RunMetadata& metadata);
+
     /**
      * @brief Async peer of run() — returns an awaitable yielding the result.
      *
@@ -505,6 +520,9 @@ public:
      */
     asio::awaitable<RunResult> run_async(RunConfig config);
 
+    /// Async peer that preserves the supplied C++ run metadata.
+    asio::awaitable<RunResult> run_async(RunConfig config, RunMetadata metadata);
+
     /**
      * @brief Execute the graph with streaming event callbacks.
      * @param config Run configuration.
@@ -514,11 +532,20 @@ public:
     RunResult run_stream(const RunConfig& config,
                          const GraphStreamCallback& cb);
 
+    /// Streaming execution with optional C++ deadline and trace metadata.
+    RunResult run_stream(const RunConfig& config,
+                         const GraphStreamCallback& cb,
+                         const RunMetadata& metadata);
+
     /// Async peer of run_stream — non-blocking coroutine surface.
     /// `config` and `cb` are taken by value for the same reason as
     /// run_async() — see that overload's docstring.
     asio::awaitable<RunResult> run_stream_async(
         RunConfig config, GraphStreamCallback cb);
+
+    /// Async streaming peer that preserves the supplied C++ run metadata.
+    asio::awaitable<RunResult> run_stream_async(
+        RunConfig config, GraphStreamCallback cb, RunMetadata metadata);
 
     /**
      * @brief Resume execution from a HITL interrupt.
@@ -536,7 +563,7 @@ public:
                      const GraphStreamCallback& cb = nullptr);
 
     /**
-     * @brief Resume while preserving caller cancellation and deadline settings.
+     * @brief Resume while preserving caller cancellation settings.
      *
      * `config.thread_id` identifies the interrupted session. Input is ignored;
      * the latest checkpoint remains the source of resumed graph state.
@@ -544,6 +571,14 @@ public:
     RunResult resume(const RunConfig&           config,
                      const json&                resume_value = json(),
                      const GraphStreamCallback& cb           = nullptr);
+
+    /// Resume with metadata for this new execution attempt. Deadlines are not
+    /// checkpointed because an absolute deadline from a previous attempt may be
+    /// stale; callers intentionally provide a fresh RunMetadata value.
+    RunResult resume(const RunConfig&           config,
+                     const json&                resume_value,
+                     const GraphStreamCallback& cb,
+                     const RunMetadata&         metadata);
 
     /// Async peer of resume — non-blocking coroutine surface.
     /// All arguments are copied before this function returns, so the returned
@@ -556,8 +591,14 @@ public:
 
     /// Async peer of the RunConfig-preserving resume overload.
     asio::awaitable<RunResult> resume_async(RunConfig           config,
-                                            json                resume_value = json(),
-                                            GraphStreamCallback cb           = nullptr);
+                                             json                resume_value = json(),
+                                             GraphStreamCallback cb           = nullptr);
+
+    /// Async resume peer with metadata for this new execution attempt.
+    asio::awaitable<RunResult> resume_async(RunConfig           config,
+                                             json                resume_value,
+                                             GraphStreamCallback cb,
+                                             RunMetadata          metadata);
 
     /// @brief Borrow the state-administration facade for this engine.
     GraphAdmin admin() noexcept;
@@ -770,6 +811,14 @@ public:
     const std::string& get_graph_name() const { return name_; }
 
 private:
+    friend class SubgraphNode;
+
+    struct RuntimeResources {
+        std::optional<std::shared_ptr<CheckpointStore>> checkpoint_store;
+        std::optional<std::shared_ptr<Store>> store;
+        std::optional<ToolGate> parent_tool_gate;
+    };
+
     GraphEngine() = default;
 
     static std::unique_ptr<GraphEngine> link_impl(CompiledGraph graph,
@@ -789,6 +838,24 @@ private:
         json resume_value,
         GraphStreamCallback cb);
 
+    asio::awaitable<RunResult> run_async_with_runtime(
+        RunConfig config,
+        GraphStreamCallback cb,
+        RunMetadata metadata,
+        RuntimeResources resources);
+
+    asio::awaitable<RunResult> resume_async_with_runtime(
+        RunConfig config,
+        json resume_value,
+        GraphStreamCallback cb,
+        RunMetadata metadata,
+        RuntimeResources resources);
+
+    asio::awaitable<RunResult> run_subgraph_async(
+        RunConfig config,
+        const RunContext& parent,
+        GraphStreamCallback cb);
+
     /// Super-step loop (coroutine). Owns: state init, interrupt
     /// gates, resume load, super-step commit, routing via Scheduler.
     /// Delegates: node invocation to NodeExecutor, checkpoint
@@ -798,7 +865,9 @@ private:
         const RunConfig& config,
         const GraphStreamCallback& cb,
         const std::vector<std::string>& resume_from = {},
-        const json* resume_value = nullptr);
+        const json* resume_value = nullptr,
+        const RunMetadata& metadata = {},
+        const RuntimeResources* resources = nullptr);
 
     RetryPolicy get_retry_policy(const std::string& node_name) const;
 

--- a/include/neograph/graph/node.h
+++ b/include/neograph/graph/node.h
@@ -17,8 +17,7 @@
  *
  * The engine threads `RunContext` through `NodeInput::ctx`. Nodes can use
  * cancellation, usage accounting, thread/step/stream metadata, Store access,
- * and resume values. The deadline and trace-id fields are reserved extension
- * slots and are not populated by current `RunConfig` APIs.
+ * resume values, and C++ RunMetadata deadline/trace metadata.
  *
  * Example overrides that match the v0.4.x surface:
  *   - `examples/01_react_agent.cpp` — basic ReAct agent
@@ -54,8 +53,8 @@ struct NodeInput {
     const GraphState&  state;
 
     /// Per-run metadata threaded by the engine — cancel token, usage,
-    /// thread_id, current super-step, stream mode, Store, and resume value.
-    /// Deadline and trace-id members are reserved and currently unpopulated.
+    /// thread_id, current super-step, stream mode, Store, resume value, and
+    /// any deadline/trace metadata supplied through C++ RunMetadata.
     const RunContext&  ctx;
 
     /// Streaming sink. ``nullptr`` for non-streaming runs (the engine
@@ -257,6 +256,18 @@ private:
  *
  * Enables the Supervisor pattern and nested workflows. Channels are
  * mapped between parent and child graphs via input_map and output_map.
+ *
+ * Runtime context is deliberately derived at the engine boundary rather than
+ * stored in additional public RunContext fields: cancellation reaches a child
+ * through a descendant operation token; usage, deadline, trace ID, and stream
+ * mode are inherited; and a non-empty child thread ID is a deterministic
+ * derivative of the parent invocation. An unscoped parent (empty thread ID)
+ * leaves the child unscoped, preserving the checkpoint coordinator's disabled
+ * behavior. A parent Store or checkpoint backend takes precedence when present,
+ * otherwise the child engine keeps its own configured resource.
+ * Parent ToolGate policy runs before the child's policy, so a child can narrow
+ * access but cannot bypass a parent deny or interrupt. A resumed parent resumes
+ * a child only when that child's derived checkpoint identity exists.
  *
  * @code
  * // Map parent "messages" -> child "messages", child "result" -> parent "findings"

--- a/include/neograph/graph/run_context.h
+++ b/include/neograph/graph/run_context.h
@@ -31,10 +31,10 @@ struct RunContext {
     /// Shared token accounting sink for this run and its subgraphs.
     std::shared_ptr<UsageAccumulator> usage;
 
-    /// Reserved absolute monotonic-clock deadline.
+    /// Absolute monotonic-clock deadline supplied through RunMetadata, when set.
     std::optional<std::chrono::steady_clock::time_point> deadline;
 
-    /// Reserved per-run trace correlator.
+    /// Per-run trace correlator supplied through RunMetadata.
     std::string trace_id;
 
     /// Mirrors RunConfig::thread_id.
@@ -52,8 +52,11 @@ struct RunContext {
     /// Optional cross-thread shared memory.
     std::shared_ptr<Store> store;
 
-    /// Engine-wide tool policy, empty when no gate is configured.
+    /// Effective tool policy for this invocation. It includes any inherited
+    /// parent policy and this engine's own policy, so a subgraph cannot weaken
+    /// a parent gate by using a different GraphEngine instance.
     ToolGate tool_gate;
+
 };
 
 /// @brief Fold a completion's token usage into the run's running total.

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -1,4 +1,6 @@
 #include <neograph/graph/engine.h>
+
+#include "run_context_runtime.h"
 #include <neograph/graph/loader.h>
 #include <neograph/graph/validator.h>
 #include <neograph/graph/coordinator.h>
@@ -29,6 +31,32 @@ namespace {
 std::size_t default_worker_count() {
     auto n = std::thread::hardware_concurrency();
     return n > 0 ? static_cast<std::size_t>(n) : 4u;
+}
+
+// Preserve every policy boundary when a parent graph runs a child graph. The
+// parent decides first; only an Allow reaches the child policy. A parent rewrite
+// becomes the child's input, while a child rewrite can further narrow it.
+ToolGate compose_tool_gates(ToolGate parent, ToolGate local) {
+    if (!parent) return local;
+    if (!local) return parent;
+
+    return [parent = std::move(parent), local = std::move(local)](
+               ToolCall call, ToolGateContext context) -> asio::awaitable<ToolDecision> {
+        auto parent_decision = co_await parent(call, context);
+        if (parent_decision.kind != ToolDecision::Kind::Allow) {
+            co_return parent_decision;
+        }
+
+        if (parent_decision.args) {
+            call.arguments = parent_decision.args->dump();
+        }
+
+        auto local_decision = co_await local(std::move(call), std::move(context));
+        if (local_decision.kind != ToolDecision::Kind::Allow || local_decision.args) {
+            co_return local_decision;
+        }
+        co_return parent_decision;
+    };
 }
 
 void report_validation(const ValidationReport& report, int schema_version) {
@@ -500,6 +528,10 @@ void GraphEngine::apply_input(GraphState& state, const json& input) const {
 // =========================================================================
 
 RunResult GraphEngine::run(const RunConfig& config) {
+    return run(config, {});
+}
+
+RunResult GraphEngine::run(const RunConfig& config, const RunMetadata& metadata) {
     // Drive the async super-step loop on a single-threaded io_context
     // owned by the caller's stack — the coroutine machinery adds
     // roughly a promise/future per call, so we skip the extra
@@ -511,7 +543,7 @@ RunResult GraphEngine::run(const RunConfig& config) {
         operation_config.cancel_token = config.cancel_token->fork();
     }
     return neograph::async::detail::run_sync_operation(
-        execute_graph_async(operation_config, nullptr),
+        execute_graph_async(operation_config, nullptr, {}, nullptr, metadata),
         operation_config.cancel_token);
 }
 
@@ -526,12 +558,27 @@ RunResult GraphEngine::run(const RunConfig& config) {
 // alive on their own stack frame.
 asio::awaitable<RunResult>
 GraphEngine::run_async(RunConfig config) {
+    co_return co_await run_async(std::move(config), {});
+}
+
+asio::awaitable<RunResult>
+GraphEngine::run_async(RunConfig config, RunMetadata metadata) {
+    co_return co_await run_async_with_runtime(
+        std::move(config), nullptr, std::move(metadata), {});
+}
+
+asio::awaitable<RunResult> GraphEngine::run_async_with_runtime(
+    RunConfig config,
+    GraphStreamCallback cb,
+    RunMetadata metadata,
+    RuntimeResources resources) {
     auto operation = config.cancel_token
         ? config.cancel_token->fork()
         : std::shared_ptr<CancelToken>{};
     config.cancel_token = operation;
     if (!operation) {
-        co_return co_await execute_graph_async(config, nullptr);
+        co_return co_await execute_graph_async(
+            config, cb, {}, nullptr, metadata, &resources);
     }
 
     auto executor = co_await asio::this_coro::executor;
@@ -540,7 +587,7 @@ GraphEngine::run_async(RunConfig config) {
     try {
         co_return co_await asio::co_spawn(
             executor,
-            execute_graph_async(config, nullptr),
+            execute_graph_async(config, cb, {}, nullptr, metadata, &resources),
             asio::bind_cancellation_slot(
                 operation->slot(), asio::use_awaitable));
     } catch (const asio::system_error& error) {
@@ -554,46 +601,33 @@ GraphEngine::run_async(RunConfig config) {
 
 RunResult GraphEngine::run_stream(const RunConfig& config,
                                    const GraphStreamCallback& cb) {
+    return run_stream(config, cb, {});
+}
+
+RunResult GraphEngine::run_stream(const RunConfig& config,
+                                   const GraphStreamCallback& cb,
+                                   const RunMetadata& metadata) {
     RunConfig operation_config = config;
     if (config.cancel_token) {
         operation_config.cancel_token = config.cancel_token->fork();
     }
     return neograph::async::detail::run_sync_operation(
-        execute_graph_async(operation_config, cb),
+        execute_graph_async(operation_config, cb, {}, nullptr, metadata),
         operation_config.cancel_token);
 }
 
 asio::awaitable<RunResult>
 GraphEngine::run_stream_async(RunConfig config,
-                              GraphStreamCallback cb) {
-    // Same lifetime concern as run_async — both config and cb might
-    // be stack-local at the callsite, captured into a co_spawn'd
-    // awaitable that outlives the callsite. Take both by value.
-    auto operation = config.cancel_token
-        ? config.cancel_token->fork()
-        : std::shared_ptr<CancelToken>{};
-    config.cancel_token = operation;
-    if (!operation) {
-        co_return co_await execute_graph_async(config, cb);
-    }
+                               GraphStreamCallback cb) {
+    co_return co_await run_stream_async(std::move(config), std::move(cb), {});
+}
 
-    auto executor = co_await asio::this_coro::executor;
-    operation->bind_executor(executor);
-    operation->throw_if_cancelled("run_stream_async entry");
-    try {
-        co_return co_await asio::co_spawn(
-            executor,
-            execute_graph_async(config, cb),
-            asio::bind_cancellation_slot(
-                operation->slot(), asio::use_awaitable));
-    } catch (const asio::system_error& error) {
-        if (operation->is_cancelled() &&
-            error.code() == asio::error::operation_aborted) {
-            throw CancelledException(
-                "run_stream_async operation aborted");
-        }
-        throw;
-    }
+asio::awaitable<RunResult>
+GraphEngine::run_stream_async(RunConfig config,
+                              GraphStreamCallback cb,
+                              RunMetadata metadata) {
+    co_return co_await run_async_with_runtime(
+        std::move(config), std::move(cb), std::move(metadata), {});
 }
 
 RunResult GraphEngine::resume(const std::string& thread_id,
@@ -605,9 +639,17 @@ RunResult GraphEngine::resume(const std::string& thread_id,
 }
 
 RunResult GraphEngine::resume(const RunConfig&           config,
-                              const json&                resume_value,
-                              const GraphStreamCallback& cb) {
+                               const json&                resume_value,
+                               const GraphStreamCallback& cb) {
     return neograph::async::run_sync(resume_async(config, resume_value, cb));
+}
+
+RunResult GraphEngine::resume(const RunConfig&           config,
+                               const json&                resume_value,
+                               const GraphStreamCallback& cb,
+                               const RunMetadata&         metadata) {
+    return neograph::async::run_sync(
+        resume_async(config, resume_value, cb, metadata));
 }
 
 asio::awaitable<RunResult> GraphEngine::resume_async(const std::string&         thread_id,
@@ -620,12 +662,35 @@ asio::awaitable<RunResult> GraphEngine::resume_async(const std::string&         
 }
 
 asio::awaitable<RunResult> GraphEngine::resume_async(RunConfig           config,
-                                                     json                resume_value,
-                                                     GraphStreamCallback cb) {
+                                                       json                resume_value,
+                                                       GraphStreamCallback cb) {
+    co_return co_await resume_async_with_runtime(
+        std::move(config), std::move(resume_value), std::move(cb), {}, {});
+}
+
+asio::awaitable<RunResult> GraphEngine::resume_async(
+    RunConfig config,
+    json resume_value,
+    GraphStreamCallback cb,
+    RunMetadata metadata) {
+    co_return co_await resume_async_with_runtime(
+        std::move(config), std::move(resume_value), std::move(cb),
+        std::move(metadata), {});
+}
+
+asio::awaitable<RunResult> GraphEngine::resume_async_with_runtime(
+    RunConfig config,
+    json resume_value,
+    GraphStreamCallback cb,
+    RunMetadata metadata,
+    RuntimeResources resources) {
     // Sem 3.7.5: real async resume. Mirrors sync resume() but the
     // load_latest and the downstream super-step loop go through
     // their *_async peers, so the whole resume path is non-blocking.
-    if (!checkpoint_store_)
+    auto checkpoint_store = resources.checkpoint_store
+        ? *resources.checkpoint_store
+        : checkpoint_store_;
+    if (!checkpoint_store)
         throw std::runtime_error("Cannot resume: no checkpoint store configured");
 
     if (config.thread_id.empty()) {
@@ -633,7 +698,7 @@ asio::awaitable<RunResult> GraphEngine::resume_async(RunConfig           config,
     }
     const auto& thread_id = config.thread_id;
 
-    auto cp_opt = co_await checkpoint_store_->load_latest_async(thread_id);
+    auto cp_opt = co_await checkpoint_store->load_latest_async(thread_id);
     if (!cp_opt)
         throw std::runtime_error("No checkpoint found for thread: " + thread_id);
 
@@ -646,7 +711,42 @@ asio::awaitable<RunResult> GraphEngine::resume_async(RunConfig           config,
     }
 
     co_return co_await execute_graph_async(
-        config, cb, cp_opt->next_nodes, &resume_value);
+        config, cb, cp_opt->next_nodes, &resume_value, metadata, &resources);
+}
+
+asio::awaitable<RunResult> GraphEngine::run_subgraph_async(
+    RunConfig config,
+    const RunContext& parent,
+    GraphStreamCallback cb) {
+    RunMetadata metadata;
+    metadata.deadline = parent.deadline;
+    metadata.trace_id = parent.trace_id;
+
+    RuntimeResources resources;
+    auto parent_runtime = detail::runtime_for(parent);
+    if (parent_runtime && parent_runtime->checkpoint_store) {
+        resources.checkpoint_store = parent_runtime->checkpoint_store;
+    }
+    if (parent.store) {
+        resources.store = parent.store;
+    }
+    resources.parent_tool_gate = parent.tool_gate;
+
+    if (parent_runtime && parent_runtime->is_resume && resources.checkpoint_store) {
+        auto checkpoint = co_await (*resources.checkpoint_store)->load_latest_async(
+            config.thread_id);
+        if (checkpoint) {
+            const json resume_value = parent.resume_value
+                ? *parent.resume_value
+                : json();
+            co_return co_await resume_async_with_runtime(
+                std::move(config), resume_value, std::move(cb),
+                std::move(metadata), std::move(resources));
+        }
+    }
+
+    co_return co_await run_async_with_runtime(
+        std::move(config), std::move(cb), std::move(metadata), std::move(resources));
 }
 
 // =========================================================================
@@ -665,9 +765,11 @@ asio::awaitable<RunResult> GraphEngine::resume_async(RunConfig           config,
 
 asio::awaitable<RunResult>
 GraphEngine::execute_graph_async(const RunConfig& config,
-                                 const GraphStreamCallback& cb,
-                                 const std::vector<std::string>& resume_from,
-                                 const json* resume_value) {
+                                  const GraphStreamCallback& cb,
+                                  const std::vector<std::string>& resume_from,
+                                  const json* resume_value,
+                                  const RunMetadata& metadata,
+                                  const RuntimeResources* resources) {
     const bool is_resume = !resume_from.empty();
 
     // RAII inc/dec on the inflight-run counter — set_worker_count()
@@ -690,7 +792,10 @@ GraphEngine::execute_graph_async(const RunConfig& config,
     // below) on every NodeInput.
 
     StreamMode stream_mode = config.stream_mode;
-    CheckpointCoordinator coord(checkpoint_store_, config.thread_id);
+    auto checkpoint_store = resources && resources->checkpoint_store
+        ? *resources->checkpoint_store
+        : checkpoint_store_;
+    CheckpointCoordinator coord(checkpoint_store, config.thread_id);
 
     // PR 1 (v0.4.0): build the per-run RunContext from RunConfig and
     // carry it by reference through every NodeExecutor hop. Plumbing-
@@ -706,18 +811,26 @@ GraphEngine::execute_graph_async(const RunConfig& config,
     // otherwise this run gets a fresh one. Either way ctx.usage is non-null, so
     // node bodies never have to check.
     ctx.usage        = config.usage ? config.usage
-                                    : std::make_shared<UsageAccumulator>();
+                                     : std::make_shared<UsageAccumulator>();
+    ctx.deadline     = metadata.deadline;
+    ctx.trace_id     = metadata.trace_id;
     ctx.thread_id    = config.thread_id;
     ctx.stream_mode  = stream_mode;
-    ctx.store        = store_;   // issue #27 — node bodies reach Store via in.ctx.store
+    ctx.store = resources && resources->store ? *resources->store : store_;
     // issue #94 — the human's answer, readable by any node. Left empty on a
     // fresh run, which is how a node distinguishes "nobody has answered yet"
     // from "the answer was no". Only engaged on an actual resume, so the
     // common path pays no json allocation.
     if (resume_value && !resume_value->is_null()) ctx.resume_value = *resume_value;
-    ctx.tool_gate    = tool_gate_;   // issue #89 — engine-level, so resume() keeps it
-    // ctx.deadline / ctx.trace_id stay default-constructed for now —
-    // RunConfig has no source field for either. Future PRs add them.
+    auto parent_tool_gate = resources && resources->parent_tool_gate
+        ? *resources->parent_tool_gate
+        : ToolGate{};
+    ctx.tool_gate = compose_tool_gates(std::move(parent_tool_gate), tool_gate_);
+
+    auto runtime = std::make_shared<detail::RunContextRuntime>();
+    runtime->checkpoint_store = checkpoint_store;
+    runtime->is_resume = is_resume;
+    detail::ScopedRunContextRuntime runtime_scope(ctx, std::move(runtime));
 
     std::string last_checkpoint_id;
     int start_step = 0;
@@ -764,9 +877,9 @@ GraphEngine::execute_graph_async(const RunConfig& config,
         // overwritten. start_step continues monotonically from the
         // checkpoint's recorded step so per-thread step numbering
         // stays meaningful in the trace.
-        if (config.resume_if_exists && checkpoint_store_) {
+        if (config.resume_if_exists && checkpoint_store) {
             auto cp_opt =
-                co_await checkpoint_store_->load_latest_async(config.thread_id);
+                co_await checkpoint_store->load_latest_async(config.thread_id);
             if (cp_opt) {
                 state.restore(cp_opt->channel_values);
                 last_checkpoint_id = cp_opt->id;

--- a/src/core/graph_executor.cpp
+++ b/src/core/graph_executor.cpp
@@ -5,6 +5,8 @@
 #include <neograph/graph/registry.h>
 #include <neograph/graph/state.h>
 
+#include "run_context_runtime.h"
+
 #include <asio/co_spawn.hpp>
 #include <asio/deferred.hpp>
 #include <asio/error.hpp>
@@ -63,6 +65,19 @@ inline std::string make_send_task_id(int step, size_t idx,
     return "s" + std::to_string(step) + ":send[" + std::to_string(idx)
            + "]:" + target + ":" + fnv1a_hex(input.dump());
 }
+
+class ScopedInvocationContext {
+public:
+    ScopedInvocationContext(const RunContext& parent, const std::string& task_id)
+        : context_(parent),
+          runtime_scope_(context_, detail::runtime_for_invocation(parent, task_id)) {}
+
+    const RunContext& context() const { return context_; }
+
+private:
+    RunContext context_;
+    detail::ScopedRunContextRuntime runtime_scope_;
+};
 
 } // namespace
 
@@ -395,8 +410,9 @@ asio::awaitable<NodeResult> NodeExecutor::run_one_async(
             // do NOT re-record. Just apply the recorded writes.
             ok_result.emplace(replay_it->second);
         } else {
+            ScopedInvocationContext node_ctx(ctx, task_id);
             ok_result.emplace(co_await execute_node_with_retry_async(
-                node_name, state, cb, stream_mode, ctx));
+                node_name, state, cb, stream_mode, node_ctx.context()));
 
             // Record BEFORE apply_writes so a crash between the two
             // still leaves a durable log for resume to replay.
@@ -490,8 +506,9 @@ NodeExecutor::run_parallel_async(
             // GCC-13: cannot co_await inside a catch handler. Classify
             // here, save + rethrow outside the try/catch.
             try {
+                ScopedInvocationContext node_ctx(ctx, task_id);
                 nr = co_await execute_node_with_retry_async(
-                    node_name, state, cb, stream_mode, ctx);
+                    node_name, state, cb, stream_mode, node_ctx.context());
             } catch (const NodeInterrupt& ni) {
                 interrupt = ni;
             }
@@ -549,8 +566,9 @@ NodeExecutor::run_parallel_async(
         if (replay_it != replay.end()) {
             co_return replay_it->second;
         }
+        ScopedInvocationContext node_ctx(ctx, task_id);
         auto nr = co_await execute_node_with_retry_async(
-            node_name, state, cb, stream_mode, ctx);
+            node_name, state, cb, stream_mode, node_ctx.context());
         co_await coord.record_pending_write_async(
             parent_cp_id, task_id, task_id, node_name, nr, step);
         co_return nr;
@@ -715,8 +733,9 @@ asio::awaitable<std::vector<StepRouting>> NodeExecutor::run_sends_async(
             nr = replay_it->second;
         } else {
             apply_input(state, s.input);
+            ScopedInvocationContext node_ctx(ctx, task_id);
             nr = co_await execute_node_with_retry_async(
-                s.target_node, state, cb, stream_mode, ctx);
+                s.target_node, state, cb, stream_mode, node_ctx.context());
             co_await coord.record_pending_write_async(parent_cp_id,
                 task_id, task_id, s.target_node, nr, step);
         }
@@ -776,8 +795,9 @@ asio::awaitable<std::vector<StepRouting>> NodeExecutor::run_sends_async(
         // is captured by value into this worker lambda — no
         // serialize/restore hop, no manual forward.
 
+        ScopedInvocationContext node_ctx(ctx, task_id);
         auto nr = co_await execute_node_with_retry_async(
-            s.target_node, send_state, cb, stream_mode, ctx);
+            s.target_node, send_state, cb, stream_mode, node_ctx.context());
         co_await coord.record_pending_write_async(parent_cp_id,
             task_id, task_id, s.target_node, nr, step);
         co_return nr;

--- a/src/core/graph_node.cpp
+++ b/src/core/graph_node.cpp
@@ -2,6 +2,8 @@
 #include <neograph/graph/engine.h>   // RunContext (forward-declared in node.h)
 #include <neograph/async/run_sync.h>
 #include <neograph/tool_dispatch.h>
+
+#include "run_context_runtime.h"
 #include <asio/co_spawn.hpp>
 #include <asio/deferred.hpp>
 #include <asio/experimental/parallel_group.hpp>
@@ -9,9 +11,35 @@
 #include <asio/use_awaitable.hpp>
 #include <algorithm>
 #include <stdexcept>
+#include <string_view>
 #include <vector>
 
 namespace neograph::graph {
+
+namespace {
+
+std::string length_frame(std::string_view value) {
+    return std::to_string(value.size()) + ":" + std::string(value);
+}
+
+// Child checkpoint identities must be stable for one logical invocation yet
+// distinct for sibling Send workers. Length-framing avoids delimiter collisions
+// when callers use arbitrary thread IDs or node names.
+std::string child_thread_id(const RunContext& parent, std::string_view node_name) {
+    // An empty root thread ID intentionally disables checkpointing. Deriving a
+    // shared anonymous child ID would re-enable it and let concurrent anonymous
+    // runs collide in the same child namespace.
+    if (parent.thread_id.empty()) return {};
+
+    const auto runtime = detail::runtime_for(parent);
+    const std::string invocation_id = runtime ? runtime->invocation_id : "root";
+    return "subgraph/" + length_frame(parent.thread_id)
+         + length_frame(node_name)
+         + length_frame(std::to_string(parent.step))
+         + length_frame(invocation_id);
+}
+
+}  // namespace
 
 // v1.0 destructive removal (9b): the 8-virtual `execute*` legacy chain,
 // the ExecuteDefaultGuard recursion guard, and the
@@ -310,7 +338,9 @@ std::vector<ChannelWrite> SubgraphNode::extract_output(
 
 asio::awaitable<NodeOutput> SubgraphNode::run(NodeInput in) {
     RunConfig config;
+    config.thread_id    = child_thread_id(in.ctx, name_);
     config.input        = build_subgraph_input(in.state);
+    config.stream_mode  = in.ctx.stream_mode;
     config.cancel_token = in.ctx.cancel_token;
     // #88: hand the parent's accumulator down. A subgraph runs on its own engine
     // with its own RunConfig, so without this a graph that delegates its LLM work
@@ -322,10 +352,28 @@ asio::awaitable<NodeOutput> SubgraphNode::run(NodeInput in) {
         // Forward the parent's stream sink so subgraph events (LLM
         // tokens, node enter/exit, etc.) surface at the parent
         // graph's caller without buffering.
-        auto result = co_await subgraph_->run_stream_async(config, *in.stream_cb);
+        auto result = co_await subgraph_->run_subgraph_async(
+            std::move(config), in.ctx, *in.stream_cb);
+        if (result.interrupted) {
+            const auto reason = result.interrupt_value.value(
+                "reason", "subgraph interrupted");
+            if (result.interrupt_value.contains("value")) {
+                throw NodeInterrupt(reason, result.interrupt_value["value"]);
+            }
+            throw NodeInterrupt(reason);
+        }
         subgraph_output = std::move(result.output);
     } else {
-        auto result = co_await subgraph_->run_async(config);
+        auto result = co_await subgraph_->run_subgraph_async(
+            std::move(config), in.ctx, nullptr);
+        if (result.interrupted) {
+            const auto reason = result.interrupt_value.value(
+                "reason", "subgraph interrupted");
+            if (result.interrupt_value.contains("value")) {
+                throw NodeInterrupt(reason, result.interrupt_value["value"]);
+            }
+            throw NodeInterrupt(reason);
+        }
         subgraph_output = std::move(result.output);
     }
 

--- a/src/core/run_context_runtime.cpp
+++ b/src/core/run_context_runtime.cpp
@@ -1,0 +1,59 @@
+#include "run_context_runtime.h"
+
+#include <mutex>
+#include <unordered_map>
+#include <utility>
+
+namespace neograph::graph::detail {
+
+namespace {
+
+std::mutex runtime_mutex;
+std::unordered_map<const RunContext*, std::shared_ptr<const RunContextRuntime>> runtimes;
+
+}  // namespace
+
+std::shared_ptr<const RunContextRuntime> runtime_for(const RunContext& context) {
+    std::lock_guard<std::mutex> lock(runtime_mutex);
+    const auto it = runtimes.find(&context);
+    return it == runtimes.end() ? nullptr : it->second;
+}
+
+std::shared_ptr<const RunContextRuntime> runtime_for_invocation(
+    const RunContext& context, const std::string& invocation_id) {
+    auto parent = runtime_for(context);
+    auto runtime = parent
+        ? std::make_shared<RunContextRuntime>(*parent)
+        : std::make_shared<RunContextRuntime>();
+    runtime->invocation_id = invocation_id;
+    return runtime;
+}
+
+ScopedRunContextRuntime::ScopedRunContextRuntime(
+    const RunContext& context,
+    std::shared_ptr<const RunContextRuntime> runtime)
+    : context_(&context) {
+    if (!runtime) return;
+
+    std::lock_guard<std::mutex> lock(runtime_mutex);
+    const auto it = runtimes.find(context_);
+    if (it != runtimes.end()) previous_ = it->second;
+    runtime_ = std::move(runtime);
+    runtimes[context_] = runtime_;
+    installed_ = true;
+}
+
+ScopedRunContextRuntime::~ScopedRunContextRuntime() {
+    if (!installed_) return;
+
+    std::lock_guard<std::mutex> lock(runtime_mutex);
+    const auto current = runtimes.find(context_);
+    if (current == runtimes.end() || current->second != runtime_) return;
+    if (previous_) {
+        runtimes[context_] = std::move(previous_);
+    } else {
+        runtimes.erase(context_);
+    }
+}
+
+}  // namespace neograph::graph::detail

--- a/src/core/run_context_runtime.h
+++ b/src/core/run_context_runtime.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <neograph/graph/checkpoint.h>
+#include <neograph/graph/run_context.h>
+
+#include <memory>
+#include <string>
+
+namespace neograph::graph::detail {
+
+// Execution-only state deliberately lives outside the public RunContext ABI.
+// A scope binds it to the context object while a node coroutine is active.
+struct RunContextRuntime {
+    std::shared_ptr<CheckpointStore> checkpoint_store;
+    std::string invocation_id;
+    bool is_resume = false;
+};
+
+std::shared_ptr<const RunContextRuntime> runtime_for(const RunContext& context);
+
+std::shared_ptr<const RunContextRuntime> runtime_for_invocation(
+    const RunContext& context, const std::string& invocation_id);
+
+class ScopedRunContextRuntime {
+public:
+    ScopedRunContextRuntime(
+        const RunContext& context,
+        std::shared_ptr<const RunContextRuntime> runtime);
+    ~ScopedRunContextRuntime();
+
+    ScopedRunContextRuntime(const ScopedRunContextRuntime&) = delete;
+    ScopedRunContextRuntime& operator=(const ScopedRunContextRuntime&) = delete;
+
+private:
+    const RunContext* context_ = nullptr;
+    std::shared_ptr<const RunContextRuntime> runtime_;
+    std::shared_ptr<const RunContextRuntime> previous_;
+    bool installed_ = false;
+};
+
+}  // namespace neograph::graph::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(neograph_tests
     test_pending_writes.cpp
     test_channel_write_mode.cpp
     test_usage_accounting.cpp
+    test_subgraph_context.cpp
     test_plan_execute_graph.cpp
     test_signal_dispatch.cpp
     test_multi_node_resume.cpp

--- a/tests/test_subgraph_context.cpp
+++ b/tests/test_subgraph_context.cpp
@@ -1,0 +1,618 @@
+#include <gtest/gtest.h>
+
+#include <neograph/neograph.h>
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+struct ContextSnapshot {
+    std::shared_ptr<CancelToken> cancel_token;
+    std::shared_ptr<UsageAccumulator> usage;
+    std::optional<std::chrono::steady_clock::time_point> deadline;
+    std::string trace_id;
+    std::string thread_id;
+    StreamMode stream_mode = StreamMode::ALL;
+    std::shared_ptr<Store> store;
+    std::optional<json> store_value;
+    bool has_tool_gate = false;
+};
+
+struct ContextCapture {
+    std::mutex mutex;
+    std::vector<ContextSnapshot> snapshots;
+    std::optional<Namespace> store_namespace;
+    std::string store_key;
+
+    void add(const RunContext& ctx) {
+        std::lock_guard<std::mutex> lock(mutex);
+        ContextSnapshot snapshot{ctx.cancel_token, ctx.usage, ctx.deadline,
+                                 ctx.trace_id, ctx.thread_id, ctx.stream_mode,
+                                 ctx.store, std::nullopt,
+                                 static_cast<bool>(ctx.tool_gate)};
+        if (store_namespace && ctx.store) {
+            if (auto item = ctx.store->get(*store_namespace, store_key)) {
+                snapshot.store_value = item->value;
+            }
+        }
+        snapshots.push_back(std::move(snapshot));
+    }
+};
+
+class CaptureContextNode final : public GraphNode {
+public:
+    CaptureContextNode(std::string name, std::shared_ptr<ContextCapture> capture)
+        : name_(std::move(name)), capture_(std::move(capture)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        capture_->add(in.ctx);
+        co_return NodeOutput{};
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+    std::shared_ptr<ContextCapture> capture_;
+};
+
+class FanoutNode final : public GraphNode {
+public:
+    explicit FanoutNode(std::string name) : name_(std::move(name)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.sends.push_back(Send{"child", json{{"slot", "zero"}}});
+        out.sends.push_back(Send{"child", json{{"slot", "one"}}});
+        co_return out;
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+};
+
+class WaitForParentCancelNode final : public GraphNode {
+public:
+    WaitForParentCancelNode(std::string name, std::atomic<bool>* entered,
+                            std::atomic<bool>* observed_cancel)
+        : name_(std::move(name)), entered_(entered), observed_cancel_(observed_cancel) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        entered_->store(true, std::memory_order_release);
+        const auto timeout = std::chrono::steady_clock::now()
+            + std::chrono::seconds(2);
+        while (!in.ctx.cancel_token || !in.ctx.cancel_token->is_cancelled()) {
+            if (std::chrono::steady_clock::now() >= timeout) {
+                throw std::runtime_error("parent cancellation did not reach grandchild");
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        observed_cancel_->store(true, std::memory_order_release);
+        in.ctx.cancel_token->throw_if_cancelled("grandchild observed parent cancel");
+        co_return NodeOutput{};
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+    std::atomic<bool>* entered_;
+    std::atomic<bool>* observed_cancel_;
+};
+
+class SpyTool final : public Tool {
+public:
+    explicit SpyTool(std::atomic<int>* calls, json* observed_args = nullptr)
+        : calls_(calls), observed_args_(observed_args) {}
+
+    ChatTool get_definition() const override {
+        ChatTool definition;
+        definition.name = "nested_tool";
+        return definition;
+    }
+
+    std::string execute(const json& arguments) override {
+        calls_->fetch_add(1, std::memory_order_relaxed);
+        if (observed_args_) *observed_args_ = arguments;
+        return R"({"ok":true})";
+    }
+
+    std::string get_name() const override { return "nested_tool"; }
+
+private:
+    std::atomic<int>* calls_;
+    json* observed_args_;
+};
+
+class CountingToolSeedNode final : public GraphNode {
+public:
+    CountingToolSeedNode(std::string name, std::atomic<int>* calls)
+        : name_(std::move(name)), calls_(calls) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        calls_->fetch_add(1, std::memory_order_relaxed);
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"messages", json::array({{
+            {"role", "assistant"},
+            {"content", ""},
+            {"tool_calls", json::array({{
+                {"id", "nested"},
+                {"name", "nested_tool"},
+                {"arguments", "{}"},
+            }})},
+        }})});
+        co_return out;
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+    std::atomic<int>* calls_;
+};
+
+json one_node_graph(const std::string& name, const std::string& node_type,
+                    const std::string& node_name = "node") {
+    return {
+        {"name", name},
+        {"channels", json::object()},
+        {"nodes", {{node_name, {{"type", node_type}}}}},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", node_name}},
+            {{"from", node_name}, {"to", "__end__"}},
+        })},
+    };
+}
+
+void register_subgraph_factory(const std::string& type,
+                               std::shared_ptr<GraphEngine> child) {
+    NodeFactory::instance().register_type(
+        type, [child = std::move(child)](const std::string& name, const json&,
+                                         const NodeContext&) {
+            return std::make_unique<SubgraphNode>(name, child);
+        });
+}
+
+json add_messages_channel(json definition) {
+    definition["channels"] = {{"messages", {{"reducer", "append"}}}};
+    return definition;
+}
+
+json seed_then_tool_graph(const std::string& name, const std::string& seed_type) {
+    return {
+        {"name", name},
+        {"channels", {{"messages", {{"reducer", "append"}}}}},
+        {"nodes", {
+            {"seed", {{"type", seed_type}}},
+            {"tool", {{"type", "tool_dispatch"}}},
+        }},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "seed"}},
+            {{"from", "seed"}, {"to", "tool"}},
+            {{"from", "tool"}, {"to", "__end__"}},
+        })},
+    };
+}
+
+}  // namespace
+
+TEST(SubgraphContext, MultiLevelRunInheritsRuntimeResourcesAndIdentity) {
+    auto capture = std::make_shared<ContextCapture>();
+    capture->store_namespace = Namespace{"tenant", "root/with:separators"};
+    capture->store_key = "setting";
+    NodeFactory::instance().register_type(
+        "subgraph_context_capture_196",
+        [capture](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<CaptureContextNode>(name, capture);
+        });
+
+    auto leaf = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(one_node_graph("leaf", "subgraph_context_capture_196"),
+                             NodeContext{}).release());
+    register_subgraph_factory("subgraph_context_middle_196", leaf);
+    auto middle = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(one_node_graph("middle", "subgraph_context_middle_196"),
+                             NodeContext{}).release());
+    register_subgraph_factory("subgraph_context_outer_196", middle);
+
+    auto checkpoints = std::make_shared<InMemoryCheckpointStore>();
+    auto store = std::make_shared<InMemoryStore>();
+    store->put(*capture->store_namespace, capture->store_key,
+               json{{"inherited", true}});
+    auto engine = GraphEngine::compile(
+        one_node_graph("root", "subgraph_context_outer_196"), NodeContext{}, checkpoints);
+    engine->set_store(store);
+
+    auto cancel = std::make_shared<CancelToken>();
+    auto usage = std::make_shared<UsageAccumulator>();
+    RunConfig config;
+    config.thread_id = "root/with:separators";
+    config.cancel_token = cancel;
+    config.usage = usage;
+    config.stream_mode = StreamMode::TOKENS;
+
+    RunMetadata metadata;
+    metadata.deadline = std::chrono::steady_clock::now() + std::chrono::minutes(1);
+    metadata.trace_id = "trace-196";
+
+    std::vector<GraphEvent> events;
+    auto callback = [&events](GraphEvent event) { events.push_back(std::move(event)); };
+
+    ASSERT_NO_THROW(engine->run_stream(config, callback, metadata));
+    ASSERT_NO_THROW(engine->run_stream(config, callback, metadata));
+
+    std::lock_guard<std::mutex> lock(capture->mutex);
+    ASSERT_EQ(capture->snapshots.size(), 2u);
+    const auto& first = capture->snapshots[0];
+    const auto& second = capture->snapshots[1];
+    EXPECT_EQ(first.thread_id, second.thread_id);
+    EXPECT_NE(first.thread_id, config.thread_id);
+    EXPECT_FALSE(first.thread_id.empty());
+    EXPECT_EQ(first.usage, usage);
+    EXPECT_EQ(first.deadline, metadata.deadline);
+    EXPECT_EQ(first.trace_id, metadata.trace_id);
+    EXPECT_EQ(first.stream_mode, config.stream_mode);
+    EXPECT_EQ(first.store, store);
+    ASSERT_TRUE(first.store_value);
+    EXPECT_EQ(*first.store_value, json({{"inherited", true}}));
+    EXPECT_TRUE(first.cancel_token);
+    EXPECT_FALSE(checkpoints->list(first.thread_id).empty());
+    EXPECT_TRUE(events.empty())
+        << "a TOKENS-only parent must not let a child widen its stream mode";
+}
+
+TEST(SubgraphContext, ParentToolGateCannotBeWeakenedByNestedEngine) {
+    std::atomic<int> tool_calls{0};
+    std::atomic<int> parent_gate_calls{0};
+    std::atomic<int> child_gate_calls{0};
+    SpyTool tool(&tool_calls);
+
+    NodeContext leaf_context;
+    leaf_context.tools = {&tool};
+    auto leaf = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(
+            add_messages_channel(one_node_graph("leaf", "tool_dispatch", "tool")),
+            leaf_context).release());
+    leaf->set_tool_gate([&child_gate_calls](ToolCall, ToolGateContext)
+                            -> asio::awaitable<ToolDecision> {
+        child_gate_calls.fetch_add(1, std::memory_order_relaxed);
+        co_return ToolDecision::allow();
+    });
+    register_subgraph_factory("subgraph_context_gated_child_196", leaf);
+    auto middle = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(add_messages_channel(
+                                 one_node_graph("middle", "subgraph_context_gated_child_196")),
+                             NodeContext{}).release());
+    register_subgraph_factory("subgraph_context_gated_outer_196", middle);
+
+    auto engine = GraphEngine::compile(
+        add_messages_channel(one_node_graph("root", "subgraph_context_gated_outer_196")),
+        NodeContext{});
+    engine->set_tool_gate([&parent_gate_calls](ToolCall, ToolGateContext)
+                              -> asio::awaitable<ToolDecision> {
+        parent_gate_calls.fetch_add(1, std::memory_order_relaxed);
+        co_return ToolDecision::deny("parent policy denies nested tool");
+    });
+
+    RunConfig config;
+    config.thread_id = "tool-gate-root";
+    config.input = {
+        {"messages", json::array({{
+            {"role", "assistant"},
+            {"content", ""},
+            {"tool_calls", json::array({{
+                {"id", "nested"},
+                {"name", "nested_tool"},
+                {"arguments", "{}"},
+            }})},
+        }})},
+    };
+    ASSERT_NO_THROW(engine->run(config));
+    EXPECT_EQ(parent_gate_calls.load(), 1);
+    EXPECT_EQ(child_gate_calls.load(), 0);
+    EXPECT_EQ(tool_calls.load(), 0);
+}
+
+TEST(SubgraphContext, NestedToolGatesApplyRewritesInParentThenChildOrder) {
+    std::atomic<int> tool_calls{0};
+    json observed_args;
+    SpyTool tool(&tool_calls, &observed_args);
+
+    NodeContext leaf_context;
+    leaf_context.tools = {&tool};
+    auto leaf = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(
+            add_messages_channel(one_node_graph("leaf", "tool_dispatch", "tool")),
+            leaf_context).release());
+    leaf->set_tool_gate([](ToolCall call, ToolGateContext)
+                            -> asio::awaitable<ToolDecision> {
+        auto args = json::parse(call.arguments);
+        if (!args.value("parent", false)) {
+            co_return ToolDecision::deny("child did not receive parent rewrite");
+        }
+        args["child"] = true;
+        co_return ToolDecision::allow(std::move(args));
+    });
+    register_subgraph_factory("subgraph_context_rewrite_child_196", leaf);
+    auto middle = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(add_messages_channel(
+                                 one_node_graph("middle", "subgraph_context_rewrite_child_196")),
+                             NodeContext{}).release());
+    register_subgraph_factory("subgraph_context_rewrite_outer_196", middle);
+
+    auto engine = GraphEngine::compile(
+        add_messages_channel(one_node_graph("root", "subgraph_context_rewrite_outer_196")),
+        NodeContext{});
+    engine->set_tool_gate([](ToolCall call, ToolGateContext)
+                              -> asio::awaitable<ToolDecision> {
+        auto args = json::parse(call.arguments);
+        args["parent"] = true;
+        co_return ToolDecision::allow(std::move(args));
+    });
+
+    RunConfig config;
+    config.thread_id = "tool-gate-rewrite-root";
+    config.input = {
+        {"messages", json::array({{
+            {"role", "assistant"},
+            {"content", ""},
+            {"tool_calls", json::array({{
+                {"id", "nested"},
+                {"name", "nested_tool"},
+                {"arguments", "{\"original\":true}"},
+            }})},
+        }})},
+    };
+
+    ASSERT_NO_THROW(engine->run(config));
+    EXPECT_EQ(tool_calls.load(), 1);
+    EXPECT_TRUE(observed_args.value("original", false));
+    EXPECT_TRUE(observed_args.value("parent", false));
+    EXPECT_TRUE(observed_args.value("child", false));
+}
+
+TEST(SubgraphContext, ParentResumeResumesInterruptedGrandchild) {
+    std::atomic<int> tool_calls{0};
+    std::atomic<int> gate_calls{0};
+    std::atomic<int> seed_calls{0};
+    SpyTool tool(&tool_calls);
+
+    NodeFactory::instance().register_type(
+        "subgraph_context_resume_seed_196",
+        [&seed_calls](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<CountingToolSeedNode>(name, &seed_calls);
+        });
+
+    NodeContext leaf_context;
+    leaf_context.tools = {&tool};
+    auto leaf = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(
+            seed_then_tool_graph("leaf", "subgraph_context_resume_seed_196"),
+            leaf_context).release());
+    register_subgraph_factory("subgraph_context_resume_child_196", leaf);
+    auto middle = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(add_messages_channel(
+                                 one_node_graph("middle", "subgraph_context_resume_child_196")),
+                             NodeContext{}).release());
+    register_subgraph_factory("subgraph_context_resume_outer_196", middle);
+
+    auto checkpoints = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(
+        add_messages_channel(one_node_graph("root", "subgraph_context_resume_outer_196")),
+        NodeContext{}, checkpoints);
+    engine->set_tool_gate([&gate_calls](ToolCall, ToolGateContext context)
+                              -> asio::awaitable<ToolDecision> {
+        gate_calls.fetch_add(1, std::memory_order_relaxed);
+        if (!context.resume_value) {
+            co_return ToolDecision::interrupt("approval required");
+        }
+        if (context.resume_value->value("approved", false)) {
+            co_return ToolDecision::allow();
+        }
+        co_return ToolDecision::deny("approval refused");
+    });
+
+    RunConfig config;
+    config.thread_id = "nested-resume-root";
+
+    auto interrupted = engine->run(config);
+    ASSERT_TRUE(interrupted.interrupted);
+    EXPECT_EQ(tool_calls.load(), 0);
+    EXPECT_EQ(seed_calls.load(), 1);
+
+    auto reinterrupted = engine->resume(config.thread_id);
+    EXPECT_TRUE(reinterrupted.interrupted);
+    EXPECT_EQ(tool_calls.load(), 0);
+    EXPECT_EQ(gate_calls.load(), 2);
+    EXPECT_EQ(seed_calls.load(), 1)
+        << "a null-payload parent resume must resume, not restart, the grandchild";
+
+    auto resumed = engine->resume(config.thread_id, json{{"approved", true}});
+    EXPECT_FALSE(resumed.interrupted);
+    EXPECT_EQ(tool_calls.load(), 1);
+    EXPECT_EQ(gate_calls.load(), 3);
+    EXPECT_EQ(seed_calls.load(), 1)
+        << "a fresh grandchild run would execute the seed node twice";
+}
+
+TEST(SubgraphContext, SendSiblingsReceiveDistinctCheckpointIdentities) {
+    auto capture = std::make_shared<ContextCapture>();
+    NodeFactory::instance().register_type(
+        "subgraph_context_sibling_capture_196",
+        [capture](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<CaptureContextNode>(name, capture);
+        });
+    NodeFactory::instance().register_type(
+        "subgraph_context_fanout_196",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<FanoutNode>(name);
+        });
+
+    auto child = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(one_node_graph("child", "subgraph_context_sibling_capture_196"),
+                             NodeContext{}).release());
+    register_subgraph_factory("subgraph_context_send_child_196", child);
+
+    json root = {
+        {"name", "root"},
+        {"channels", json::object()},
+        {"nodes", {
+            {"fanout", {{"type", "subgraph_context_fanout_196"}}},
+            {"child", {{"type", "subgraph_context_send_child_196"}}},
+        }},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "fanout"}},
+            {{"from", "child"}, {"to", "__end__"}},
+        })},
+    };
+    auto checkpoints = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(root, NodeContext{}, checkpoints);
+    engine->set_worker_count(2);
+
+    RunConfig config;
+    config.thread_id = "send-root";
+    ASSERT_NO_THROW(engine->run(config));
+
+    std::lock_guard<std::mutex> lock(capture->mutex);
+    ASSERT_EQ(capture->snapshots.size(), 2u);
+    const auto& first = capture->snapshots[0];
+    const auto& second = capture->snapshots[1];
+    EXPECT_NE(first.thread_id, second.thread_id);
+    EXPECT_FALSE(checkpoints->list(first.thread_id).empty());
+    EXPECT_FALSE(checkpoints->list(second.thread_id).empty());
+}
+
+TEST(SubgraphContext, StaticParallelSiblingsReceiveDistinctCheckpointIdentities) {
+    auto capture = std::make_shared<ContextCapture>();
+    NodeFactory::instance().register_type(
+        "subgraph_context_static_capture_196",
+        [capture](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<CaptureContextNode>(name, capture);
+        });
+
+    auto child = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(one_node_graph("child", "subgraph_context_static_capture_196"),
+                             NodeContext{}).release());
+    register_subgraph_factory("subgraph_context_static_child_196", child);
+
+    json root = {
+        {"name", "root"},
+        {"channels", json::object()},
+        {"nodes", {
+            {"left", {{"type", "subgraph_context_static_child_196"}}},
+            {"right", {{"type", "subgraph_context_static_child_196"}}},
+        }},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "left"}},
+            {{"from", "__start__"}, {"to", "right"}},
+            {{"from", "left"}, {"to", "__end__"}},
+            {{"from", "right"}, {"to", "__end__"}},
+        })},
+    };
+    auto checkpoints = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(root, NodeContext{}, checkpoints);
+    engine->set_worker_count(2);
+
+    RunConfig config;
+    config.thread_id = "static-root";
+    ASSERT_NO_THROW(engine->run(config));
+
+    std::lock_guard<std::mutex> lock(capture->mutex);
+    ASSERT_EQ(capture->snapshots.size(), 2u);
+    const auto& first = capture->snapshots[0];
+    const auto& second = capture->snapshots[1];
+    EXPECT_NE(first.thread_id, second.thread_id);
+    EXPECT_FALSE(first.thread_id.empty());
+    EXPECT_FALSE(second.thread_id.empty());
+    EXPECT_FALSE(checkpoints->list(first.thread_id).empty());
+    EXPECT_FALSE(checkpoints->list(second.thread_id).empty());
+}
+
+TEST(SubgraphContext, AnonymousParentDisablesChildCheckpointing) {
+    auto capture = std::make_shared<ContextCapture>();
+    NodeFactory::instance().register_type(
+        "subgraph_context_anonymous_capture_196",
+        [capture](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<CaptureContextNode>(name, capture);
+        });
+
+    auto child = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(one_node_graph("child", "subgraph_context_anonymous_capture_196"),
+                             NodeContext{}).release());
+    register_subgraph_factory("subgraph_context_anonymous_child_196", child);
+
+    auto checkpoints = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(
+        one_node_graph("root", "subgraph_context_anonymous_child_196"),
+        NodeContext{}, checkpoints);
+
+    ASSERT_NO_THROW(engine->run(RunConfig{}));
+
+    std::lock_guard<std::mutex> lock(capture->mutex);
+    ASSERT_EQ(capture->snapshots.size(), 1u);
+    EXPECT_TRUE(capture->snapshots.front().thread_id.empty());
+    EXPECT_TRUE(checkpoints->list("").empty());
+}
+
+TEST(SubgraphContext, ParentCancellationReachesGrandchild) {
+    std::atomic<bool> entered{false};
+    std::atomic<bool> observed_cancel{false};
+    NodeFactory::instance().register_type(
+        "subgraph_context_wait_cancel_196",
+        [&entered, &observed_cancel](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<WaitForParentCancelNode>(
+                name, &entered, &observed_cancel);
+        });
+
+    auto leaf = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(one_node_graph("leaf", "subgraph_context_wait_cancel_196"),
+                             NodeContext{}).release());
+    register_subgraph_factory("subgraph_context_cancel_middle_196", leaf);
+    auto middle = std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(one_node_graph("middle", "subgraph_context_cancel_middle_196"),
+                             NodeContext{}).release());
+    register_subgraph_factory("subgraph_context_cancel_outer_196", middle);
+    auto engine = GraphEngine::compile(
+        one_node_graph("root", "subgraph_context_cancel_outer_196"), NodeContext{});
+
+    auto cancel = std::make_shared<CancelToken>();
+    RunConfig config;
+    config.thread_id = "cancel-root";
+    config.cancel_token = cancel;
+
+    std::exception_ptr result;
+    std::thread runner([&] {
+        try {
+            engine->run(config);
+        } catch (...) {
+            result = std::current_exception();
+        }
+    });
+
+    const auto timeout = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!entered.load(std::memory_order_acquire)
+           && std::chrono::steady_clock::now() < timeout) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    cancel->cancel();
+    runner.join();
+
+    EXPECT_TRUE(entered.load(std::memory_order_acquire));
+    EXPECT_TRUE(observed_cancel.load(std::memory_order_acquire));
+    ASSERT_TRUE(result);
+    EXPECT_THROW(std::rethrow_exception(result), CancelledException);
+}


### PR DESCRIPTION
## Summary
- Propagate nested execution resources through a private runtime sidecar without changing the public RunConfig or RunContext ABI.
- Derive stable, sibling-safe child checkpoint identities and preserve anonymous-run checkpoint disabling.
- Compose parent and child ToolGate policy, inherit Store/checkpoint resources, and carry cancellation, usage, deadline, trace, stream mode, and HITL resume state through nested graphs.
- Add multi-level context regression coverage and document the propagation contract.

## Verification
- `ctest --test-dir /tmp/opencode/neograph-build-196 --output-on-failure` (625 passed; 3 live integration tests skipped)
- `ctest --test-dir /tmp/opencode/neograph-build-196-asan -R SubgraphContext --output-on-failure` (8 passed)
- `setarch x86_64 -R ctest --test-dir /tmp/opencode/neograph-build-196-tsan -R SubgraphContext --output-on-failure` (8 passed)
- `PYTHONPATH=/tmp/opencode/neograph-build-196-py python3 -c "import neograph_engine; print(neograph_engine.__version__)"` (`0.11.1`)

Tracks #196. The issue acceptance checklist will be updated after merge, using CI and merge evidence.