### PR TITLE
fix(util): make RequestQueue admission atomic

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -168,7 +168,11 @@ log("pending={} active={} completed={} rejected={}",
 `RunResult` via a shared output slot (as above) or a per-task
 `std::promise<RunResult>`. The queue is backed by
 `moodycamel::ConcurrentQueue` (lock-free) and workers park on a
-condvar when idle — no busy-spin.
+condvar when idle — no busy-spin. Admission atomically reserves a pending
+slot, so concurrent callers cannot exceed `max_queue_size`. A full queue
+returns `{false, invalid_future}` for ordinary backpressure; an internal
+enqueue failure instead returns `{false, valid_future}`, and that future
+throws `std::runtime_error` when observed.
 
 ## Rules for safe concurrent use
 

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -3065,8 +3065,9 @@ public:
     RequestQueue(const RequestQueue&) = delete;
     RequestQueue& operator=(const RequestQueue&) = delete;
 
-    // Submit a task. Returns {accepted, future}.
-    // If the queue is full, returns {false, invalid_future}.
+    // Submit a task. Concurrent callers cannot exceed max_queue_size.
+    // A full queue returns {false, invalid_future}; an internal enqueue
+    // failure returns {false, valid_future}, which throws on get().
     template<typename F>
     std::pair<bool, std::future<void>> submit(F&& task);
 
@@ -3082,7 +3083,7 @@ public:
 
 | Method | Description |
 |--------|-------------|
-| `submit(task)` | Enqueues a callable. Returns a pair: `first` is `true` if accepted (or `false` if the queue is full -- backpressure), `second` is a `std::future<void>` that resolves when the task completes or propagates exceptions |
+| `submit(task)` | Atomically reserves pending capacity, then enqueues a callable. Returns a pair: `first` is `true` if accepted. A full queue returns `false` with an invalid future; an internal enqueue failure returns `false` with a valid future that propagates the error. Accepted futures resolve when the task completes or propagates task exceptions. |
 | `stats()` | Returns a snapshot of current queue statistics |
 
 The queue uses `moodycamel::ConcurrentQueue` internally for lock-free enqueue/dequeue

--- a/include/neograph/util/request_queue.h
+++ b/include/neograph/util/request_queue.h
@@ -9,16 +9,76 @@
 #pragma once
 
 #include <concurrentqueue.h>
+#include <chrono>
 #include <thread>
 #include <vector>
 #include <atomic>
 #include <functional>
 #include <future>
-#include <iostream>
+#include <memory>
 #include <mutex>
 #include <condition_variable>
+#include <exception>
+#include <stdexcept>
 
 namespace neograph::util {
+
+namespace detail {
+
+// This is separate from RequestQueue only so tests can force the rare
+// enqueue-failure branch without relying on allocator failure. It does not
+// change RequestQueue's public object layout.
+template <typename Queue, typename F>
+std::pair<bool, std::future<void>> enqueue_reserved_task(
+    Queue& queue,
+    std::atomic<size_t>& pending,
+    std::atomic<size_t>& rejected,
+    F&& task) {
+    bool reservation_active = true;
+    auto rollback_reservation = [&] {
+        if (!reservation_active) return;
+        pending.fetch_sub(1, std::memory_order_acq_rel);
+        rejected.fetch_add(1, std::memory_order_relaxed);
+        reservation_active = false;
+    };
+
+    std::shared_ptr<std::promise<void>> promise;
+    std::future<void> future;
+    try {
+        promise = std::make_shared<std::promise<void>>();
+        future = promise->get_future();
+        std::function<void()> queued_task(
+            [t = std::forward<F>(task), p = promise]() mutable {
+                try {
+                    t();
+                    p->set_value();
+                } catch (...) {
+                    p->set_exception(std::current_exception());
+                }
+            });
+
+        // Vendored ConcurrentQueue documents enqueue() as thread-safe but
+        // fallible; see deps/concurrentqueue.h:997-1017, checked for #207.
+        if (!queue.enqueue(std::move(queued_task))) {
+            rollback_reservation();
+            promise->set_exception(std::make_exception_ptr(
+                std::runtime_error("RequestQueue enqueue failed")));
+            return {false, std::move(future)};
+        }
+        reservation_active = false;
+        return {true, std::move(future)};
+    } catch (...) {
+        const auto error = std::current_exception();
+        rollback_reservation();
+        if (promise && future.valid()) {
+            promise->set_exception(error);
+            return {false, std::move(future)};
+        }
+        throw;
+    }
+}
+
+} // namespace detail
 
 /**
  * @brief Lock-free task queue with a fixed worker thread pool and backpressure.
@@ -76,38 +136,30 @@ public:
     /**
      * @brief Submit a task to the queue.
      *
-     * If the queue is full (pending >= max_queue_size), the task is
-     * rejected and the rejected counter is incremented.
+     * Admission atomically reserves one pending slot before enqueueing, so
+     * concurrent submitters cannot exceed max_queue_size. A full queue returns
+     * {false, invalid_future}. If the underlying queue rejects an already
+     * reserved task, the reservation is rolled back and the returned future is
+     * valid but completes with an exception.
      *
      * @tparam F Callable type (must be invocable with no arguments).
      * @param task The task to execute.
      * @return A pair of {accepted, future}: accepted is true if the task
      *         was enqueued; future can be waited on for completion.
-     *         If rejected, future is default-constructed (invalid).
+     *         Capacity rejection returns an invalid future; enqueue failure
+     *         returns a valid future that propagates the failure.
      */
     template<typename F>
     std::pair<bool, std::future<void>> submit(F&& task) {
-        if (pending_.load(std::memory_order_relaxed) >= max_queue_size_) {
+        if (!try_reserve_pending_slot()) {
             rejected_.fetch_add(1, std::memory_order_relaxed);
             return {false, std::future<void>()};
         }
 
-        auto promise = std::make_shared<std::promise<void>>();
-        auto future  = promise->get_future();
-
-        pending_.fetch_add(1, std::memory_order_relaxed);
-        queue_.enqueue(
-            [t = std::forward<F>(task), p = std::move(promise)]() mutable {
-                try {
-                    t();
-                    p->set_value();
-                } catch (...) {
-                    p->set_exception(std::current_exception());
-                }
-            });
-        cv_.notify_one();
-
-        return {true, std::move(future)};
+        auto result = detail::enqueue_reserved_task(
+            queue_, pending_, rejected_, std::forward<F>(task));
+        if (result.first) cv_.notify_one();
+        return result;
     }
 
     /**
@@ -126,13 +178,32 @@ public:
     }
 
 private:
+    bool try_reserve_pending_slot() {
+        size_t pending = pending_.load(std::memory_order_relaxed);
+        while (pending < max_queue_size_) {
+            if (pending_.compare_exchange_weak(
+                    pending, pending + 1,
+                    std::memory_order_acq_rel,
+                    std::memory_order_relaxed)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     void worker_loop() {
         std::function<void()> task;
         while (running_.load(std::memory_order_relaxed)) {
             if (queue_.try_dequeue(task)) {
-                pending_.fetch_sub(1, std::memory_order_relaxed);
+                pending_.fetch_sub(1, std::memory_order_acq_rel);
                 active_.fetch_add(1, std::memory_order_relaxed);
-                task();
+                try {
+                    task();
+                } catch (...) {
+                    // A task wrapper should already complete its promise, but
+                    // a malformed task must not strand accounting or kill the
+                    // worker thread.
+                }
                 active_.fetch_sub(1, std::memory_order_relaxed);
                 completed_.fetch_add(1, std::memory_order_relaxed);
             } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -113,6 +113,10 @@ if(NEOGRAPH_BUILD_A2A)
     )
 endif()
 
+if(NEOGRAPH_BUILD_UTIL)
+    target_sources(neograph_tests PRIVATE test_request_queue.cpp)
+endif()
+
 if(NEOGRAPH_BUILD_ACP)
     target_sources(neograph_tests PRIVATE
         test_acp_types.cpp
@@ -180,6 +184,10 @@ endif()
 
 if(NEOGRAPH_BUILD_ACP)
     target_link_libraries(neograph_tests PRIVATE neograph::acp)
+endif()
+
+if(NEOGRAPH_BUILD_UTIL)
+    target_link_libraries(neograph_tests PRIVATE neograph::util)
 endif()
 
 if(NEOGRAPH_BUILD_POSTGRES)

--- a/tests/test_request_queue.cpp
+++ b/tests/test_request_queue.cpp
@@ -1,0 +1,150 @@
+#include <gtest/gtest.h>
+
+#include <neograph/util/request_queue.h>
+
+#include <atomic>
+#include <barrier>
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace {
+
+class RejectingQueue {
+public:
+    bool enqueue(std::function<void()>&&) { return false; }
+};
+
+TEST(RequestQueue, ConcurrentAdmissionNeverExceedsCapacity) {
+    constexpr std::size_t kCapacity = 8;
+    constexpr std::size_t kSubmitters = 48;
+    neograph::util::RequestQueue queue(1, kCapacity);
+
+    std::mutex gate_mutex;
+    std::condition_variable gate_cv;
+    bool worker_started = false;
+    bool release_worker = false;
+
+    auto [running_accepted, running] = queue.submit([&] {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        worker_started = true;
+        gate_cv.notify_all();
+        gate_cv.wait(lock, [&] { return release_worker; });
+    });
+    ASSERT_TRUE(running_accepted);
+    {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        ASSERT_TRUE(gate_cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return worker_started;
+        }));
+    }
+
+    std::barrier start(kSubmitters + 1);
+    std::atomic<std::size_t> accepted{0};
+    std::atomic<std::size_t> rejected{0};
+    std::atomic<std::size_t> observed_max_pending{0};
+    std::atomic<bool> rejected_future_valid{false};
+    std::mutex futures_mutex;
+    std::vector<std::future<void>> futures;
+    futures.reserve(kSubmitters);
+    std::vector<std::thread> submitters;
+    submitters.reserve(kSubmitters);
+
+    for (std::size_t i = 0; i < kSubmitters; ++i) {
+        submitters.emplace_back([&] {
+            start.arrive_and_wait();
+            auto [was_accepted, future] = queue.submit([] {});
+            const auto pending = queue.stats().pending;
+            auto previous = observed_max_pending.load(std::memory_order_relaxed);
+            while (previous < pending
+                   && !observed_max_pending.compare_exchange_weak(
+                       previous, pending, std::memory_order_relaxed)) {
+            }
+
+            if (was_accepted) {
+                accepted.fetch_add(1, std::memory_order_relaxed);
+                std::lock_guard<std::mutex> lock(futures_mutex);
+                futures.push_back(std::move(future));
+            } else {
+                if (future.valid()) {
+                    rejected_future_valid.store(true, std::memory_order_relaxed);
+                }
+                rejected.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+
+    start.arrive_and_wait();
+    for (auto& submitter : submitters) submitter.join();
+
+    EXPECT_EQ(accepted.load(), kCapacity);
+    EXPECT_EQ(rejected.load(), kSubmitters - kCapacity);
+    EXPECT_EQ(queue.stats().pending, kCapacity);
+    EXPECT_LE(observed_max_pending.load(), kCapacity);
+    EXPECT_FALSE(rejected_future_valid.load());
+
+    {
+        std::lock_guard<std::mutex> lock(gate_mutex);
+        release_worker = true;
+    }
+    gate_cv.notify_all();
+
+    ASSERT_NO_THROW(running.get());
+    for (auto& future : futures) ASSERT_NO_THROW(future.get());
+
+    const auto expected_completed = kCapacity + 1;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while ((queue.stats().completed != expected_completed || queue.stats().active != 0)
+           && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    const auto stats = queue.stats();
+    EXPECT_EQ(stats.pending, 0u);
+    EXPECT_EQ(stats.active, 0u);
+    EXPECT_EQ(stats.completed, expected_completed);
+    EXPECT_EQ(stats.rejected, kSubmitters - kCapacity);
+}
+
+TEST(RequestQueue, FailedEnqueueRollsBackReservationAndReportsError) {
+    RejectingQueue queue;
+    std::atomic<std::size_t> pending{1};
+    std::atomic<std::size_t> rejected{0};
+
+    auto [accepted, future] = neograph::util::detail::enqueue_reserved_task(
+        queue, pending, rejected, [] {});
+
+    EXPECT_FALSE(accepted);
+    ASSERT_TRUE(future.valid());
+    EXPECT_THROW(future.get(), std::runtime_error);
+    EXPECT_EQ(pending.load(), 0u);
+    EXPECT_EQ(rejected.load(), 1u);
+}
+
+TEST(RequestQueue, TaskExceptionsDoNotLeakPendingOrActiveAccounting) {
+    neograph::util::RequestQueue queue(1, 1);
+
+    auto [accepted, future] = queue.submit([] {
+        throw std::runtime_error("expected task failure");
+    });
+
+    ASSERT_TRUE(accepted);
+    EXPECT_THROW(future.get(), std::runtime_error);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (queue.stats().completed != 1
+           && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    const auto stats = queue.stats();
+    EXPECT_EQ(stats.pending, 0u);
+    EXPECT_EQ(stats.active, 0u);
+    EXPECT_EQ(stats.completed, 1u);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary
- Atomically reserve RequestQueue pending capacity before enqueueing so concurrent submitters cannot exceed the configured bound.
- Roll back reservation and complete a valid future exceptionally when the underlying queue rejects or setup fails after reservation.
- Keep RequestQueue's direct-member public layout intact and add deterministic contention, enqueue-failure, and accounting regressions.
- Document stable backpressure and internal-enqueue failure outcomes.

## Verification
- `ctest --test-dir /tmp/opencode/neograph-build-196 --output-on-failure` (628 passed; 3 live integration tests skipped)
- `ctest --test-dir /tmp/opencode/neograph-build-196 -R RequestQueue.ConcurrentAdmissionNeverExceedsCapacity --repeat until-fail:100 --output-on-failure`
- `ctest --test-dir /tmp/opencode/neograph-build-196-asan -R RequestQueue --output-on-failure` (3 passed)
- `setarch x86_64 -R ctest --test-dir /tmp/opencode/neograph-build-196-tsan -R RequestQueue --output-on-failure` (3 passed)

Tracks #207. The issue acceptance checklist will be updated after merge using CI and local verification evidence.