### PR TITLE
fix(util): define RequestQueue lifecycle

### DIFF
--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -174,6 +174,14 @@ returns `{false, invalid_future}` for ordinary backpressure; an internal
 enqueue failure instead returns `{false, valid_future}`, and that future
 throws `std::runtime_error` when observed.
 
+Construct the queue with at least one worker. `close()` is idempotent: it
+rejects later submissions, waits for workers, lets a callable already claimed
+by a worker finish, and completes all unclaimed futures with
+`std::runtime_error("RequestQueue is closed")`. A callable may invoke `close()`
+itself to initiate shutdown, but that worker returns rather than waiting for
+itself. The destructor uses the same close path, so accepted futures are never
+silently stranded during teardown.
+
 ## Rules for safe concurrent use
 
 - Configuration mutators (`set_retry_policy`, `set_checkpoint_store`,

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -3052,12 +3052,13 @@ public:
     struct Stats {
         size_t pending;        // Tasks waiting in queue
         size_t active;         // Tasks currently executing
-        size_t completed;      // Total completed tasks
-        size_t rejected;       // Tasks rejected due to full queue
+        size_t completed;      // Total settled tasks, including cancellation
+        size_t rejected;       // Tasks rejected during admission
         size_t num_workers;    // Number of worker threads
         size_t max_queue_size; // Maximum queue capacity
     };
 
+    // num_workers must be greater than zero.
     RequestQueue(size_t num_workers = 128, size_t max_queue_size = 10000);
     ~RequestQueue();
 
@@ -3071,6 +3072,10 @@ public:
     template<typename F>
     std::pair<bool, std::future<void>> submit(F&& task);
 
+    // Idempotently reject new work, cancel queued tasks, and wait for workers.
+    void close();
+    bool is_closed() const noexcept;
+
     // Get current queue statistics
     Stats stats() const;
 };
@@ -3078,12 +3083,14 @@ public:
 
 | Constructor Parameter | Type | Default | Description |
 |-----------------------|------|---------|-------------|
-| `num_workers` | `size_t` | `128` | Number of worker threads in the pool |
+| `num_workers` | `size_t` | `128` | Number of worker threads in the pool; zero throws `std::invalid_argument` |
 | `max_queue_size` | `size_t` | `10000` | Maximum number of pending tasks. Tasks beyond this limit are rejected |
 
 | Method | Description |
 |--------|-------------|
-| `submit(task)` | Atomically reserves pending capacity, then enqueues a callable. Returns a pair: `first` is `true` if accepted. A full queue returns `false` with an invalid future; an internal enqueue failure returns `false` with a valid future that propagates the error. Accepted futures resolve when the task completes or propagates task exceptions. |
+| `submit(task)` | Atomically reserves pending capacity, then enqueues a callable. Returns a pair: `first` is `true` if accepted. A full or closed queue returns `false` with an invalid future; an internal enqueue failure returns `false` with a valid future that propagates the error. Accepted futures resolve when the task completes or propagates task exceptions. |
+| `close()` | Idempotently rejects new work. An external caller waits for all workers to finish shutdown, then unclaimed work completes with `std::runtime_error("RequestQueue is closed")`. A callable claimed by a worker before closure may finish. A callable may invoke `close()` to initiate shutdown, but cannot wait for itself. |
+| `is_closed()` | Reports whether `close()` has begun rejecting new work. |
 | `stats()` | Returns a snapshot of current queue statistics |
 
 The queue uses `moodycamel::ConcurrentQueue` internally for lock-free enqueue/dequeue

--- a/include/neograph/util/request_queue.h
+++ b/include/neograph/util/request_queue.h
@@ -20,6 +20,7 @@
 #include <condition_variable>
 #include <exception>
 #include <stdexcept>
+#include <utility>
 
 namespace neograph::util {
 
@@ -98,22 +99,239 @@ public:
     struct Stats {
         size_t pending;         ///< Tasks waiting in the queue.
         size_t active;          ///< Tasks currently being executed.
-        size_t completed;       ///< Total tasks finished.
-        size_t rejected;        ///< Tasks rejected due to backpressure (queue full).
+        size_t completed;       ///< Total tasks settled, including close cancellation.
+        size_t rejected;        ///< Tasks rejected during admission.
         size_t num_workers;     ///< Number of worker threads.
         size_t max_queue_size;  ///< Maximum queue capacity.
     };
 
+private:
+    struct State {
+        explicit State(size_t max_queue_size)
+            : max_queue_size_(max_queue_size) {}
+
+        template<typename F>
+        std::pair<bool, std::future<void>> submit(F&& task) {
+            std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+            if (!running_.load(std::memory_order_acquire)) {
+                rejected_.fetch_add(1, std::memory_order_relaxed);
+                return {false, std::future<void>()};
+            }
+            if (!try_reserve_pending_slot()) {
+                rejected_.fetch_add(1, std::memory_order_relaxed);
+                return {false, std::future<void>()};
+            }
+
+            auto result = detail::enqueue_reserved_task(
+                queue_, pending_, rejected_,
+                [this, t = std::forward<F>(task)]() mutable {
+                    if (!claim_task_start()) {
+                        throw std::runtime_error("RequestQueue is closed");
+                    }
+                    t();
+                });
+            if (result.first) cv_.notify_one();
+            return result;
+        }
+
+        void close() {
+            const bool caller_is_worker = current_worker_ == this;
+            const auto caller_id = std::this_thread::get_id();
+            {
+                std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+                if (close_started_) {
+                    if (caller_is_worker) return;
+                    cv_.wait(lock, [this] { return close_complete_; });
+                    return;
+                }
+
+                close_started_ = true;
+                worker_initiated_close_ = caller_is_worker;
+                running_.store(false, std::memory_order_release);
+            }
+            cv_.notify_all();
+
+            if (caller_is_worker) {
+                // A worker cannot join itself. Detach only that thread, then
+                // wait for every other claimed callback before the facade can
+                // be destroyed. State remains alive through the detached
+                // worker until it exits and marks shutdown complete.
+                for (auto& worker : workers_) {
+                    if (!worker.joinable()) continue;
+                    if (worker.get_id() == caller_id) {
+                        worker.detach();
+                    } else {
+                        worker.join();
+                    }
+                }
+                cancel_pending_tasks();
+                {
+                    std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+                    cancellation_complete_ = true;
+                }
+                return;
+            }
+
+            for (auto& worker : workers_) {
+                if (worker.joinable()) worker.join();
+            }
+            cancel_pending_tasks();
+            {
+                std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+                cancellation_complete_ = true;
+                close_complete_ = true;
+            }
+            cv_.notify_all();
+        }
+
+        bool is_closed() const noexcept {
+            return !running_.load(std::memory_order_acquire);
+        }
+
+        Stats stats() const {
+            return {
+                pending_.load(std::memory_order_relaxed),
+                active_.load(std::memory_order_relaxed),
+                completed_.load(std::memory_order_relaxed),
+                rejected_.load(std::memory_order_relaxed),
+                workers_.size(),
+                max_queue_size_
+            };
+        }
+
+        void run_worker() {
+            current_worker_ = this;
+            worker_loop();
+            worker_exited();
+            current_worker_ = nullptr;
+        }
+
+        std::mutex lifecycle_mutex_;
+        std::condition_variable cv_;
+        std::vector<std::thread> workers_;
+        std::atomic<bool> running_{true};
+        std::atomic<size_t> pending_{0};
+        std::atomic<size_t> active_{0};
+        std::atomic<size_t> completed_{0};
+        std::atomic<size_t> rejected_{0};
+        size_t max_queue_size_;
+        size_t workers_alive_{0};
+        bool close_started_{false};
+        bool close_complete_{false};
+        bool cancellation_complete_{false};
+        bool worker_initiated_close_{false};
+        inline static thread_local State* current_worker_ = nullptr;
+
+    private:
+        bool try_reserve_pending_slot() {
+            size_t pending = pending_.load(std::memory_order_relaxed);
+            while (pending < max_queue_size_) {
+                if (pending_.compare_exchange_weak(
+                        pending, pending + 1,
+                        std::memory_order_acq_rel,
+                        std::memory_order_relaxed)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        bool claim_task_start() {
+            std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+            return running_.load(std::memory_order_acquire);
+        }
+
+        void worker_loop() {
+            std::function<void()> task;
+            while (running_.load(std::memory_order_acquire)) {
+                if (queue_.try_dequeue(task)) {
+                    pending_.fetch_sub(1, std::memory_order_acq_rel);
+                    execute_task(task);
+                } else {
+                    // No busy-spin — sleep until notified by submit().
+                    std::unique_lock<std::mutex> lock(lifecycle_mutex_);
+                    cv_.wait_for(lock, std::chrono::milliseconds(50), [this] {
+                        return !running_.load(std::memory_order_acquire)
+                            || queue_.size_approx() > 0;
+                    });
+                }
+            }
+        }
+
+        void worker_exited() {
+            bool finalize_worker_close = false;
+            {
+                std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+                --workers_alive_;
+                finalize_worker_close = close_started_
+                    && worker_initiated_close_
+                    && !close_complete_
+                    && workers_alive_ == 0;
+            }
+            if (!finalize_worker_close) return;
+
+            bool cancel_pending = false;
+            {
+                std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+                cancel_pending = !cancellation_complete_;
+            }
+            if (cancel_pending) cancel_pending_tasks();
+            {
+                std::lock_guard<std::mutex> lock(lifecycle_mutex_);
+                cancellation_complete_ = true;
+                close_complete_ = true;
+            }
+            cv_.notify_all();
+        }
+
+        void cancel_pending_tasks() {
+            std::function<void()> task;
+            while (queue_.try_dequeue(task)) {
+                pending_.fetch_sub(1, std::memory_order_acq_rel);
+                try {
+                    task();
+                } catch (...) {
+                    // The task wrapper owns its promise and reports errors.
+                }
+                completed_.fetch_add(1, std::memory_order_relaxed);
+            }
+        }
+
+        void execute_task(std::function<void()>& task) {
+            active_.fetch_add(1, std::memory_order_relaxed);
+            try {
+                task();
+            } catch (...) {
+                // A task wrapper should already complete its promise, but a
+                // malformed task must not strand accounting or kill a worker.
+            }
+            active_.fetch_sub(1, std::memory_order_relaxed);
+            completed_.fetch_add(1, std::memory_order_relaxed);
+        }
+
+        moodycamel::ConcurrentQueue<std::function<void()>> queue_;
+    };
+
+public:
     /**
      * @brief Construct a request queue with a worker thread pool.
      * @param num_workers Number of worker threads to spawn (default: 128).
      * @param max_queue_size Maximum number of pending tasks before backpressure (default: 10000).
+     * @throws std::invalid_argument if num_workers is zero.
      */
     RequestQueue(size_t num_workers = 128, size_t max_queue_size = 10000)
-        : max_queue_size_(max_queue_size)
+        : state_(std::make_shared<State>(max_queue_size))
     {
-        for (size_t i = 0; i < num_workers; ++i) {
-            workers_.emplace_back([this] { worker_loop(); });
+        if (num_workers == 0) {
+            throw std::invalid_argument("RequestQueue requires at least one worker");
+        }
+        try {
+            for (size_t i = 0; i < num_workers; ++i) {
+                start_worker();
+            }
+        } catch (...) {
+            state_->close();
+            throw;
         }
         // No banner on stdout — library code shouldn't pollute the
         // host process's stdout (breaks scripts that parse it). If
@@ -121,13 +339,9 @@ public:
         // instead of std::cout.
     }
 
-    /// Destructor: stops all workers and waits for them to finish.
+    /// Destructor: applies the same cancel-on-close policy as close().
     ~RequestQueue() {
-        running_ = false;
-        cv_.notify_all();
-        for (auto& w : workers_) {
-            if (w.joinable()) w.join();
-        }
+        close();
     }
 
     RequestQueue(const RequestQueue&) = delete;
@@ -147,19 +361,31 @@ public:
      * @return A pair of {accepted, future}: accepted is true if the task
      *         was enqueued; future can be waited on for completion.
      *         Capacity rejection returns an invalid future; enqueue failure
-     *         returns a valid future that propagates the failure.
+     *         returns a valid future that propagates the failure. Closure
+     *         rejection returns an invalid future.
      */
     template<typename F>
     std::pair<bool, std::future<void>> submit(F&& task) {
-        if (!try_reserve_pending_slot()) {
-            rejected_.fetch_add(1, std::memory_order_relaxed);
-            return {false, std::future<void>()};
-        }
+        return state_->submit(std::forward<F>(task));
+    }
 
-        auto result = detail::enqueue_reserved_task(
-            queue_, pending_, rejected_, std::forward<F>(task));
-        if (result.first) cv_.notify_one();
-        return result;
+    /**
+     * @brief Stop accepting work, cancel queued tasks, and wait for workers.
+     *
+     * The first caller transitions the queue to closed. Work a worker claimed
+     * before that transition may finish; all unclaimed work completes its
+     * future with `std::runtime_error("RequestQueue is closed")`. Concurrent
+     * and repeated external callers wait for that same shutdown to complete.
+     * A task may call close() to initiate shutdown, but cannot wait for itself.
+     */
+    void close() {
+        auto state = state_;
+        state->close();
+    }
+
+    /// True once close() has started rejecting new work.
+    bool is_closed() const noexcept {
+        return state_->is_closed();
     }
 
     /**
@@ -167,66 +393,26 @@ public:
      * @return Stats snapshot with pending, active, completed, and rejected counts.
      */
     Stats stats() const {
-        return {
-            pending_.load(std::memory_order_relaxed),
-            active_.load(std::memory_order_relaxed),
-            completed_.load(std::memory_order_relaxed),
-            rejected_.load(std::memory_order_relaxed),
-            workers_.size(),
-            max_queue_size_
-        };
+        return state_->stats();
     }
 
 private:
-    bool try_reserve_pending_slot() {
-        size_t pending = pending_.load(std::memory_order_relaxed);
-        while (pending < max_queue_size_) {
-            if (pending_.compare_exchange_weak(
-                    pending, pending + 1,
-                    std::memory_order_acq_rel,
-                    std::memory_order_relaxed)) {
-                return true;
-            }
+    void start_worker() {
+        {
+            std::lock_guard<std::mutex> lock(state_->lifecycle_mutex_);
+            ++state_->workers_alive_;
         }
-        return false;
-    }
-
-    void worker_loop() {
-        std::function<void()> task;
-        while (running_.load(std::memory_order_relaxed)) {
-            if (queue_.try_dequeue(task)) {
-                pending_.fetch_sub(1, std::memory_order_acq_rel);
-                active_.fetch_add(1, std::memory_order_relaxed);
-                try {
-                    task();
-                } catch (...) {
-                    // A task wrapper should already complete its promise, but
-                    // a malformed task must not strand accounting or kill the
-                    // worker thread.
-                }
-                active_.fetch_sub(1, std::memory_order_relaxed);
-                completed_.fetch_add(1, std::memory_order_relaxed);
-            } else {
-                // No busy-spin — sleep until notified by submit()
-                std::unique_lock<std::mutex> lock(cv_mutex_);
-                cv_.wait_for(lock, std::chrono::milliseconds(50), [this] {
-                    return !running_.load(std::memory_order_relaxed)
-                        || queue_.size_approx() > 0;
-                });
-            }
+        try {
+            auto state = state_;
+            state_->workers_.emplace_back([state] { state->run_worker(); });
+        } catch (...) {
+            std::lock_guard<std::mutex> lock(state_->lifecycle_mutex_);
+            --state_->workers_alive_;
+            throw;
         }
     }
 
-    moodycamel::ConcurrentQueue<std::function<void()>> queue_;
-    std::vector<std::thread> workers_;
-    std::mutex cv_mutex_;
-    std::condition_variable cv_;
-    std::atomic<bool> running_{true};
-    std::atomic<size_t> pending_{0};
-    std::atomic<size_t> active_{0};
-    std::atomic<size_t> completed_{0};
-    std::atomic<size_t> rejected_{0};
-    size_t max_queue_size_;
+    std::shared_ptr<State> state_;
 };
 
 } // namespace neograph::util

--- a/tests/test_request_queue.cpp
+++ b/tests/test_request_queue.cpp
@@ -147,4 +147,337 @@ TEST(RequestQueue, TaskExceptionsDoNotLeakPendingOrActiveAccounting) {
     EXPECT_EQ(stats.completed, 1u);
 }
 
+TEST(RequestQueue, ZeroWorkersAreRejected) {
+    EXPECT_THROW(neograph::util::RequestQueue(0, 1), std::invalid_argument);
+}
+
+TEST(RequestQueue, CloseCancelsQueuedTasksAndRejectsNewWork) {
+    neograph::util::RequestQueue queue(1, 4);
+    std::mutex gate_mutex;
+    std::condition_variable gate_cv;
+    bool worker_started = false;
+    bool release_worker = false;
+    std::atomic<int> queued_executions{0};
+
+    auto [active_accepted, active] = queue.submit([&] {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        worker_started = true;
+        gate_cv.notify_all();
+        gate_cv.wait(lock, [&] { return release_worker; });
+    });
+    ASSERT_TRUE(active_accepted);
+    {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        ASSERT_TRUE(gate_cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return worker_started;
+        }));
+    }
+
+    auto [first_accepted, first] = queue.submit([&] {
+        queued_executions.fetch_add(1, std::memory_order_relaxed);
+    });
+    auto [second_accepted, second] = queue.submit([&] {
+        queued_executions.fetch_add(1, std::memory_order_relaxed);
+    });
+    ASSERT_TRUE(first_accepted);
+    ASSERT_TRUE(second_accepted);
+
+    std::thread closer([&] { queue.close(); });
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!queue.is_closed() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    const bool observed_closed = queue.is_closed();
+
+    auto [post_close_accepted, post_close] = queue.submit([] {});
+    EXPECT_FALSE(post_close_accepted);
+    EXPECT_FALSE(post_close.valid());
+
+    {
+        std::lock_guard<std::mutex> lock(gate_mutex);
+        release_worker = true;
+    }
+    gate_cv.notify_all();
+    closer.join();
+
+    EXPECT_TRUE(observed_closed);
+    EXPECT_TRUE(queue.is_closed());
+    ASSERT_NO_THROW(active.get());
+    ASSERT_EQ(first.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    ASSERT_EQ(second.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    EXPECT_THROW(first.get(), std::runtime_error);
+    EXPECT_THROW(second.get(), std::runtime_error);
+    EXPECT_EQ(queued_executions.load(), 0);
+
+    queue.close();
+    const auto stats = queue.stats();
+    EXPECT_EQ(stats.pending, 0u);
+    EXPECT_EQ(stats.active, 0u);
+    EXPECT_EQ(stats.completed, 3u);
+    EXPECT_EQ(stats.rejected, 1u);
+}
+
+TEST(RequestQueue, ConcurrentCloseCallsAreIdempotent) {
+    constexpr std::size_t kClosers = 8;
+    neograph::util::RequestQueue queue(1, 1);
+    std::mutex gate_mutex;
+    std::condition_variable gate_cv;
+    bool worker_started = false;
+    bool release_worker = false;
+
+    auto [active_accepted, active] = queue.submit([&] {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        worker_started = true;
+        gate_cv.notify_all();
+        gate_cv.wait(lock, [&] { return release_worker; });
+    });
+    ASSERT_TRUE(active_accepted);
+    {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        ASSERT_TRUE(gate_cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return worker_started;
+        }));
+    }
+
+    auto [queued_accepted, queued] = queue.submit([] {});
+    ASSERT_TRUE(queued_accepted);
+
+    std::barrier start(kClosers + 1);
+    std::atomic<std::size_t> returned{0};
+    std::vector<std::thread> closers;
+    closers.reserve(kClosers);
+    for (std::size_t i = 0; i < kClosers; ++i) {
+        closers.emplace_back([&] {
+            start.arrive_and_wait();
+            queue.close();
+            returned.fetch_add(1, std::memory_order_relaxed);
+        });
+    }
+
+    start.arrive_and_wait();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!queue.is_closed() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    const bool observed_closed = queue.is_closed();
+    {
+        std::lock_guard<std::mutex> lock(gate_mutex);
+        release_worker = true;
+    }
+    gate_cv.notify_all();
+
+    for (auto& closer : closers) closer.join();
+
+    EXPECT_TRUE(observed_closed);
+    EXPECT_EQ(returned.load(), kClosers);
+    ASSERT_NO_THROW(active.get());
+    ASSERT_EQ(queued.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    EXPECT_THROW(queued.get(), std::runtime_error);
+}
+
+TEST(RequestQueue, SubmitCloseRaceResolvesEveryAcceptedFuture) {
+    constexpr std::size_t kSubmitters = 32;
+    neograph::util::RequestQueue queue(1, kSubmitters + 1);
+    std::mutex gate_mutex;
+    std::condition_variable gate_cv;
+    bool worker_started = false;
+    bool release_worker = false;
+    std::atomic<int> queued_executions{0};
+
+    auto [active_accepted, active] = queue.submit([&] {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        worker_started = true;
+        gate_cv.notify_all();
+        gate_cv.wait(lock, [&] { return release_worker; });
+    });
+    ASSERT_TRUE(active_accepted);
+    {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        ASSERT_TRUE(gate_cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return worker_started;
+        }));
+    }
+
+    std::barrier start(kSubmitters + 2);
+    std::mutex futures_mutex;
+    std::vector<std::future<void>> accepted_futures;
+    std::atomic<std::size_t> accepted{0};
+    std::atomic<std::size_t> rejected{0};
+    std::vector<std::thread> submitters;
+    submitters.reserve(kSubmitters);
+    for (std::size_t i = 0; i < kSubmitters; ++i) {
+        submitters.emplace_back([&] {
+            start.arrive_and_wait();
+            auto [was_accepted, future] = queue.submit([&] {
+                queued_executions.fetch_add(1, std::memory_order_relaxed);
+            });
+            if (was_accepted) {
+                accepted.fetch_add(1, std::memory_order_relaxed);
+                std::lock_guard<std::mutex> lock(futures_mutex);
+                accepted_futures.push_back(std::move(future));
+            } else {
+                EXPECT_FALSE(future.valid());
+                rejected.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+    }
+    std::thread closer([&] {
+        start.arrive_and_wait();
+        queue.close();
+    });
+
+    start.arrive_and_wait();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (!queue.is_closed() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    const bool observed_closed = queue.is_closed();
+    {
+        std::lock_guard<std::mutex> lock(gate_mutex);
+        release_worker = true;
+    }
+    gate_cv.notify_all();
+
+    for (auto& submitter : submitters) submitter.join();
+    closer.join();
+
+    EXPECT_TRUE(observed_closed);
+    ASSERT_NO_THROW(active.get());
+    for (auto& future : accepted_futures) {
+        ASSERT_EQ(future.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+        EXPECT_THROW(future.get(), std::runtime_error);
+    }
+    EXPECT_EQ(queued_executions.load(), 0);
+    EXPECT_EQ(accepted.load() + rejected.load(), kSubmitters);
+
+    const auto stats = queue.stats();
+    EXPECT_EQ(stats.pending, 0u);
+    EXPECT_EQ(stats.active, 0u);
+    EXPECT_EQ(stats.completed, accepted.load() + 1);
+}
+
+TEST(RequestQueue, DestructorCancelsQueuedFutures) {
+    std::future<void> queued;
+    {
+        neograph::util::RequestQueue queue(1, 2);
+        std::promise<void> worker_started;
+        auto started = worker_started.get_future();
+
+        auto [active_accepted, active] = queue.submit([&] {
+            worker_started.set_value();
+            const auto deadline = std::chrono::steady_clock::now()
+                + std::chrono::seconds(2);
+            while (!queue.is_closed()) {
+                if (std::chrono::steady_clock::now() >= deadline) {
+                    throw std::runtime_error("RequestQueue destructor did not close");
+                }
+                std::this_thread::yield();
+            }
+        });
+        ASSERT_TRUE(active_accepted);
+        ASSERT_EQ(started.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+
+        auto [queued_accepted, future] = queue.submit([] {});
+        ASSERT_TRUE(queued_accepted);
+        queued = std::move(future);
+    }
+
+    ASSERT_EQ(queued.wait_for(std::chrono::seconds(0)), std::future_status::ready);
+    EXPECT_THROW(queued.get(), std::runtime_error);
+}
+
+TEST(RequestQueue, WorkerDestructionCancelsQueuedFutures) {
+    auto* queue = new neograph::util::RequestQueue(1, 2);
+    std::mutex gate_mutex;
+    std::condition_variable gate_cv;
+    bool worker_started = false;
+    bool release_worker = false;
+    std::atomic<int> queued_executions{0};
+
+    auto [active_accepted, active] = queue->submit([&] {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        worker_started = true;
+        gate_cv.notify_all();
+        gate_cv.wait(lock, [&] { return release_worker; });
+    });
+    ASSERT_TRUE(active_accepted);
+    {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        ASSERT_TRUE(gate_cv.wait_for(lock, std::chrono::seconds(2), [&] {
+            return worker_started;
+        }));
+    }
+
+    auto [destroy_accepted, destroy] = queue->submit([queue] {
+        delete queue;
+    });
+    auto [queued_accepted, queued] = queue->submit([&] {
+        queued_executions.fetch_add(1, std::memory_order_relaxed);
+    });
+    ASSERT_TRUE(destroy_accepted);
+    ASSERT_TRUE(queued_accepted);
+
+    {
+        std::lock_guard<std::mutex> lock(gate_mutex);
+        release_worker = true;
+    }
+    gate_cv.notify_all();
+
+    ASSERT_EQ(active.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    ASSERT_NO_THROW(active.get());
+    ASSERT_EQ(destroy.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    ASSERT_NO_THROW(destroy.get());
+    ASSERT_EQ(queued.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    EXPECT_THROW(queued.get(), std::runtime_error);
+    EXPECT_EQ(queued_executions.load(), 0);
+}
+
+TEST(RequestQueue, WorkerDestructionWaitsForOtherClaimedWorkers) {
+    auto* queue = new neograph::util::RequestQueue(2, 2);
+    std::mutex gate_mutex;
+    std::condition_variable gate_cv;
+    bool other_worker_started = false;
+    bool release_other_worker = false;
+    std::promise<void> destruction_started_promise;
+    auto destruction_started = destruction_started_promise.get_future();
+    std::promise<void> destruction_returned_promise;
+    auto destruction_returned = destruction_returned_promise.get_future();
+
+    auto [other_accepted, other] = queue->submit([&] {
+        std::unique_lock<std::mutex> lock(gate_mutex);
+        other_worker_started = true;
+        gate_cv.notify_all();
+        gate_cv.wait(lock, [&] { return release_other_worker; });
+    });
+    ASSERT_TRUE(other_accepted);
+
+    auto [destroy_accepted, destroy] = queue->submit([&] {
+        {
+            std::unique_lock<std::mutex> lock(gate_mutex);
+            gate_cv.wait(lock, [&] { return other_worker_started; });
+        }
+        destruction_started_promise.set_value();
+        delete queue;
+        destruction_returned_promise.set_value();
+    });
+    ASSERT_TRUE(destroy_accepted);
+
+    ASSERT_EQ(destruction_started.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    EXPECT_EQ(destruction_returned.wait_for(std::chrono::milliseconds(100)),
+              std::future_status::timeout);
+
+    {
+        std::lock_guard<std::mutex> lock(gate_mutex);
+        release_other_worker = true;
+    }
+    gate_cv.notify_all();
+
+    ASSERT_EQ(other.wait_for(std::chrono::seconds(2)), std::future_status::ready);
+    ASSERT_NO_THROW(other.get());
+    ASSERT_EQ(destruction_returned.wait_for(std::chrono::seconds(2)),
+              std::future_status::ready);
+    ASSERT_NO_THROW(destroy.get());
+}
+
 }  // namespace


### PR DESCRIPTION
## Summary
- Reject zero-worker queues and define idempotent cancel-on-close semantics.
- Serialize task claims with shutdown and retain worker state independently of the public facade, including destruction from a worker callback.
- Document close, admission, and statistics semantics; add lifecycle, race, teardown, and worker-destruction regressions.

## Verification
- `ctest --test-dir /tmp/opencode/neograph-build-208 --output-on-failure -j$(nproc)` (636 passed; 3 live tests skipped)
- ASan/UBSan full CTest (636 passed; 4 environment-gated tests skipped)
- TSan full CTest via `setarch x86_64 -R` (636 passed; 3 live tests skipped)
- ASan/UBSan `RequestQueue` suite repeated 100 times
- TSan `RequestQueue` suite repeated 20 times

Tracks #208. The issue acceptance checklist will be updated after merge using CI and local verification evidence.