### PR TITLE
fix: complete residual bug batch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1520,6 +1520,10 @@ if(NEOGRAPH_BUILD_TESTS)
     set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
 
+    if(NEOGRAPH_BUILD_A2A)
+        target_compile_definitions(neograph_a2a PRIVATE NEOGRAPH_A2A_TESTING)
+    endif()
+
     if(NEOGRAPH_BUILD_ACP)
         target_compile_definitions(neograph_acp PRIVATE NEOGRAPH_ACP_TESTING)
     endif()

--- a/benchmarks/bench_async_http.cpp
+++ b/benchmarks/bench_async_http.cpp
@@ -14,6 +14,10 @@
 //                      Mirrors today's schema_provider wire shape.
 //       --mode async : `--client-threads` io_context workers + N
 //                      coroutines each doing M async_post() calls.
+//       --mode ownership_construct : construct and destroy public HTTP
+//                      awaitables without resuming them. This isolates
+//                      the API-entry ownership facade cost from TCP, HTTP
+//                      parse, and coroutine scheduling.
 //
 // Output identical to bench_async_fanout (wall, ops/s, peak RSS) so
 // the two can be read side-by-side.
@@ -47,7 +51,9 @@
 #include <cstdio>
 #include <cstdlib>
 #include <fstream>
+#include <functional>
 #include <iostream>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -62,6 +68,8 @@ struct Config {
     int         client_threads = 0;     // async only; 0 = hardware_concurrency
     int         server_threads = 4;
     int         port           = 18080;
+    std::string ownership_api  = "post"; // ownership_construct only
+    int         body_bytes     = 32;      // ownership_construct only
 };
 
 Config parse(int argc, char** argv) {
@@ -76,6 +84,8 @@ Config parse(int argc, char** argv) {
         else if (a == "--client-threads")  c.client_threads = std::stoi(next());
         else if (a == "--server-threads")  c.server_threads = std::stoi(next());
         else if (a == "--port")            c.port           = std::stoi(next());
+        else if (a == "--ownership-api")   c.ownership_api  = next();
+        else if (a == "--body-bytes")      c.body_bytes     = std::stoi(next());
     }
     if (c.client_threads == 0)
         c.client_threads = static_cast<int>(std::thread::hardware_concurrency());
@@ -95,6 +105,23 @@ double peak_rss_mb() {
         }
     }
     return -1.0;
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+template <class T>
+void do_not_optimize(const T& value) {
+    asm volatile("" : : "g"(&value) : "memory");
+}
+#else
+template <class T>
+void do_not_optimize(const T& value) {
+    (void)value;
+}
+#endif
+
+std::string make_body(int bytes) {
+    if (bytes <= 0) return {};
+    return std::string(static_cast<std::size_t>(bytes), 'x');
 }
 
 // ── Mock HTTP server ──────────────────────────────────────────────────
@@ -364,10 +391,67 @@ void run_async_pool(const Config& cfg) {
     for (auto& t : ts) t.join();
 }
 
+
+void run_ownership_construct(const Config& cfg) {
+    asio::io_context io;
+    const auto ex = io.get_executor();
+    neograph::async::ConnPool pool(ex);
+    const std::string host = "127.0.0.1";
+    const std::string port = std::to_string(cfg.port);
+    const std::string path = "/v1/messages";
+    const std::string body = make_body(cfg.body_bytes);
+    const std::vector<std::pair<std::string, std::string>> headers = {
+        {"Content-Type", "application/json"},
+        {"X-Bench", "ownership"},
+    };
+    std::function<void(std::string_view)> on_chunk = [](std::string_view) {};
+    const int total = cfg.concur * cfg.rounds;
+
+    for (int i = 0; i < total; ++i) {
+        if (cfg.ownership_api == "post") {
+            auto op = neograph::async::async_post(
+                ex, host, port, path, body, headers, false);
+            do_not_optimize(op);
+        } else if (cfg.ownership_api == "get") {
+            auto op = neograph::async::async_get(
+                ex, host, port, path, headers, false);
+            do_not_optimize(op);
+        } else if (cfg.ownership_api == "stream") {
+            auto op = neograph::async::async_post_stream(
+                ex, host, port, path, body, headers, false, on_chunk);
+            do_not_optimize(op);
+        } else if (cfg.ownership_api == "pool") {
+            auto op = pool.async_post(host, port, path, body, headers, false);
+            do_not_optimize(op);
+        } else {
+            throw std::runtime_error("unknown --ownership-api: " + cfg.ownership_api);
+        }
+    }
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
     Config cfg = parse(argc, argv);
+
+    if (cfg.mode == "ownership_construct") {
+        auto t0 = std::chrono::steady_clock::now();
+        try {
+            run_ownership_construct(cfg);
+        } catch (const std::exception& e) {
+            std::cerr << e.what() << "\n";
+            return 2;
+        }
+        auto wall = std::chrono::duration<double>(
+            std::chrono::steady_clock::now() - t0).count();
+        const double total_ops = static_cast<double>(cfg.concur) * cfg.rounds;
+        std::printf("mode=%s api=%s ops=%.0f body_bytes=%d wall=%0.6fs "
+                    "ns/op=%0.1f rss_mb=%0.1f\n",
+                    cfg.mode.c_str(), cfg.ownership_api.c_str(), total_ops,
+                    cfg.body_bytes, wall, wall * 1.0e9 / total_ops,
+                    peak_rss_mb());
+        return 0;
+    }
 
     // Start the server. Its destructor (end of scope) stops the io.
     Server server(cfg.port, cfg.server_threads, cfg.latency_ms);

--- a/bindings/python/src/bind_graph.cpp
+++ b/bindings/python/src/bind_graph.cpp
@@ -1014,7 +1014,8 @@ void init_graph(py::module_& m) {
             "serially on a single thread until this (or set_worker_count(N)) "
             "is called explicitly. Must be called before any run().")
 
-        .def("set_node_cache_enabled", &GraphEngine::set_node_cache_enabled,
+        .def("set_node_cache_enabled",
+             py::overload_cast<const std::string&, bool>(&GraphEngine::set_node_cache_enabled),
             py::arg("node_name"), py::arg("enabled"),
             "Opt a node into result caching. The executor hashes the "
             "input state and replays a cached NodeResult on hit, "
@@ -1022,7 +1023,8 @@ void init_graph(py::module_& m) {
             "only enable for pure nodes (deterministic, no side "
             "effects). Streaming runs (run_stream) bypass the cache "
             "for the affected node because cached hits cannot replay "
-            "LLM_TOKEN events.")
+            "LLM_TOKEN events. Cache entries are execution-local; cross-run "
+            "reuse is available only through the C++ CacheKeyPolicy API.")
 
         .def("clear_node_cache", &GraphEngine::clear_node_cache,
             "Drop all cached NodeResults. Per-node enable state is "

--- a/bindings/python/tests/test_node_cache.py
+++ b/bindings/python/tests/test_node_cache.py
@@ -54,16 +54,18 @@ def test_cache_off_by_default():
 
 def test_enable_caches_identical_runs():
     e, node = _build()
+    # Python exposes the backward-compatible safe default only; cross-run
+    # reuse requires the C++ CacheKeyPolicy API.
     e.set_node_cache_enabled("work", True)
 
     for tid in ("a", "b", "c"):
         e.run(ng.RunConfig(thread_id=tid, input={}, max_steps=5))
 
-    assert node.calls == 1
+    assert node.calls == 3
     stats = e.node_cache_stats()
-    assert stats["hits"]   == 2
-    assert stats["misses"] == 1
-    assert stats["size"]   == 1
+    assert stats["hits"]   == 0
+    assert stats["misses"] == 3
+    assert stats["size"]   == 3
 
 
 def test_clear_drops_entries():

--- a/examples/47_node_cache.cpp
+++ b/examples/47_node_cache.cpp
@@ -1,8 +1,8 @@
 // NeoGraph Example 42: Per-node result cache (NodeCache)
 //
-// Demonstrates GraphEngine::set_node_cache_enabled — replays a node's
-// outcome when the input state hash is unchanged. Useful for expensive
-// pure nodes (embedding, deterministic LLM, heavy compute).
+// Demonstrates GraphEngine::set_node_cache_enabled with an explicit reusable
+// scope. Default caching is execution-local; use CacheScope::Reusable only for
+// a node proved independent of all RunContext values.
 //
 // We instrument a counter node so we can prove the cache short-circuits
 // the second run; hit_count must be 1, miss_count must be 1.
@@ -57,7 +57,9 @@ int main() {
 
     NodeContext ctx;
     auto        engine =
-        GraphEngine::build(def, EngineConfig{.node_context = ctx, .cached_nodes = {"expensive"}});
+        GraphEngine::build(def, EngineConfig{.node_context = ctx});
+    engine->set_node_cache_enabled(
+        "expensive", true, CacheKeyPolicy{CacheScope::Reusable, {}});
 
     // First run — miss.
     RunConfig cfg;

--- a/include/neograph/a2a/client.h
+++ b/include/neograph/a2a/client.h
@@ -23,6 +23,9 @@
 
 #include <chrono>
 #include <functional>
+#include <memory>
+#include <atomic>
+#include <mutex>
 #include <string>
 
 namespace neograph::a2a {
@@ -48,7 +51,7 @@ class NEOGRAPH_API A2AClient {
     explicit A2AClient(std::string base_url);
 
     /// Override the default 30 s request timeout.
-    void set_timeout(std::chrono::seconds t) { timeout_ = t; }
+    void set_timeout(std::chrono::seconds t);
 
     /**
      * @brief GET /.well-known/agent-card.json.
@@ -133,11 +136,16 @@ class NEOGRAPH_API A2AClient {
   private:
     std::string base_url_;
     std::chrono::seconds timeout_ = std::chrono::seconds(30);
-    int request_id_ = 0;
+    std::atomic<int> request_id_{0};
+
+    mutable std::shared_ptr<std::mutex> state_mutex_ = std::make_shared<std::mutex>();
+    bool card_loading_ = false;
 
     /// Cached agent card (populated by fetch_agent_card).
     AgentCard cached_card_;
     bool      card_loaded_ = false;
+
+    std::chrono::seconds request_timeout() const;
 };
 
 } // namespace neograph::a2a

--- a/include/neograph/a2a/client.h
+++ b/include/neograph/a2a/client.h
@@ -33,8 +33,14 @@ namespace neograph::a2a {
 /**
  * @brief A2A client — call a remote agent over JSON-RPC + HTTP.
  *
- * Thread-safe: every public method acquires its own ephemeral HTTP
- * connection; no shared in-flight state. Reuses
+ * Thread-safe for concurrent use of one instance. `base_url` is immutable;
+ * `set_timeout` is synchronized and each request snapshots the timeout before
+ * network I/O, so a timeout update cannot race or alter an in-flight request.
+ * JSON-RPC request IDs are process-local atomic counters. Agent-card cache
+ * initialization and `force` refreshes are single-flight and synchronized;
+ * waiting callers receive a copy, and no network I/O occurs under the state
+ * lock. Stream callbacks still run on the network thread and must provide
+ * their own synchronization for shared application state. Reuses
  * neograph::async::async_post for transport.
  *
  * @code

--- a/include/neograph/a2a/server.h
+++ b/include/neograph/a2a/server.h
@@ -26,11 +26,16 @@
 #include <neograph/graph/engine.h>
 
 #include <functional>
+#include <cstddef>
 #include <memory>
 #include <optional>
 #include <string>
 
 namespace neograph::a2a {
+
+#ifdef NEOGRAPH_A2A_TESTING
+namespace test { class A2AServerTestAccess; }
+#endif
 
 /**
  * @brief Adapt a NeoGraph run to the A2A request/response shape.
@@ -121,8 +126,22 @@ class NEOGRAPH_API A2AServer {
     int port() const;
 
   private:
+#ifdef NEOGRAPH_A2A_TESTING
+    friend class test::A2AServerTestAccess;
+#endif
     struct Impl;
     std::unique_ptr<Impl> impl_;
 };
 
 }  // namespace neograph::a2a
+
+#ifdef NEOGRAPH_A2A_TESTING
+namespace neograph::a2a::test {
+
+class A2AServerTestAccess {
+  public:
+    static void set_max_inflight_runs(A2AServer& server, std::size_t cap);
+};
+
+}  // namespace neograph::a2a::test
+#endif

--- a/include/neograph/acp/server.h
+++ b/include/neograph/acp/server.h
@@ -237,7 +237,9 @@ class NEOGRAPH_API ACPServer {
 
     /// Where session/update notifications go. Default: dropped on the
     /// floor (test-friendly). When run() is driving, the sink is set to
-    /// write to the output stream automatically.
+    /// write to the output stream automatically. A sink retained by a
+    /// shared_ptr-owned server must capture that server weakly to avoid an
+    /// ownership cycle.
     void set_notification_sink(NotificationSink sink);
 
     /// Signal a running run() loop to exit at the next message boundary.

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -781,13 +781,20 @@ public:
      * @brief Enable or disable per-node result caching.
      *
      * When enabled for a node, the executor hashes the input state and
-     * looks up `(node_name, hash)` in the engine's NodeCache. On hit,
+     * looks up an execution-local `(node_name, scope, hash)` key in the
+     * engine's NodeCache. On hit,
      * the cached NodeResult is replayed without invoking the node — no
      * LLM call, no tool execution. On miss, the node runs and the
      * result is stored.
      *
      * Cache is OFF by default. Only opt in for nodes that are pure
      * (deterministic, no external side effects, no time dependence).
+     * The default CacheScope::Execution never reuses a result across
+     * `run()` or `resume()` calls, so it cannot cross tenant, Store,
+     * ToolGate, provider/model, or resume boundaries. Pass
+     * CacheScope::Reusable only for a node proven independent of all such
+     * context, optionally with a CacheKeyPolicy context key that declares
+     * stable, non-secret context partitions.
      * Streaming runs (`run_stream`) bypass the cache for the affected
      * nodes because cached hits cannot replay LLM_TOKEN events.
      *
@@ -795,6 +802,11 @@ public:
      * @param enabled   True to enable caching; false to disable.
      */
     void set_node_cache_enabled(const std::string& node_name, bool enabled);
+
+    /// Enable or disable caching with an explicit identity policy.
+    void set_node_cache_enabled(const std::string& node_name,
+                                bool enabled,
+                                CacheKeyPolicy policy);
 
     /**
      * @brief Drop all cached entries (per-node enable state preserved).
@@ -918,6 +930,7 @@ private:
     /// Stored by value so the engine owns it; NodeExecutor holds a
     /// non-owning pointer threaded through set_worker_count() rebuilds.
     NodeCache node_cache_;
+    std::atomic<std::uint64_t> next_cache_execution_id_{1};
 
     /// Inflight-run counter. Incremented at the top of
     /// execute_graph_async and decremented at coroutine completion

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -78,7 +78,9 @@ struct EngineConfig {
     /// Fan-out worker count. One preserves the historical no-pool fast path.
     std::size_t worker_count = 1;
 
-    /// Pure nodes whose result cache should be enabled at construction time.
+    /// Pure, context-independent nodes whose results may be reused across
+    /// executions. This is an explicit CacheScope::Reusable opt-in; use the
+    /// two-argument set_node_cache_enabled() API for execution-local caching.
     std::set<std::string> cached_nodes;
 };
 

--- a/include/neograph/graph/node_cache.h
+++ b/include/neograph/graph/node_cache.h
@@ -8,6 +8,7 @@
 #include <neograph/graph/types.h>
 
 #include <cstddef>
+#include <functional>
 #include <mutex>
 #include <optional>
 #include <set>
@@ -16,12 +17,44 @@
 
 namespace neograph::graph {
 
+struct RunContext;
+
+/**
+ * @brief Lifetime boundary for a cached node result.
+ *
+ * Execution is the safe default: results never cross a `run()` or `resume()`
+ * call. Reusable is an explicit assertion that the node is pure with respect
+ * to every run context dependency. A context key may further partition a
+ * Reusable cache by declared, stable context identity.
+ */
+enum class CacheScope {
+    Execution,
+    Reusable,
+};
+
+/**
+ * @brief Explicit cache identity policy for one node.
+ *
+ * `context_key` is only used with CacheScope::Reusable. It must return a
+ * deterministic, non-secret logical identifier (for example a tenant ID or
+ * provider/model revision), never a pointer address, token, or credential.
+ * The value is retained only in the in-process cache key and is not emitted by
+ * cache diagnostics.
+ */
+struct CacheKeyPolicy {
+    CacheScope scope = CacheScope::Execution;
+    std::function<std::string(const RunContext&)> context_key;
+};
+
 /**
  * @brief Per-node result cache. Opt-in per node — callers must
  * explicitly enable caching via `set_enabled(name, true)` so semantics
  * never silently change for non-deterministic nodes.
  *
- * Cache key = `node_name + ":" + hash(state.serialize())`. Cache
+ * Cache key = node name + state hash + an explicit scope key. The default
+ * scope key is a unique execution ID, so cache entries never cross tenant,
+ * Store, ToolGate, provider/model, resume, or other RunContext boundaries.
+ * Reusable caching is an explicit policy decision. Cache
  * values are full `NodeResult`s (writes + Command + Sends), so a
  * cached hit replays the original outcome without re-running the
  * node. Hit / miss counters are exposed for tests + observability.
@@ -45,13 +78,30 @@ public:
     /// True iff `set_enabled(node_name, true)` was the last call for it.
     bool is_enabled(const std::string& node_name) const;
 
+    /// Set a node's cache identity policy. The default is execution-local.
+    void set_policy(const std::string& node_name, CacheKeyPolicy policy);
+
+    /// Return a node's policy, or the safe execution-local default.
+    CacheKeyPolicy policy_for(const std::string& node_name) const;
+
     /// Lookup. nullopt if no cached result for this (node, state_hash).
     std::optional<NodeResult> lookup(const std::string& node_name,
                                      const std::string& state_hash) const;
 
+    /// Lookup with the execution or caller-declared reusable scope key.
+    std::optional<NodeResult> lookup(const std::string& node_name,
+                                     const std::string& state_hash,
+                                     const std::string& scope_key) const;
+
     /// Store the NodeResult for this (node, state_hash).
     void store(const std::string& node_name,
                const std::string& state_hash,
+               NodeResult result);
+
+    /// Store with the execution or caller-declared reusable scope key.
+    void store(const std::string& node_name,
+               const std::string& state_hash,
+               const std::string& scope_key,
                NodeResult result);
 
     /// Drop all cached entries (per-node enable/disable state preserved).
@@ -68,10 +118,12 @@ public:
 
 private:
     static std::string make_key(const std::string& node_name,
-                                const std::string& state_hash);
+                                const std::string& state_hash,
+                                const std::string& scope_key);
 
     mutable std::mutex mu_;
     std::set<std::string> enabled_nodes_;
+    std::unordered_map<std::string, CacheKeyPolicy> policies_;
     std::unordered_map<std::string, NodeResult> entries_;
     mutable std::size_t hits_   = 0;
     mutable std::size_t misses_ = 0;

--- a/include/neograph/graph/run_context.h
+++ b/include/neograph/graph/run_context.h
@@ -11,6 +11,7 @@
 #include <neograph/types.h>
 
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -39,6 +40,10 @@ struct RunContext {
 
     /// Mirrors RunConfig::thread_id.
     std::string thread_id;
+
+    /// Engine-assigned identity for this run or resume call. Used only for
+    /// execution-local cache isolation; it is not derived from user data.
+    std::uint64_t cache_execution_id = 0;
 
     /// Current super-step index.
     int step = 0;

--- a/spec/issue-199-async-http-ownership.sdd.yaml
+++ b/spec/issue-199-async-http-ownership.sdd.yaml
@@ -73,6 +73,7 @@ resolution:
     - tests/test_async_http_stream.cpp
     - tests/test_async_conn_pool.cpp
     - tests/test_async_ws_loopback.cpp
+    - benchmarks/bench_async_http.cpp
   compatibility:
     - Public function signatures and ConnPool/WsClient object layouts are unchanged.
     - Timeout, redirect, pooling, SSE chunk, and WebSocket wire behavior are unchanged.
@@ -92,7 +93,14 @@ resolution:
     values, so the fix adds no copy per hop or retry. The 2026-07-26 delayed
     cancellation regression exercises the streaming timeout race and confirms
     the callback capture stays alive while the stored awaitable is pending,
-    releases after the timeout completes, and receives no late chunks.
+    releases after the timeout completes, and receives no late chunks. The
+    reproducible ownership_construct benchmark in bench_async_http isolates
+    API-entry awaitable construction/destruction from networking. On this host
+    with 200000 constructions, short-body API-entry cost measured 207.5 ns/op
+    for GET, 223.3 ns/op for POST, 244.1 ns/op for streaming POST, and
+    246.3 ns/op for ConnPool POST. A 65536-byte POST body measured 18135.7 ns/op,
+    demonstrating that large-body copies scale with payload size while no
+    redirect/retry loop adds additional copies.
 
 verification:
   targeted:
@@ -114,6 +122,16 @@ verification:
       ./build-issue199-202-asan/tests/neograph_tests
       --gtest_filter=AsyncHttpOwnership.*:WsLoopback.DelayedOperationsOwnEndpointAndPayloads
     result: "7 passed, 0 failed"
+  ownership_construct_benchmark:
+    configuration: >-
+      Release; NEOGRAPH_BUILD_BENCHMARKS=ON; optional service backends disabled.
+    command: >-
+      ./build-issue199-bench/bench_async_http --mode ownership_construct
+      --ownership-api {post,get,stream,pool} --concur 200000 --rounds 1
+    result: >-
+      post body_bytes=32: 223.3 ns/op; post body_bytes=65536: 18135.7 ns/op;
+      get body_bytes=32: 207.5 ns/op; stream body_bytes=32: 244.1 ns/op;
+      pool body_bytes=32: 246.3 ns/op.
   behavior_matrix:
     command: >-
       ./build/tests/neograph_tests

--- a/spec/issue-199-async-http-ownership.sdd.yaml
+++ b/spec/issue-199-async-http-ownership.sdd.yaml
@@ -89,14 +89,31 @@ resolution:
     allocation for short values. Header vectors and callback wrappers retain
     their prior by-value copy behavior and are moved into the owned frame.
     Redirect and stale-connection retry loops receive the same frame-owned
-    values, so the fix adds no copy per hop or retry.
+    values, so the fix adds no copy per hop or retry. The 2026-07-26 delayed
+    cancellation regression exercises the streaming timeout race and confirms
+    the callback capture stays alive while the stored awaitable is pending,
+    releases after the timeout completes, and receives no late chunks.
 
 verification:
   targeted:
     command: >-
       ./build/tests/neograph_tests
       --gtest_filter=AsyncHttpOwnership.*:WsLoopback.DelayedOperationsOwnEndpointAndPayloads
-    result: "6 passed, 0 failed"
+    result: "6 passed, 0 failed before the delayed streaming cancellation regression was added"
+  delayed_stream_cancel:
+    command: >-
+      ./build-issue199-202/tests/neograph_tests
+      --gtest_filter=AsyncHttpOwnership.*:WsLoopback.DelayedOperationsOwnEndpointAndPayloads
+    result: "7 passed, 0 failed"
+  delayed_stream_cancel_asan:
+    configuration: >-
+      Debug; -fsanitize=address,undefined; ASAN_OPTIONS
+      detect_stack_use_after_return=1.
+    command: >-
+      ASAN_OPTIONS=detect_stack_use_after_return=1
+      ./build-issue199-202-asan/tests/neograph_tests
+      --gtest_filter=AsyncHttpOwnership.*:WsLoopback.DelayedOperationsOwnEndpointAndPayloads
+    result: "7 passed, 0 failed"
   behavior_matrix:
     command: >-
       ./build/tests/neograph_tests

--- a/spec/issue-202-send-target-validation.sdd.yaml
+++ b/spec/issue-202-send-target-validation.sdd.yaml
@@ -38,3 +38,45 @@ implementation:
 acceptance:
   - Unknown Send never becomes silent success.
   - Existing valid Send, retry, interrupt, and resume tests pass.
+
+observed:
+  current_send_representation: >-
+    Dynamic Send values are produced by GraphNode::run as runtime NodeOutput
+    data. The compiled graph JSON names node implementations and topology but
+    does not contain a statically enumerable Send target field, and GraphNode has
+    no API that declares possible Send targets ahead of execution. Therefore
+    GraphEngine::compile cannot soundly validate arbitrary Send targets in this
+    codebase today. The executor validates the complete runtime Send batch
+    before accepting any Send target task.
+  unsupported_static_validation: >-
+    The issue checklist item for compile-time validation remains unsupported,
+    not satisfied. It would require a new static Send declaration surface in the
+    graph schema or GraphNode interface; guessing from dynamic node types would
+    miss generated target names and create false guarantees.
+
+resolution:
+  design: >-
+    NodeExecutor::run_sends_async validates every Send target against nodes_
+    before the single-Send and multi-Send branches diverge. A mixed batch is
+    rejected before any valid sibling executes or records a pending target-task
+    write. The same exception message includes the source node, unknown target,
+    and Send invocation index for run, run_stream, and resume paths.
+  changed_files:
+    - src/core/graph_executor.cpp
+    - tests/test_multi_send_routing.cpp
+    - spec/issue-202-send-target-validation.sdd.yaml
+  verification:
+    command: >-
+      ./build-issue199-202/tests/neograph_tests
+      --gtest_filter=MultiSendRouting.UnknownSingleSendReportsTargetAndInvocation:MultiSendRouting.MixedMultiSendRejectsBatchBeforeValidSiblingRuns:MultiSendRouting.UnknownSendReportsSameDiagnosticThroughStream:MultiSendRouting.ResumeAfterInvalidSendDoesNotRecordInvalidTargetCompletion
+    result: "4 passed, 0 failed"
+  sanitizer_verification:
+    configuration: >-
+      Debug; -fsanitize=address,undefined; ASAN_OPTIONS
+      detect_stack_use_after_return=1.
+    command: >-
+      ASAN_OPTIONS=detect_stack_use_after_return=1
+      ./build-issue199-202-asan/tests/neograph_tests
+      --gtest_filter=MultiSendRouting.UnknownSingleSendReportsTargetAndInvocation:MultiSendRouting.MixedMultiSendRejectsBatchBeforeValidSiblingRuns:MultiSendRouting.UnknownSendReportsSameDiagnosticThroughStream:MultiSendRouting.ResumeAfterInvalidSendDoesNotRecordInvalidTargetCompletion
+    result: "4 passed, 0 failed"
+

--- a/spec/issue-202-send-target-validation.sdd.yaml
+++ b/spec/issue-202-send-target-validation.sdd.yaml
@@ -41,18 +41,25 @@ acceptance:
 
 observed:
   current_send_representation: >-
-    Dynamic Send values are produced by GraphNode::run as runtime NodeOutput
-    data. The compiled graph JSON names node implementations and topology but
-    does not contain a statically enumerable Send target field, and GraphNode has
-    no API that declares possible Send targets ahead of execution. Therefore
-    GraphEngine::compile cannot soundly validate arbitrary Send targets in this
-    codebase today. The executor validates the complete runtime Send batch
-    before accepting any Send target task.
-  unsupported_static_validation: >-
-    The issue checklist item for compile-time validation remains unsupported,
-    not satisfied. It would require a new static Send declaration surface in the
-    graph schema or GraphNode interface; guessing from dynamic node types would
-    miss generated target names and create false guarantees.
+    Dynamic Send values are normally produced by GraphNode::run as runtime
+    NodeOutput data. The compiled graph JSON names node implementations and
+    topology but does not contain a generic statically enumerable Send target
+    field: GraphCompiler::parse consumes channels, nodes, edges,
+    conditional_edges, interrupt sets, and retry policy, but no Send-target key;
+    GraphNode exposes only run(NodeInput) -> awaitable<NodeOutput>; and Send is
+    just a NodeResult vector element with target_node/input/source_node. Generic
+    GraphEngine::compile therefore cannot soundly validate arbitrary dynamic
+    Send targets ahead of execution. The executor validates each complete
+    runtime Send batch before accepting any Send target task.
+  statically_knowable_cases: >-
+    Source search found one built-in statically knowable dynamic Send target:
+    SupervisorDispatchNode in deep_research_graph.cpp emits Send{"researcher", ...}.
+    That factory also constructs the "researcher" node in the same local node set;
+    the target string is now centralized as kResearcherNodeName and guarded before
+    compile so the only currently known static Send target is validated where
+    possible. No public graph-schema or GraphNode declaration surface exists for
+    user-defined dynamic Sends, so no broader compile-time validation can be
+    honestly claimed without adding a new API.
 
 resolution:
   design: >-
@@ -63,6 +70,7 @@ resolution:
     and Send invocation index for run, run_stream, and resume paths.
   changed_files:
     - src/core/graph_executor.cpp
+    - src/core/deep_research_graph.cpp
     - tests/test_multi_send_routing.cpp
     - spec/issue-202-send-target-validation.sdd.yaml
   verification:
@@ -77,6 +85,17 @@ resolution:
     command: >-
       ASAN_OPTIONS=detect_stack_use_after_return=1
       ./build-issue199-202-asan/tests/neograph_tests
-      --gtest_filter=MultiSendRouting.UnknownSingleSendReportsTargetAndInvocation:MultiSendRouting.MixedMultiSendRejectsBatchBeforeValidSiblingRuns:MultiSendRouting.UnknownSendReportsSameDiagnosticThroughStream:MultiSendRouting.ResumeAfterInvalidSendDoesNotRecordInvalidTargetCompletion
-    result: "4 passed, 0 failed"
+      --gtest_filter=DeepResearchHumanReview.*:MultiSendRouting.UnknownSingleSendReportsTargetAndInvocation:MultiSendRouting.MixedMultiSendRejectsBatchBeforeValidSiblingRuns:MultiSendRouting.UnknownSendReportsSameDiagnosticThroughStream:MultiSendRouting.ResumeAfterInvalidSendDoesNotRecordInvalidTargetCompletion
+    result: "6 passed, 0 failed"
+  static_send_target_validation:
+    source_evidence:
+      - "include/neograph/graph/types.h:237-243 defines Send as runtime data."
+      - "include/neograph/graph/node.h:95-134 exposes run(NodeInput) only."
+      - "src/core/graph_compiler.cpp:238-405 parses no generic Send target key."
+      - "src/core/deep_research_graph.cpp:437 emits the only hard-coded Send target found."
+      - "src/core/deep_research_graph.cpp:1213-1241 constructs and guards that target."
+    command: >-
+      ./build-issue199-202/tests/neograph_tests
+      --gtest_filter=DeepResearchHumanReview.*:MultiSendRouting.UnknownSingleSendReportsTargetAndInvocation:MultiSendRouting.MixedMultiSendRejectsBatchBeforeValidSiblingRuns:MultiSendRouting.UnknownSendReportsSameDiagnosticThroughStream:MultiSendRouting.ResumeAfterInvalidSendDoesNotRecordInvalidTargetCompletion
+    result: "6 passed, 0 failed"
 

--- a/spec/issue-202-send-target-validation.sdd.yaml
+++ b/spec/issue-202-send-target-validation.sdd.yaml
@@ -98,4 +98,3 @@ resolution:
       ./build-issue199-202/tests/neograph_tests
       --gtest_filter=DeepResearchHumanReview.*:MultiSendRouting.UnknownSingleSendReportsTargetAndInvocation:MultiSendRouting.MixedMultiSendRejectsBatchBeforeValidSiblingRuns:MultiSendRouting.UnknownSendReportsSameDiagnosticThroughStream:MultiSendRouting.ResumeAfterInvalidSendDoesNotRecordInvalidTargetCompletion
     result: "6 passed, 0 failed"
-

--- a/spec/issue-205-a2a-task-single-flight.sdd.yaml
+++ b/spec/issue-205-a2a-task-single-flight.sdd.yaml
@@ -2,7 +2,7 @@ spec:
   id: issue-205-a2a-task-single-flight
   issue: 205
   parent: 187
-  status: proposed
+  status: implemented
   priority: P1
   kind: concurrency
   depends_on: [197]
@@ -37,3 +37,7 @@ implementation:
 acceptance:
   - Same-task races cannot corrupt checkpoints or task state.
   - Cancellation, reconnect, lookup, and eviction tests pass.
+decision:
+  duplicate_policy: reject
+  duplicate_reason: "task_id is already running"
+  max_inflight_runs: 32

--- a/src/a2a/a2a_caller_node.cpp
+++ b/src/a2a/a2a_caller_node.cpp
@@ -2,9 +2,23 @@
 
 #include <neograph/graph/state.h>
 
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
 #include <stdexcept>
 
 namespace neograph::a2a {
+
+namespace {
+std::string fresh_caller_message_id() {
+    static std::atomic<std::uint64_t> counter{0};
+    char buf[40];
+    std::snprintf(buf, sizeof(buf), "ng-a2a-call-%016llx",
+                  static_cast<unsigned long long>(
+                      counter.fetch_add(1, std::memory_order_relaxed)));
+    return buf;
+}
+}
 
 using neograph::graph::ChannelWrite;
 using neograph::graph::GraphState;
@@ -38,8 +52,7 @@ asio::awaitable<NodeOutput> A2ACallerNode::run(NodeInput in) {
     auto context_id_val = in.state.get(output_key_ + "_context_id");
 
     MessageSendParams params;
-    params.message.message_id = name_ + "-" + std::to_string(
-        reinterpret_cast<std::uintptr_t>(this) & 0xFFFF);
+    params.message.message_id = fresh_caller_message_id();
     params.message.role = Role::User;
     params.message.parts.push_back(Part::text_part(std::move(prompt)));
     if (task_id_val.is_string())    params.message.task_id    = task_id_val.get<std::string>();

--- a/src/a2a/client.cpp
+++ b/src/a2a/client.cpp
@@ -5,6 +5,7 @@
 #include <neograph/async/run_sync.h>
 
 #include <asio/awaitable.hpp>
+#include <asio/steady_timer.hpp>
 #include <asio/this_coro.hpp>
 
 #include <atomic>
@@ -49,6 +50,16 @@ json parse_response_body(const std::string& body) {
 A2AClient::A2AClient(std::string base_url)
     : base_url_(normalize_base_url(std::move(base_url))) {}
 
+void A2AClient::set_timeout(std::chrono::seconds t) {
+    std::lock_guard<std::mutex> lock(*state_mutex_);
+    timeout_ = t;
+}
+
+std::chrono::seconds A2AClient::request_timeout() const {
+    std::lock_guard<std::mutex> lock(*state_mutex_);
+    return timeout_;
+}
+
 // ---------------------------------------------------------------------------
 // JSON-RPC dispatch
 // ---------------------------------------------------------------------------
@@ -57,7 +68,7 @@ asio::awaitable<json>
 A2AClient::rpc_call_async(const std::string& method, const json& params) {
     json body = {
         {"jsonrpc", "2.0"},
-        {"id",      ++request_id_},
+        {"id",      request_id_.fetch_add(1, std::memory_order_relaxed) + 1},
         {"method",  method},
         {"params",  params},
     };
@@ -70,7 +81,7 @@ A2AClient::rpc_call_async(const std::string& method, const json& params) {
     };
 
     async::RequestOptions opts;
-    opts.timeout = timeout_;
+    opts.timeout = request_timeout();
 
     auto ex = co_await asio::this_coro::executor;
     async::HttpResponse res;
@@ -184,14 +195,35 @@ constexpr MethodPair k_cancel_task   = {"CancelTask",   "tasks/cancel"};
 
 asio::awaitable<AgentCard>
 A2AClient::fetch_agent_card_async(bool force) {
-    if (!force && card_loaded_) co_return cached_card_;
+    for (;;) {
+        {
+            std::lock_guard<std::mutex> lock(*state_mutex_);
+            if (!force && card_loaded_) co_return cached_card_;
+            if (!card_loading_) {
+                card_loading_ = true;
+                break;
+            }
+        }
+        auto timer = asio::steady_timer(co_await asio::this_coro::executor);
+        timer.expires_after(std::chrono::milliseconds(1));
+        co_await timer.async_wait(asio::use_awaitable);
+    }
+
+    std::function<void()> release_loading = [this] {
+        std::lock_guard<std::mutex> lock(*state_mutex_);
+        card_loading_ = false;
+    };
+    struct LoadingGuard {
+        std::function<void()> release;
+        ~LoadingGuard() { if (release) release(); }
+    } guard{release_loading};
 
     auto endpoint = async::split_async_endpoint(base_url_);
     std::vector<std::pair<std::string, std::string>> headers = {
         {"Accept", "application/json"},
     };
     async::RequestOptions opts;
-    opts.timeout = timeout_;
+    opts.timeout = request_timeout();
 
     auto ex = co_await asio::this_coro::executor;
     auto path = endpoint.prefix + kDiscoveryPath;
@@ -220,8 +252,13 @@ A2AClient::fetch_agent_card_async(bool force) {
             std::string("A2A AgentCard not valid JSON: ") + e.what());
     }
 
-    cached_card_ = card;
-    card_loaded_ = true;
+    {
+        std::lock_guard<std::mutex> lock(*state_mutex_);
+        cached_card_ = card;
+        card_loaded_ = true;
+        card_loading_ = false;
+    }
+    guard.release = {};
     co_return card;
 }
 
@@ -387,7 +424,7 @@ Task A2AClient::send_message_stream(const MessageSendParams& params,
     to_json(p, params);
     json body = {
         {"jsonrpc", "2.0"},
-        {"id",      ++request_id_},
+        {"id",      request_id_.fetch_add(1, std::memory_order_relaxed) + 1},
         {"method",  "message/stream"},
         {"params",  p},
     };
@@ -399,7 +436,7 @@ Task A2AClient::send_message_stream(const MessageSendParams& params,
     };
 
     async::RequestOptions opts;
-    opts.timeout = timeout_;
+    opts.timeout = request_timeout();
 
     Task last_task;
     SseFrameSplitter splitter;

--- a/src/a2a/server.cpp
+++ b/src/a2a/server.cpp
@@ -304,6 +304,14 @@ struct A2AServer::Impl {
                              httplib::Response& res);
 };
 
+#ifdef NEOGRAPH_A2A_TESTING
+void test::A2AServerTestAccess::set_max_inflight_runs(
+    A2AServer& server, std::size_t cap) {
+    std::lock_guard lk(server.impl_->tasks_mu);
+    server.impl_->max_inflight_runs = cap;
+}
+#endif
+
 void A2AServer::Impl::register_routes() {
     svr.Get("/.well-known/agent-card.json",
             [this](const httplib::Request&, httplib::Response& res) {
@@ -374,45 +382,39 @@ Task A2AServer::Impl::run_graph(
     cfg.thread_id = task_id;
 
     std::shared_ptr<neograph::graph::CancelToken> task_cancel;
+    std::optional<Task> rejected;
     std::uint64_t generation = 0;
     {
         std::lock_guard lk(tasks_mu);
         if (active_runs.contains(task_id)) {
-            auto rejected = build_rejected_task(
+            rejected = build_rejected_task(
                 task_id, context_id, "task_id is already running");
-            if (on_event) {
-                TaskStatusUpdateEvent ev;
-                ev.task_id = task_id;
-                ev.context_id = context_id;
-                ev.status = rejected.status;
-                ev.final = true;
-                on_event(ev);
-            }
-            return rejected;
-        }
-        if (active_runs.size() >= max_inflight_runs) {
-            auto rejected = build_rejected_task(
+        } else if (active_runs.size() >= max_inflight_runs) {
+            rejected = build_rejected_task(
                 task_id, context_id, "A2A server is at its in-flight task limit");
-            if (on_event) {
-                TaskStatusUpdateEvent ev;
-                ev.task_id = task_id;
-                ev.context_id = context_id;
-                ev.status = rejected.status;
-                ev.final = true;
-                on_event(ev);
-            }
-            return rejected;
+        } else {
+            Task working;
+            working.id             = task_id;
+            working.context_id     = context_id;
+            working.status.state   = TaskState::Working;
+            tasks[task_id]         = working;
+            task_cancel = std::make_shared<neograph::graph::CancelToken>();
+            generation = next_generation++;
+            active_runs[task_id] = ActiveRun{task_cancel, generation};
+            touch_task_unlocked(task_id);
+            evict_lru_unlocked();
         }
-        Task working;
-        working.id            = task_id;
-        working.context_id    = context_id;
-        working.status.state  = TaskState::Working;
-        tasks[task_id]        = working;
-        task_cancel = std::make_shared<neograph::graph::CancelToken>();
-        generation = next_generation++;
-        active_runs[task_id] = ActiveRun{task_cancel, generation};
-        touch_task_unlocked(task_id);
-        evict_lru_unlocked();
+    }
+    if (rejected) {
+        if (on_event) {
+            TaskStatusUpdateEvent ev;
+            ev.task_id = task_id;
+            ev.context_id = context_id;
+            ev.status = rejected->status;
+            ev.final = true;
+            on_event(ev);
+        }
+        return *rejected;
     }
     cfg.cancel_token = task_cancel;
 

--- a/src/a2a/server.cpp
+++ b/src/a2a/server.cpp
@@ -173,6 +173,25 @@ Task build_failure_task(const std::string& task_id,
     return t;
 }
 
+Task build_rejected_task(const std::string& task_id,
+                        const std::string& context_id,
+                        const std::string& reason) {
+    Message reply;
+    reply.message_id = fresh_uuid_like();
+    reply.role       = Role::Agent;
+    reply.task_id    = task_id;
+    reply.context_id = context_id;
+    reply.parts.push_back(Part::text_part(reason));
+
+    Task t;
+    t.id             = task_id;
+    t.context_id     = context_id;
+    t.status.state   = TaskState::Rejected;
+    t.status.message = reply;
+    t.history.push_back(std::move(reply));
+    return t;
+}
+
 bool is_terminal(TaskState state) {
     return state == TaskState::Completed || state == TaskState::Canceled
         || state == TaskState::Failed || state == TaskState::Rejected
@@ -237,6 +256,7 @@ struct A2AServer::Impl {
     std::unordered_map<std::string, std::list<std::string>::iterator>
                                                               task_lru_pos;
     std::size_t max_tasks = 1024;
+    std::size_t max_inflight_runs = 32;
 
     /// Move a task_id to the most-recently-used (back) position, or
     /// insert it if it's new. Caller must hold tasks_mu.
@@ -357,6 +377,32 @@ Task A2AServer::Impl::run_graph(
     std::uint64_t generation = 0;
     {
         std::lock_guard lk(tasks_mu);
+        if (active_runs.contains(task_id)) {
+            auto rejected = build_rejected_task(
+                task_id, context_id, "task_id is already running");
+            if (on_event) {
+                TaskStatusUpdateEvent ev;
+                ev.task_id = task_id;
+                ev.context_id = context_id;
+                ev.status = rejected.status;
+                ev.final = true;
+                on_event(ev);
+            }
+            return rejected;
+        }
+        if (active_runs.size() >= max_inflight_runs) {
+            auto rejected = build_rejected_task(
+                task_id, context_id, "A2A server is at its in-flight task limit");
+            if (on_event) {
+                TaskStatusUpdateEvent ev;
+                ev.task_id = task_id;
+                ev.context_id = context_id;
+                ev.status = rejected.status;
+                ev.final = true;
+                on_event(ev);
+            }
+            return rejected;
+        }
         Task working;
         working.id            = task_id;
         working.context_id    = context_id;

--- a/src/a2a/server.cpp
+++ b/src/a2a/server.cpp
@@ -348,12 +348,10 @@ Task A2AServer::Impl::run_graph(
     const std::string& context_id,
     std::function<void(const TaskStatusUpdateEvent&)> on_event) {
 
-    auto user_text = extract_user_text(inbound);
     auto& a = *adapter;
 
     neograph::graph::RunConfig cfg;
     cfg.thread_id = task_id;
-    cfg.input     = a.build_initial_state(user_text);
 
     std::shared_ptr<neograph::graph::CancelToken> task_cancel;
     std::uint64_t generation = 0;
@@ -383,6 +381,9 @@ Task A2AServer::Impl::run_graph(
 
     Task result;
     try {
+        // Reserve the generation before adapter work so tasks/cancel can
+        // signal this run even while input preparation is still in progress.
+        cfg.input = a.build_initial_state(extract_user_text(inbound));
         auto rr = engine->run(cfg);
         if (task_cancel->is_cancelled()) {
             result = build_failure_task(task_id, context_id, "(canceled)");

--- a/src/acp/server.cpp
+++ b/src/acp/server.cpp
@@ -457,6 +457,17 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
         std::thread worker(
             [this, req = std::move(req), id, task_cancel, reservation,
              resume_pending]() mutable {
+                bool response_attempted = false;
+                auto cleanup = [&] {
+                    reservation->release_session();
+                    std::lock_guard lk(sessions_mu);
+                    auto it = active_cancel_tokens.find(req.session_id);
+                    if (it != active_cancel_tokens.end()
+                        && it->second == task_cancel) {
+                        active_cancel_tokens.erase(it);
+                    }
+                };
+
                 try {
                     auto& a = *adapter;
 
@@ -563,23 +574,16 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
                     // The graph and all session-state updates are complete.
                     // Admit the next turn before publishing this response so a
                     // reentrant/fast client cannot observe a stale busy state.
-                    reservation->release_session();
-                    {
-                        std::lock_guard lk(sessions_mu);
-                        auto it = active_cancel_tokens.find(req.session_id);
-                        if (it != active_cancel_tokens.end()
-                            && it->second == task_cancel) {
-                            active_cancel_tokens.erase(it);
-                        }
-                    }
+                    cleanup();
+                    response_attempted = true;
                     emit(jsonrpc_result(std::move(rj), id));
                 } catch (const std::exception& e) {
-                    reservation->release_session();
-                    emit_internal_error(
+                    cleanup();
+                    if (!response_attempted) emit_internal_error(
                         id, "ACP prompt worker failed: ", e.what());
                 } catch (...) {
-                    reservation->release_session();
-                    emit_internal_error(
+                    cleanup();
+                    if (!response_attempted) emit_internal_error(
                         id, "ACP prompt worker failed: unknown exception");
                 }
                 // The captured reservation is the last owner after dispatch

--- a/src/core/deep_research_graph.cpp
+++ b/src/core/deep_research_graph.cpp
@@ -10,11 +10,14 @@
 #include <memory>
 #include <mutex>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 namespace neograph::graph {
 namespace {
+
+constexpr const char* kResearcherNodeName = "researcher";
 
 // =========================================================================
 // Prompts — inspired by langchain-ai/open_deep_research/prompts.py.
@@ -431,7 +434,7 @@ public:
                 }
             } catch (...) { /* empty topic handled by researcher */ }
 
-            nr.sends.push_back(Send{"researcher", json{
+            nr.sends.push_back(Send{kResearcherNodeName, json{
                 {"current_topic",    topic},
                 {"current_call_id",  tc.id}
             }});
@@ -1207,7 +1210,7 @@ std::unique_ptr<GraphEngine> create_deep_research_graph(
             {"max_iterations", cfg.max_supervisor_iterations},
             {"max_concurrent", cfg.max_concurrent_researchers}
         }},
-        {"researcher",   {
+        {kResearcherNodeName,   {
             {"type", "__dr_researcher"},
             {"max_iterations", cfg.max_researcher_iterations}
         }},
@@ -1231,6 +1234,12 @@ std::unique_ptr<GraphEngine> create_deep_research_graph(
     edges.push_back({{"from", "brief"},      {"to", "supervisor"}});
     edges.push_back({{"from", "supervisor"}, {"to", "dispatch"}});
     edges.push_back({{"from", "dispatch"},   {"to", "supervisor"}});
+
+    if (!nodes.contains(kResearcherNodeName)) {
+        throw std::logic_error(
+            "deep_research dispatch Send target 'researcher' is missing from "
+            "the factory-built node set");
+    }
 
     if (cfg.enable_human_review) {
         // Add the `messages` channel that engine.resume writes the user's
@@ -1277,7 +1286,7 @@ std::unique_ptr<GraphEngine> create_deep_research_graph(
     llm_retry.backoff_multiplier = 2.0f;
     llm_retry.max_delay_ms      = 45'000;
     engine->set_node_retry_policy("supervisor",   llm_retry);
-    engine->set_node_retry_policy("researcher",   llm_retry);
+    engine->set_node_retry_policy(kResearcherNodeName, llm_retry);
     engine->set_node_retry_policy("final_report", llm_retry);
 
     return engine;

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -217,7 +217,8 @@ std::unique_ptr<GraphEngine> GraphEngine::link_impl(CompiledGraph   cg,
     engine->tool_gate_           = std::move(config.tool_gate);
     engine->owned_tools_         = std::move(resources.tools).release();
     for (const auto& node_name : config.cached_nodes) {
-        engine->node_cache_.set_enabled(node_name, true);
+        engine->set_node_cache_enabled(
+            node_name, true, CacheKeyPolicy{CacheScope::Reusable, {}});
     }
 
     // Signal-based dispatch — see Scheduler. A node becomes ready in

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -16,6 +16,7 @@
 #include <asio/use_awaitable.hpp>
 
 #include <stdexcept>
+#include <utility>
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
@@ -816,6 +817,8 @@ GraphEngine::execute_graph_async(const RunConfig& config,
     ctx.trace_id     = metadata.trace_id;
     ctx.thread_id    = config.thread_id;
     ctx.stream_mode  = stream_mode;
+    ctx.cache_execution_id = next_cache_execution_id_.fetch_add(
+        1, std::memory_order_relaxed);
     ctx.store = resources && resources->store ? *resources->store : store_;
     // issue #94 — the human's answer, readable by any node. Left empty on a
     // fresh run, which is how a node distinguishes "nobody has answered yet"
@@ -1176,6 +1179,13 @@ GraphEngine::execute_graph_async(const RunConfig& config,
     }
 
     co_return result;
+}
+
+void GraphEngine::set_node_cache_enabled(const std::string& node_name,
+                                         bool enabled,
+                                         CacheKeyPolicy policy) {
+    node_cache_.set_policy(node_name, std::move(policy));
+    node_cache_.set_enabled(node_name, enabled);
 }
 
 } // namespace neograph::graph

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -341,6 +341,7 @@ void GraphEngine::set_worker_count_auto() {
 
 void GraphEngine::set_node_cache_enabled(const std::string& node_name,
                                           bool enabled) {
+    node_cache_.set_policy(node_name, CacheKeyPolicy{});
     node_cache_.set_enabled(node_name, enabled);
 }
 

--- a/src/core/graph_executor.cpp
+++ b/src/core/graph_executor.cpp
@@ -211,9 +211,18 @@ asio::awaitable<NodeResult> NodeExecutor::execute_node_with_retry_async(
     const bool cache_eligible =
         node_cache_ && !cb && node_cache_->is_enabled(node_name);
     std::string cache_state_hash;
+    std::string cache_scope_key;
     if (cache_eligible) {
         cache_state_hash = hash_state_for_cache(state.serialize());
-        if (auto cached = node_cache_->lookup(node_name, cache_state_hash);
+        const auto policy = node_cache_->policy_for(node_name);
+        if (policy.scope == CacheScope::Execution) {
+            cache_scope_key = "execution:" + std::to_string(ctx.cache_execution_id);
+        } else if (policy.context_key) {
+            cache_scope_key = "reusable:" + policy.context_key(ctx);
+        } else {
+            cache_scope_key = "reusable";
+        }
+        if (auto cached = node_cache_->lookup(node_name, cache_state_hash, cache_scope_key);
             cached) {
             co_return std::move(*cached);
         }
@@ -327,7 +336,7 @@ asio::awaitable<NodeResult> NodeExecutor::execute_node_with_retry_async(
                 }
             }
             if (cache_eligible) {
-                node_cache_->store(node_name, cache_state_hash, nr);
+                node_cache_->store(node_name, cache_state_hash, cache_scope_key, nr);
             }
             co_return std::move(nr);
         }

--- a/src/core/node_cache.cpp
+++ b/src/core/node_cache.cpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <utility>
 
 namespace neograph::graph {
 
@@ -16,21 +17,41 @@ bool NodeCache::is_enabled(const std::string& node_name) const {
     return enabled_nodes_.count(node_name) != 0;
 }
 
+void NodeCache::set_policy(const std::string& node_name, CacheKeyPolicy policy) {
+    std::lock_guard<std::mutex> lock(mu_);
+    policies_[node_name] = std::move(policy);
+}
+
+CacheKeyPolicy NodeCache::policy_for(const std::string& node_name) const {
+    std::lock_guard<std::mutex> lock(mu_);
+    auto it = policies_.find(node_name);
+    return it == policies_.end() ? CacheKeyPolicy{} : it->second;
+}
+
 std::string NodeCache::make_key(const std::string& node_name,
-                                const std::string& state_hash) {
+                                 const std::string& state_hash,
+                                 const std::string& scope_key) {
     std::string k;
-    k.reserve(node_name.size() + 1 + state_hash.size());
-    k.append(node_name);
-    k.push_back(':');
-    k.append(state_hash);
+    k.reserve(node_name.size() + state_hash.size() + scope_key.size() + 32);
+    for (const auto* part : {&node_name, &scope_key, &state_hash}) {
+        k.append(std::to_string(part->size()));
+        k.push_back(':');
+        k.append(*part);
+    }
     return k;
 }
 
 std::optional<NodeResult> NodeCache::lookup(const std::string& node_name,
-                                            const std::string& state_hash) const {
+                                             const std::string& state_hash) const {
+    return lookup(node_name, state_hash, {});
+}
+
+std::optional<NodeResult> NodeCache::lookup(const std::string& node_name,
+                                             const std::string& state_hash,
+                                             const std::string& scope_key) const {
     std::lock_guard<std::mutex> lock(mu_);
     if (enabled_nodes_.count(node_name) == 0) return std::nullopt;
-    auto it = entries_.find(make_key(node_name, state_hash));
+    auto it = entries_.find(make_key(node_name, state_hash, scope_key));
     if (it == entries_.end()) {
         ++misses_;
         return std::nullopt;
@@ -42,9 +63,16 @@ std::optional<NodeResult> NodeCache::lookup(const std::string& node_name,
 void NodeCache::store(const std::string& node_name,
                       const std::string& state_hash,
                       NodeResult result) {
+    store(node_name, state_hash, {}, std::move(result));
+}
+
+void NodeCache::store(const std::string& node_name,
+                      const std::string& state_hash,
+                      const std::string& scope_key,
+                      NodeResult result) {
     std::lock_guard<std::mutex> lock(mu_);
     if (enabled_nodes_.count(node_name) == 0) return;
-    entries_[make_key(node_name, state_hash)] = std::move(result);
+    entries_[make_key(node_name, state_hash, scope_key)] = std::move(result);
 }
 
 void NodeCache::clear() {

--- a/src/llm/openai_provider.cpp
+++ b/src/llm/openai_provider.cpp
@@ -1,4 +1,8 @@
 #include <neograph/llm/openai_provider.h>
+#include <neograph/graph/cancel.h>
+#include <asio/bind_cancellation_slot.hpp>
+#include <asio/co_spawn.hpp>
+#include <asio/use_awaitable.hpp>
 
 #include <neograph/async/conn_pool.h>
 #include <neograph/async/endpoint.h>
@@ -149,7 +153,7 @@ OpenAIProvider::complete_async(const CompletionParams& params)
         opts.timeout = std::chrono::seconds(config_.timeout_seconds);
     }
 
-    auto res = co_await conn_pool_->async_post(
+    auto request = conn_pool_->async_post(
         endpoint.host,
         endpoint.port,
         chat_completions_path(endpoint.prefix),
@@ -157,6 +161,19 @@ OpenAIProvider::complete_async(const CompletionParams& params)
         std::move(headers),
         endpoint.tls,
         opts);
+    auto executor = co_await asio::this_coro::executor;
+    auto operation = params.cancel_token
+        ? params.cancel_token->fork()
+        : std::shared_ptr<neograph::graph::CancelToken>{};
+    if (operation) {
+        operation->bind_executor(executor);
+    }
+    auto res = operation
+        ? co_await asio::co_spawn(
+              executor, std::move(request),
+              asio::bind_cancellation_slot(
+                  operation->slot(), asio::use_awaitable))
+        : co_await std::move(request);
 
     if (res.status == 429) {
         throw RateLimitError(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,7 @@ if(NEOGRAPH_BUILD_MCP_CLIENT AND NEOGRAPH_BUILD_MCP_SERVER)
 endif()
 
 if(NEOGRAPH_BUILD_A2A)
+    target_compile_definitions(neograph_tests PRIVATE NEOGRAPH_A2A_TESTING)
     target_sources(neograph_tests PRIVATE
         test_a2a_types.cpp
         test_a2a_client.cpp

--- a/tests/test_a2a_client.cpp
+++ b/tests/test_a2a_client.cpp
@@ -10,7 +10,11 @@
 
 #include <gtest/gtest.h>
 #include <neograph/a2a/client.h>
+#include <neograph/a2a/a2a_caller_node.h>
 #include <neograph/a2a/harness_backend.h>
+#include <neograph/async/run_sync.h>
+#include <neograph/graph/run_context.h>
+#include <neograph/graph/state.h>
 
 #define CPPHTTPLIB_OPENSSL_SUPPORT
 #include <httplib.h>
@@ -38,6 +42,7 @@ struct MockA2AServer {
     std::atomic<int>           card_count{0};
     std::mutex                 observed_mutex;
     std::vector<int>           request_ids;
+    std::vector<std::string>  message_ids;
     std::string                last_method;
     json                       last_params;
     std::string                last_card_request_path;
@@ -106,6 +111,8 @@ struct MockA2AServer {
             {
                 std::lock_guard<std::mutex> lock(observed_mutex);
                 request_ids.push_back(id);
+                if (parsed.contains("params") && parsed["params"].contains("message"))
+                    message_ids.push_back(parsed["params"]["message"].value("messageId", std::string()));
             }
 
             json envelope;
@@ -222,6 +229,53 @@ TEST(A2AClient, ConcurrentCallsHaveUniqueRequestIdsWhileTimeoutChanges) {
     std::set<int> ids(srv.request_ids.begin(), srv.request_ids.end());
     EXPECT_EQ(srv.request_ids.size(), static_cast<std::size_t>(callers));
     EXPECT_EQ(ids.size(), srv.request_ids.size());
+}
+
+TEST(A2ACallerNode, RepeatedCallsUseUniqueCallScopedMessageIds) {
+    MockA2AServer srv;
+    auto client = std::make_shared<A2AClient>(srv.url());
+    A2ACallerNode node("caller", client);
+    neograph::graph::GraphState state;
+    state.init_channel("prompt", neograph::graph::ReducerType::OVERWRITE,
+        [](const json&, const json& incoming) { return incoming; });
+    state.write("prompt", "hello");
+    neograph::graph::RunContext ctx;
+
+    for (int i = 0; i < 8; ++i)
+        (void)neograph::async::run_sync(node.run({state, ctx}));
+
+    std::lock_guard<std::mutex> lock(srv.observed_mutex);
+    std::set<std::string> ids(srv.message_ids.begin(), srv.message_ids.end());
+    EXPECT_EQ(srv.message_ids.size(), 8u);
+    EXPECT_EQ(ids.size(), srv.message_ids.size());
+    for (const auto& id : srv.message_ids) {
+        EXPECT_EQ(id.rfind("ng-a2a-call-", 0), 0u);
+        EXPECT_EQ(id.find("0x"), std::string::npos);
+    }
+}
+
+TEST(A2ACallerNode, ConcurrentCallsUseUniqueCallScopedMessageIds) {
+    MockA2AServer srv;
+    auto client = std::make_shared<A2AClient>(srv.url());
+    A2ACallerNode node("caller", client);
+    neograph::graph::GraphState state;
+    state.init_channel("prompt", neograph::graph::ReducerType::OVERWRITE,
+        [](const json&, const json& incoming) { return incoming; });
+    state.write("prompt", "hello");
+    neograph::graph::RunContext ctx;
+    constexpr int callers = 32;
+    std::vector<std::future<void>> futures;
+    for (int i = 0; i < callers; ++i) {
+        futures.push_back(std::async(std::launch::async, [&] {
+            (void)neograph::async::run_sync(node.run({state, ctx}));
+        }));
+    }
+    for (auto& future : futures) future.get();
+
+    std::lock_guard<std::mutex> lock(srv.observed_mutex);
+    std::set<std::string> ids(srv.message_ids.begin(), srv.message_ids.end());
+    EXPECT_EQ(srv.message_ids.size(), static_cast<std::size_t>(callers));
+    EXPECT_EQ(ids.size(), srv.message_ids.size());
 }
 
 TEST(A2AClient, SendMessageUsesCanonicalMethodName) {

--- a/tests/test_a2a_client.cpp
+++ b/tests/test_a2a_client.cpp
@@ -42,7 +42,7 @@ struct MockA2AServer {
     std::atomic<int>           card_count{0};
     std::mutex                 observed_mutex;
     std::vector<int>           request_ids;
-    std::vector<std::string>  message_ids;
+    std::vector<std::string>   message_ids;
     std::string                last_method;
     json                       last_params;
     std::string                last_card_request_path;
@@ -229,6 +229,53 @@ TEST(A2AClient, ConcurrentCallsHaveUniqueRequestIdsWhileTimeoutChanges) {
     std::set<int> ids(srv.request_ids.begin(), srv.request_ids.end());
     EXPECT_EQ(srv.request_ids.size(), static_cast<std::size_t>(callers));
     EXPECT_EQ(ids.size(), srv.request_ids.size());
+}
+
+TEST(A2AClient, ConcurrentSendAndGetUseUniqueRequestIds) {
+    MockA2AServer srv;
+    A2AClient client(srv.url());
+    constexpr int callers = 16;
+    std::atomic<bool> start{false};
+    std::vector<std::future<void>> futures;
+    futures.reserve(callers * 2);
+
+    for (int i = 0; i < callers; ++i) {
+        futures.push_back(std::async(std::launch::async, [&] {
+            while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+            (void)client.send_message_sync("send");
+        }));
+        futures.push_back(std::async(std::launch::async, [&] {
+            while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+            (void)client.get_task("task-concurrent");
+        }));
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& future : futures) future.get();
+
+    std::lock_guard<std::mutex> lock(srv.observed_mutex);
+    std::set<int> ids(srv.request_ids.begin(), srv.request_ids.end());
+    EXPECT_EQ(srv.request_ids.size(), static_cast<std::size_t>(callers * 2));
+    EXPECT_EQ(ids.size(), srv.request_ids.size());
+}
+
+TEST(A2AClient, ConcurrentForcedCardRefreshesAreSerialized) {
+    MockA2AServer srv;
+    A2AClient client(srv.url());
+    (void)client.fetch_agent_card();
+    constexpr int callers = 8;
+    std::atomic<bool> start{false};
+    std::vector<std::future<AgentCard>> futures;
+    futures.reserve(callers);
+
+    for (int i = 0; i < callers; ++i) {
+        futures.push_back(std::async(std::launch::async, [&] {
+            while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+            return client.fetch_agent_card(true);
+        }));
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& future : futures) EXPECT_EQ(future.get().name, "mock-agent");
+    EXPECT_EQ(srv.card_count.load(), callers + 1);
 }
 
 TEST(A2ACallerNode, RepeatedCallsUseUniqueCallScopedMessageIds) {

--- a/tests/test_a2a_client.cpp
+++ b/tests/test_a2a_client.cpp
@@ -17,8 +17,12 @@
 
 #include <atomic>
 #include <chrono>
+#include <future>
+#include <mutex>
+#include <set>
 #include <string>
 #include <thread>
+#include <vector>
 
 using namespace neograph;
 using namespace neograph::a2a;
@@ -32,6 +36,8 @@ struct MockA2AServer {
 
     std::atomic<int>           rpc_count{0};
     std::atomic<int>           card_count{0};
+    std::mutex                 observed_mutex;
+    std::vector<int>           request_ids;
     std::string                last_method;
     json                       last_params;
     std::string                last_card_request_path;
@@ -75,7 +81,10 @@ struct MockA2AServer {
         svr.Get("/.well-known/agent-card.json",
                 [this](const httplib::Request& req, httplib::Response& res) {
                     card_count.fetch_add(1, std::memory_order_relaxed);
-                    last_card_request_path = req.path;
+                    {
+                        std::lock_guard<std::mutex> lock(observed_mutex);
+                        last_card_request_path = req.path;
+                    }
                     res.status = 200;
                     res.set_content(card.dump(), "application/json");
                 });
@@ -83,14 +92,21 @@ struct MockA2AServer {
         svr.Post("/", [this](const httplib::Request& req, httplib::Response& res) {
             rpc_count.fetch_add(1, std::memory_order_relaxed);
             int id = 0;
+            json parsed;
             try {
-                auto parsed = json::parse(req.body);
+                parsed = json::parse(req.body);
                 if (parsed.is_object()) {
                     id           = parsed.value("id", 0);
+                    std::lock_guard<std::mutex> lock(observed_mutex);
                     last_method  = parsed.value("method", std::string());
                     if (parsed.contains("params")) last_params = parsed["params"];
                 }
             } catch (...) {}
+
+            {
+                std::lock_guard<std::mutex> lock(observed_mutex);
+                request_ids.push_back(id);
+            }
 
             json envelope;
             envelope["jsonrpc"] = "2.0";
@@ -159,6 +175,53 @@ TEST(A2AClient, FetchAgentCardCachesByDefault) {
 
     (void)client.fetch_agent_card(/*force=*/true);
     EXPECT_EQ(srv.card_count.load(), 2);
+}
+
+TEST(A2AClient, ConcurrentFirstCardFetchInitializesCacheOnce) {
+    MockA2AServer srv;
+    A2AClient client(srv.url());
+    constexpr int callers = 16;
+    std::atomic<bool> start{false};
+    std::vector<std::future<AgentCard>> futures;
+    futures.reserve(callers);
+
+    for (int i = 0; i < callers; ++i) {
+        futures.push_back(std::async(std::launch::async, [&] {
+            while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+            return client.fetch_agent_card();
+        }));
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& future : futures) EXPECT_EQ(future.get().name, "mock-agent");
+    EXPECT_EQ(srv.card_count.load(), 1);
+}
+
+TEST(A2AClient, ConcurrentCallsHaveUniqueRequestIdsWhileTimeoutChanges) {
+    MockA2AServer srv;
+    A2AClient client(srv.url());
+    constexpr int callers = 32;
+    std::atomic<bool> start{false};
+    std::vector<std::future<void>> futures;
+    futures.reserve(callers);
+
+    std::thread config_writer([&] {
+        while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+        for (int i = 1; i <= 1000; ++i) client.set_timeout(std::chrono::seconds(i % 3 + 1));
+    });
+    for (int i = 0; i < callers; ++i) {
+        futures.push_back(std::async(std::launch::async, [&] {
+            while (!start.load(std::memory_order_acquire)) std::this_thread::yield();
+            (void)client.send_message_sync("concurrent");
+        }));
+    }
+    start.store(true, std::memory_order_release);
+    for (auto& future : futures) future.get();
+    config_writer.join();
+
+    std::lock_guard<std::mutex> lock(srv.observed_mutex);
+    std::set<int> ids(srv.request_ids.begin(), srv.request_ids.end());
+    EXPECT_EQ(srv.request_ids.size(), static_cast<std::size_t>(callers));
+    EXPECT_EQ(ids.size(), srv.request_ids.size());
 }
 
 TEST(A2AClient, SendMessageUsesCanonicalMethodName) {

--- a/tests/test_a2a_server.cpp
+++ b/tests/test_a2a_server.cpp
@@ -103,6 +103,147 @@ class CancelAwareNode : public GraphNode {
     std::shared_ptr<CancelProbe> probe_;
 };
 
+class BlockingAdapter final : public GraphAgentAdapter {
+  public:
+    std::promise<void> entered;
+    std::shared_future<void> release;
+
+    neograph::json build_initial_state(const std::string& text) const override {
+        const_cast<BlockingAdapter*>(this)->entered.set_value();
+        release.wait();
+        return GraphAgentAdapter::build_initial_state(text);
+    }
+};
+
+struct OverlapProbe {
+    std::atomic<int> active{0};
+    std::atomic<int> max_active{0};
+    std::atomic<bool> release{false};
+};
+
+class OverlapNode final : public GraphNode {
+  public:
+    OverlapNode(std::string name, std::shared_ptr<OverlapProbe> probe)
+        : name_(std::move(name)), probe_(std::move(probe)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        const auto active = probe_->active.fetch_add(1) + 1;
+        auto max = probe_->max_active.load();
+        while (active > max &&
+               !probe_->max_active.compare_exchange_weak(max, active)) {}
+        while (!probe_->release.load(std::memory_order_acquire)) {
+            if (in.ctx.cancel_token && in.ctx.cancel_token->is_cancelled()) {
+                probe_->active.fetch_sub(1);
+                throw neograph::graph::CancelledException();
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+        probe_->active.fetch_sub(1);
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"response", json("overlap")});
+        co_return out;
+    }
+
+    std::string get_name() const override { return name_; }
+
+  private:
+    std::string name_;
+    std::shared_ptr<OverlapProbe> probe_;
+};
+
+std::shared_ptr<GraphEngine> build_overlap_engine(
+    const std::shared_ptr<OverlapProbe>& probe) {
+    NodeFactory::instance().register_type("a2a_overlap",
+        [probe](const std::string& name, const neograph::json&, const NodeContext&) {
+            return std::make_unique<OverlapNode>(name, probe);
+        });
+    neograph::json def = {
+        {"name", "a2a-overlap"},
+        {"channels", {{"prompt", {{"reducer", "overwrite"}}},
+                      {"response", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"worker", {{"type", "a2a_overlap"}}}}},
+        {"edges", neograph::json::array({
+            neograph::json{{"from", "__start__"}, {"to", "worker"}},
+            neograph::json{{"from", "worker"}, {"to", "__end__"}},
+        })},
+    };
+    return std::shared_ptr<GraphEngine>(GraphEngine::compile(def, NodeContext{}));
+}
+
+struct DependencyProbe {
+    std::atomic<bool> provider_started{false};
+    std::atomic<bool> provider_cancelled{false};
+    std::atomic<bool> tool_started{false};
+    std::atomic<bool> tool_cancelled{false};
+    std::shared_ptr<neograph::graph::CancelToken> token;
+};
+
+class CancellableProvider final : public neograph::Provider {
+  public:
+    explicit CancellableProvider(std::shared_ptr<DependencyProbe> probe)
+        : probe_(std::move(probe)) {}
+    asio::awaitable<neograph::ChatCompletion> complete_async(
+        const neograph::CompletionParams& params) override {
+        probe_->provider_started.store(true, std::memory_order_release);
+        while (true) {
+            if (params.cancel_token && params.cancel_token->is_cancelled()) {
+                probe_->provider_cancelled.store(true, std::memory_order_release);
+                throw neograph::graph::CancelledException();
+            }
+            std::this_thread::sleep_for(1ms);
+        }
+    }
+    neograph::ChatCompletion complete(const neograph::CompletionParams&) override {
+        throw std::runtime_error("sync provider path not expected");
+    }
+    std::string get_name() const override { return "cancellable"; }
+  private:
+    std::shared_ptr<DependencyProbe> probe_;
+};
+
+class ProviderNode final : public GraphNode {
+  public:
+    ProviderNode(std::string name, std::shared_ptr<neograph::Provider> provider,
+                 std::shared_ptr<DependencyProbe> probe)
+        : name_(std::move(name)), provider_(std::move(provider)),
+          probe_(std::move(probe)) {}
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        probe_->token = in.ctx.cancel_token;
+        neograph::CompletionParams params;
+        params.model = "mock";
+        params.cancel_token = in.ctx.cancel_token;
+        (void)co_await provider_->complete_async(params);
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{"response", json("provider")});
+        co_return out;
+    }
+    std::string get_name() const override { return name_; }
+  private:
+    std::string name_;
+    std::shared_ptr<neograph::Provider> provider_;
+    std::shared_ptr<DependencyProbe> probe_;
+};
+
+std::shared_ptr<GraphEngine> build_provider_engine(
+    const std::shared_ptr<neograph::Provider>& provider,
+    const std::shared_ptr<DependencyProbe>& probe) {
+    NodeFactory::instance().register_type("a2a_provider",
+        [provider, probe](const std::string& name, const neograph::json&, const NodeContext&) {
+            return std::make_unique<ProviderNode>(name, provider, probe);
+        });
+    neograph::json def = {
+        {"name", "a2a-provider"},
+        {"channels", {{"prompt", {{"reducer", "overwrite"}}},
+                      {"response", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"provider", {{"type", "a2a_provider"}}}}},
+        {"edges", neograph::json::array({
+            neograph::json{{"from", "__start__"}, {"to", "provider"}},
+            neograph::json{{"from", "provider"}, {"to", "__end__"}},
+        })},
+    };
+    return std::shared_ptr<GraphEngine>(GraphEngine::compile(def, NodeContext{}));
+}
+
 std::shared_ptr<GraphEngine> build_echo_engine() {
     auto& factory = NodeFactory::instance();
     factory.register_type("echo",
@@ -401,6 +542,195 @@ TEST(A2AServer, DuplicateTaskIdIsRejectedWithoutReplacingOwner) {
     EXPECT_EQ(canceller.cancel_task(task_id).status.state, TaskState::Canceled);
     ASSERT_EQ(done.wait_for(500ms), std::future_status::ready);
     EXPECT_EQ(done.get().status.state, TaskState::Canceled);
+    runner.join();
+    server.stop();
+}
+
+TEST(A2AServer, CancelBeforeGraphStartStopsBeforeNodeRuns) {
+    auto probe = std::make_shared<CancelProbe>();
+    auto adapter = std::make_shared<BlockingAdapter>();
+    std::promise<void> release;
+    adapter->release = release.get_future().share();
+    A2AServer server(build_cancel_aware_engine(probe), build_card(0), adapter);
+    ASSERT_TRUE(server.start_async("127.0.0.1", 0));
+    const std::string url = "http://127.0.0.1:" + std::to_string(server.port());
+    const std::string task_id = "a2a-cancel-before-start";
+
+    std::promise<Task> completion;
+    auto done = completion.get_future();
+    std::thread runner([&] {
+        try {
+            A2AClient client(url);
+            completion.set_value(client.send_message_sync("blocked", task_id));
+        } catch (...) {
+            completion.set_exception(std::current_exception());
+        }
+    });
+    auto entered = adapter->entered.get_future();
+    ASSERT_EQ(entered.wait_for(500ms), std::future_status::ready);
+
+    A2AClient canceller(url);
+    EXPECT_EQ(canceller.cancel_task(task_id).status.state, TaskState::Canceled);
+    release.set_value();
+    ASSERT_EQ(done.wait_for(500ms), std::future_status::ready);
+    EXPECT_EQ(done.get().status.state, TaskState::Canceled);
+    EXPECT_EQ(probe->starts.load(std::memory_order_relaxed), 0);
+    runner.join();
+    server.stop();
+}
+
+TEST(A2AServer, CancelAfterCompletionDoesNotChangeTask) {
+    LiveServer srv;
+    A2AClient client(srv.url());
+    auto task = client.send_message_sync("complete", "a2a-after-complete");
+    ASSERT_EQ(task.status.state, TaskState::Completed);
+    auto canceled = client.cancel_task(task.id);
+    EXPECT_EQ(canceled.status.state, TaskState::Completed);
+    EXPECT_EQ(client.get_task(task.id).status.state, TaskState::Completed);
+}
+
+TEST(A2AServer, CancelledStreamEmitsOneTerminalStatusSequence) {
+    auto probe = std::make_shared<CancelProbe>();
+    A2AServer server(build_cancel_aware_engine(probe), build_card(0));
+    ASSERT_TRUE(server.start_async("127.0.0.1", 0));
+    const std::string url = "http://127.0.0.1:" + std::to_string(server.port());
+    const std::string task_id = "a2a-stream-cancel";
+    std::atomic<int> terminal_statuses{0};
+    std::atomic<int> task_events{0};
+    std::atomic<int> cancel_ack{0};
+    std::promise<Task> completion;
+    auto done = completion.get_future();
+    std::thread runner([&] {
+        try {
+            A2AClient client(url);
+            auto task = client.send_message_stream(
+                "stream cancel",
+                [&](const StreamEvent& ev) {
+                    if (ev.type == StreamEvent::Type::StatusUpdate &&
+                        ev.status_update) {
+                        if (ev.status_update->status.state == TaskState::Working) {
+                            A2AClient canceller(url);
+                            cancel_ack.store(
+                                canceller.cancel_task(task_id).status.state ==
+                                    TaskState::Canceled ? 1 : -1);
+                        }
+                        if (ev.status_update->final) {
+                            terminal_statuses.fetch_add(1);
+                        }
+                    }
+                    if (ev.type == StreamEvent::Type::Task) task_events.fetch_add(1);
+                    return true;
+                }, task_id);
+            completion.set_value(std::move(task));
+        } catch (...) {
+            completion.set_exception(std::current_exception());
+        }
+    });
+    ASSERT_EQ(done.wait_for(1s), std::future_status::ready);
+    auto task = done.get();
+    runner.join();
+    server.stop();
+    EXPECT_EQ(cancel_ack.load(), 1);
+    EXPECT_EQ(task.status.state, TaskState::Canceled);
+    EXPECT_EQ(terminal_statuses.load(), 1);
+    EXPECT_EQ(task_events.load(), 1);
+}
+
+TEST(A2AServer, DifferentTaskRunsOverlapAndReconnectCanLookup) {
+    auto probe = std::make_shared<OverlapProbe>();
+    A2AServer server(build_overlap_engine(probe), build_card(0));
+    ASSERT_TRUE(server.start_async("127.0.0.1", 0));
+    const std::string url = "http://127.0.0.1:" + std::to_string(server.port());
+    std::promise<Task> first_done, second_done;
+    auto first = first_done.get_future();
+    auto second = second_done.get_future();
+    std::thread one([&] {
+        try { first_done.set_value(A2AClient(url).send_message_sync("one", "a2a-one")); }
+        catch (...) { first_done.set_exception(std::current_exception()); }
+    });
+    std::thread two([&] {
+        try { second_done.set_value(A2AClient(url).send_message_sync("two", "a2a-two")); }
+        catch (...) { second_done.set_exception(std::current_exception()); }
+    });
+    for (int i = 0; i < 200 && probe->active.load() < 2; ++i) {
+        std::this_thread::sleep_for(5ms);
+    }
+    ASSERT_EQ(probe->active.load(), 2);
+    EXPECT_GE(probe->max_active.load(), 2);
+    probe->release.store(true, std::memory_order_release);
+    ASSERT_EQ(first.wait_for(500ms), std::future_status::ready);
+    ASSERT_EQ(second.wait_for(500ms), std::future_status::ready);
+    EXPECT_EQ(first.get().status.state, TaskState::Completed);
+    EXPECT_EQ(second.get().status.state, TaskState::Completed);
+    one.join();
+    two.join();
+
+    A2AClient reconnect(url);
+    EXPECT_EQ(reconnect.get_task("a2a-one").status.state, TaskState::Completed);
+    server.stop();
+}
+
+TEST(A2AServer, GlobalAdmissionRejectsDistinctTaskAtCap) {
+    auto probe = std::make_shared<OverlapProbe>();
+    A2AServer server(build_overlap_engine(probe), build_card(0));
+    test::A2AServerTestAccess::set_max_inflight_runs(server, 1);
+    ASSERT_TRUE(server.start_async("127.0.0.1", 0));
+    const std::string url = "http://127.0.0.1:" + std::to_string(server.port());
+    std::promise<Task> owner_done;
+    auto owner_future = owner_done.get_future();
+    std::thread owner([&] {
+        try {
+            owner_done.set_value(
+                A2AClient(url).send_message_sync("owner", "a2a-admission-owner"));
+        } catch (...) {
+            owner_done.set_exception(std::current_exception());
+        }
+    });
+
+    for (int i = 0; i < 200 && probe->active.load() < 1; ++i) {
+        std::this_thread::sleep_for(5ms);
+    }
+    ASSERT_EQ(probe->active.load(), 1);
+
+    auto rejected = A2AClient(url).send_message_sync(
+        "second", "a2a-admission-second");
+    EXPECT_EQ(rejected.status.state, TaskState::Rejected);
+    EXPECT_EQ(rejected.status.message->parts.front().text,
+              "A2A server is at its in-flight task limit");
+    EXPECT_EQ(A2AClient(url).get_task("a2a-admission-owner").status.state,
+              TaskState::Working);
+
+    probe->release.store(true, std::memory_order_release);
+    ASSERT_EQ(owner_future.wait_for(500ms), std::future_status::ready);
+    EXPECT_EQ(owner_future.get().status.state, TaskState::Completed);
+    owner.join();
+    server.stop();
+}
+
+TEST(A2AServer, CancelReachesCooperativeProviderFixture) {
+    auto probe = std::make_shared<DependencyProbe>();
+    auto provider = std::make_shared<CancellableProvider>(probe);
+    A2AServer server(build_provider_engine(provider, probe), build_card(0));
+    ASSERT_TRUE(server.start_async("127.0.0.1", 0));
+    const std::string url = "http://127.0.0.1:" + std::to_string(server.port());
+    const std::string task_id = "a2a-provider-cancel";
+    std::promise<Task> completion;
+    auto done = completion.get_future();
+    std::thread runner([&] {
+        try {
+            completion.set_value(A2AClient(url).send_message_sync("provider", task_id));
+        } catch (...) {
+            completion.set_exception(std::current_exception());
+        }
+    });
+    for (int i = 0; i < 200 && !probe->provider_started.load(); ++i) {
+        std::this_thread::sleep_for(5ms);
+    }
+    ASSERT_TRUE(probe->provider_started.load());
+    EXPECT_EQ(A2AClient(url).cancel_task(task_id).status.state, TaskState::Canceled);
+    ASSERT_EQ(done.wait_for(500ms), std::future_status::ready);
+    EXPECT_EQ(done.get().status.state, TaskState::Canceled);
+    EXPECT_TRUE(probe->provider_cancelled.load());
     runner.join();
     server.stop();
 }

--- a/tests/test_a2a_server.cpp
+++ b/tests/test_a2a_server.cpp
@@ -70,6 +70,7 @@ class JsonSiteNode : public GraphNode {
 };
 
 struct CancelProbe {
+    std::atomic<int> starts{0};
     std::atomic<bool> entered{false};
     std::atomic<bool> normal_completion{false};
 };
@@ -80,6 +81,7 @@ class CancelAwareNode : public GraphNode {
         : name_(std::move(name)), probe_(std::move(probe)) {}
 
     asio::awaitable<NodeOutput> run(NodeInput in) override {
+        probe_->starts.fetch_add(1, std::memory_order_relaxed);
         probe_->entered.store(true, std::memory_order_release);
         const auto deadline = std::chrono::steady_clock::now() + 1s;
         while (std::chrono::steady_clock::now() < deadline) {
@@ -362,6 +364,45 @@ TEST(A2AServer, CancelUnknownBeforeStartIsDeterministic) {
             throw;
         }
     }, std::runtime_error);
+}
+
+TEST(A2AServer, DuplicateTaskIdIsRejectedWithoutReplacingOwner) {
+    auto probe = std::make_shared<CancelProbe>();
+    A2AServer server(build_cancel_aware_engine(probe), build_card(0));
+    ASSERT_TRUE(server.start_async("127.0.0.1", 0));
+    const std::string url = "http://127.0.0.1:" + std::to_string(server.port());
+    const std::string task_id = "a2a-duplicate";
+
+    std::promise<Task> completion;
+    auto done = completion.get_future();
+    std::thread runner([&] {
+        try {
+            A2AClient client(url);
+            completion.set_value(client.send_message_sync("owner", task_id));
+        } catch (...) {
+            completion.set_exception(std::current_exception());
+        }
+    });
+
+    for (int i = 0; i < 200 && !probe->entered.load(std::memory_order_acquire); ++i) {
+        std::this_thread::sleep_for(5ms);
+    }
+    ASSERT_TRUE(probe->entered.load(std::memory_order_acquire));
+
+    A2AClient duplicate(url);
+    auto rejected = duplicate.send_message_sync("duplicate", task_id);
+    EXPECT_EQ(rejected.status.state, TaskState::Rejected);
+    ASSERT_FALSE(rejected.history.empty());
+    EXPECT_EQ(rejected.history.back().parts[0].text,
+              "task_id is already running");
+    EXPECT_EQ(probe->starts.load(std::memory_order_relaxed), 1);
+
+    A2AClient canceller(url);
+    EXPECT_EQ(canceller.cancel_task(task_id).status.state, TaskState::Canceled);
+    ASSERT_EQ(done.wait_for(500ms), std::future_status::ready);
+    EXPECT_EQ(done.get().status.state, TaskState::Canceled);
+    runner.join();
+    server.stop();
 }
 
 TEST(A2AServer, MethodNotFoundReturnsCorrectCode) {

--- a/tests/test_a2a_server.cpp
+++ b/tests/test_a2a_server.cpp
@@ -350,6 +350,20 @@ TEST(A2AServer, CancelTaskAbortsInflightGraphAndIsIdempotent) {
     EXPECT_LT(std::chrono::steady_clock::now() - start, 500ms);
 }
 
+TEST(A2AServer, CancelUnknownBeforeStartIsDeterministic) {
+    LiveServer srv;
+    A2AClient client(srv.url());
+    EXPECT_THROW({
+        try {
+            (void)client.cancel_task("not-started");
+        } catch (const std::runtime_error& e) {
+            EXPECT_NE(std::string(e.what()).find("Task not found"),
+                      std::string::npos);
+            throw;
+        }
+    }, std::runtime_error);
+}
+
 TEST(A2AServer, MethodNotFoundReturnsCorrectCode) {
     LiveServer srv;
     A2AClient client(srv.url());

--- a/tests/test_acp_server.cpp
+++ b/tests/test_acp_server.cpp
@@ -754,10 +754,16 @@ TEST(ACPServer, CancelAbortsInflightPrompt) {
     neograph::json cancel = {{"jsonrpc", "2.0"}, {"method", "session/cancel"},
                               {"params", {{"sessionId", sid}}}};
     server.handle_message(cancel);
+    server.handle_message(cancel);
     auto response = cap.wait_for_response(1, std::chrono::milliseconds(500));
     ASSERT_TRUE(response.contains("result")) << response.dump();
     EXPECT_EQ(response["result"].value("stopReason", std::string()), "cancelled");
     EXPECT_FALSE(probe->completed.load(std::memory_order_acquire));
+    int response_count = 0;
+    for (const auto& env : cap.envs) {
+        if (env.value("id", 0) == 1 && env.contains("result")) ++response_count;
+    }
+    EXPECT_EQ(response_count, 1);
 }
 
 TEST(ACPServer, UnknownMethodReturnsMethodNotFound) {

--- a/tests/test_acp_server.cpp
+++ b/tests/test_acp_server.cpp
@@ -1154,23 +1154,26 @@ TEST(ACPServer, NodeCallsBackToEditorViaFsRead) {
     neograph::json info = {{"name", "acp-bidir"}, {"version", "0.0.1"}};
     auto server = std::make_shared<ACPServer>(engine, info);
     server->attach_client(client);
+    auto weak_server = std::weak_ptr<ACPServer>(server);
 
     // Stub editor. The sink does double duty: capture envelopes for
     // assertions AND respond to outbound fs/read_text_file requests by
     // feeding a synthetic response back through handle_message.
     CapturingSink cap;
     auto cap_sink = cap.as_sink();
-    server->set_notification_sink([&, cap_sink, server](const neograph::json& env) {
+    server->set_notification_sink([&, cap_sink, weak_server](const neograph::json& env) {
         cap_sink(env);
         if (env.value("method", std::string()) == "fs/read_text_file"
             && env.contains("id")) {
             auto reply_id = env["id"];
-            std::thread([server, reply_id]() {
+            std::thread([weak_server, reply_id]() {
                 neograph::json reply;
                 reply["jsonrpc"] = "2.0";
                 reply["id"]      = reply_id;
                 reply["result"]  = {{"content", "void main(){}\n"}};
-                server->handle_message(reply);
+                if (auto server = weak_server.lock()) {
+                    server->handle_message(reply);
+                }
             }).detach();
         }
     });
@@ -1285,20 +1288,23 @@ make_gated_server(std::shared_ptr<ACPClient> client,
     neograph::json info = {{"name", "acp-gate"}, {"version", "0.0.1"}};
     auto server = std::make_shared<ACPServer>(engine, info);
     server->attach_client(client);
+    auto weak_server = std::weak_ptr<ACPServer>(server);
 
     auto cap_sink = cap.as_sink();
-    server->set_notification_sink([cap_sink, server, reply_for](const neograph::json& env) {
+    server->set_notification_sink([cap_sink, weak_server, reply_for](const neograph::json& env) {
         cap_sink(env);
         if (env.value("method", std::string()) == "session/request_permission"
             && env.contains("id")) {
             auto reply_id = env["id"];
             auto outcome  = reply_for(env);
-            std::thread([server, reply_id, outcome]() {
+            std::thread([weak_server, reply_id, outcome]() {
                 neograph::json reply;
                 reply["jsonrpc"] = "2.0";
                 reply["id"]      = reply_id;
                 reply["result"]  = outcome;
-                server->handle_message(reply);
+                if (auto server = weak_server.lock()) {
+                    server->handle_message(reply);
+                }
             }).detach();
         }
     });
@@ -1447,11 +1453,12 @@ TEST(ACPServer, FsWriteTextFileRoundTrip) {
     neograph::json info = {{"name", "acp-write-test"}, {"version", "0.0.1"}};
     auto server = std::make_shared<ACPServer>(engine, info);
     server->attach_client(client);
+    auto weak_server = std::weak_ptr<ACPServer>(server);
 
     CapturingSink cap;
     auto cap_sink = cap.as_sink();
     std::string seen_path, seen_body;
-    server->set_notification_sink([&, cap_sink, server](const neograph::json& env) {
+    server->set_notification_sink([&, cap_sink, weak_server](const neograph::json& env) {
         cap_sink(env);
         if (env.value("method", std::string()) == "fs/write_text_file"
             && env.contains("id")) {
@@ -1460,12 +1467,14 @@ TEST(ACPServer, FsWriteTextFileRoundTrip) {
             seen_path = p.value("path", std::string());
             seen_body = p.value("content", std::string());
             auto reply_id = env["id"];
-            std::thread([server, reply_id]() {
+            std::thread([weak_server, reply_id]() {
                 neograph::json reply;
                 reply["jsonrpc"] = "2.0";
                 reply["id"]      = reply_id;
                 reply["result"]  = neograph::json::object();
-                server->handle_message(reply);
+                if (auto server = weak_server.lock()) {
+                    server->handle_message(reply);
+                }
             }).detach();
         }
     });

--- a/tests/test_acp_server.cpp
+++ b/tests/test_acp_server.cpp
@@ -96,6 +96,107 @@ class CancelAwareNode : public GraphNode {
     std::shared_ptr<CancelProbe> probe_;
 };
 
+struct DependencyProbe {
+    std::atomic<bool> provider_started{false};
+    std::atomic<bool> provider_release{false};
+    std::atomic<bool> provider_cancelled{false};
+    std::atomic<bool> tool_started{false};
+    std::atomic<bool> tool_cancelled{false};
+    std::shared_ptr<neograph::graph::CancelToken> token;
+};
+
+class CancellableProvider final : public neograph::Provider {
+  public:
+    explicit CancellableProvider(std::shared_ptr<DependencyProbe> probe)
+        : probe_(std::move(probe)) {}
+    asio::awaitable<neograph::ChatCompletion> complete_async(
+        const neograph::CompletionParams& params) override {
+        probe_->provider_started.store(true, std::memory_order_release);
+        while (true) {
+            if (probe_->provider_release.load(std::memory_order_acquire)) {
+                co_return neograph::ChatCompletion{};
+            }
+            if (params.cancel_token && params.cancel_token->is_cancelled()) {
+                probe_->provider_cancelled.store(true, std::memory_order_release);
+                throw neograph::graph::CancelledException();
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+    neograph::ChatCompletion complete(const neograph::CompletionParams&) override {
+        throw std::runtime_error("sync provider path not expected");
+    }
+    std::string get_name() const override { return "cancellable"; }
+  private:
+    std::shared_ptr<DependencyProbe> probe_;
+};
+
+class CancellableTool final : public neograph::AsyncTool {
+  public:
+    explicit CancellableTool(std::shared_ptr<DependencyProbe> probe)
+        : probe_(std::move(probe)) {}
+    neograph::ChatTool get_definition() const override {
+        return {"mock_tool", "mock", neograph::json::object()};
+    }
+    std::string get_name() const override { return "mock_tool"; }
+    asio::awaitable<std::string> execute_async(const neograph::json&) override {
+        probe_->tool_started.store(true, std::memory_order_release);
+        while (true) {
+            if (probe_->token && probe_->token->is_cancelled()) {
+                probe_->tool_cancelled.store(true, std::memory_order_release);
+                throw neograph::graph::CancelledException();
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+  private:
+    std::shared_ptr<DependencyProbe> probe_;
+};
+
+class DependencyNode final : public GraphNode {
+  public:
+    DependencyNode(std::string name, std::shared_ptr<neograph::Provider> provider,
+                   std::shared_ptr<CancellableTool> tool,
+                   std::shared_ptr<DependencyProbe> probe)
+        : name_(std::move(name)), provider_(std::move(provider)),
+          tool_(std::move(tool)), probe_(std::move(probe)) {}
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        probe_->token = in.ctx.cancel_token;
+        neograph::CompletionParams params;
+        params.model = "mock";
+        params.cancel_token = in.ctx.cancel_token;
+        (void)co_await provider_->complete_async(params);
+        (void)co_await tool_->execute_async({});
+        co_return NodeOutput{};
+    }
+    std::string get_name() const override { return name_; }
+  private:
+    std::string name_;
+    std::shared_ptr<neograph::Provider> provider_;
+    std::shared_ptr<CancellableTool> tool_;
+    std::shared_ptr<DependencyProbe> probe_;
+};
+
+std::shared_ptr<GraphEngine> build_dependency_engine(
+    const std::shared_ptr<neograph::Provider>& provider,
+    const std::shared_ptr<CancellableTool>& tool,
+    const std::shared_ptr<DependencyProbe>& probe) {
+    NodeFactory::instance().register_type("acp_dependency",
+        [provider, tool, probe](const std::string& name, const neograph::json&, const NodeContext&) {
+            return std::make_unique<DependencyNode>(name, provider, tool, probe);
+        });
+    neograph::json def = {
+        {"name", "acp-dependency"},
+        {"channels", {{"prompt", {{"reducer", "overwrite"}}}}},
+        {"nodes", {{"worker", {{"type", "acp_dependency"}}}}},
+        {"edges", neograph::json::array({
+            neograph::json{{"from", "__start__"}, {"to", "worker"}},
+            neograph::json{{"from", "worker"}, {"to", "__end__"}},
+        })},
+    };
+    return std::shared_ptr<GraphEngine>(GraphEngine::compile(def, NodeContext{}));
+}
+
 std::shared_ptr<GraphEngine> build_echo_engine() {
     NodeFactory::instance().register_type("acp_echo",
         [](const std::string& n, const neograph::json&, const NodeContext&) {
@@ -764,6 +865,75 @@ TEST(ACPServer, CancelAbortsInflightPrompt) {
         if (env.value("id", 0) == 1 && env.contains("result")) ++response_count;
     }
     EXPECT_EQ(response_count, 1);
+}
+
+TEST(ACPServer, CancelReachesProviderAndToolFixtures) {
+    auto probe = std::make_shared<DependencyProbe>();
+    auto provider = std::make_shared<CancellableProvider>(probe);
+    auto tool = std::make_shared<CancellableTool>(probe);
+    ACPServer server(build_dependency_engine(provider, tool, probe),
+                     {{"name", "test-acp"}, {"version", "0.0.1"}});
+    CapturingSink cap;
+    server.set_notification_sink(cap.as_sink());
+    const std::string sid = "acp-dependency-cancel";
+    server.handle_message(make_request(1, "session/prompt",
+        {{"sessionId", sid}, {"prompt", neograph::json::array({
+            neograph::json{{"type", "text"}, {"text", "provider"}}})}}));
+    for (int i = 0; i < 200 && !probe->provider_started.load(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_TRUE(probe->provider_started.load());
+    server.handle_message({{"jsonrpc", "2.0"}, {"method", "session/cancel"},
+                           {"params", {{"sessionId", sid}}}});
+    auto canceled_provider = cap.wait_for_response(1);
+    ASSERT_TRUE(canceled_provider.contains("result"));
+    EXPECT_EQ(canceled_provider["result"].value("stopReason", std::string()),
+              "cancelled");
+    EXPECT_TRUE(probe->provider_cancelled.load());
+
+    probe->provider_release.store(true, std::memory_order_release);
+    const std::string tool_sid = "acp-tool-cancel";
+    server.handle_message(make_request(2, "session/prompt",
+        {{"sessionId", tool_sid}, {"prompt", neograph::json::array({
+            neograph::json{{"type", "text"}, {"text", "tool"}}})}}));
+    for (int i = 0; i < 200 && !probe->tool_started.load(); ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_TRUE(probe->tool_started.load());
+    server.handle_message({{"jsonrpc", "2.0"}, {"method", "session/cancel"},
+                           {"params", {{"sessionId", tool_sid}}}});
+    auto canceled_tool = cap.wait_for_response(2);
+    ASSERT_TRUE(canceled_tool.contains("result"));
+    EXPECT_EQ(canceled_tool["result"].value("stopReason", std::string()),
+              "cancelled");
+    EXPECT_TRUE(probe->tool_cancelled.load());
+}
+
+TEST(ACPServer, CancelAndDestructorDrainWithoutDuplicateResponse) {
+    auto probe = std::make_shared<CancelProbe>();
+    CapturingSink cap;
+    {
+        auto server = std::make_unique<ACPServer>(
+            build_cancel_aware_engine(probe),
+            neograph::json{{"name", "test-acp"}, {"version", "0.0.1"}});
+        server->set_notification_sink(cap.as_sink());
+        const std::string sid = "acp-dtor-cancel";
+        server->handle_message(make_request(7, "session/prompt",
+            {{"sessionId", sid}, {"prompt", neograph::json::array({
+                neograph::json{{"type", "text"}, {"text", "dtor"}}})}}));
+        for (int i = 0; i < 200 && !probe->entered.load(); ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        }
+        ASSERT_TRUE(probe->entered.load());
+        server->handle_message({{"jsonrpc", "2.0"}, {"method", "session/cancel"},
+                                {"params", {{"sessionId", sid}}}});
+    }
+    int responses = 0;
+    for (const auto& env : cap.envs) {
+        if (env.value("id", 0) == 7 && env.contains("result")) ++responses;
+    }
+    EXPECT_EQ(responses, 1);
+    EXPECT_FALSE(probe->completed.load());
 }
 
 TEST(ACPServer, UnknownMethodReturnsMethodNotFound) {

--- a/tests/test_async_http_options.cpp
+++ b/tests/test_async_http_options.cpp
@@ -297,9 +297,12 @@ TEST(RequestOptions, TimeoutTriggers) {
             worker = std::thread([this]{ io.run(); });
         }
         ~StallingServer() {
-            asio::error_code ec;
-            acc.close(ec);
-            io.stop();
+            // The acceptor belongs to the I/O thread. Closing it there lets
+            // the pending accept finish before the thread is joined.
+            asio::post(io, [this] {
+                asio::error_code ec;
+                acc.close(ec);
+            });
             if (worker.joinable()) worker.join();
         }
         asio::awaitable<void> loop() {
@@ -367,9 +370,12 @@ TEST(RequestOptions, PoolTimeoutTriggers) {
             worker = std::thread([this]{ io.run(); });
         }
         ~StallingServer() {
-            asio::error_code ec;
-            acc.close(ec);
-            io.stop();
+            // The acceptor belongs to the I/O thread. Closing it there lets
+            // the pending accept finish before the thread is joined.
+            asio::post(io, [this] {
+                asio::error_code ec;
+                acc.close(ec);
+            });
             if (worker.joinable()) worker.join();
         }
         asio::awaitable<void> loop() {

--- a/tests/test_async_http_stream.cpp
+++ b/tests/test_async_http_stream.cpp
@@ -27,8 +27,10 @@
 #include <atomic>
 #include <chrono>
 #include <exception>
+#include <memory>
 #include <istream>
 #include <string>
+#include <system_error>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -322,6 +324,97 @@ TEST(AsyncHttpOwnership, StreamSnapshotsEndpointAndCallbackBeforeFirstResume) {
 
     EXPECT_EQ(resp.status, 200);
     EXPECT_EQ(received, "owned");
+}
+
+TEST(AsyncHttpOwnership, StreamCancellationOwnsCallbackUntilAwaitableCompletes) {
+    struct SlowStreamServer {
+        asio::io_context io;
+        asio::ip::tcp::acceptor acceptor{io};
+        std::thread worker;
+        unsigned short port = 0;
+
+        SlowStreamServer() {
+            acceptor.open(asio::ip::tcp::v4());
+            acceptor.set_option(asio::ip::tcp::acceptor::reuse_address(true));
+            acceptor.bind(asio::ip::tcp::endpoint(asio::ip::tcp::v4(), 0));
+            acceptor.listen();
+            port = acceptor.local_endpoint().port();
+            asio::co_spawn(io, accept_loop(), asio::detached);
+            worker = std::thread([this] { io.run(); });
+        }
+
+        ~SlowStreamServer() {
+            asio::error_code ec;
+            acceptor.close(ec);
+            io.stop();
+            if (worker.joinable()) worker.join();
+        }
+
+        asio::awaitable<void> accept_loop() {
+            asio::ip::tcp::socket sock{io};
+            asio::error_code ec;
+            co_await acceptor.async_accept(
+                sock, asio::redirect_error(asio::use_awaitable, ec));
+            if (ec) co_return;
+            try {
+                asio::streambuf buf;
+                co_await asio::async_read_until(sock, buf, "\r\n\r\n",
+                                                asio::use_awaitable);
+                asio::steady_timer timer(io);
+                timer.expires_after(std::chrono::milliseconds(200));
+                co_await timer.async_wait(asio::use_awaitable);
+                const std::string resp =
+                    "HTTP/1.1 200 OK\r\n"
+                    "Transfer-Encoding: chunked\r\n"
+                    "Connection: close\r\n\r\n"
+                    "4\r\nlate\r\n"
+                    "0\r\n\r\n";
+                co_await asio::async_write(sock, asio::buffer(resp),
+                                           asio::use_awaitable);
+            } catch (...) { }
+            asio::error_code ignored;
+            sock.close(ignored);
+        }
+    } srv;
+
+    struct CallbackState {
+        std::atomic<int>* chunks;
+        explicit CallbackState(std::atomic<int>* chunks) : chunks(chunks) {}
+        void operator()(std::string_view) const {
+            chunks->fetch_add(1, std::memory_order_relaxed);
+        }
+    };
+
+    asio::io_context io;
+    std::atomic<int> chunks{0};
+    std::weak_ptr<CallbackState> weak_callback;
+
+    asio::awaitable<neograph::async::HttpStreamResponse> operation;
+    {
+        auto callback_state = std::make_shared<CallbackState>(&chunks);
+        weak_callback = callback_state;
+        neograph::async::RequestOptions opts;
+        opts.timeout = std::chrono::milliseconds(25);
+        operation = neograph::async::async_post_stream(
+            io.get_executor(), "127.0.0.1", std::to_string(srv.port),
+            "/v1/stream", "{}", {}, false,
+            [callback_state](std::string_view chunk) {
+                (*callback_state)(chunk);
+            },
+            opts);
+    }
+
+    ASSERT_FALSE(weak_callback.expired())
+        << "stored awaitable must own the callback before first resume";
+
+    auto future = asio::co_spawn(io, std::move(operation), asio::use_future);
+    io.run();
+
+    EXPECT_THROW((void)future.get(), asio::system_error);
+    EXPECT_TRUE(weak_callback.expired())
+        << "cancelled stream should release callback captures on completion";
+    EXPECT_EQ(chunks.load(std::memory_order_relaxed), 0)
+        << "timeout cancellation must not deliver late chunks";
 }
 
 }  // namespace

--- a/tests/test_multi_send_routing.cpp
+++ b/tests/test_multi_send_routing.cpp
@@ -388,3 +388,97 @@ TEST(MultiSendRouting, MixedMultiSendRejectsBatchBeforeValidSiblingRuns) {
     }
     EXPECT_EQ(0, worker_calls->load(std::memory_order_relaxed));
 }
+
+TEST(MultiSendRouting, UnknownSendReportsSameDiagnosticThroughStream) {
+    NodeFactory::instance().register_type("__rt_planner_unknown_stream",
+        [](const std::string&, const json&, const NodeContext&)
+            -> std::unique_ptr<GraphNode> {
+            return std::make_unique<SendTargetPlannerNode>(
+                std::vector<std::string>{"missing_stream_worker"});
+        });
+
+    json def = {
+        {"name", "unknown_stream_send"},
+        {"channels", json::object()},
+        {"nodes", {{"planner", {{"type", "__rt_planner_unknown_stream"}}}}},
+        {"edges", json::array({{{"from", "__start__"}, {"to", "planner"}}})}
+    };
+
+    auto engine = GraphEngine::compile(def, NodeContext{});
+    RunConfig rc;
+    rc.stream_mode = StreamMode::EVENTS | StreamMode::DEBUG;
+
+    int event_count = 0;
+    try {
+        engine->run_stream(rc, [&](const GraphEvent&) { ++event_count; });
+        FAIL() << "streaming run accepted an unknown Send target";
+    } catch (const std::runtime_error& error) {
+        const std::string message = error.what();
+        EXPECT_NE(std::string::npos, message.find("planner"));
+        EXPECT_NE(std::string::npos, message.find("missing_stream_worker"));
+        EXPECT_NE(std::string::npos, message.find("Send invocation index 0"));
+    }
+    EXPECT_GT(event_count, 0)
+        << "regression must exercise run_stream, not just run";
+}
+
+TEST(MultiSendRouting, ResumeAfterInvalidSendDoesNotRecordInvalidTargetCompletion) {
+    NodeFactory::instance().register_type("__rt_setup_invalid_send",
+        [](const std::string&, const json&, const NodeContext&)
+            -> std::unique_ptr<GraphNode> {
+            return std::make_unique<BridgeNode>();
+        });
+    NodeFactory::instance().register_type("__rt_planner_unknown_resume",
+        [](const std::string&, const json&, const NodeContext&)
+            -> std::unique_ptr<GraphNode> {
+            return std::make_unique<SendTargetPlannerNode>(
+                std::vector<std::string>{"missing_resume_worker"});
+        });
+
+    json def = {
+        {"name", "unknown_resume_send"},
+        {"channels", {{"bridged", {{"reducer", "overwrite"}}}}},
+        {"nodes", {
+            {"setup", {{"type", "__rt_setup_invalid_send"}}},
+            {"planner", {{"type", "__rt_planner_unknown_resume"}}}
+        }},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "setup"}},
+            {{"from", "setup"}, {"to", "planner"}}
+        })}
+    };
+
+    auto store = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(def, NodeContext{}, store);
+    RunConfig rc;
+    rc.thread_id = "invalid-send-resume";
+
+    EXPECT_THROW(engine->run(rc), std::runtime_error);
+
+    auto cp = store->load_latest(rc.thread_id);
+    ASSERT_TRUE(cp.has_value());
+    EXPECT_EQ(cp->current_node, "setup");
+
+    auto pending = store->get_writes(rc.thread_id, cp->id);
+    ASSERT_EQ(pending.size(), 1u)
+        << "only the planner result may be pending; no invalid Send target "
+           "task may be recorded as completed";
+    EXPECT_EQ(pending[0].node_name, "planner");
+    EXPECT_EQ(pending[0].sends.size(), 1u);
+    EXPECT_EQ(pending[0].sends[0]["target_node"], "missing_resume_worker");
+
+    try {
+        engine->resume(rc.thread_id);
+        FAIL() << "resume accepted an unknown Send target";
+    } catch (const std::runtime_error& error) {
+        const std::string message = error.what();
+        EXPECT_NE(std::string::npos, message.find("planner"));
+        EXPECT_NE(std::string::npos, message.find("missing_resume_worker"));
+        EXPECT_NE(std::string::npos, message.find("Send invocation index 0"));
+    }
+
+    pending = store->get_writes(rc.thread_id, cp->id);
+    ASSERT_EQ(pending.size(), 1u)
+        << "resume must not add a completed pending write for the invalid target";
+    EXPECT_EQ(pending[0].node_name, "planner");
+}

--- a/tests/test_node_cache.cpp
+++ b/tests/test_node_cache.cpp
@@ -273,3 +273,20 @@ TEST(NodeCache, LegacyEnableResetsReusablePolicy) {
     EXPECT_EQ(counter->load(), 2);
     EXPECT_EQ(engine->node_cache().hit_count(), 0u);
 }
+TEST(NodeCache, DefaultScopePartitionsAutoResume) {
+    auto counter = std::make_shared<std::atomic<int>>(0);
+    auto engine = build_engine_with_node(counter);
+    engine->set_node_cache_enabled("work", true);
+
+    RunConfig cfg;
+    cfg.thread_id = "resume-thread";
+    cfg.input = json::object();
+    cfg.max_steps = 5;
+    engine->run(cfg);
+    cfg.resume_if_exists = true;
+    engine->run(cfg);
+
+    EXPECT_EQ(counter->load(), 2);
+    EXPECT_EQ(engine->node_cache().hit_count(), 0u);
+    EXPECT_EQ(engine->node_cache().miss_count(), 2u);
+}

--- a/tests/test_node_cache.cpp
+++ b/tests/test_node_cache.cpp
@@ -79,11 +79,31 @@ TEST(NodeCache, DisabledByDefault) {
     EXPECT_EQ(engine->node_cache().miss_count(), 0u);
 }
 
+TEST(NodeCache, DefaultScopePartitionsTenants) {
+    auto counter = std::make_shared<std::atomic<int>>(0);
+    auto engine  = build_engine_with_node(counter);
+    engine->set_node_cache_enabled("work", true);
+
+    RunConfig cfg;
+    cfg.input = json::object();
+    cfg.max_steps = 5;
+    cfg.thread_id = "tenant-a";
+    engine->run(cfg);
+    cfg.thread_id = "tenant-b";
+    engine->run(cfg);
+
+    EXPECT_EQ(counter->load(), 2);
+    EXPECT_EQ(engine->node_cache().hit_count(), 0u);
+    EXPECT_EQ(engine->node_cache().miss_count(), 2u);
+    EXPECT_EQ(engine->node_cache().size(), 2u);
+}
+
 TEST(NodeCache, EnabledNodeReplaysCachedResult) {
     auto counter = std::make_shared<std::atomic<int>>(0);
     auto engine  = build_engine_with_node(counter);
 
-    engine->set_node_cache_enabled("work", true);
+    engine->set_node_cache_enabled(
+        "work", true, CacheKeyPolicy{CacheScope::Reusable, {}});
 
     RunConfig cfg;
     cfg.thread_id = "t1";
@@ -171,4 +191,25 @@ TEST(NodeCache, DifferentInputsProduceDifferentEntries) {
     // Different seed inputs → different state hashes → two misses.
     EXPECT_EQ(counter->load(), 2);
     EXPECT_EQ(engine->node_cache().size(), 2u);
+}
+TEST(NodeCache, ReusableScopePartitionsDeclaredContext) {
+    auto counter = std::make_shared<std::atomic<int>>(0);
+    auto engine  = build_engine_with_node(counter);
+    engine->set_node_cache_enabled(
+        "work", true, CacheKeyPolicy{
+            CacheScope::Reusable,
+            [](const RunContext& ctx) { return ctx.thread_id; }});
+
+    RunConfig cfg;
+    cfg.input = json::object();
+    cfg.max_steps = 5;
+    cfg.thread_id = "tenant-a";
+    engine->run(cfg);
+    engine->run(cfg);
+    cfg.thread_id = "tenant-b";
+    engine->run(cfg);
+
+    EXPECT_EQ(counter->load(), 2);
+    EXPECT_EQ(engine->node_cache().hit_count(), 1u);
+    EXPECT_EQ(engine->node_cache().miss_count(), 2u);
 }

--- a/tests/test_node_cache.cpp
+++ b/tests/test_node_cache.cpp
@@ -23,10 +23,20 @@ public:
 
     std::string get_name() const override { return name_; }
 
-    asio::awaitable<NodeOutput> run(NodeInput /*in*/) override {
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
         counter_->fetch_add(1, std::memory_order_relaxed);
+        std::string value = "hit";
+        if (in.ctx.store) {
+            if (auto item = in.ctx.store->get({"cache"}, "value")) {
+                value = item->value.get<std::string>();
+            }
+        }
+        if (in.ctx.tool_gate) {
+            auto decision = co_await in.ctx.tool_gate(ToolCall{}, ToolGateContext{});
+            value = decision.kind == ToolDecision::Kind::Allow ? "allow" : "deny";
+        }
         NodeOutput out;
-        out.writes.push_back(ChannelWrite{"out", json("hit")});
+        out.writes.push_back(ChannelWrite{"out", json(value)});
         co_return out;
     }
 
@@ -212,4 +222,54 @@ TEST(NodeCache, ReusableScopePartitionsDeclaredContext) {
     EXPECT_EQ(counter->load(), 2);
     EXPECT_EQ(engine->node_cache().hit_count(), 1u);
     EXPECT_EQ(engine->node_cache().miss_count(), 2u);
+}
+std::string cached_out(const RunResult& result) {
+    return result.output["channels"]["out"]["value"].get<std::string>();
+}
+
+TEST(NodeCache, DefaultScopePartitionsStoreAndToolGate) {
+    auto counter = std::make_shared<std::atomic<int>>(0);
+    auto engine = build_engine_with_node(counter);
+    engine->set_node_cache_enabled("work", true);
+
+    auto first_store = std::make_shared<InMemoryStore>();
+    first_store->put({"cache"}, "value", "store-a");
+    engine->set_store(first_store);
+    RunConfig cfg;
+    cfg.thread_id = "same-thread";
+    cfg.input = json::object();
+    cfg.max_steps = 5;
+    EXPECT_EQ(cached_out(engine->run(cfg)), "store-a");
+
+    auto second_store = std::make_shared<InMemoryStore>();
+    second_store->put({"cache"}, "value", "store-b");
+    engine->set_store(second_store);
+    EXPECT_EQ(cached_out(engine->run(cfg)), "store-b");
+
+    engine->set_store({});
+    engine->set_tool_gate([](ToolCall, ToolGateContext) -> asio::awaitable<ToolDecision> {
+        co_return ToolDecision::allow();
+    });
+    EXPECT_EQ(cached_out(engine->run(cfg)), "allow");
+    engine->set_tool_gate([](ToolCall, ToolGateContext) -> asio::awaitable<ToolDecision> {
+        co_return ToolDecision::deny("policy-b");
+    });
+    EXPECT_EQ(cached_out(engine->run(cfg)), "deny");
+    EXPECT_EQ(counter->load(), 4);
+    EXPECT_EQ(engine->node_cache().hit_count(), 0u);
+}
+
+TEST(NodeCache, LegacyEnableResetsReusablePolicy) {
+    auto counter = std::make_shared<std::atomic<int>>(0);
+    auto engine = build_engine_with_node(counter);
+    engine->set_node_cache_enabled("work", true, CacheKeyPolicy{CacheScope::Reusable, {}});
+    RunConfig cfg;
+    cfg.input = json::object();
+    cfg.max_steps = 5;
+    engine->run(cfg);
+    engine->set_node_cache_enabled("work", false);
+    engine->set_node_cache_enabled("work", true);
+    engine->run(cfg);
+    EXPECT_EQ(counter->load(), 2);
+    EXPECT_EQ(engine->node_cache().hit_count(), 0u);
 }

--- a/tests/test_openai_provider_async.cpp
+++ b/tests/test_openai_provider_async.cpp
@@ -14,13 +14,17 @@
 #include <gtest/gtest.h>
 #include <neograph/llm/openai_provider.h>
 #include <neograph/async/run_sync.h>
+#include <neograph/graph/cancel.h>
+#include <future>
 
 #define CPPHTTPLIB_OPENSSL_SUPPORT
 #include <httplib.h>
 
 #include <asio/io_context.hpp>
 #include <asio/co_spawn.hpp>
+#include <asio/bind_cancellation_slot.hpp>
 #include <asio/detached.hpp>
+#include <asio/this_coro.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -55,6 +59,7 @@ struct MockServer {
     std::thread     t;
     int             port = 0;
     std::atomic<int> request_count{0};
+    std::atomic<bool> hold{false};
     int             status = 200;
     std::string     body  = kOpenAIBody;
     std::string     retry_after;  // header value when status == 429
@@ -62,6 +67,9 @@ struct MockServer {
     MockServer() {
         const auto handler = [this](const httplib::Request&, httplib::Response& res) {
             request_count.fetch_add(1, std::memory_order_relaxed);
+            while (hold.load(std::memory_order_acquire)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
             res.status = status;
             if (!retry_after.empty()) {
                 res.set_header("Retry-After", retry_after);
@@ -108,6 +116,39 @@ CompletionParams make_params() {
 }
 
 } // namespace
+
+TEST(OpenAIProviderAsync, CancelTokenAbortsLocalProviderSocket) {
+    MockServer mock;
+    mock.hold.store(true, std::memory_order_release);
+    auto provider = llm::OpenAIProvider::create(make_config(mock));
+    auto params = make_params();
+    auto token = std::make_shared<neograph::graph::CancelToken>();
+    params.cancel_token = token;
+
+    asio::io_context io;
+    std::promise<bool> finished;
+    auto result = finished.get_future();
+    asio::co_spawn(io, [&]() -> asio::awaitable<void> {
+        try {
+            token->bind_executor(co_await asio::this_coro::executor);
+            (void)co_await provider->complete_async(params);
+            finished.set_value(false);
+        } catch (...) {
+            finished.set_value(true);
+        }
+    }, asio::bind_cancellation_slot(token->slot(), asio::detached));
+    std::thread runner([&] { io.run(); });
+    for (int i = 0; i < 200 && mock.request_count.load() == 0; ++i) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+    ASSERT_EQ(mock.request_count.load(), 1);
+    token->cancel();
+    ASSERT_EQ(result.wait_for(std::chrono::milliseconds(500)),
+              std::future_status::ready);
+    EXPECT_TRUE(result.get());
+    mock.hold.store(false, std::memory_order_release);
+    runner.join();
+}
 
 TEST(OpenAIProviderAsync, CompleteAsyncReturnsParsedCompletion) {
     MockServer mock;


### PR DESCRIPTION
## Scope

Completes the remaining correctness work from parent tracker #187 in one integration branch.

Related issues: #197, #198, #199, #202, #204, #205, #206, #210.

## Changes

- Wire A2A and ACP cancellation through graph/provider/tool execution, with deterministic cleanup and single terminal completion.
- Make public HTTP awaitables own deferred inputs and add cancellation lifetime coverage plus an ownership benchmark.
- Reject statically known invalid Send targets and extend dynamic-routing coverage.
- Synchronize A2A client shared state and enforce bounded single-flight A2A task admission.
- Generate call-scoped A2A caller message IDs.
- Scope node-cache identity to each execution by default, with explicit reusable-context opt-in.
- Repair sanitizer-discovered ACP callback ownership cycles and asynchronous HTTP test-server teardown races.

## Validation

- `cmake --build /tmp/opencode/neograph-bug-batch-build -j2 && ctest --test-dir /tmp/opencode/neograph-bug-batch-build --output-on-failure -j2`
  - 883 passed, 34 environment-gated tests skipped.
- ASan/UBSan full CTest: 883 passed, 34 environment-gated tests skipped.
- TSan full CTest via `setarch x86_64 -R`: 768 passed, 3 optional live-service tests skipped.
- Pybind build plus full Python suite: 262 passed, 3 skipped.

## Issue Completion

Linked issues intentionally remain open. After merge, update each GitHub checklist with this PR and its verified evidence, then close only after every acceptance criterion is checked.