### PR TITLE
fix(graph): preserve subgraph output deltas

### DIFF
--- a/docs/concepts.ja.md
+++ b/docs/concepts.ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/concepts.md locale=ja source_sha256=a7d9bae682dca57211d6c7ad0795977dc811bd5123934d73e9187a13e89e25f1 -->
+<!-- neograph-i18n: source=docs/concepts.md locale=ja source_sha256=d464b5809d02624a3016c2ae8a6de8ff7d7073fda09ddbd842e3989d7394d498 -->
 # NeoGraph のコアコンセプト — ナラティブガイド
 
 **Languages:** [English](concepts.md) | [한국어](concepts.ko.md) | [日本語](concepts.ja.md) | [简体中文](concepts.zh-CN.md)

--- a/docs/concepts.ko.md
+++ b/docs/concepts.ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/concepts.md locale=ko source_sha256=a7d9bae682dca57211d6c7ad0795977dc811bd5123934d73e9187a13e89e25f1 -->
+<!-- neograph-i18n: source=docs/concepts.md locale=ko source_sha256=d464b5809d02624a3016c2ae8a6de8ff7d7073fda09ddbd842e3989d7394d498 -->
 **Languages:** [English](concepts.md) | [한국어](concepts.ko.md) | [日本語](concepts.ja.md) | [简体中文](concepts.zh-CN.md)
 
 # NeoGraph 핵심 개념 - 서술형 가이드

--- a/docs/concepts.zh-CN.md
+++ b/docs/concepts.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/concepts.md locale=zh-CN source_sha256=a7d9bae682dca57211d6c7ad0795977dc811bd5123934d73e9187a13e89e25f1 -->
+<!-- neograph-i18n: source=docs/concepts.md locale=zh-CN source_sha256=d464b5809d02624a3016c2ae8a6de8ff7d7073fda09ddbd842e3989d7394d498 -->
 # NeoGraph 核心概念——叙事指南
 
 **Languages:** [English](concepts.md) | [한국어](concepts.ko.md) | [日本語](concepts.ja.md) | [简体中文](concepts.zh-CN.md)

--- a/docs/concurrency.ja.md
+++ b/docs/concurrency.ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/concurrency.md locale=ja source_sha256=fe3657f31d0895edf67431f7c6135b418f6677d2d4b8cc90699617f5ab343df8 -->
+<!-- neograph-i18n: source=docs/concurrency.md locale=ja source_sha256=53d5843f1b9147b72df94827ed3d1463c1a60be53f9edff281267ba5b82653f8 -->
 # 同時実行性と非同期性
 
 **Languages:** [English](concurrency.md) | [한국어](concurrency.ko.md) | [日本語](concurrency.ja.md) | [简体中文](concurrency.zh-CN.md)
@@ -165,11 +165,21 @@ log("pending={} active={} completed={} rejected={}",
     s.pending, s.active, s.completed, s.rejected);
 ```
 
-`submit()` は `{accepted, std::future<void>}` を返します: をキャプチャします。
-`RunResult` (上記のような共有出力スロット経由) またはタスクごと
-`std::promise<RunResult>`。キューを支えているのは、
-`moodycamel::ConcurrentQueue` (ロックフリー) と作業員が駐車する
-アイドル時の condvar — ビジースピンなし。
+`submit()` は `{accepted, std::future<void>}` を返します。`RunResult` は共有出力
+スロット（上記）またはタスクごとの `std::promise<RunResult>` で受け渡せます。
+キューはロックフリーの `moodycamel::ConcurrentQueue` を使用し、アイドル中の
+ワーカーは condvar で待機するため busy-spin しません。admission は pending
+スロットを原子的に予約するため、同時呼び出しでも `max_queue_size` を超えません。
+満杯による通常の backpressure は `{false, invalid_future}` を返します。内部の
+enqueue 失敗は代わりに `{false, valid_future}` を返し、その future を監視すると
+`std::runtime_error` が送出されます。
+
+キューは 1 つ以上のワーカーで構築してください。`close()` は冪等で、以後の投入を
+拒否し、ワーカーの終了を待ち、すでにワーカーが取得した callable は完了させ、未取得の
+future はすべて `std::runtime_error("RequestQueue is closed")` で完了させます。
+callable 自身が `close()` を呼んで終了を開始することもできますが、そのワーカーは
+自分自身を待たずに戻ります。デストラクターも同じ close 経路を使うため、teardown 中に
+受理済み future が暗黙に取り残されることはありません。
 
 ## 安全な同時使用のためのルール
 

--- a/docs/concurrency.ko.md
+++ b/docs/concurrency.ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/concurrency.md locale=ko source_sha256=fe3657f31d0895edf67431f7c6135b418f6677d2d4b8cc90699617f5ab343df8 -->
+<!-- neograph-i18n: source=docs/concurrency.md locale=ko source_sha256=53d5843f1b9147b72df94827ed3d1463c1a60be53f9edff281267ba5b82653f8 -->
 **Languages:** [English](concurrency.md) | [한국어](concurrency.ko.md) | [日本語](concurrency.ja.md) | [简体中文](concurrency.zh-CN.md)
 
 # 동시성 및 비동기
@@ -166,11 +166,21 @@ log("pending={} active={} completed={} rejected={}",
     s.pending, s.active, s.completed, s.rejected);
 ```
 
-`submit()`는 `{accepted, std::future<void>}`를 반환합니다.
-공유 출력 슬롯(위와 같음) 또는 작업별을 통한 `RunResult`
-`std::promise<RunResult>`. 대기열은 다음에 의해 지원됩니다.
-`moodycamel::ConcurrentQueue`(잠금 장치 없음) 및 작업자 주차 공간
-유휴 상태일 때 condvar - 바쁜 회전이 없습니다.
+`submit()`는 `{accepted, std::future<void>}`를 반환합니다. `RunResult`는 공유
+출력 슬롯(위 예시)이나 작업별 `std::promise<RunResult>`로 전달할 수 있습니다.
+큐는 lock-free `moodycamel::ConcurrentQueue`를 사용하고, 유휴 작업자는 condvar에서
+대기하므로 busy-spin하지 않습니다. Admission은 pending 슬롯을 원자적으로 예약하므로
+동시 호출자도 `max_queue_size`를 초과할 수 없습니다. 큐가 가득 찬 일반 backpressure는
+`{false, invalid_future}`를 반환합니다. 내부 enqueue 실패는 대신
+`{false, valid_future}`를 반환하며, 해당 future를 관찰하면 `std::runtime_error`가
+발생합니다.
+
+큐는 작업자를 한 명 이상 지정해 생성해야 합니다. `close()`는 멱등적이며 이후 제출을
+거부하고, 작업자가 종료될 때까지 기다리고, 이미 작업자가 가져간 callable은 완료하게
+하며, 아직 가져가지 않은 모든 future는 `std::runtime_error("RequestQueue is closed")`로
+완료합니다. callable 내부에서 `close()`를 호출해 종료를 시작할 수도 있지만 해당 작업자는
+자기 자신을 기다리지 않고 반환합니다. 소멸자도 같은 close 경로를 사용하므로 teardown 중
+승인된 future가 조용히 방치되지 않습니다.
 
 ## 안전한 동시 사용을 위한 규칙
 

--- a/docs/concurrency.zh-CN.md
+++ b/docs/concurrency.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/concurrency.md locale=zh-CN source_sha256=fe3657f31d0895edf67431f7c6135b418f6677d2d4b8cc90699617f5ab343df8 -->
+<!-- neograph-i18n: source=docs/concurrency.md locale=zh-CN source_sha256=53d5843f1b9147b72df94827ed3d1463c1a60be53f9edff281267ba5b82653f8 -->
 # 并发与异步
 
 **Languages:** [English](concurrency.md) | [한국어](concurrency.ko.md) | [日本語](concurrency.ja.md) | [简体中文](concurrency.zh-CN.md)
@@ -125,7 +125,18 @@ log("pending={} active={} completed={} rejected={}",
     s.pending, s.active, s.completed, s.rejected);
 ```
 
-`submit()`返回`{accepted, std::future<void>}`: 捕获`RunResult`通过共享输出槽（如上所述）或每个任务`std::promise<RunResult>`。队列底层使用`moodycamel::ConcurrentQueue`（无锁）并且工作器在闲置时在 condvar 上休眠 - 无忙旋转。
+`submit()` 返回 `{accepted, std::future<void>}`。可以通过共享输出槽（如上）或每任务
+`std::promise<RunResult>` 传递 `RunResult`。队列底层使用无锁
+`moodycamel::ConcurrentQueue`，空闲工作线程在 condvar 上等待，因此不会 busy-spin。
+admission 会原子地预留 pending 槽位，所以并发调用者无法超过 `max_queue_size`。
+队列已满时，普通背压返回 `{false, invalid_future}`；内部 enqueue 失败则返回
+`{false, valid_future}`，观察该 future 时会抛出 `std::runtime_error`。
+
+构造队列时至少要有一个工作线程。`close()` 是幂等的：它拒绝后续提交、等待工作线程
+退出、允许已经被工作线程领取的 callable 完成，并以
+`std::runtime_error("RequestQueue is closed")` 完成所有尚未领取的 future。callable
+本身可以调用 `close()` 发起关闭，但该工作线程会直接返回而不会等待自身。析构函数使用
+同一 close 路径，因此 teardown 期间不会静默遗留已接受的 future。
 
 ## 安全并发使用规则
 

--- a/docs/migration-v0.4-to-v1.0.ja.md
+++ b/docs/migration-v0.4-to-v1.0.ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/migration-v0.4-to-v1.0.md locale=ja source_sha256=5ec95b54abb4ec639a30a3eb4da6cf300fffa1e34c0afc2679b9ecf7272c4709 -->
+<!-- neograph-i18n: source=docs/migration-v0.4-to-v1.0.md locale=ja source_sha256=f63fe99a9d0380a2de9284c52a5f775630d9e9416e53d0071a81873d1feb1462 -->
 # 移行ガイド: レガシー 8 仮想メソッド → `run(NodeInput)` (v0.4.x → v0.9+)
 
 **Languages:** [English](migration-v0.4-to-v1.0.md) | [한국어](migration-v0.4-to-v1.0.ko.md) | [日本語](migration-v0.4-to-v1.0.ja.md) | [简体中文](migration-v0.4-to-v1.0.zh-CN.md)

--- a/docs/migration-v0.4-to-v1.0.ko.md
+++ b/docs/migration-v0.4-to-v1.0.ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/migration-v0.4-to-v1.0.md locale=ko source_sha256=5ec95b54abb4ec639a30a3eb4da6cf300fffa1e34c0afc2679b9ecf7272c4709 -->
+<!-- neograph-i18n: source=docs/migration-v0.4-to-v1.0.md locale=ko source_sha256=f63fe99a9d0380a2de9284c52a5f775630d9e9416e53d0071a81873d1feb1462 -->
 # 이전 안내: 기존 8 가상 함수 → `run(NodeInput)` (v0.4.x → v0.9+)
 
 **Languages:** [English](migration-v0.4-to-v1.0.md) | [한국어](migration-v0.4-to-v1.0.ko.md) | [日本語](migration-v0.4-to-v1.0.ja.md) | [简体中文](migration-v0.4-to-v1.0.zh-CN.md)

--- a/docs/migration-v0.4-to-v1.0.zh-CN.md
+++ b/docs/migration-v0.4-to-v1.0.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/migration-v0.4-to-v1.0.md locale=zh-CN source_sha256=5ec95b54abb4ec639a30a3eb4da6cf300fffa1e34c0afc2679b9ecf7272c4709 -->
+<!-- neograph-i18n: source=docs/migration-v0.4-to-v1.0.md locale=zh-CN source_sha256=f63fe99a9d0380a2de9284c52a5f775630d9e9416e53d0071a81873d1feb1462 -->
 # 迁移指南：旧的 8 个虚函数 → `run(NodeInput)`（v0.4.x → v0.9+）
 
 **Languages:** [English](migration-v0.4-to-v1.0.md) | [한국어](migration-v0.4-to-v1.0.ko.md) | [日本語](migration-v0.4-to-v1.0.ja.md) | [简体中文](migration-v0.4-to-v1.0.zh-CN.md)

--- a/docs/python-binding.ja.md
+++ b/docs/python-binding.ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/python-binding.md locale=ja source_sha256=b40776921ea20e60f80d2d186f1cee9ac1c3eb8c53e7fe2bdd85ed6782f83064 -->
+<!-- neograph-i18n: source=docs/python-binding.md locale=ja source_sha256=60b0675d8856a38a51c9eaa809e78f39c236d2c2977b14b62d69bc8ccb7fb217 -->
 # Python バインディング
 
 **Languages:** [English](python-binding.md) | [한국어](python-binding.ko.md) | [日本語](python-binding.ja.md) | [简体中文](python-binding.zh-CN.md)

--- a/docs/python-binding.ko.md
+++ b/docs/python-binding.ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/python-binding.md locale=ko source_sha256=b40776921ea20e60f80d2d186f1cee9ac1c3eb8c53e7fe2bdd85ed6782f83064 -->
+<!-- neograph-i18n: source=docs/python-binding.md locale=ko source_sha256=60b0675d8856a38a51c9eaa809e78f39c236d2c2977b14b62d69bc8ccb7fb217 -->
 **Languages:** [English](python-binding.md) | [한국어](python-binding.ko.md) | [日本語](python-binding.ja.md) | [简体中文](python-binding.zh-CN.md)
 
 # 파이썬 바인딩

--- a/docs/python-binding.zh-CN.md
+++ b/docs/python-binding.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/python-binding.md locale=zh-CN source_sha256=b40776921ea20e60f80d2d186f1cee9ac1c3eb8c53e7fe2bdd85ed6782f83064 -->
+<!-- neograph-i18n: source=docs/python-binding.md locale=zh-CN source_sha256=60b0675d8856a38a51c9eaa809e78f39c236d2c2977b14b62d69bc8ccb7fb217 -->
 # Python 绑定
 
 **Languages:** [English](python-binding.md) | [한국어](python-binding.ko.md) | [日本語](python-binding.ja.md) | [简体中文](python-binding.zh-CN.md)

--- a/docs/reference-en.md
+++ b/docs/reference-en.md
@@ -1090,9 +1090,17 @@ public:
 | `name` | `std::string` | Node name in the parent graph |
 | `subgraph` | `std::shared_ptr<GraphEngine>` | The compiled child graph engine |
 | `input_map` | `std::map<std::string, std::string>` | `parent_channel -> child_channel` mapping. Read from parent, write to child input |
-| `output_map` | `std::map<std::string, std::string>` | `child_channel -> parent_channel` mapping. Read from child result, write to parent |
+| `output_map` | `std::map<std::string, std::string>` | `child_channel -> parent_channel` mapping. Rename and forward child-produced write deltas to the parent |
 
 If the maps are empty, channels are mapped by name (identity mapping).
+
+Input mapping copies the parent's current channel values into the child's input.
+Output mapping is deliberately different: it forwards the child's ordered
+`ChannelWrite` deltas, preserving each write's `Mode`, rather than treating the
+child's final serialized state as a new reducer input. Consequently inherited
+append/custom values are not applied twice. Output mapping does not infer
+snapshot replacement; a child must emit `ChannelWrite::Mode::Overwrite` when it
+intends to replace the mapped parent value.
 
 #### Runtime-context propagation
 

--- a/docs/reference-ja.md
+++ b/docs/reference-ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/reference-en.md locale=ja source_sha256=6780e2507de2b228368944012cc9ad6c04e504aced4b69b172f87ef51e90ff69 -->
+<!-- neograph-i18n: source=docs/reference-en.md locale=ja source_sha256=b39068ee8e2c2a525841913e920f7115f35ecbb40d153c6d2cc7866510bfca37 -->
 # NeoGraph API — ナラティブツアー
 **Languages:** [English](reference-en.md) | [한국어](reference-ko.md) | [日本語](reference-ja.md) | [简体中文](reference-zh-CN.md)
 この文書は NeoGraph の公開 API を順に案内する **ナラティブツアー** であり、
@@ -906,8 +906,31 @@ public:
 | `name` | `std::string` | 親グラフ内のノード名 |
 | `subgraph` | `std::shared_ptr<GraphEngine>` | コンパイル済みの子グラフエンジン |
 | `input_map` | `std::map<std::string, std::string>` | `parent_channel -> child_channel` の対応付け。親から読み、子の入力へ書き込みます |
-| `output_map` | `std::map<std::string, std::string>` | `child_channel -> parent_channel` の対応付け。子の結果から読み、親へ書き込みます |
+| `output_map` | `std::map<std::string, std::string>` | `child_channel -> parent_channel` の対応付け。子が生成した write delta のチャネル名を変更して親へ転送します |
 マップが空の場合、チャネルは名前でマッピングされます (identity mapping)。
+
+入力マッピングは親の現在のチャネル値を子の入力へコピーします。出力マッピングは
+意図的に異なり、子の最終シリアライズ状態を新しい reducer 入力として扱わず、子が
+生成した順序で `ChannelWrite` delta を転送して各 write の `Mode` を保持します。
+そのため、継承した append/custom 値が二重に適用されません。出力マッピングは
+snapshot replacement を推論しません。マッピング先の親値を置き換える場合、子は
+`ChannelWrite::Mode::Overwrite` を明示的に送出する必要があります。
+
+#### ランタイムコンテキストの伝播
+
+`SubgraphNode` はエンジン境界で子の実行コンテキストを派生させます。公開
+`RunContext` のレイアウトは変更しません。
+
+| コンテキスト値 | 子での意味 |
+|---------------|-----------------|
+| `cancel_token` | 子操作用トークンを作成するため、親のキャンセルはすべての子と孫へ届きます。 |
+| `usage`, `deadline`, `trace_id`, `stream_mode` | 継承します。`deadline` と `trace_id` は `RunMetadata` 由来で、子は親の stream mode を広げられません。 |
+| `thread_id` | 親 thread ID が空でなければ、親 ID、subgraph ノード名、super-step、invocation identity から決定的に派生します。そのため sibling `Send` 呼び出しは別々の checkpoint identity を得ます。親 thread ID が空なら子もスコープなしとなり checkpointing は無効です。 |
+| `step` | 子実行にローカルで、子 checkpoint または 0 から始まります。 |
+| `store` | 親 Store があれば継承し、なければ子エンジンに設定された Store を維持します。 |
+| Tool policy | 親 `ToolGate` が子の gate より先に実行されます。子は許可された呼び出しをさらに制限または rewrite できますが、親の deny/interrupt は回避できません。 |
+| Checkpoint backend and resume value | 親 backend があれば継承し、なければ子の backend を維持します。親 resume は派生した子 checkpoint identity が存在する場合のみ子 checkpoint を resume し、null でない resume value を転送します。Checkpoint routing は公開 `RunContext` フィールドではなく内部実装です。 |
+
 ---
 ## 7. GraphEngine
 **ヘッダー:** `<neograph/graph/engine.h>`
@@ -962,18 +985,22 @@ struct RunConfig {
 | `usage` | `std::shared_ptr<UsageAccumulator>` | `nullptr` | 任意のトークン集計器。省略時はエンジンが作成し、実行中の集計器を `in.ctx.usage` として公開します |
 | `resume_if_exists` | `bool` | `false` | `true` かつ `thread_id` のチェックポイントが存在する場合、`input` を適用する前にそこから初期化します (複数ターンのチャット形状) |
 ### RunContext (v0.4 PR 1、`NodeInput.ctx` 経由でノードに公開)
-エンジンが実行ごとに運ぶディスパッチメタデータです。`RunConfig`、エンジンの Store、指定がなければ新しく作成される使用量アキュムレーター、任意の再開値から構築されます。ノードは `run(NodeInput) -> NodeOutput` のオーバーライド内で `in.ctx` 経由で利用します。
+エンジンが実行ごとに運ぶディスパッチメタデータです。`RunConfig`（未指定時は新しい
+usage accumulator を作成）、`RunMetadata`、有効な Store、任意の resume value
+から構築されます。ノードは `run(NodeInput) -> NodeOutput` のオーバーライド内で
+`in.ctx` 経由で利用します。
 ```cpp
 struct RunContext {
     std::shared_ptr<CancelToken>  cancel_token;
     std::shared_ptr<UsageAccumulator> usage;
-    std::optional<std::chrono::steady_clock::time_point> deadline; // reserved
-    std::string                   trace_id;     // reserved
+    std::optional<std::chrono::steady_clock::time_point> deadline;
+    std::string                   trace_id;
     std::string                   thread_id;
     int                           step;
     StreamMode                    stream_mode;
     std::optional<json>           resume_value;
     std::shared_ptr<Store>        store;
+    ToolGate                      tool_gate;
 };
 ```
 
@@ -981,13 +1008,14 @@ struct RunContext {
 |-------|-------------|
 | `cancel_token` | 実行中のトークン。`provider.complete(params)` に渡すと、キャンセル時に LLM HTTP ソケットを中断できます。独自ループでは `is_cancelled()` をポーリングします |
 | `usage` | エンジンが値を入れる共有トークン集計先 |
-| `deadline` | 予約済み (まだ `RunConfig.deadline` フィールドはありません) |
-| `trace_id` | OTel 連携用に予約済み |
+| `deadline` | C++ `RunMetadata` から渡される任意の絶対 deadline |
+| `trace_id` | C++ `RunMetadata` から渡される任意の trace correlator |
 | `thread_id` | `RunConfig.thread_id` を反映します |
 | `step` | 現在のスーパーステップ番号。反復ごとに更新されます |
 | `stream_mode` | `RunConfig.stream_mode` を反映します |
 | `resume_value` | `GraphEngine::resume()` に渡された値。新規実行では空です |
 | `store` | エンジンに設定された Store。未設定の場合は `nullptr` |
+| `tool_gate` | 継承された親ポリシーを含む、この invocation の有効なポリシー |
 ### CancelToken
 呼び出し側とエンジンで共有する協調的なキャンセル基本単位です。`std::make_shared<CancelToken>()` で作成し、`RunConfig.cancel_token` に渡して、
 実行中のスレッドから `cancel()` を呼ぶと実行を中断できます。
@@ -1334,9 +1362,15 @@ std::vector<Checkpoint> get_state_history(const std::string& thread_id,
 void update_state(const std::string& thread_id,
                   const json& channel_writes,
                   const std::string& as_node = "");
+
+void update_state_writes(const std::string& thread_id,
+                         const std::vector<ChannelWrite>& channel_writes,
+                         const std::string& as_node = "");
 ```
 
-チャネル書き込みを適用してスレッドの状態を手動更新し、更新済み状態で新しいチェックポイントを作成します。
+チャネル write を適用してスレッド状態を手動更新します。JSON object 形式はチャネル名ごとに
+reducer write を適用します。`ChannelWrite` vector 形式は write 順序と明示的な overwrite
+mode を保持します。どちらも更新済み状態で新しい checkpoint を作成します。
 | パラメーター | 型 | 説明 |
 |-----------|------|-------------|
 | `thread_id` | `std::string` | 対象スレッド |
@@ -2541,12 +2575,13 @@ public:
     struct Stats {
         size_t pending;        // Tasks waiting in queue
         size_t active;         // Tasks currently executing
-        size_t completed;      // Total completed tasks
-        size_t rejected;       // Tasks rejected due to full queue
+        size_t completed;      // Total settled tasks, including cancellation
+        size_t rejected;       // Tasks rejected during admission
         size_t num_workers;    // Number of worker threads
         size_t max_queue_size; // Maximum queue capacity
     };
 
+    // num_workers must be greater than zero.
     RequestQueue(size_t num_workers = 128, size_t max_queue_size = 10000);
     ~RequestQueue();
 
@@ -2554,10 +2589,15 @@ public:
     RequestQueue(const RequestQueue&) = delete;
     RequestQueue& operator=(const RequestQueue&) = delete;
 
-    // Submit a task. Returns {accepted, future}.
-    // If the queue is full, returns {false, invalid_future}.
+    // Submit a task. Concurrent callers cannot exceed max_queue_size.
+    // A full queue returns {false, invalid_future}; an internal enqueue
+    // failure returns {false, valid_future}, which throws on get().
     template<typename F>
     std::pair<bool, std::future<void>> submit(F&& task);
+
+    // Idempotently reject new work, cancel queued tasks, and wait for workers.
+    void close();
+    bool is_closed() const noexcept;
 
     // Get current queue statistics
     Stats stats() const;
@@ -2566,11 +2606,13 @@ public:
 
 | コンストラクターパラメーター | 型 | デフォルト | 説明 |
 |-----------------------|------|---------|-------------|
-| `num_workers` | `size_t` | `128` | プール内のワーカースレッド数 |
+| `num_workers` | `size_t` | `128` | プール内のワーカースレッド数。0 は `std::invalid_argument` を送出 |
 | `max_queue_size` | `size_t` | `10000` | 保留できるタスクの最大数。超過分は拒否 |
 | メソッド | 説明 |
 |--------|-------------|
-| `submit(task)` | 呼び出し可能オブジェクトをキューへ追加。受理時は `first=true`、満杯時は `false` (バックプレッシャー)。`second` は完了時に解決する、または例外を伝播する `std::future<void>` |
+| `submit(task)` | pending capacity を原子的に予約してから callable を enqueue します。受理時は `first=true`。満杯または閉じたキューは invalid future と `false` を返し、内部 enqueue 失敗はエラーを伝播する valid future と `false` を返します。受理済み future は完了時に解決するかタスク例外を伝播します。 |
+| `close()` | 新しい作業を冪等に拒否します。外部呼び出しは全 worker の終了を待ち、未取得作業は `std::runtime_error("RequestQueue is closed")` で完了します。取得済み callable は完了できます。callable 自身が `close()` を呼んで終了を開始できますが、自分自身は待ちません。 |
+| `is_closed()` | `close()` が新しい作業の拒否を開始したか報告します。 |
 | `stats()` | 現在のキュー統計のスナップショットを返す |
 キュー内部ではロックフリーの enqueue/dequeue に `moodycamel::ConcurrentQueue` を使い、
 条件変数でアイドル状態のワーカーを起こします。

--- a/docs/reference-ko.md
+++ b/docs/reference-ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/reference-en.md locale=ko source_sha256=6780e2507de2b228368944012cc9ad6c04e504aced4b69b172f87ef51e90ff69 -->
+<!-- neograph-i18n: source=docs/reference-en.md locale=ko source_sha256=b39068ee8e2c2a525841913e920f7115f35ecbb40d153c6d2cc7866510bfca37 -->
 # NeoGraph API — 내러티브 투어
 
 **Languages:** [English](reference-en.md) | [한국어](reference-ko.md) | [日本語](reference-ja.md) | [简体中文](reference-zh-CN.md)
@@ -1089,9 +1089,31 @@ public:
 | `name` | `std::string` | Node name in the parent graph |
 | `subgraph` | `std::shared_ptr<GraphEngine>` | The compiled child graph engine |
 | `input_map` | `std::map<std::string, std::string>` | `parent_channel -> child_channel` mapping. Read from parent, write to child input |
-| `output_map` | `std::map<std::string, std::string>` | `child_channel -> parent_channel` mapping. Read from child result, write to parent |
+| `output_map` | `std::map<std::string, std::string>` | `child_channel -> parent_channel` 매핑. 자식이 생성한 write delta의 채널명을 바꿔 부모로 전달 |
 
-If the maps are empty, channels are mapped by name (identity mapping).
+맵이 비어 있으면 채널 이름을 그대로 사용하는 identity mapping이 적용됩니다.
+
+입력 매핑은 부모의 현재 채널 값을 자식 입력으로 복사합니다. 출력 매핑은 의도적으로
+다르게 동작합니다. 자식의 최종 직렬화 상태를 새 reducer 입력으로 취급하지 않고, 자식이
+생성한 순서대로 `ChannelWrite` delta를 전달하며 각 write의 `Mode`를 보존합니다. 따라서
+상속된 append/custom 값이 두 번 적용되지 않습니다. 출력 매핑은 snapshot replacement를
+추론하지 않습니다. 매핑된 부모 값을 교체하려면 자식이 명시적으로
+`ChannelWrite::Mode::Overwrite`를 내보내야 합니다.
+
+#### 런타임 컨텍스트 전파
+
+`SubgraphNode`는 엔진 경계에서 자식 실행 컨텍스트를 파생합니다. 공개 `RunContext`
+레이아웃은 변경하지 않습니다.
+
+| 컨텍스트 값 | 자식 의미 |
+|---------------|-----------------|
+| `cancel_token` | 하위 작업 토큰을 생성하므로 부모 취소가 모든 자식과 손자에 도달합니다. |
+| `usage`, `deadline`, `trace_id`, `stream_mode` | 상속됩니다. `deadline`과 `trace_id`는 `RunMetadata`에서 오며, 자식은 부모의 stream mode를 넓힐 수 없습니다. |
+| `thread_id` | 부모 thread ID가 비어 있지 않으면 부모 ID, subgraph 노드명, super-step, invocation identity에서 결정적으로 파생합니다. 따라서 sibling `Send` 호출은 서로 다른 checkpoint identity를 받습니다. 빈 부모 thread ID는 자식도 scope 없이 유지해 checkpointing을 비활성화합니다. |
+| `step` | 자식 실행에 로컬이며 자식 checkpoint 또는 0에서 시작합니다. |
+| `store` | 부모 Store가 있으면 상속하고, 없으면 자식 엔진에 설정된 Store를 유지합니다. |
+| Tool policy | 부모 `ToolGate`가 자식 gate보다 먼저 실행됩니다. 자식은 허용된 호출을 더 제한하거나 rewrite할 수 있지만 부모 deny/interrupt를 우회할 수 없습니다. |
+| Checkpoint backend and resume value | 부모 backend가 있으면 상속하고, 없으면 자식 backend를 유지합니다. 부모 resume은 파생된 자식 checkpoint identity가 존재할 때만 해당 자식 checkpoint를 resume하며 null이 아닌 resume value를 전달합니다. Checkpoint routing은 공개 `RunContext` 필드가 아니라 내부 구현입니다. |
 
 ---
 
@@ -1160,22 +1182,22 @@ struct RunConfig {
 
 ### RunContext (v0.4 PR 1, exposed to nodes via `NodeInput.ctx`)
 
-Per-run dispatch metadata threaded by the engine. Constructed from `RunConfig`
-(with a new usage accumulator when none was supplied), the engine's Store,
-and an optional resume value. Nodes consume it inside a
-`run(NodeInput) -> NodeOutput` override via `in.ctx`.
+엔진이 전달하는 실행별 dispatch metadata입니다. `RunConfig`(미지정 시 새 usage
+accumulator 포함), `RunMetadata`, 유효 Store, 선택적 resume value로 구성합니다.
+노드는 `run(NodeInput) -> NodeOutput` override 안에서 `in.ctx`로 사용합니다.
 
 ```cpp
 struct RunContext {
     std::shared_ptr<CancelToken>  cancel_token;
     std::shared_ptr<UsageAccumulator> usage;
-    std::optional<std::chrono::steady_clock::time_point> deadline; // reserved
-    std::string                   trace_id;     // reserved
+    std::optional<std::chrono::steady_clock::time_point> deadline;
+    std::string                   trace_id;
     std::string                   thread_id;
     int                           step;
     StreamMode                    stream_mode;
     std::optional<json>           resume_value;
     std::shared_ptr<Store>        store;
+    ToolGate                      tool_gate;
 };
 ```
 
@@ -1183,13 +1205,14 @@ struct RunContext {
 |-------|-------------|
 | `cancel_token` | The active token. Pass to `provider.complete(params)` so an LLM HTTP socket aborts on cancel, or poll `is_cancelled()` for your own loops |
 | `usage` | Shared token-accounting sink populated by the engine |
-| `deadline` | Reserved (no `RunConfig.deadline` field yet) |
-| `trace_id` | Reserved for OTel integration |
+| `deadline` | C++ `RunMetadata`의 선택적 절대 deadline |
+| `trace_id` | C++ `RunMetadata`의 선택적 trace correlator |
 | `thread_id` | Mirror of `RunConfig.thread_id` |
 | `step` | Current super-step index, updated each iteration |
 | `stream_mode` | Mirror of `RunConfig.stream_mode` |
 | `resume_value` | Value supplied to `GraphEngine::resume()`, or empty on a fresh run |
 | `store` | Store installed on the engine, or `nullptr` when none is configured |
+| `tool_gate` | 상속된 부모 정책을 포함해 이 invocation에 적용되는 유효 정책 |
 
 ### CancelToken
 
@@ -1584,10 +1607,15 @@ Returns the checkpoint history for a thread, ordered by timestamp (newest first)
 void update_state(const std::string& thread_id,
                   const json& channel_writes,
                   const std::string& as_node = "");
+
+void update_state_writes(const std::string& thread_id,
+                         const std::vector<ChannelWrite>& channel_writes,
+                         const std::string& as_node = "");
 ```
 
-Manually updates the state for a thread by applying channel writes. Creates a new
-checkpoint with the updated state.
+채널 write를 적용해 thread 상태를 수동으로 갱신합니다. JSON object 형식은 채널명별
+reducer write를 적용합니다. `ChannelWrite` vector 형식은 write 순서와 명시적 overwrite
+mode를 보존합니다. 두 형식 모두 갱신된 상태로 새 checkpoint를 생성합니다.
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
@@ -3028,12 +3056,13 @@ public:
     struct Stats {
         size_t pending;        // Tasks waiting in queue
         size_t active;         // Tasks currently executing
-        size_t completed;      // Total completed tasks
-        size_t rejected;       // Tasks rejected due to full queue
+        size_t completed;      // Total settled tasks, including cancellation
+        size_t rejected;       // Tasks rejected during admission
         size_t num_workers;    // Number of worker threads
         size_t max_queue_size; // Maximum queue capacity
     };
 
+    // num_workers must be greater than zero.
     RequestQueue(size_t num_workers = 128, size_t max_queue_size = 10000);
     ~RequestQueue();
 
@@ -3041,10 +3070,15 @@ public:
     RequestQueue(const RequestQueue&) = delete;
     RequestQueue& operator=(const RequestQueue&) = delete;
 
-    // Submit a task. Returns {accepted, future}.
-    // If the queue is full, returns {false, invalid_future}.
+    // Submit a task. Concurrent callers cannot exceed max_queue_size.
+    // A full queue returns {false, invalid_future}; an internal enqueue
+    // failure returns {false, valid_future}, which throws on get().
     template<typename F>
     std::pair<bool, std::future<void>> submit(F&& task);
+
+    // Idempotently reject new work, cancel queued tasks, and wait for workers.
+    void close();
+    bool is_closed() const noexcept;
 
     // Get current queue statistics
     Stats stats() const;
@@ -3053,12 +3087,14 @@ public:
 
 | Constructor Parameter | Type | Default | Description |
 |-----------------------|------|---------|-------------|
-| `num_workers` | `size_t` | `128` | Number of worker threads in the pool |
+| `num_workers` | `size_t` | `128` | Worker thread 수. 0이면 `std::invalid_argument` 발생 |
 | `max_queue_size` | `size_t` | `10000` | Maximum number of pending tasks. Tasks beyond this limit are rejected |
 
 | Method | Description |
 |--------|-------------|
-| `submit(task)` | Enqueues a callable. Returns a pair: `first` is `true` if accepted (or `false` if the queue is full -- backpressure), `second` is a `std::future<void>` that resolves when the task completes or propagates exceptions |
+| `submit(task)` | pending capacity를 원자적으로 예약한 뒤 callable을 enqueue합니다. 수락되면 `first`가 `true`입니다. 가득 찼거나 닫힌 큐는 invalid future와 함께 `false`를 반환하고, 내부 enqueue 실패는 오류를 전파하는 valid future와 함께 `false`를 반환합니다. 수락된 future는 작업 완료 시 resolve되거나 작업 예외를 전파합니다. |
+| `close()` | 멱등적으로 새 작업을 거부합니다. 외부 호출자는 모든 worker 종료를 기다리고, 가져가지 않은 작업은 `std::runtime_error("RequestQueue is closed")`로 완료됩니다. 이미 가져간 callable은 완료할 수 있습니다. callable이 `close()`를 호출해 종료를 시작할 수 있지만 자기 자신을 기다리지는 않습니다. |
+| `is_closed()` | `close()`가 새 작업 거부를 시작했는지 보고합니다. |
 | `stats()` | Returns a snapshot of current queue statistics |
 
 The queue uses `moodycamel::ConcurrentQueue` internally for lock-free enqueue/dequeue

--- a/docs/reference-zh-CN.md
+++ b/docs/reference-zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/reference-en.md locale=zh-CN source_sha256=6780e2507de2b228368944012cc9ad6c04e504aced4b69b172f87ef51e90ff69 -->
+<!-- neograph-i18n: source=docs/reference-en.md locale=zh-CN source_sha256=b39068ee8e2c2a525841913e920f7115f35ecbb40d153c6d2cc7866510bfca37 -->
 # NeoGraph API — 叙述式导览
 
 **Languages:** [English](reference-en.md) | [한국어](reference-ko.md) | [日本語](reference-ja.md) | [简体中文](reference-zh-CN.md)
@@ -1063,9 +1063,29 @@ public:
 | `name` | `std::string` | 父图中的节点名称 |
 | `subgraph` | `std::shared_ptr<GraphEngine>` | 编译后的子图引擎 |
 | `input_map` | `std::map<std::string, std::string>` | `parent_channel -> child_channel` 映射。从父读取，写入子输入 |
-| `output_map` | `std::map<std::string, std::string>` | `child_channel -> parent_channel` 映射。从子结果读取，写入父 |
+| `output_map` | `std::map<std::string, std::string>` | `child_channel -> parent_channel` 映射。重命名子图生成的 write delta 并转发到父图 |
 
 如果映射为空，通道按名称映射（恒等映射）。
+
+输入映射会把父图当前的通道值复制到子图输入。输出映射有意采用不同语义：它不会把
+子图最终序列化状态当作新的 reducer 输入，而是按生成顺序转发子图的
+`ChannelWrite` delta，并保留每个 write 的 `Mode`。因此，继承的 append/custom
+值不会被重复应用。输出映射不会推断 snapshot replacement；若要替换映射后的父值，
+子图必须显式发出 `ChannelWrite::Mode::Overwrite`。
+
+#### 运行时上下文传播
+
+`SubgraphNode` 在引擎边界派生子执行上下文，不改变公开 `RunContext` 的布局。
+
+| 上下文值 | 子图语义 |
+|---------------|-----------------|
+| `cancel_token` | 创建子操作 token，因此父取消会到达所有子图和孙图。 |
+| `usage`, `deadline`, `trace_id`, `stream_mode` | 继承。`deadline` 和 `trace_id` 来自 `RunMetadata`；子图不能扩大父图的 stream mode。 |
+| `thread_id` | 父 thread ID 非空时，根据父 ID、subgraph 节点名、super-step 和 invocation identity 确定性派生。因此 sibling `Send` 调用获得不同的 checkpoint identity。空父 thread ID 会让子图保持无作用域并禁用 checkpointing。 |
+| `step` | 子执行本地值，从子 checkpoint 或 0 开始。 |
+| `store` | 存在父 Store 时继承，否则保留子引擎配置的 Store。 |
+| Tool policy | 父 `ToolGate` 先于子 gate 运行。子图可以进一步限制或 rewrite 已允许的调用，但不能绕过父 deny/interrupt。 |
+| Checkpoint backend and resume value | 存在父 backend 时继承，否则保留子 backend。只有派生的子 checkpoint identity 存在时，父 resume 才会 resume 对应子 checkpoint，并转发非 null resume value。Checkpoint routing 是内部实现，不是公开 `RunContext` 字段。 |
 
 ---
 
@@ -1132,21 +1152,22 @@ struct RunConfig {
 
 ### RunContext（v0.4 PR 1，通过 `NodeInput.ctx` 暴露给节点）
 
-引擎传递的每次运行分发元数据。由 `RunConfig` 构造（当未提供时带有新的
-用法累加器）、引擎的 Store 和可选的恢复值。节点在 `run(NodeInput) ->
-NodeOutput` 重写中通过 `in.ctx` 消费它。
+引擎传递的每次运行分发元数据。由 `RunConfig`（未提供时创建新的 usage
+累加器）、`RunMetadata`、有效 Store 和可选 resume value 构造。节点在
+`run(NodeInput) -> NodeOutput` 重写中通过 `in.ctx` 使用它。
 
 ```cpp
 struct RunContext {
     std::shared_ptr<CancelToken>  cancel_token;
     std::shared_ptr<UsageAccumulator> usage;
-    std::optional<std::chrono::steady_clock::time_point> deadline; // reserved
-    std::string                   trace_id;     // reserved
+    std::optional<std::chrono::steady_clock::time_point> deadline;
+    std::string                   trace_id;
     std::string                   thread_id;
     int                           step;
     StreamMode                    stream_mode;
     std::optional<json>           resume_value;
     std::shared_ptr<Store>        store;
+    ToolGate                      tool_gate;
 };
 ```
 
@@ -1154,13 +1175,14 @@ struct RunContext {
 |-------|-------------|
 | `cancel_token` | 活跃 token。传递给 `provider.complete(params)`，使 LLM HTTP 套接字在取消时中止，或轮询 `is_cancelled()` 用于自己的循环 |
 | `usage` | 引擎填充的共享 token-记账接收器 |
-| `deadline` | 保留（尚无 `RunConfig.deadline` 字段） |
-| `trace_id` | 为 OTel 集成保留 |
+| `deadline` | 来自 C++ `RunMetadata` 的可选绝对 deadline |
+| `trace_id` | 来自 C++ `RunMetadata` 的可选 trace correlator |
 | `thread_id` | `RunConfig.thread_id` 的镜像 |
 | `step` | 当前超级步骤索引，每次迭代更新 |
 | `stream_mode` | `RunConfig.stream_mode` 的镜像 |
 | `resume_value` | 提供给 `GraphEngine::resume()` 的值，或在新运行时为空 |
 | `store` | 安装在引擎上的 Store，或在未配置时为 `nullptr` |
+| `tool_gate` | 此 invocation 的有效策略，包括继承的父策略 |
 
 ### CancelToken
 
@@ -1543,9 +1565,15 @@ std::vector<Checkpoint> get_state_history(const std::string& thread_id,
 void update_state(const std::string& thread_id,
                   const json& channel_writes,
                   const std::string& as_node = "");
+
+void update_state_writes(const std::string& thread_id,
+                         const std::vector<ChannelWrite>& channel_writes,
+                         const std::string& as_node = "");
 ```
 
-通过应用通道写入手动更新线程的状态。使用更新后的状态创建新的检查点。
+通过应用通道 write 手动更新线程状态。JSON object 形式按通道名应用 reducer write。
+`ChannelWrite` vector 形式保留 write 顺序和显式 overwrite mode。两种形式都会使用
+更新后的状态创建新 checkpoint。
 
 | 参数 | 类型 | 描述 |
 |-----------|------|-------------|
@@ -2952,12 +2980,13 @@ public:
     struct Stats {
         size_t pending;        // Tasks waiting in queue
         size_t active;         // Tasks currently executing
-        size_t completed;      // Total completed tasks
-        size_t rejected;       // Tasks rejected due to full queue
+        size_t completed;      // Total settled tasks, including cancellation
+        size_t rejected;       // Tasks rejected during admission
         size_t num_workers;    // Number of worker threads
         size_t max_queue_size; // Maximum queue capacity
     };
 
+    // num_workers must be greater than zero.
     RequestQueue(size_t num_workers = 128, size_t max_queue_size = 10000);
     ~RequestQueue();
 
@@ -2965,10 +2994,15 @@ public:
     RequestQueue(const RequestQueue&) = delete;
     RequestQueue& operator=(const RequestQueue&) = delete;
 
-    // Submit a task. Returns {accepted, future}.
-    // If the queue is full, returns {false, invalid_future}.
+    // Submit a task. Concurrent callers cannot exceed max_queue_size.
+    // A full queue returns {false, invalid_future}; an internal enqueue
+    // failure returns {false, valid_future}, which throws on get().
     template<typename F>
     std::pair<bool, std::future<void>> submit(F&& task);
+
+    // Idempotently reject new work, cancel queued tasks, and wait for workers.
+    void close();
+    bool is_closed() const noexcept;
 
     // Get current queue statistics
     Stats stats() const;
@@ -2977,12 +3011,14 @@ public:
 
 | Constructor 参数 | 类型 | 默认值 | 描述 |
 |-----------------------|------|---------|-------------|
-| `num_workers` | `size_t` | `128` | 工作线程池中的线程数 |
+| `num_workers` | `size_t` | `128` | 工作线程池中的线程数；0 会抛出 `std::invalid_argument` |
 | `max_queue_size` | `size_t` | `10000` | 待处理任务的最大数量。超过该上限的任务会被拒绝 |
 
 | 方法 | 描述 |
 |--------|-------------|
-| `submit(task)` | 将可调用对象入队。返回一对值：接受时 `first` 为 `true`（队列已满、发生背压时为 `false`），任务完成或传播异常时 `second` 对应的 `std::future<void>` 会就绪 |
+| `submit(task)` | 原子预留 pending capacity 后将 callable 入队。接受时 `first` 为 `true`。已满或已关闭的队列返回 `false` 和 invalid future；内部 enqueue 失败返回 `false` 和可传播错误的 valid future。已接受的 future 在任务完成时就绪或传播任务异常。 |
+| `close()` | 幂等地拒绝新工作。外部调用者等待所有 worker 退出，未领取的工作以 `std::runtime_error("RequestQueue is closed")` 完成。已领取 callable 可完成。callable 可以调用 `close()` 发起关闭，但不会等待自身。 |
+| `is_closed()` | 报告 `close()` 是否已开始拒绝新工作。 |
 | `stats()` | 返回当前队列统计信息的快照 |
 
 队列内部使用 `moodycamel::ConcurrentQueue` 实现无锁入队/出队，

--- a/examples/06_subgraph.cpp
+++ b/examples/06_subgraph.cpp
@@ -91,7 +91,9 @@ int main() {
                         {{"from", "tools"}, {"to", "llm"}}
                     })}
                 }}
-                // input_map/output_map omitted → auto-mapped by same-name channels
+                // input_map/output_map omitted -> identity mapping. Parent values
+                // seed the child once; only child-produced ChannelWrite deltas
+                // return, in order and with each write mode preserved.
             }}
         }},
         {"edges", neograph::json::array({

--- a/include/neograph/graph/checkpoint.h
+++ b/include/neograph/graph/checkpoint.h
@@ -47,7 +47,11 @@ namespace neograph::graph {
 // Absent means Reduce, so a v2 blob loads unchanged — same tolerant shape as the
 // v1 -> v2 barrier_state addition. Nothing rejects an older version on read; the
 // number records what the writer was capable of.
-constexpr std::uint32_t CHECKPOINT_SCHEMA_VERSION = 3;
+// v4 (#235): child checkpoints may carry the cumulative subgraph write journal
+// in metadata. Standalone checkpoints remain readable as before; resuming a
+// captured subgraph from an older checkpoint fails explicitly because an
+// arbitrary custom reducer cannot reconstruct its historical deltas.
+constexpr std::uint32_t CHECKPOINT_SCHEMA_VERSION = 4;
 
 /// Phase at which a Checkpoint was produced. Drives resume semantics —
 /// `Before` means "re-enter before the target node runs", `After` /

--- a/include/neograph/graph/coordinator.h
+++ b/include/neograph/graph/coordinator.h
@@ -150,6 +150,18 @@ public:
         const std::string& parent_id,
         const BarrierState& barrier_state) const;
 
+    /// Internal extension used by subgraph execution to persist its cumulative
+    /// write journal without changing CheckpointCoordinator's object layout.
+    asio::awaitable<std::string> save_super_step_async(
+        const GraphState& state,
+        const std::string& current_node,
+        const std::vector<std::string>& next_nodes,
+        CheckpointPhase phase,
+        int step,
+        const std::string& parent_id,
+        const BarrierState& barrier_state,
+        const json& metadata) const;
+
     asio::awaitable<void> record_pending_write_async(
         const std::string& parent_cp_id,
         const std::string& task_id,

--- a/include/neograph/graph/engine.h
+++ b/include/neograph/graph/engine.h
@@ -43,6 +43,7 @@
 namespace neograph::graph {
 
 class ValidatedTopology;
+namespace detail { struct SubgraphWriteJournal; }
 
 /**
  * @brief Construction-time configuration for a GraphEngine.
@@ -827,10 +828,16 @@ public:
 private:
     friend class SubgraphNode;
 
+    struct SubgraphRunResult {
+        RunResult result;
+        std::vector<ChannelWrite> writes;
+    };
+
     struct RuntimeResources {
         std::optional<std::shared_ptr<CheckpointStore>> checkpoint_store;
         std::optional<std::shared_ptr<Store>> store;
         std::optional<ToolGate> parent_tool_gate;
+        std::shared_ptr<detail::SubgraphWriteJournal> subgraph_write_journal;
     };
 
     GraphEngine() = default;
@@ -865,7 +872,7 @@ private:
         RunMetadata metadata,
         RuntimeResources resources);
 
-    asio::awaitable<RunResult> run_subgraph_async(
+    asio::awaitable<SubgraphRunResult> run_subgraph_async(
         RunConfig config,
         const RunContext& parent,
         GraphStreamCallback cb);

--- a/include/neograph/graph/node.h
+++ b/include/neograph/graph/node.h
@@ -254,8 +254,11 @@ private:
 /**
  * @brief Node that runs a compiled GraphEngine as a single node (hierarchical composition).
  *
- * Enables the Supervisor pattern and nested workflows. Channels are
- * mapped between parent and child graphs via input_map and output_map.
+ * Enables the Supervisor pattern and nested workflows. Input mappings seed the
+ * child from the parent's current channel values. Output mappings forward only
+ * child-produced ChannelWrite deltas, in execution order and with Mode intact;
+ * they never feed the child's final state snapshot through the parent reducer.
+ * An explicit child Mode::Overwrite is the snapshot-replacement operation.
  *
  * Runtime context is deliberately derived at the engine boundary rather than
  * stored in additional public RunContext fields: cancellation reaches a child
@@ -283,7 +286,8 @@ public:
      * @param name Unique node name within the parent graph.
      * @param subgraph Compiled GraphEngine to run as a sub-workflow.
      * @param input_map Mapping of parent_channel -> child_channel for input.
-     * @param output_map Mapping of child_channel -> parent_channel for output.
+     * @param output_map Mapping of child_channel -> parent_channel for ordered
+     *                   child write deltas. Empty means identity mapping.
      */
     SubgraphNode(const std::string& name,
                  std::shared_ptr<GraphEngine> subgraph,
@@ -306,7 +310,8 @@ private:
     std::map<std::string, std::string> output_map_;
 
     json build_subgraph_input(const GraphState& state) const;
-    std::vector<ChannelWrite> extract_output(const json& subgraph_output) const;
+    std::vector<ChannelWrite> map_output_writes(
+        const std::vector<ChannelWrite>& child_writes) const;
 };
 
 } // namespace neograph::graph

--- a/src/core/channel_write_codec.h
+++ b/src/core/channel_write_codec.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <neograph/graph/types.h>
+
+namespace neograph::graph::detail {
+
+inline json serialize_channel_writes(const std::vector<ChannelWrite>& writes) {
+    json result = json::array();
+    for (const auto& write : writes) {
+        json item{{"channel", write.channel}, {"value", write.value}};
+        if (write.mode == ChannelWrite::Mode::Overwrite) {
+            item["mode"] = "overwrite";
+        }
+        result.push_back(std::move(item));
+    }
+    return result;
+}
+
+inline std::vector<ChannelWrite> deserialize_channel_writes(const json& value) {
+    std::vector<ChannelWrite> result;
+    if (!value.is_array()) return result;
+    result.reserve(value.size());
+    for (const auto& item : value) {
+        ChannelWrite write{
+            item.value("channel", std::string{}),
+            item.contains("value") ? item["value"] : json(),
+        };
+        if (item.value("mode", std::string{}) == "overwrite") {
+            write.mode = ChannelWrite::Mode::Overwrite;
+        }
+        result.push_back(std::move(write));
+    }
+    return result;
+}
+
+}  // namespace neograph::graph::detail

--- a/src/core/graph_coordinator.cpp
+++ b/src/core/graph_coordinator.cpp
@@ -1,5 +1,7 @@
 #include <neograph/graph/coordinator.h>
 #include <neograph/graph/state.h>
+
+#include "channel_write_codec.h"
 #include <chrono>
 
 namespace neograph::graph {
@@ -12,56 +14,18 @@ namespace {
 // NodeResult and the on-store PendingWrite record; moved here because
 // only the coordinator drives both directions now.
 
-// A write's mode has to survive this round trip, or a replayed Overwrite comes
-// back as a Reduce and the resumed run reconstructs a different state than the
-// original — silently (#91).
-//
-// The field is emitted only when it is not the default, so a graph that never
-// overwrites produces byte-identical records to the pre-#91 format, and a
-// checkpoint written before this existed reads back as Reduce. Same shape as the
-// v1 -> v2 barrier_state addition.
-inline json serialize_writes(const std::vector<ChannelWrite>& writes) {
-    json arr = json::array();
-    for (const auto& w : writes) {
-        json item{{"channel", w.channel}, {"value", w.value}};
-        if (w.mode == ChannelWrite::Mode::Overwrite) {
-            item["mode"] = "overwrite";
-        }
-        arr.push_back(std::move(item));
-    }
-    return arr;
-}
-inline std::vector<ChannelWrite> deserialize_writes(const json& arr) {
-    std::vector<ChannelWrite> out;
-    if (!arr.is_array()) return out;
-    out.reserve(arr.size());
-    for (const auto& item : arr) {
-        ChannelWrite w{
-            item.value("channel", std::string{}),
-            item.contains("value") ? item["value"] : json()
-        };
-        // Absent, unknown, or "reduce" -> Reduce. An older engine reading a
-        // record it does not understand must not silently invent an Overwrite.
-        if (item.value("mode", std::string{}) == "overwrite") {
-            w.mode = ChannelWrite::Mode::Overwrite;
-        }
-        out.push_back(std::move(w));
-    }
-    return out;
-}
-
 inline json serialize_command(const std::optional<Command>& cmd) {
     if (!cmd) return json();
     return {
         {"goto_node", cmd->goto_node},
-        {"updates",   serialize_writes(cmd->updates)}
+        {"updates",   detail::serialize_channel_writes(cmd->updates)}
     };
 }
 inline std::optional<Command> deserialize_command(const json& j) {
     if (j.is_null() || !j.is_object()) return std::nullopt;
     Command c;
     c.goto_node = j.value("goto_node", std::string{});
-    c.updates   = deserialize_writes(j.value("updates", json::array()));
+    c.updates   = detail::deserialize_channel_writes(j.value("updates", json::array()));
     return c;
 }
 
@@ -94,7 +58,7 @@ inline PendingWrite make_pending_write(const std::string& task_id,
     pw.task_id   = task_id;
     pw.task_path = task_path;
     pw.node_name = node_name;
-    pw.writes    = serialize_writes(nr.writes);
+    pw.writes    = detail::serialize_channel_writes(nr.writes);
     pw.command   = serialize_command(nr.command);
     pw.sends     = serialize_sends(nr.sends);
     pw.step      = step;
@@ -105,7 +69,7 @@ inline PendingWrite make_pending_write(const std::string& task_id,
 
 inline NodeResult pending_to_node_result(const PendingWrite& pw) {
     NodeResult nr;
-    nr.writes  = deserialize_writes(pw.writes);
+    nr.writes  = detail::deserialize_channel_writes(pw.writes);
     nr.command = deserialize_command(pw.command);
     nr.sends   = deserialize_sends(pw.sends);
     return nr;
@@ -239,6 +203,22 @@ CheckpointCoordinator::save_super_step_async(
     const std::string& parent_id,
     const BarrierState& barrier_state) const {
 
+    co_return co_await save_super_step_async(
+        state, current_node, next_nodes, phase, step, parent_id,
+        barrier_state, json());
+}
+
+asio::awaitable<std::string>
+CheckpointCoordinator::save_super_step_async(
+    const GraphState& state,
+    const std::string& current_node,
+    const std::vector<std::string>& next_nodes,
+    CheckpointPhase phase,
+    int step,
+    const std::string& parent_id,
+    const BarrierState& barrier_state,
+    const json& metadata) const {
+
     if (!enabled()) co_return std::string{};
 
     Checkpoint cp;
@@ -250,6 +230,7 @@ CheckpointCoordinator::save_super_step_async(
     cp.next_nodes      = next_nodes;
     cp.interrupt_phase = phase;
     cp.barrier_state   = barrier_state;
+    cp.metadata        = metadata;
     cp.step            = step;
     cp.timestamp       = now_ms();
 

--- a/src/core/graph_engine.cpp
+++ b/src/core/graph_engine.cpp
@@ -717,7 +717,7 @@ asio::awaitable<RunResult> GraphEngine::resume_async_with_runtime(
         config, cb, cp_opt->next_nodes, &resume_value, metadata, &resources);
 }
 
-asio::awaitable<RunResult> GraphEngine::run_subgraph_async(
+asio::awaitable<GraphEngine::SubgraphRunResult> GraphEngine::run_subgraph_async(
     RunConfig config,
     const RunContext& parent,
     GraphStreamCallback cb) {
@@ -734,22 +734,29 @@ asio::awaitable<RunResult> GraphEngine::run_subgraph_async(
         resources.store = parent.store;
     }
     resources.parent_tool_gate = parent.tool_gate;
+    auto journal = std::make_shared<detail::SubgraphWriteJournal>();
+    resources.subgraph_write_journal = journal;
 
     if (parent_runtime && parent_runtime->is_resume && resources.checkpoint_store) {
         auto checkpoint = co_await (*resources.checkpoint_store)->load_latest_async(
             config.thread_id);
         if (checkpoint) {
+            detail::restore_subgraph_write_journal(*checkpoint, journal);
             const json resume_value = parent.resume_value
                 ? *parent.resume_value
                 : json();
-            co_return co_await resume_async_with_runtime(
+            auto result = co_await resume_async_with_runtime(
                 std::move(config), resume_value, std::move(cb),
                 std::move(metadata), std::move(resources));
+            co_return SubgraphRunResult{
+                std::move(result), std::move(journal->writes)};
         }
     }
 
-    co_return co_await run_async_with_runtime(
+    auto result = co_await run_async_with_runtime(
         std::move(config), std::move(cb), std::move(metadata), std::move(resources));
+    co_return SubgraphRunResult{
+        std::move(result), std::move(journal->writes)};
 }
 
 // =========================================================================
@@ -834,6 +841,9 @@ GraphEngine::execute_graph_async(const RunConfig& config,
 
     auto runtime = std::make_shared<detail::RunContextRuntime>();
     runtime->checkpoint_store = checkpoint_store;
+    if (resources) {
+        runtime->subgraph_write_journal = resources->subgraph_write_journal;
+    }
     runtime->is_resume = is_resume;
     detail::ScopedRunContextRuntime runtime_scope(ctx, std::move(runtime));
 
@@ -934,7 +944,7 @@ GraphEngine::execute_graph_async(const RunConfig& config,
                     auto cp_id = co_await coord.save_super_step_async(state,
                         node_name, ready,
                         CheckpointPhase::Before, step, last_checkpoint_id,
-                        barrier_state);
+                        barrier_state, detail::checkpoint_metadata_for(ctx));
 
                     RunResult result;
                     result.usage = ctx.usage->snapshot();   // #88
@@ -1070,7 +1080,8 @@ GraphEngine::execute_graph_async(const RunConfig& config,
 
                 auto cp_id = co_await coord.save_super_step_async(state,
                     node_name, nexts, CheckpointPhase::After, step,
-                    last_checkpoint_id, barrier_state);
+                    last_checkpoint_id, barrier_state,
+                    detail::checkpoint_metadata_for(ctx));
 
                 RunResult result;
                 result.usage = ctx.usage->snapshot();   // #88
@@ -1154,7 +1165,8 @@ GraphEngine::execute_graph_async(const RunConfig& config,
                 : trace.back();
             auto cp_id = co_await coord.save_super_step_async(state,
                 trace_tag, next_nodes_for_cp, CheckpointPhase::Completed,
-                step, parent_cp_id, barrier_state);
+                step, parent_cp_id, barrier_state,
+                detail::checkpoint_metadata_for(ctx));
             last_checkpoint_id = cp_id;
 
             co_await coord.clear_pending_writes_async(parent_cp_id);

--- a/src/core/graph_executor.cpp
+++ b/src/core/graph_executor.cpp
@@ -79,6 +79,17 @@ private:
     detail::ScopedRunContextRuntime runtime_scope_;
 };
 
+void apply_node_result(GraphState& state,
+                       const NodeResult& result,
+                       const RunContext& context) {
+    state.apply_writes(result.writes);
+    detail::append_applied_writes(context, result.writes);
+    if (result.command) {
+        state.apply_writes(result.command->updates);
+        detail::append_applied_writes(context, result.command->updates);
+    }
+}
+
 } // namespace
 
 // =========================================================================
@@ -450,7 +461,7 @@ asio::awaitable<NodeResult> NodeExecutor::run_one_async(
         co_await coord.save_super_step_async(state,
             node_name, next_nodes,
             CheckpointPhase::NodeInterrupt, step, parent_cp_id,
-            barrier_state);
+            barrier_state, detail::checkpoint_metadata_for(ctx));
         // The executor is the only layer that knows the graph's name for
         // this node — the node body does not.
         interrupt->set_node(node_name);
@@ -458,10 +469,7 @@ asio::awaitable<NodeResult> NodeExecutor::run_one_async(
     }
 
     auto& nr = *ok_result;
-    state.apply_writes(nr.writes);
-    if (nr.command) {
-        state.apply_writes(nr.command->updates);
-    }
+    apply_node_result(state, nr, ctx);
 
     trace.push_back(node_name);
     co_return std::move(nr);
@@ -527,15 +535,14 @@ NodeExecutor::run_parallel_async(
                 co_await coord.save_super_step_async(state,
                     node_name, next_nodes,
                     CheckpointPhase::NodeInterrupt, step, parent_cp_id,
-                    barrier_state);
+                    barrier_state, detail::checkpoint_metadata_for(ctx));
                 interrupt->set_node(node_name);
                 throw *interrupt;
             }
             co_await coord.record_pending_write_async(
                 parent_cp_id, task_id, task_id, node_name, nr, step);
         }
-        state.apply_writes(nr.writes);
-        if (nr.command) state.apply_writes(nr.command->updates);
+        apply_node_result(state, nr, ctx);
         trace.push_back(node_name);
         std::vector<NodeResult> result;
         result.push_back(std::move(nr));
@@ -649,7 +656,7 @@ NodeExecutor::run_parallel_async(
             co_await coord.save_super_step_async(state,
                 first_exception_node, next_nodes,
                 CheckpointPhase::NodeInterrupt, step, parent_cp_id,
-                barrier_state);
+                barrier_state, detail::checkpoint_metadata_for(ctx));
             // Drop the worker eptr and throw a fresh NodeInterrupt —
             // see comment above the loop. The fresh exception is
             // wholly owned by the current (main) thread.
@@ -664,10 +671,7 @@ NodeExecutor::run_parallel_async(
     std::vector<NodeResult> step_results;
     step_results.reserve(ready.size());
     for (std::size_t i = 0; i < ready.size(); ++i) {
-        state.apply_writes(values[i].writes);
-        if (values[i].command) {
-            state.apply_writes(values[i].command->updates);
-        }
+        apply_node_result(state, values[i], ctx);
         step_results.push_back(std::move(values[i]));
         trace.push_back(ready[i]);
     }
@@ -748,8 +752,7 @@ asio::awaitable<std::vector<StepRouting>> NodeExecutor::run_sends_async(
             co_await coord.record_pending_write_async(parent_cp_id,
                 task_id, task_id, s.target_node, nr, step);
         }
-        state.apply_writes(nr.writes);
-        if (nr.command) state.apply_writes(nr.command->updates);
+        apply_node_result(state, nr, ctx);
         trace.push_back(s.target_node + "[send]");
 
         StepRouting r;
@@ -841,8 +844,7 @@ asio::awaitable<std::vector<StepRouting>> NodeExecutor::run_sends_async(
     // flow into the next super-step's routing decision.
     routings.reserve(sends.size());
     for (std::size_t si = 0; si < sends.size(); ++si) {
-        state.apply_writes(values[si].writes);
-        if (values[si].command) state.apply_writes(values[si].command->updates);
+        apply_node_result(state, values[si], ctx);
         trace.push_back(sends[si].target_node + "[send]");
 
         StepRouting r;

--- a/src/core/graph_node.cpp
+++ b/src/core/graph_node.cpp
@@ -313,29 +313,21 @@ json SubgraphNode::build_subgraph_input(const GraphState& state) const {
     return input;
 }
 
-std::vector<ChannelWrite> SubgraphNode::extract_output(
-    const json& subgraph_output) const {
-
+std::vector<ChannelWrite> SubgraphNode::map_output_writes(
+    const std::vector<ChannelWrite>& child_writes) const {
     std::vector<ChannelWrite> writes;
-
-    if (!subgraph_output.contains("channels")) return writes;
-    const auto& channels = subgraph_output["channels"];
-
-    if (output_map_.empty()) {
-        // Default: write all child channels back to parent (same name)
-        for (const auto& [ch_name, ch_data] : channels.items()) {
-            if (ch_data.contains("value")) {
-                writes.push_back(ChannelWrite{ch_name, ch_data["value"]});
-            }
+    writes.reserve(child_writes.size());
+    for (const auto& child_write : child_writes) {
+        auto parent_channel = child_write.channel;
+        if (!output_map_.empty()) {
+            const auto mapped = output_map_.find(child_write.channel);
+            if (mapped == output_map_.end()) continue;
+            parent_channel = mapped->second;
         }
-    } else {
-        for (const auto& [child_ch, parent_ch] : output_map_) {
-            if (channels.contains(child_ch) && channels[child_ch].contains("value")) {
-                writes.push_back(ChannelWrite{parent_ch, channels[child_ch]["value"]});
-            }
-        }
+        auto parent_write = child_write;
+        parent_write.channel = std::move(parent_channel);
+        writes.push_back(std::move(parent_write));
     }
-
     return writes;
 }
 
@@ -350,38 +342,38 @@ asio::awaitable<NodeOutput> SubgraphNode::run(NodeInput in) {
     // to a subgraph reports zero tokens — which reads as "this run was free".
     config.usage        = in.ctx.usage;
 
-    json subgraph_output;
+    std::vector<ChannelWrite> child_writes;
     if (in.stream_cb) {
         // Forward the parent's stream sink so subgraph events (LLM
         // tokens, node enter/exit, etc.) surface at the parent
         // graph's caller without buffering.
         auto result = co_await subgraph_->run_subgraph_async(
             std::move(config), in.ctx, *in.stream_cb);
-        if (result.interrupted) {
-            const auto reason = result.interrupt_value.value(
+        if (result.result.interrupted) {
+            const auto reason = result.result.interrupt_value.value(
                 "reason", "subgraph interrupted");
-            if (result.interrupt_value.contains("value")) {
-                throw NodeInterrupt(reason, result.interrupt_value["value"]);
+            if (result.result.interrupt_value.contains("value")) {
+                throw NodeInterrupt(reason, result.result.interrupt_value["value"]);
             }
             throw NodeInterrupt(reason);
         }
-        subgraph_output = std::move(result.output);
+        child_writes = std::move(result.writes);
     } else {
         auto result = co_await subgraph_->run_subgraph_async(
             std::move(config), in.ctx, nullptr);
-        if (result.interrupted) {
-            const auto reason = result.interrupt_value.value(
+        if (result.result.interrupted) {
+            const auto reason = result.result.interrupt_value.value(
                 "reason", "subgraph interrupted");
-            if (result.interrupt_value.contains("value")) {
-                throw NodeInterrupt(reason, result.interrupt_value["value"]);
+            if (result.result.interrupt_value.contains("value")) {
+                throw NodeInterrupt(reason, result.result.interrupt_value["value"]);
             }
             throw NodeInterrupt(reason);
         }
-        subgraph_output = std::move(result.output);
+        child_writes = std::move(result.writes);
     }
 
     NodeOutput out;
-    out.writes = extract_output(subgraph_output);
+    out.writes = map_output_writes(child_writes);
     co_return out;
 }
 

--- a/src/core/run_context_runtime.cpp
+++ b/src/core/run_context_runtime.cpp
@@ -1,5 +1,7 @@
 #include "run_context_runtime.h"
 
+#include "channel_write_codec.h"
+
 #include <mutex>
 #include <unordered_map>
 #include <utility>
@@ -10,6 +12,10 @@ namespace {
 
 std::mutex runtime_mutex;
 std::unordered_map<const RunContext*, std::shared_ptr<const RunContextRuntime>> runtimes;
+
+constexpr const char* kMetadataNamespace = "_neograph";
+constexpr const char* kJournalVersion = "subgraph_write_journal_version";
+constexpr const char* kJournal = "subgraph_write_journal";
 
 }  // namespace
 
@@ -27,6 +33,46 @@ std::shared_ptr<const RunContextRuntime> runtime_for_invocation(
         : std::make_shared<RunContextRuntime>();
     runtime->invocation_id = invocation_id;
     return runtime;
+}
+
+void append_applied_writes(const RunContext& context,
+                           const std::vector<ChannelWrite>& writes) {
+    if (writes.empty()) return;
+    auto runtime = runtime_for(context);
+    if (!runtime || !runtime->subgraph_write_journal) return;
+    auto& journal = runtime->subgraph_write_journal->writes;
+    journal.insert(journal.end(), writes.begin(), writes.end());
+}
+
+json checkpoint_metadata_for(const RunContext& context) {
+    auto runtime = runtime_for(context);
+    if (!runtime || !runtime->subgraph_write_journal) return json();
+
+    json metadata;
+    metadata[kMetadataNamespace][kJournalVersion] = 1;
+    metadata[kMetadataNamespace][kJournal] =
+        serialize_channel_writes(runtime->subgraph_write_journal->writes);
+    return metadata;
+}
+
+void restore_subgraph_write_journal(
+    const Checkpoint& checkpoint,
+    const std::shared_ptr<SubgraphWriteJournal>& journal) {
+    if (!journal) return;
+
+    const bool has_journal = checkpoint.metadata.is_object()
+        && checkpoint.metadata.contains(kMetadataNamespace)
+        && checkpoint.metadata[kMetadataNamespace].is_object()
+        && checkpoint.metadata[kMetadataNamespace].value(kJournalVersion, 0) == 1
+        && checkpoint.metadata[kMetadataNamespace].contains(kJournal);
+    if (!has_journal) {
+        throw std::runtime_error(
+            "Cannot resume subgraph checkpoint without a write journal; "
+            "restart the parent invocation with NeoGraph checkpoint schema v4 or newer");
+    }
+
+    journal->writes = deserialize_channel_writes(
+        checkpoint.metadata[kMetadataNamespace][kJournal]);
 }
 
 ScopedRunContextRuntime::ScopedRunContextRuntime(

--- a/src/core/run_context_runtime.h
+++ b/src/core/run_context_runtime.h
@@ -5,13 +5,19 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace neograph::graph::detail {
+
+struct SubgraphWriteJournal {
+    std::vector<ChannelWrite> writes;
+};
 
 // Execution-only state deliberately lives outside the public RunContext ABI.
 // A scope binds it to the context object while a node coroutine is active.
 struct RunContextRuntime {
     std::shared_ptr<CheckpointStore> checkpoint_store;
+    std::shared_ptr<SubgraphWriteJournal> subgraph_write_journal;
     std::string invocation_id;
     bool is_resume = false;
 };
@@ -20,6 +26,15 @@ std::shared_ptr<const RunContextRuntime> runtime_for(const RunContext& context);
 
 std::shared_ptr<const RunContextRuntime> runtime_for_invocation(
     const RunContext& context, const std::string& invocation_id);
+
+void append_applied_writes(const RunContext& context,
+                           const std::vector<ChannelWrite>& writes);
+
+json checkpoint_metadata_for(const RunContext& context);
+
+void restore_subgraph_write_journal(
+    const Checkpoint& checkpoint,
+    const std::shared_ptr<SubgraphWriteJournal>& journal);
 
 class ScopedRunContextRuntime {
 public:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(neograph_tests
     test_channel_write_mode.cpp
     test_usage_accounting.cpp
     test_subgraph_context.cpp
+    test_subgraph_output_deltas.cpp
     test_plan_execute_graph.cpp
     test_signal_dispatch.cpp
     test_multi_node_resume.cpp

--- a/tests/test_barrier_persistence.cpp
+++ b/tests/test_barrier_persistence.cpp
@@ -59,8 +59,8 @@ TEST(BarrierPersistence, FreshCheckpointHasEmptyBarrierState) {
     Checkpoint cp;
     EXPECT_TRUE(cp.barrier_state.empty());
     EXPECT_EQ(cp.schema_version, CHECKPOINT_SCHEMA_VERSION);
-    EXPECT_EQ(CHECKPOINT_SCHEMA_VERSION, 3)
-        << "barrier_state requires schema v2; v3 adds ChannelWrite::Mode (#91)";
+    EXPECT_EQ(CHECKPOINT_SCHEMA_VERSION, 4)
+        << "v3 adds ChannelWrite::Mode; v4 adds the subgraph write journal";
 }
 
 // =========================================================================

--- a/tests/test_subgraph_context.cpp
+++ b/tests/test_subgraph_context.cpp
@@ -447,6 +447,11 @@ TEST(SubgraphContext, ParentResumeResumesInterruptedGrandchild) {
     EXPECT_EQ(gate_calls.load(), 3);
     EXPECT_EQ(seed_calls.load(), 1)
         << "a fresh grandchild run would execute the seed node twice";
+    const auto messages = resumed.channel<json>("messages");
+    ASSERT_EQ(messages.size(), 3u);
+    EXPECT_EQ(messages[0].value("role", std::string{}), "user");
+    EXPECT_EQ(messages[1].value("role", std::string{}), "assistant");
+    EXPECT_EQ(messages[2].value("role", std::string{}), "tool");
 }
 
 TEST(SubgraphContext, SendSiblingsReceiveDistinctCheckpointIdentities) {

--- a/tests/test_subgraph_output_deltas.cpp
+++ b/tests/test_subgraph_output_deltas.cpp
@@ -1,0 +1,417 @@
+#include <gtest/gtest.h>
+
+#include <neograph/neograph.h>
+
+#include <atomic>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace neograph;
+using namespace neograph::graph;
+
+namespace {
+
+class WritesNode final : public GraphNode {
+public:
+    WritesNode(std::string name,
+               std::vector<ChannelWrite> writes,
+               std::vector<ChannelWrite> command_updates = {},
+               std::atomic<int>* calls = nullptr,
+               std::atomic<int>* failures_remaining = nullptr)
+        : name_(std::move(name)),
+          writes_(std::move(writes)),
+          command_updates_(std::move(command_updates)),
+          calls_(calls),
+          failures_remaining_(failures_remaining) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        if (calls_) calls_->fetch_add(1, std::memory_order_relaxed);
+        if (failures_remaining_ &&
+            failures_remaining_->fetch_sub(1, std::memory_order_relaxed) > 0) {
+            throw std::runtime_error("transient child failure");
+        }
+
+        NodeOutput out;
+        out.writes = writes_;
+        if (!command_updates_.empty()) {
+            Command command;
+            command.updates = command_updates_;
+            out.command = std::move(command);
+        }
+        co_return out;
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+    std::vector<ChannelWrite> writes_;
+    std::vector<ChannelWrite> command_updates_;
+    std::atomic<int>* calls_;
+    std::atomic<int>* failures_remaining_;
+};
+
+class FailOnceNode final : public GraphNode {
+public:
+    FailOnceNode(std::string name, std::atomic<int>* calls)
+        : name_(std::move(name)), calls_(calls) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        const int call = calls_->fetch_add(1, std::memory_order_relaxed);
+        if (call == 0) throw std::runtime_error("fail parent super-step once");
+        co_return NodeOutput{};
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+    std::atomic<int>* calls_;
+};
+
+class FanoutNode final : public GraphNode {
+public:
+    explicit FanoutNode(std::string name) : name_(std::move(name)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput) override {
+        NodeOutput out;
+        out.sends.push_back(Send{"worker", {{"slot", "zero"}}});
+        out.sends.push_back(Send{"worker", {{"slot", "one"}}});
+        co_return out;
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+};
+
+class SendValueNode final : public GraphNode {
+public:
+    explicit SendValueNode(std::string name) : name_(std::move(name)) {}
+
+    asio::awaitable<NodeOutput> run(NodeInput in) override {
+        NodeOutput out;
+        out.writes.push_back(ChannelWrite{
+            "results", json::array({in.state.get("slot")})});
+        co_return out;
+    }
+
+    std::string get_name() const override { return name_; }
+
+private:
+    std::string name_;
+};
+
+json one_node_graph(const std::string& name,
+                    const std::string& node_type,
+                    json channels,
+                    json retry_policy = json()) {
+    json graph = {
+        {"name", name},
+        {"channels", std::move(channels)},
+        {"nodes", {{"node", {{"type", node_type}}}}},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "node"}},
+            {{"from", "node"}, {"to", "__end__"}},
+        })},
+    };
+    if (!retry_policy.is_null()) graph["retry_policy"] = std::move(retry_policy);
+    return graph;
+}
+
+std::shared_ptr<GraphEngine> shared_engine(const json& definition,
+                                           std::shared_ptr<CheckpointStore> store = nullptr) {
+    return std::shared_ptr<GraphEngine>(
+        GraphEngine::compile(definition, NodeContext{}, std::move(store)).release());
+}
+
+void register_writer(const std::string& type,
+                     std::vector<ChannelWrite> writes,
+                     std::vector<ChannelWrite> command_updates = {},
+                     std::atomic<int>* calls = nullptr,
+                     std::atomic<int>* failures_remaining = nullptr) {
+    NodeFactory::instance().register_type(
+        type,
+        [writes = std::move(writes),
+         command_updates = std::move(command_updates),
+         calls,
+         failures_remaining](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<WritesNode>(
+                name, writes, command_updates, calls, failures_remaining);
+        });
+}
+
+void register_subgraph(const std::string& type,
+                       std::shared_ptr<GraphEngine> child,
+                       std::map<std::string, std::string> input_map = {},
+                       std::map<std::string, std::string> output_map = {}) {
+    NodeFactory::instance().register_type(
+        type,
+        [child = std::move(child),
+         input_map = std::move(input_map),
+         output_map = std::move(output_map)](
+            const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<SubgraphNode>(
+                name, child, input_map, output_map);
+        });
+}
+
+json message(const std::string& role, const std::string& content) {
+    return {{"role", role}, {"content", content}};
+}
+
+json append_channels() {
+    return {{"messages", {{"reducer", "append"}}}};
+}
+
+}  // namespace
+
+TEST(SubgraphOutputDeltas, IdentityMappingDoesNotReduceInheritedAppendStateTwice) {
+    register_writer("issue235_identity_writer", {
+        ChannelWrite{"messages", json::array({message("assistant", "child reply")})},
+    });
+    auto child = shared_engine(one_node_graph(
+        "identity_child", "issue235_identity_writer", append_channels()));
+    register_subgraph("issue235_identity_subgraph", child);
+
+    auto parent = GraphEngine::compile(one_node_graph(
+        "identity_parent", "issue235_identity_subgraph", append_channels()),
+        NodeContext{});
+
+    RunConfig config;
+    config.input = {{"messages", json::array({message("user", "hello")})}};
+    const auto result = parent->run(config);
+
+    const auto messages = result.channel<json>("messages");
+    ASSERT_EQ(messages.size(), 2u);
+    EXPECT_EQ(messages[0], message("user", "hello"));
+    EXPECT_EQ(messages[1], message("assistant", "child reply"));
+}
+
+TEST(SubgraphOutputDeltas, ExplicitMappingAppliesAppendCustomAndOverwriteDeterministically) {
+    ReducerRegistry::instance().register_reducer(
+        "issue235_decimal",
+        [](const json& current, const json& incoming) {
+            return json(current.get<int>() * 10 + incoming.get<int>());
+        });
+
+    const json child_channels = {
+        {"child_append", {{"reducer", "append"}}},
+        {"child_custom", {{"reducer", "issue235_decimal"}, {"initial", 0}}},
+        {"child_scalar", {{"reducer", "overwrite"}}},
+    };
+    register_writer("issue235_explicit_writer", {
+        ChannelWrite{"child_append", json::array({"child"})},
+        ChannelWrite{"child_custom", 3},
+        ChannelWrite{"child_scalar", "after"},
+    });
+    auto child = shared_engine(one_node_graph(
+        "explicit_child", "issue235_explicit_writer", child_channels));
+    register_subgraph(
+        "issue235_explicit_subgraph", child,
+        {{"parent_append", "child_append"},
+         {"parent_custom", "child_custom"},
+         {"parent_scalar", "child_scalar"}},
+        {{"child_append", "parent_append"},
+         {"child_custom", "parent_custom"},
+         {"child_scalar", "parent_scalar"}});
+
+    const json parent_channels = {
+        {"parent_append", {{"reducer", "append"}}},
+        {"parent_custom", {{"reducer", "issue235_decimal"}, {"initial", 0}}},
+        {"parent_scalar", {{"reducer", "overwrite"}}},
+    };
+    auto parent = GraphEngine::compile(one_node_graph(
+        "explicit_parent", "issue235_explicit_subgraph", parent_channels),
+        NodeContext{});
+
+    RunConfig config;
+    config.input = {
+        {"parent_append", json::array({"parent"})},
+        {"parent_custom", 2},
+        {"parent_scalar", "before"},
+    };
+    const auto result = parent->run(config);
+
+    EXPECT_EQ(result.channel<json>("parent_append"), json::array({"parent", "child"}));
+    EXPECT_EQ(result.channel<int>("parent_custom"), 23);
+    EXPECT_EQ(result.channel<std::string>("parent_scalar"), "after");
+}
+
+TEST(SubgraphOutputDeltas, ChildOverwriteModeCrossesTheBoundary) {
+    ChannelWrite replace{"messages", json::array({message("assistant", "reset")})};
+    replace.mode = ChannelWrite::Mode::Overwrite;
+    register_writer("issue235_overwrite_writer", {replace});
+    auto child = shared_engine(one_node_graph(
+        "overwrite_child", "issue235_overwrite_writer", append_channels()));
+    register_subgraph("issue235_overwrite_subgraph", child);
+
+    auto parent = GraphEngine::compile(one_node_graph(
+        "overwrite_parent", "issue235_overwrite_subgraph", append_channels()),
+        NodeContext{});
+    RunConfig config;
+    config.input = {{"messages", json::array({message("user", "discard me")})}};
+
+    EXPECT_EQ(parent->run(config).channel<json>("messages"),
+              json::array({message("assistant", "reset")}));
+}
+
+TEST(SubgraphOutputDeltas, PreservesWriteThenCommandUpdateOrder) {
+    register_writer(
+        "issue235_command_writer",
+        {ChannelWrite{"messages", json::array({"write"})}},
+        {ChannelWrite{"messages", json::array({"command"})}});
+    auto child = shared_engine(one_node_graph(
+        "command_child", "issue235_command_writer", append_channels()));
+    register_subgraph("issue235_command_subgraph", child);
+
+    auto parent = GraphEngine::compile(one_node_graph(
+        "command_parent", "issue235_command_subgraph", append_channels()),
+        NodeContext{});
+
+    EXPECT_EQ(parent->run(RunConfig{}).channel<json>("messages"),
+              json::array({"write", "command"}));
+}
+
+TEST(SubgraphOutputDeltas, NestedIdentityMappingDoesNotAmplifyInheritedHistory) {
+    register_writer("issue235_nested_leaf_writer", {
+        ChannelWrite{"messages", json::array({message("assistant", "leaf")})},
+    });
+    auto leaf = shared_engine(one_node_graph(
+        "nested_leaf", "issue235_nested_leaf_writer", append_channels()));
+    register_subgraph("issue235_nested_middle_subgraph", leaf);
+    auto middle = shared_engine(one_node_graph(
+        "nested_middle", "issue235_nested_middle_subgraph", append_channels()));
+    register_subgraph("issue235_nested_outer_subgraph", middle);
+    auto parent = GraphEngine::compile(one_node_graph(
+        "nested_parent", "issue235_nested_outer_subgraph", append_channels()),
+        NodeContext{});
+
+    RunConfig config;
+    config.input = {{"messages", json::array({message("user", "root")})}};
+    const auto messages = parent->run(config).channel<json>("messages");
+
+    ASSERT_EQ(messages.size(), 2u);
+    EXPECT_EQ(messages[0], message("user", "root"));
+    EXPECT_EQ(messages[1], message("assistant", "leaf"));
+}
+
+TEST(SubgraphOutputDeltas, RetryExportsOnlyTheSuccessfulAttempt) {
+    std::atomic<int> calls{0};
+    std::atomic<int> failures_remaining{1};
+    register_writer(
+        "issue235_retry_writer",
+        {ChannelWrite{"messages", json::array({"success"})}},
+        {}, &calls, &failures_remaining);
+    auto child = shared_engine(one_node_graph(
+        "retry_child", "issue235_retry_writer", append_channels(),
+        {{"max_retries", 1}, {"initial_delay_ms", 0}}));
+    register_subgraph("issue235_retry_subgraph", child);
+    auto parent = GraphEngine::compile(one_node_graph(
+        "retry_parent", "issue235_retry_subgraph", append_channels()),
+        NodeContext{});
+
+    EXPECT_EQ(parent->run(RunConfig{}).channel<json>("messages"),
+              json::array({"success"}));
+    EXPECT_EQ(calls.load(), 2);
+}
+
+TEST(SubgraphOutputDeltas, MultiSendWritesCrossInDeterministicFanInOrder) {
+    NodeFactory::instance().register_type(
+        "issue235_fanout",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<FanoutNode>(name);
+        });
+    NodeFactory::instance().register_type(
+        "issue235_send_value",
+        [](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<SendValueNode>(name);
+        });
+
+    const json child_definition = {
+        {"name", "send_child"},
+        {"channels", {
+            {"slot", {{"reducer", "overwrite"}}},
+            {"results", {{"reducer", "append"}}},
+        }},
+        {"nodes", {
+            {"fanout", {{"type", "issue235_fanout"}}},
+            {"worker", {{"type", "issue235_send_value"}}},
+        }},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "fanout"}},
+            {{"from", "fanout"}, {"to", "__end__"}},
+            {{"from", "worker"}, {"to", "__end__"}},
+        })},
+    };
+    auto child = shared_engine(child_definition);
+    child->set_worker_count(2);
+    register_subgraph(
+        "issue235_send_subgraph", child, {}, {{"results", "results"}});
+    auto parent = GraphEngine::compile(one_node_graph(
+        "send_parent", "issue235_send_subgraph",
+        {{"results", {{"reducer", "append"}}}}), NodeContext{});
+
+    EXPECT_EQ(parent->run(RunConfig{}).channel<json>("results"),
+              json::array({"zero", "one"}));
+}
+
+TEST(SubgraphOutputDeltas, ParentPendingWriteReplayDoesNotRerunOrDuplicateChild) {
+    std::atomic<int> child_calls{0};
+    std::atomic<int> sibling_calls{0};
+    register_writer("issue235_replay_setup", {
+        ChannelWrite{"setup", true},
+    });
+    register_writer(
+        "issue235_replay_child_writer",
+        {ChannelWrite{"messages", json::array({"child"})}},
+        {}, &child_calls);
+    NodeFactory::instance().register_type(
+        "issue235_replay_fail_once",
+        [&sibling_calls](const std::string& name, const json&, const NodeContext&) {
+            return std::make_unique<FailOnceNode>(name, &sibling_calls);
+        });
+
+    const json child_channels = append_channels();
+    auto child = shared_engine(one_node_graph(
+        "replay_child", "issue235_replay_child_writer", child_channels));
+    register_subgraph("issue235_replay_subgraph", child);
+
+    const json parent = {
+        {"name", "replay_parent"},
+        {"channels", {
+            {"setup", {{"reducer", "overwrite"}}},
+            {"messages", {{"reducer", "append"}}},
+        }},
+        {"nodes", {
+            {"setup", {{"type", "issue235_replay_setup"}}},
+            {"child", {{"type", "issue235_replay_subgraph"}}},
+            {"fail", {{"type", "issue235_replay_fail_once"}}},
+        }},
+        {"edges", json::array({
+            {{"from", "__start__"}, {"to", "setup"}},
+            {{"from", "setup"}, {"to", "child"}},
+            {{"from", "setup"}, {"to", "fail"}},
+            {{"from", "child"}, {"to", "__end__"}},
+            {{"from", "fail"}, {"to", "__end__"}},
+        })},
+    };
+    auto store = std::make_shared<InMemoryCheckpointStore>();
+    auto engine = GraphEngine::compile(parent, NodeContext{}, store);
+    engine->set_worker_count(2);
+
+    RunConfig config;
+    config.thread_id = "issue235-parent-replay";
+    config.input = {{"messages", json::array({"parent"})}};
+    EXPECT_THROW(engine->run(config), NodeExecutionError);
+    EXPECT_EQ(child_calls.load(), 1);
+
+    const auto resumed = engine->resume(config.thread_id);
+    EXPECT_EQ(resumed.channel<json>("messages"), json::array({"parent", "child"}));
+    EXPECT_EQ(child_calls.load(), 1);
+    EXPECT_EQ(sibling_calls.load(), 2);
+}


### PR DESCRIPTION
## Summary
- preserve child-produced `ChannelWrite` deltas, ordering, and write modes across subgraph boundaries instead of re-reducing final snapshots
- persist the cumulative child write journal in checkpoint metadata so nested retry/resume does not duplicate inherited state
- document identity/output mapping semantics and synchronize translated reference content so the Doxygen locale inventory passes

## Verification
- `ctest --test-dir build-issue235 --output-on-failure -j2` (902/902, 34 environment-dependent skips)
- ASan/UBSan focused regressions: 9/9
- ASan/UBSan `example_subgraph`
- `python3 scripts/check_docs_i18n.py` (123/123)
- `doxygen Doxyfile` and generated `docs/api/html/index.html`
- `git diff --check`

Related to #235. The issue checklist will be updated and the issue closed after this PR merges, per repository policy.