### PR TITLE
fix(docs): refresh Beast translation metadata

### DIFF
--- a/examples/cookbook/the-beast/README.ja.md
+++ b/examples/cookbook/the-beast/README.ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=examples/cookbook/the-beast/README.md locale=ja source_sha256=36894cbda7603d180ce320ff25a3abf3ed4edf1876458455f8e27eb3af220749 -->
+<!-- neograph-i18n: source=examples/cookbook/the-beast/README.md locale=ja source_sha256=aa9675ba1cbeeb80c64724416d97b82171a94f2261f16551966e181ee742405d -->
 # ビースト — 生成、進化、ロールバック
 
 **Languages:** [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)

--- a/examples/cookbook/the-beast/README.ko.md
+++ b/examples/cookbook/the-beast/README.ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=examples/cookbook/the-beast/README.md locale=ko source_sha256=36894cbda7603d180ce320ff25a3abf3ed4edf1876458455f8e27eb3af220749 -->
+<!-- neograph-i18n: source=examples/cookbook/the-beast/README.md locale=ko source_sha256=aa9675ba1cbeeb80c64724416d97b82171a94f2261f16551966e181ee742405d -->
 **Languages:** [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
 # The Beast — 생성 · 진화 · 롤백

--- a/examples/cookbook/the-beast/README.zh-CN.md
+++ b/examples/cookbook/the-beast/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=examples/cookbook/the-beast/README.md locale=zh-CN source_sha256=36894cbda7603d180ce320ff25a3abf3ed4edf1876458455f8e27eb3af220749 -->
+<!-- neograph-i18n: source=examples/cookbook/the-beast/README.md locale=zh-CN source_sha256=aa9675ba1cbeeb80c64724416d97b82171a94f2261f16551966e181ee742405d -->
 # 野兽 — 生成·进化·回滚
 
 **Languages:** [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)


### PR DESCRIPTION
## Summary

- refresh the Beast translation source hashes after the English README changed in #247
- unblock the documentation locale inventory gate that runs before Doxygen generation

## Root Cause

The translated prose was updated with its English source, but the three `neograph-i18n` metadata headers still referenced the previous source SHA256. The Doxygen deployment therefore stopped at `scripts/check_docs_i18n.py` before invoking Doxygen.

## Verification

- `python3 scripts/check_docs_i18n.py`
- `python3 scripts/check_runtime_doc_claims.py`
- `doxygen Doxyfile`
- verified `docs/api/html/index.html`
- `git diff --check`

Follow-up to #247.
