### PR TITLE
fix: complete strict topology migration

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=README.md locale=ja source_sha256=f6016fba6c70ae3d33be9ea2b574a25b9ea984822aa371dd940da43b3b0d19dd -->
+<!-- neograph-i18n: source=README.md locale=ja source_sha256=1ea76dcf312e4041ee0762b42945377e996661562c6ea90a4ccb9b35b586bdab -->
 <p align="center">
   <h1 align="center">NeoGraph</h1>
   <p align="center">
@@ -62,6 +62,7 @@ auto result = engine->run(config);
 
 ```json
 {
+  "schema_version": 1,
   "channels": { "messages": {"reducer": "append"}, "__route__": {"reducer": "overwrite"} },
   "nodes": {
     "planner":    {"type": "llm_call"},
@@ -196,6 +197,7 @@ pip install neograph-engine
 import neograph_engine as ng
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "demo",
     "channels": {"messages": {"reducer": "append"}},
     "nodes":    {"llm": {"type": "llm_call"}},

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=README.md locale=ko source_sha256=f6016fba6c70ae3d33be9ea2b574a25b9ea984822aa371dd940da43b3b0d19dd -->
+<!-- neograph-i18n: source=README.md locale=ko source_sha256=1ea76dcf312e4041ee0762b42945377e996661562c6ea90a4ccb9b35b586bdab -->
 <p align="center">
   <h1 align="center">NeoGraph</h1>
   <p align="center">
@@ -58,6 +58,7 @@ auto result = engine->run(config);
 
 ```json
 {
+  "schema_version": 1,
   "channels": { "messages": {"reducer": "append"}, "__route__": {"reducer": "overwrite"} },
   "nodes": {
     "planner":    {"type": "llm_call"},
@@ -172,6 +173,7 @@ pip install neograph-engine
 import neograph_engine as ng
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "demo",
     "channels": {"messages": {"reducer": "append"}},
     "nodes":    {"llm": {"type": "llm_call"}},

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ different agent (see [`docs/concepts.md`](docs/concepts.md)):
 
 ```json
 {
+  "schema_version": 1,
   "channels": { "messages": {"reducer": "append"}, "__route__": {"reducer": "overwrite"} },
   "nodes": {
     "planner":    {"type": "llm_call"},
@@ -193,6 +194,7 @@ pip install neograph-engine
 import neograph_engine as ng
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "demo",
     "channels": {"messages": {"reducer": "append"}},
     "nodes":    {"llm": {"type": "llm_call"}},

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=README.md locale=zh-CN source_sha256=f6016fba6c70ae3d33be9ea2b574a25b9ea984822aa371dd940da43b3b0d19dd -->
+<!-- neograph-i18n: source=README.md locale=zh-CN source_sha256=1ea76dcf312e4041ee0762b42945377e996661562c6ea90a4ccb9b35b586bdab -->
 <p align="center">
   <h1 align="center">NeoGraph</h1>
   <p align="center">
@@ -62,6 +62,7 @@ agent（参见 [`docs/concepts.md`](docs/concepts.md)）：
 
 ```json
 {
+  "schema_version": 1,
   "channels": { "messages": {"reducer": "append"}, "__route__": {"reducer": "overwrite"} },
   "nodes": {
     "planner":    {"type": "llm_call"},
@@ -194,6 +195,7 @@ pip install neograph-engine
 import neograph_engine as ng
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "demo",
     "channels": {"messages": {"reducer": "append"}},
     "nodes":    {"llm": {"type": "llm_call"}},

--- a/bindings/python/examples/01_minimal.py
+++ b/bindings/python/examples/01_minimal.py
@@ -34,6 +34,7 @@ ng.NodeFactory.register_type(
 
 # Compile a 1-node graph: __start__ → doubler → __end__
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "minimal",
     "channels": {
         "seed":    {"reducer": "overwrite"},

--- a/bindings/python/examples/02_tool_dispatch.py
+++ b/bindings/python/examples/02_tool_dispatch.py
@@ -75,6 +75,7 @@ ng.NodeFactory.register_type(
 )
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "tool_dispatch_demo",
     "channels": {"messages": {"reducer": "append"}},
     "nodes": {

--- a/bindings/python/examples/03_send_fanout.py
+++ b/bindings/python/examples/03_send_fanout.py
@@ -60,6 +60,7 @@ ng.NodeFactory.register_type(
 )
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "fanout_demo",
     "channels": {
         "item":    {"reducer": "overwrite"},

--- a/bindings/python/examples/04_async_concurrent.py
+++ b/bindings/python/examples/04_async_concurrent.py
@@ -34,6 +34,7 @@ ng.NodeFactory.register_type(
 )
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "async_demo",
     "channels": {
         "seed":    {"reducer": "overwrite"},

--- a/bindings/python/examples/05_openai_provider.py
+++ b/bindings/python/examples/05_openai_provider.py
@@ -23,6 +23,7 @@ provider = openai_provider()  # exits cleanly if no key
 # provider, writes the assistant message back. No subclassing needed
 # for the common case.
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "openai_oneshot",
     "channels": {"messages": {"reducer": "append"}},
     "nodes": {"llm": {"type": "llm_call"}},

--- a/bindings/python/examples/06_react_agent.py
+++ b/bindings/python/examples/06_react_agent.py
@@ -75,6 +75,7 @@ provider = openai_provider()
 # as a built-in). The conditional edge from `llm` routes back into
 # `dispatch` when the LLM emitted a tool call, otherwise it ends.
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "react_agent",
     "channels": {"messages": {"reducer": "append"}},
     "nodes": {

--- a/bindings/python/examples/07_checkpoint_hitl.py
+++ b/bindings/python/examples/07_checkpoint_hitl.py
@@ -92,6 +92,7 @@ ng.NodeFactory.register_type(
 #   then we inspect — and if approved, run stage 2: just the dispatch.
 
 stage1_def = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "stage1_propose",
     "channels": {"messages": {"reducer": "append"}},
     "nodes": {"llm": {"type": "fake_llm"}},
@@ -102,6 +103,7 @@ stage1_def = {
 }
 
 stage2_def = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "stage2_execute",
     "channels": {"messages": {"reducer": "append"}},
     "nodes": {"dispatch": {"type": "tool_dispatch"}},

--- a/bindings/python/examples/08_intent_routing.py
+++ b/bindings/python/examples/08_intent_routing.py
@@ -110,6 +110,7 @@ ng.NodeFactory.register_type(
 
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "intent_router",
     "channels": {
         "messages": {"reducer": "append"},

--- a/bindings/python/examples/09_state_management.py
+++ b/bindings/python/examples/09_state_management.py
@@ -46,6 +46,7 @@ ng.NodeFactory.register_type(
 )
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "counter",
     "channels": {"count": {"reducer": "overwrite"}},
     "nodes": {"i": {"type": "incr"}},

--- a/bindings/python/examples/10_command_routing.py
+++ b/bindings/python/examples/10_command_routing.py
@@ -69,6 +69,7 @@ ng.NodeFactory.register_type(
 
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "command_routing",
     "channels": {
         "value":     {"reducer": "overwrite"},

--- a/bindings/python/examples/11_reflexion.py
+++ b/bindings/python/examples/11_reflexion.py
@@ -112,6 +112,7 @@ ng.NodeFactory.register_type(
 # ends, `retry` loops back to actor. `route_channel` is a built-in
 # condition that just looks up the named channel value.
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "reflexion",
     "channels": {
         "task":       {"reducer": "overwrite"},

--- a/bindings/python/examples/12_self_ask.py
+++ b/bindings/python/examples/12_self_ask.py
@@ -129,6 +129,7 @@ ng.NodeFactory.register_type(
 
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "self_ask",
     "channels": {
         "question":     {"reducer": "overwrite"},

--- a/bindings/python/examples/13_multi_agent_debate.py
+++ b/bindings/python/examples/13_multi_agent_debate.py
@@ -126,6 +126,7 @@ ng.NodeFactory.register_type(
 
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "multi_agent_debate",
     "channels": {
         "topic":     {"reducer": "overwrite"},

--- a/bindings/python/examples/14_graph_to_json.py
+++ b/bindings/python/examples/14_graph_to_json.py
@@ -54,6 +54,7 @@ ng.NodeFactory.register_type(
 
 # Build the definition the same way you would in any other example.
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "doubler_graph",
     "channels": {
         "seed":    {"reducer": "overwrite"},

--- a/bindings/python/examples/16_deep_research_chat.py
+++ b/bindings/python/examples/16_deep_research_chat.py
@@ -239,6 +239,7 @@ for type_name, factory in [
 
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "deep_research_chat",
     "channels": {
         "messages":          {"reducer": "append"},

--- a/bindings/python/examples/17_deep_research_crawl4ai.py
+++ b/bindings/python/examples/17_deep_research_crawl4ai.py
@@ -280,6 +280,7 @@ for type_name, factory in [
 
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "deep_research_crawl4ai",
     "channels": {
         "messages":          {"reducer": "append"},

--- a/bindings/python/examples/18_node_cache.py
+++ b/bindings/python/examples/18_node_cache.py
@@ -52,6 +52,7 @@ ng.NodeFactory.register_type(
     lambda name, config, ctx, _n=node: _n)
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "cache_demo",
     "channels": {
         "topic":  {"reducer": "overwrite"},

--- a/bindings/python/examples/19_streaming_messages.py
+++ b/bindings/python/examples/19_streaming_messages.py
@@ -49,6 +49,7 @@ ng.NodeFactory.register_type(
     lambda name, config, ctx: TokenEmitter(name))
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "streaming_demo",
     "channels": {"messages": {"reducer": "append"}},
     "nodes":    {"emit":     {"type": "token_emitter"}},

--- a/bindings/python/examples/20_otel_tracing.py
+++ b/bindings/python/examples/20_otel_tracing.py
@@ -60,6 +60,7 @@ for tn, fac in [("step_a", StepA), ("step_b", StepB), ("step_c", StepC)]:
         lambda name, config, ctx, _f=fac: _f(name))
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "otel_demo",
     "channels": {"trail": {"reducer": "append"}},
     "nodes": {

--- a/bindings/python/examples/22_self_evolving_graph.py
+++ b/bindings/python/examples/22_self_evolving_graph.py
@@ -175,6 +175,7 @@ def propose_new_graph(current_graph: dict, last_reply: str,
       - may NOT introduce node types other than ``prompted_llm``
       - returns strict JSON only
     """
+    current_schema = current_graph.get("schema_version")
     instructions = f"""You are a graph-rewriter. Given a NeoGraph
 definition (JSON) and the failure mode of its last run, output a
 REVISED graph that fixes the failure.
@@ -182,6 +183,7 @@ REVISED graph that fixes the failure.
 Hard rules:
   - Output ONLY a JSON object — no prose, no markdown fences.
   - Keep the same top-level "name" field.
+  - Keep top-level "schema_version" exactly {current_schema!r}.
   - Only "prompted_llm" node type is registered. Do not invent others.
   - The graph must reach END_NODE from START_NODE.
   - You may modify any node's "config.system_prompt" or
@@ -227,15 +229,21 @@ Return the revised graph JSON now."""
         raw = raw.strip()
 
     try:
-        return json.loads(raw)
+        proposed = json.loads(raw)
     except json.JSONDecodeError as e:
         raise RuntimeError(
             f"self-modifier returned non-JSON: {e}. raw: {raw[:400]!r}")
+    if proposed.get("schema_version") != current_schema:
+        raise RuntimeError(
+            "self-modifier changed or omitted schema_version: "
+            f"expected {current_schema!r}, got {proposed.get('schema_version')!r}")
+    return proposed
 
 
 # ── Driver ──────────────────────────────────────────────────────────
 
 INITIAL_GRAPH: dict[str, Any] = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "person_profile",
     "channels": {
         "seed":      {"reducer": "overwrite"},

--- a/bindings/python/examples/23_evolving_chat_agent.py
+++ b/bindings/python/examples/23_evolving_chat_agent.py
@@ -104,6 +104,7 @@ ng.NodeFactory.register_type(
 # ── Initial agent definition ────────────────────────────────────────
 
 INITIAL_AGENT: dict[str, Any] = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "evolving_chat_v1",
     "_version": 1,
     "channels": {
@@ -136,6 +137,8 @@ def validate_agent(defn: dict) -> tuple[bool, str]:
         return False, "not an object"
     if "name" not in defn:
         return False, "missing 'name'"
+    if defn.get("schema_version") != ng.TOPOLOGY_SCHEMA_VERSION:
+        return False, "must keep current 'schema_version'"
 
     nodes = defn.get("nodes") or {}
     if not isinstance(nodes, dict) or not nodes:
@@ -178,6 +181,7 @@ def validate_agent(defn: dict) -> tuple[bool, str]:
 # is rejected before compile.
 
 def propose_new_agent(current: dict, conversation: list[dict], provider) -> tuple[dict, str]:
+    current_schema = current.get("schema_version")
     convo = "\n".join(
         f"[{m.get('role','?')}] {m.get('content','')[:200]}"
         for m in conversation[-20:]
@@ -190,6 +194,7 @@ style.
 
 Hard rules — violating any rejects your output:
   - Output ONLY a JSON object — no prose, no markdown fences.
+  - Keep top-level "schema_version" exactly {current_schema!r}.
   - Only "prompted_chat" node type is registered.
   - Keep the "messages" channel with reducer "append".
   - Keep the "__graph_meta__" channel with reducer "append".
@@ -233,6 +238,10 @@ Return the revised graph JSON."""
         proposed = json.loads(raw)
     except json.JSONDecodeError as e:
         raise RuntimeError(f"evolver returned non-JSON: {e}; raw[:300]: {raw[:300]!r}")
+    if proposed.get("schema_version") != current_schema:
+        raise RuntimeError(
+            "evolver changed or omitted schema_version: "
+            f"expected {current_schema!r}, got {proposed.get('schema_version')!r}")
 
     reason = proposed.pop("_reason", None) or "evolved from conversation"
     return proposed, reason

--- a/bindings/python/examples/24_tool_approval_gate.py
+++ b/bindings/python/examples/24_tool_approval_gate.py
@@ -111,6 +111,7 @@ class PretendModel(ng.GraphNode):
 
 
 DEFINITION = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "approval_gate",
     "channels": {"messages": {"reducer": "append"}},
     "nodes": {

--- a/bindings/python/examples/25_async_tools.py
+++ b/bindings/python/examples/25_async_tools.py
@@ -44,6 +44,7 @@ N = 3
 
 def _definition(names):
     return {
+        "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
         "name": "async_tools_demo",
         "channels": {"messages": {"reducer": "append"}},
         "nodes": {"model": {"type": "at_model"}, "tools": {"type": "tool_dispatch"}},

--- a/bindings/python/examples/26_mcp_tools.py
+++ b/bindings/python/examples/26_mcp_tools.py
@@ -130,6 +130,7 @@ class PretendModel(ng.GraphNode):
 
 
 DEFINITION = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "mcp_demo",
     "channels": {"messages": {"reducer": "append"}},
     "nodes": {"model": {"type": "mcp_model"}, "tools": {"type": "tool_dispatch"}},

--- a/bindings/python/examples/_protocol_demo.py
+++ b/bindings/python/examples/_protocol_demo.py
@@ -45,6 +45,7 @@ def make_adapter(checkpoint_store=None, input_builder=None):
         type_name, lambda name, config, ctx: EchoNode(name)
     )
     definition = {
+        "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
         "name": "protocol_demo",
         "channels": {"messages": {"reducer": "append"}},
         "nodes": {"echo": {"type": type_name}},

--- a/bindings/python/neograph_engine/__init__.py
+++ b/bindings/python/neograph_engine/__init__.py
@@ -71,11 +71,13 @@ from ._neograph import (
 
     # Pre-flight checks on a graph definition (#97)
     validate,
+    upgrade_topology,
     ValidationReport,
     Diagnostic,
 
     # Versioning
     __version__,
+    TOPOLOGY_SCHEMA_VERSION,
 
     # Provider surface
     Provider,
@@ -528,6 +530,7 @@ __all__ = [
     "InMemoryStore",
     "StoreItem",
     "validate",
+    "upgrade_topology",
     "ValidationReport",
     "Diagnostic",
     "RateLimitError",
@@ -550,6 +553,7 @@ __all__ = [
     # Postgres/SqliteCheckpointStore appended dynamically below when present.
     "StreamMode",
     "GraphEvent",
+    "TOPOLOGY_SCHEMA_VERSION",
     "START_NODE",
     "END_NODE",
 ]

--- a/bindings/python/src/bind_parity.cpp
+++ b/bindings/python/src/bind_parity.cpp
@@ -66,6 +66,8 @@ public:
 void init_parity(py::module_& m) {
     using namespace neograph::graph;
 
+    m.attr("TOPOLOGY_SCHEMA_VERSION") = py::int_(TOPOLOGY_SCHEMA_VERSION);
+
     // ── Store ────────────────────────────────────────────────────────────
     //
     // A checkpoint remembers one conversation. The Store remembers the user
@@ -204,6 +206,15 @@ void init_parity(py::module_& m) {
         "    report = ng.validate(definition)\n"
         "    if report.has_errors():\n"
         "        print(report.summary())\n");
+
+    m.def("upgrade_topology",
+        [](py::object definition) {
+            return json_to_py(
+                GraphCompiler::upgrade_to_latest(py_to_json(definition)));
+        },
+        py::arg("definition"),
+        "Return a lossless strict-schema upgrade of a legacy graph definition."
+        " Ignored legacy fields are preserved as x-upgraded-* annotations.");
 }
 
 }  // namespace neograph::pybind

--- a/bindings/python/tests/test_example_schema_versions.py
+++ b/bindings/python/tests/test_example_schema_versions.py
@@ -1,0 +1,99 @@
+"""Recommended and generated topology examples must opt into strict mode."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import neograph_engine as ng
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_python_examples_that_compile_topologies_declare_schema_version():
+    roots = [ROOT / "bindings/python/examples", ROOT / "examples/cookbook"]
+    sources = [path for root in roots for path in root.rglob("*.py")]
+
+    offenders = []
+    for path in sources:
+        text = path.read_text(encoding="utf-8")
+        if "GraphEngine.compile(" not in text:
+            continue
+        if path.name == "15_graph_from_json.py":
+            continue  # Loads the versioned output written by example 14.
+        if '"schema_version":' not in text:
+            offenders.append(path.relative_to(ROOT).as_posix())
+
+    assert not offenders, f"unversioned Python topology examples: {offenders}"
+
+
+def test_cpp_examples_that_build_topologies_declare_schema_version():
+    sources = [
+        path
+        for path in (ROOT / "examples").rglob("*.cpp")
+        if path.is_file() and "third_party" not in path.parts
+    ]
+    externally_versioned = {
+        "examples/cookbook/jarvis/src/main.cpp",  # Loads jarvis_graph.json.
+    }
+    generated_and_gated = {
+        "examples/cookbook/the-beast/the_beast_apex.cpp",
+        "examples/cookbook/the-beast/the_beast_forge.cpp",
+        "examples/cookbook/the-beast/the_beast_live.cpp",
+    }
+    minimum_markers = {
+        "examples/09_all_features.cpp": 5,
+        "examples/cookbook/multi_tenant_chatbot/server.cpp": 3,
+        "examples/cookbook/multi_tenant_chatbot/server_live_llm.cpp": 3,
+        "examples/cookbook/self_evolving_chatbot/server.cpp": 3,
+        "examples/cookbook/self_evolving_chatbot/server_multi.cpp": 3,
+        "examples/cookbook/the-beast/the_beast_gate_eval.cpp": 5,
+    }
+
+    offenders = []
+    for path in sources:
+        text = path.read_text(encoding="utf-8")
+        if "GraphEngine::build(" not in text:
+            continue
+        relative = path.relative_to(ROOT).as_posix()
+        if relative in externally_versioned:
+            continue
+        if relative in generated_and_gated:
+            if "schema_version must match TOPOLOGY_SCHEMA_VERSION" not in text:
+                offenders.append(f"{relative} (generated schema gate missing)")
+            continue
+        marker_count = text.count('{"schema_version"') + text.count('"schema_version":')
+        required = minimum_markers.get(relative, 1)
+        if marker_count < required:
+            offenders.append(f"{relative} ({marker_count} < {required})")
+
+    assert not offenders, f"unversioned C++ topology examples: {offenders}"
+
+
+def test_generated_factories_and_shipped_json_use_current_schema_version():
+    generated_sources = [
+        ROOT / "src/core/react_graph.cpp",
+        ROOT / "src/core/plan_execute_graph.cpp",
+        ROOT / "src/core/deep_research_graph.cpp",
+    ]
+    for path in generated_sources:
+        text = path.read_text(encoding="utf-8")
+        assert "TOPOLOGY_SCHEMA_VERSION" in text, path.relative_to(ROOT)
+
+    graph_files = list(
+        (ROOT / "examples/cookbook/jarvis").rglob("jarvis_graph.json")
+    )
+    assert graph_files
+    for path in graph_files:
+        definition = json.loads(path.read_text(encoding="utf-8"))
+        assert definition["schema_version"] == getattr(
+            ng, "TOPOLOGY_SCHEMA_VERSION"
+        ), path
+
+
+def test_unversioned_compatibility_boundary_is_documented():
+    policy = (ROOT / "docs/troubleshooting.md").read_text(encoding="utf-8")
+    assert "Every `0.x` release" in policy
+    assert "planned `1.0.0` boundary" in policy
+    assert "absent or zero versions" in policy

--- a/bindings/python/tests/test_parity.py
+++ b/bindings/python/tests/test_parity.py
@@ -224,6 +224,23 @@ def test_the_validator_exists():
     assert hasattr(ng, "ValidationReport")
 
 
+def test_legacy_topology_upgrade_is_lossless_and_strict():
+    legacy = {
+        "name": "legacy",
+        "conditionnal_edges": [],
+        "x-upgraded-conditionnal_edges": "existing-annotation",
+        "nodes": {},
+    }
+
+    upgraded = ng.upgrade_topology(legacy)
+
+    assert ng.TOPOLOGY_SCHEMA_VERSION == 1
+    assert upgraded["schema_version"] == ng.TOPOLOGY_SCHEMA_VERSION
+    assert upgraded["x-upgraded-conditionnal_edges"] == "existing-annotation"
+    assert upgraded["x-upgraded-conditionnal_edges-2"] == []
+    assert not ng.validate(upgraded).has_errors()
+
+
 def test_a_good_graph_has_no_errors():
     definition = {
         "name": "fine",

--- a/bindings/python/tests/test_readme_quickstart.py
+++ b/bindings/python/tests/test_readme_quickstart.py
@@ -39,6 +39,7 @@ def test_readme_five_second_demo_runs_and_produces_documented_output():
         ]
 
     definition = {
+        "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
         "name": "demo",
         "channels": {
             "name": {"reducer": "overwrite"},
@@ -111,6 +112,7 @@ def offline_react_graph():
     ctx = ng.NodeContext(tools=[CalcTool()])
 
     definition = {
+        "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
         "name": "react",
         "channels": {"messages": {"reducer": "append"}},
         "nodes": {
@@ -193,6 +195,7 @@ def test_runresult_documented_attributes_exist():
         return []
 
     definition = {
+        "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
         "name": "n",
         "channels": {"x": {"reducer": "overwrite"}},
         "nodes": {"noop": {"type": "noop"}},
@@ -249,6 +252,7 @@ def test_documented_reducers_compile(reducer_name):
 
     initial = [] if reducer_name == "append" else 0
     definition = {
+        "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
         "name": "r",
         "channels": {"ch": {"reducer": reducer_name}},
         "nodes": {"noop": {"type": "noop"}},
@@ -270,6 +274,7 @@ def test_undocumented_reducer_raises_clearly():
         return []
 
     definition = {
+        "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
         "name": "r",
         "channels": {"ch": {"reducer": "last_value"}},  # not registered
         "nodes": {"noop": {"type": "noop"}},

--- a/docs/doxygen-mainpage.ja.md
+++ b/docs/doxygen-mainpage.ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/doxygen-mainpage.md locale=ja source_sha256=11e68f6a872b8ae6ddcc70f8b1cb6a883e34d9e14d1da05358c48d47d56bf2d1 -->
+<!-- neograph-i18n: source=docs/doxygen-mainpage.md locale=ja source_sha256=8b62b237339d4244bee698f93443c1598e9ae55b631399b33d036606bab39d52 -->
 # NeoGraph C++ API リファレンス {#mainpage}
 
 **Languages:** [English](doxygen-mainpage.md) | [한국어](doxygen-mainpage.ko.md) | [日本語](doxygen-mainpage.ja.md) | [简体中文](doxygen-mainpage.zh-CN.md)
@@ -53,6 +53,7 @@ using namespace neograph::graph;
 
 int main() {
     json definition = {
+        {"schema_version", TOPOLOGY_SCHEMA_VERSION},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes",    {{"echo",     {{"type", "llm_call"}}}}},
         {"edges",    json::array({

--- a/docs/doxygen-mainpage.ko.md
+++ b/docs/doxygen-mainpage.ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/doxygen-mainpage.md locale=ko source_sha256=11e68f6a872b8ae6ddcc70f8b1cb6a883e34d9e14d1da05358c48d47d56bf2d1 -->
+<!-- neograph-i18n: source=docs/doxygen-mainpage.md locale=ko source_sha256=8b62b237339d4244bee698f93443c1598e9ae55b631399b33d036606bab39d52 -->
 **Languages:** [English](doxygen-mainpage.md) | [한국어](doxygen-mainpage.ko.md) | [日本語](doxygen-mainpage.ja.md) | [简体中文](doxygen-mainpage.zh-CN.md)
 
 # NeoGraph C++ API 참조 {#mainpage}
@@ -54,6 +54,7 @@ using namespace neograph::graph;
 
 int main() {
     json definition = {
+        {"schema_version", TOPOLOGY_SCHEMA_VERSION},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes",    {{"echo",     {{"type", "llm_call"}}}}},
         {"edges",    json::array({

--- a/docs/doxygen-mainpage.md
+++ b/docs/doxygen-mainpage.md
@@ -52,6 +52,7 @@ using namespace neograph::graph;
 
 int main() {
     json definition = {
+        {"schema_version", TOPOLOGY_SCHEMA_VERSION},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes",    {{"echo",     {{"type", "llm_call"}}}}},
         {"edges",    json::array({

--- a/docs/doxygen-mainpage.zh-CN.md
+++ b/docs/doxygen-mainpage.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/doxygen-mainpage.md locale=zh-CN source_sha256=11e68f6a872b8ae6ddcc70f8b1cb6a883e34d9e14d1da05358c48d47d56bf2d1 -->
+<!-- neograph-i18n: source=docs/doxygen-mainpage.md locale=zh-CN source_sha256=8b62b237339d4244bee698f93443c1598e9ae55b631399b33d036606bab39d52 -->
 # NeoGraph C++ API 参考 {#mainpage}
 
 **Languages:** [English](doxygen-mainpage.md) | [한국어](doxygen-mainpage.ko.md) | [日本語](doxygen-mainpage.ja.md) | [简体中文](doxygen-mainpage.zh-CN.md)
@@ -49,6 +49,7 @@ using namespace neograph::graph;
 
 int main() {
     json definition = {
+        {"schema_version", TOPOLOGY_SCHEMA_VERSION},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes",    {{"echo",     {{"type", "llm_call"}}}}},
         {"edges",    json::array({

--- a/docs/python-binding.ja.md
+++ b/docs/python-binding.ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/python-binding.md locale=ja source_sha256=60b0675d8856a38a51c9eaa809e78f39c236d2c2977b14b62d69bc8ccb7fb217 -->
+<!-- neograph-i18n: source=docs/python-binding.md locale=ja source_sha256=75569d457cedc380413c9de3526d7a4db73790213b5ac9613182126fe9f4933c -->
 # Python バインディング
 
 **Languages:** [English](python-binding.md) | [한국어](python-binding.ko.md) | [日本語](python-binding.ja.md) | [简体中文](python-binding.zh-CN.md)
@@ -25,6 +25,7 @@ def greet(state):
         [{"role": "assistant", "content": f"Hello, {state.get('name')}!"}])]
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "demo",
     "channels": {"name":     {"reducer": "overwrite"},
                  "messages": {"reducer": "append"}},
@@ -59,6 +60,7 @@ ctx = ng.NodeContext(
 )
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "react",
     "channels": {"messages": {"reducer": "append"}},
     "nodes":    {"llm": {"type": "llm_call"}, "dispatch": {"type": "tool_dispatch"}},

--- a/docs/python-binding.ko.md
+++ b/docs/python-binding.ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/python-binding.md locale=ko source_sha256=60b0675d8856a38a51c9eaa809e78f39c236d2c2977b14b62d69bc8ccb7fb217 -->
+<!-- neograph-i18n: source=docs/python-binding.md locale=ko source_sha256=75569d457cedc380413c9de3526d7a4db73790213b5ac9613182126fe9f4933c -->
 **Languages:** [English](python-binding.md) | [한국어](python-binding.ko.md) | [日本語](python-binding.ja.md) | [简体中文](python-binding.zh-CN.md)
 
 # 파이썬 바인딩
@@ -26,6 +26,7 @@ def greet(state):
         [{"role": "assistant", "content": f"Hello, {state.get('name')}!"}])]
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "demo",
     "channels": {"name":     {"reducer": "overwrite"},
                  "messages": {"reducer": "append"}},
@@ -60,6 +61,7 @@ ctx = ng.NodeContext(
 )
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "react",
     "channels": {"messages": {"reducer": "append"}},
     "nodes":    {"llm": {"type": "llm_call"}, "dispatch": {"type": "tool_dispatch"}},

--- a/docs/python-binding.md
+++ b/docs/python-binding.md
@@ -24,6 +24,7 @@ def greet(state):
         [{"role": "assistant", "content": f"Hello, {state.get('name')}!"}])]
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "demo",
     "channels": {"name":     {"reducer": "overwrite"},
                  "messages": {"reducer": "append"}},
@@ -58,6 +59,7 @@ ctx = ng.NodeContext(
 )
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "react",
     "channels": {"messages": {"reducer": "append"}},
     "nodes":    {"llm": {"type": "llm_call"}, "dispatch": {"type": "tool_dispatch"}},

--- a/docs/python-binding.zh-CN.md
+++ b/docs/python-binding.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/python-binding.md locale=zh-CN source_sha256=60b0675d8856a38a51c9eaa809e78f39c236d2c2977b14b62d69bc8ccb7fb217 -->
+<!-- neograph-i18n: source=docs/python-binding.md locale=zh-CN source_sha256=75569d457cedc380413c9de3526d7a4db73790213b5ac9613182126fe9f4933c -->
 # Python 绑定
 
 **Languages:** [English](python-binding.md) | [한국어](python-binding.ko.md) | [日本語](python-binding.ja.md) | [简体中文](python-binding.zh-CN.md)
@@ -21,6 +21,7 @@ def greet(state):
         [{"role": "assistant", "content": f"Hello, {state.get('name')}!"}])]
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "demo",
     "channels": {"name":     {"reducer": "overwrite"},
                  "messages": {"reducer": "append"}},
@@ -54,6 +55,7 @@ ctx = ng.NodeContext(
 )
 
 definition = {
+    "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
     "name": "react",
     "channels": {"messages": {"reducer": "append"}},
     "nodes":    {"llm": {"type": "llm_call"}, "dispatch": {"type": "tool_dispatch"}},

--- a/docs/troubleshooting.ja.md
+++ b/docs/troubleshooting.ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/troubleshooting.md locale=ja source_sha256=18fbe81b3233d4da002abe8e6b268f65168347f28e27740eed56dfb2ce58900f -->
+<!-- neograph-i18n: source=docs/troubleshooting.md locale=ja source_sha256=6d6541f3291390674910938c7a45100ea84f62b1b7f7dd4e864afee8507ca154 -->
 # トラブルシューティング
 
 **Languages:** [English](troubleshooting.md) | [한국어](troubleshooting.ko.md) | [日本語](troubleshooting.ja.md) | [简体中文](troubleshooting.zh-CN.md)
@@ -838,6 +838,19 @@ JSON は入力と一致しなくなりました: コンパイラーが失われ�
 - 過去の寛大な解析に戻すには、次のコマンドを削除します。
   `schema_version` — 未知のキーは再度無視され、ラウンドトリップされます。
   不一致がある場合は標準エラー出力でのみ警告されます。新しい文書は厳格であるべきです。
+
+### 互換性タイムライン
+
+- すべての `0.x` リリースでは、`schema_version` がない文書または 0 の文書を
+  寛容な互換パスに維持します。`0.x` 更新で暗黙に厳格文書へ再解釈しません。
+- 新しい定義、組み込みグラフファクトリー、保守対象の例は現在のバージョン
+  (`TOPOLOGY_SCHEMA_VERSION`、現在は `1`) を宣言します。
+- 予定されている `1.0.0` 境界では、バージョンがない入力または 0 の入力の
+  ルーティングや解析の意味を暗黙に変えず、移行診断とともに拒否します。
+- C++ 入力は `GraphCompiler::upgrade_to_latest()`、Python 入力は
+  `ng.upgrade_topology()` で更新します。無視されていたレガシーデータは衝突を
+  避ける `x-upgraded-*` 注釈として保持されます。DSL ソースは elaborator を
+  再実行し、lockfile と source map を一緒に再生成してください。
 
 ---
 

--- a/docs/troubleshooting.ko.md
+++ b/docs/troubleshooting.ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/troubleshooting.md locale=ko source_sha256=18fbe81b3233d4da002abe8e6b268f65168347f28e27740eed56dfb2ce58900f -->
+<!-- neograph-i18n: source=docs/troubleshooting.md locale=ko source_sha256=6d6541f3291390674910938c7a45100ea84f62b1b7f7dd4e864afee8507ca154 -->
 **Languages:** [English](troubleshooting.md) | [한국어](troubleshooting.ko.md) | [日本語](troubleshooting.ja.md) | [简体中文](troubleshooting.zh-CN.md)
 
 # 문제 해결
@@ -840,6 +840,19 @@ JSON는 더 이상 입력과 일치하지 않습니다. 컴파일러가 손실�
 - 과거의 관대한 구문 분석으로 돌아가려면 다음을 제거하세요.
 `schema_version` — 알 수 없는 키는 다시 무시되고 왕복됩니다.
 불일치는 stderr에서만 경고합니다. 새로운 문서는 엄격하게 유지되어야 합니다.
+
+### 호환성 일정
+
+- 모든 `0.x` 릴리스는 `schema_version`이 없거나 0인 문서를 관대한 호환
+  경로로 유지합니다. `0.x` 업데이트가 이를 조용히 엄격 문서로 재해석하지 않습니다.
+- 새 정의, 내장 그래프 팩토리, 유지보수되는 예제는 현재 버전
+  (`TOPOLOGY_SCHEMA_VERSION`, 현재 `1`)을 선언합니다.
+- 예정된 `1.0.0` 경계에서는 버전이 없거나 0인 입력의 라우팅 또는 파싱 의미를
+  조용히 바꾸는 대신 마이그레이션 진단과 함께 거부합니다.
+- C++ 입력은 `GraphCompiler::upgrade_to_latest()`, Python 입력은
+  `ng.upgrade_topology()`로 업그레이드합니다. 무시되던 레거시 데이터는 충돌을
+  피하는 `x-upgraded-*` 주석으로 보존됩니다. DSL 소스는 elaborator를 다시 실행해
+  lockfile과 source map을 함께 재생성합니다.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -839,6 +839,20 @@ something, and the message lists exactly what.
   `schema_version` — unknown keys are then ignored again and round-trip
   mismatches only warn on stderr. New documents should stay strict.
 
+### Compatibility timeline
+
+- Every `0.x` release keeps absent or zero `schema_version` documents on the
+  lenient compatibility path. No `0.x` update will silently reinterpret them as
+  strict documents.
+- New definitions, built-in graph factories, and maintained examples declare
+  the current version (`TOPOLOGY_SCHEMA_VERSION`, currently `1`).
+- The planned `1.0.0` boundary rejects absent or zero versions with a migration
+  diagnostic instead of silently changing their routing or parsing semantics.
+- Upgrade C++ input with `GraphCompiler::upgrade_to_latest()` or Python input
+  with `ng.upgrade_topology()`. Ignored legacy data is retained under collision-
+  safe `x-upgraded-*` annotations. For DSL sources, re-run the elaborator so the
+  lockfile and source map are regenerated together.
+
 ---
 
 ## Reporting a bug

--- a/docs/troubleshooting.zh-CN.md
+++ b/docs/troubleshooting.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=docs/troubleshooting.md locale=zh-CN source_sha256=18fbe81b3233d4da002abe8e6b268f65168347f28e27740eed56dfb2ce58900f -->
+<!-- neograph-i18n: source=docs/troubleshooting.md locale=zh-CN source_sha256=6d6541f3291390674910938c7a45100ea84f62b1b7f7dd4e864afee8507ca154 -->
 # 故障排除
 
 **Languages:** [English](troubleshooting.md) | [한국어](troubleshooting.ko.md) | [日本語](troubleshooting.ja.md) | [简体中文](troubleshooting.zh-CN.md)
@@ -594,6 +594,19 @@ NeoGraph自己的 .cpp 文件都一致地定义了宏。仅当下游 TU 也拉�
 (3-精氨酸`register_type`）在封闭世界中进行检查；添加`"additionalProperties": true`到模式以选择退出类型。
 - 要退回到历史宽松的解析，请删除
 `schema_version`— 然后再次忽略未知的键，并且往返不匹配仅在 stderr 上发出警告。新文件应保持严格。
+
+### 兼容性时间线
+
+- 所有 `0.x` 版本都让缺失 `schema_version` 或版本为 0 的文档继续使用宽松兼容
+  路径；`0.x` 更新不会悄悄把它们重新解释为严格文档。
+- 新定义、内置图工厂和持续维护的示例声明当前版本
+  （`TOPOLOGY_SCHEMA_VERSION`，当前为 `1`）。
+- 计划中的 `1.0.0` 边界会用迁移诊断拒绝缺失版本或版本为 0 的输入，而不是
+  静默改变其路由或解析语义。
+- C++ 输入使用 `GraphCompiler::upgrade_to_latest()`，Python 输入使用
+  `ng.upgrade_topology()`。被旧版忽略的数据会保存在避免名称冲突的
+  `x-upgraded-*` 注释中。对于 DSL 源，请重新运行 elaborator，以便同时重新生成
+  lockfile 和 source map。
 
 ---
 

--- a/examples/04_checkpoint_hitl.cpp
+++ b/examples/04_checkpoint_hitl.cpp
@@ -75,6 +75,7 @@ int main() {
 
     // Define graph via JSON — interrupt before the tools node
     neograph::json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "order_workflow"},
         {"channels", {
             {"messages", {{"reducer", "append"}}}

--- a/examples/05_parallel_fanout.cpp
+++ b/examples/05_parallel_fanout.cpp
@@ -130,6 +130,7 @@ int main() {
 
     // JSON-based graph definition
     neograph::json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "parallel_research"},
         {"channels", {
             {"findings", {{"reducer", "append"}}},

--- a/examples/06_subgraph.cpp
+++ b/examples/06_subgraph.cpp
@@ -67,6 +67,7 @@ int main() {
 
     // JSON-based graph definition — subgraph included inline
     neograph::json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "supervisor_graph"},
         {"channels", {
             {"messages", {{"reducer", "append"}}}

--- a/examples/07_intent_routing.cpp
+++ b/examples/07_intent_routing.cpp
@@ -89,6 +89,7 @@ int main() {
 
     // Graph definition
     neograph::json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "intent_router"},
         {"channels", {
             {"messages",  {{"reducer", "append"}}},

--- a/examples/08_state_management.cpp
+++ b/examples/08_state_management.cpp
@@ -78,6 +78,7 @@ int main() {
     // 2-node graph: llm → reviewer (interrupt before reviewer)
     // The user reviews the LLM response, then the reviewer does final confirmation
     neograph::json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "state_demo"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {

--- a/examples/09_all_features.cpp
+++ b/examples/09_all_features.cpp
@@ -196,6 +196,7 @@ int main() {
             });
 
         json def = {
+            {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
             {"name", "payment_graph"},
             {"channels", {
                 {"amount", {{"reducer", "overwrite"}}},
@@ -251,6 +252,7 @@ int main() {
             });
 
         json def = {
+            {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
             {"name", "retry_graph"},
             {"channels", {{"api_result", {{"reducer", "overwrite"}}}}},
             {"nodes", {{"unstable_api", {{"type", "unstable_api"}}}}},
@@ -283,6 +285,7 @@ int main() {
     section("3. StreamMode — VALUES + UPDATES mode");
     {
         json def = {
+            {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
             {"name", "stream_demo"},
             {"channels", {
                 {"amount", {{"reducer", "overwrite"}}},
@@ -357,6 +360,7 @@ int main() {
             });
 
         json def = {
+            {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
             {"name", "command_graph"},
             {"channels", {
                 {"score",     {{"reducer", "overwrite"}}},
@@ -444,6 +448,7 @@ int main() {
 
         // Connect Store to GraphEngine
         json def = {
+            {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
             {"name", "store_demo"},
             {"channels", {
                 {"amount", {{"reducer", "overwrite"}}},

--- a/examples/10_send_command.cpp
+++ b/examples/10_send_command.cpp
@@ -173,6 +173,7 @@ int main() {
     // Graph definition
     // planner → (dynamic researcher execution via Send) → evaluator → branching via Command
     json definition = {
+        {"schema_version", TOPOLOGY_SCHEMA_VERSION},
         {"name", "research_agent"},
         {"channels", {
             {"query",       {{"reducer", "overwrite"}}},

--- a/examples/14_plan_executor.cpp
+++ b/examples/14_plan_executor.cpp
@@ -120,6 +120,7 @@ public:
 // =========================================================================
 static json make_graph() {
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "plan_and_executor"},
         {"channels", {
             {"query",    {{"reducer", "overwrite"}}},

--- a/examples/20_mcp_hitl.cpp
+++ b/examples/20_mcp_hitl.cpp
@@ -49,6 +49,7 @@ int main(int argc, char** argv) {
 
     // --- Graph: ReAct with interrupt_before tools ---
     neograph::json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "mcp_hitl"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {

--- a/examples/21_mcp_fanout.cpp
+++ b/examples/21_mcp_fanout.cpp
@@ -158,6 +158,7 @@ int main(int argc, char** argv) {
         });
 
     json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "mcp_fanout"},
         {"channels", {
             {"plan",       {{"reducer", "overwrite"}}},

--- a/examples/24_mcp_feedback.cpp
+++ b/examples/24_mcp_feedback.cpp
@@ -77,6 +77,7 @@ int main(int argc, char** argv) {
         neograph::llm::OpenAIProvider::create(cfg);
 
     neograph::json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "feedback_loop"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {

--- a/examples/27_async_concurrent_runs.cpp
+++ b/examples/27_async_concurrent_runs.cpp
@@ -61,6 +61,7 @@ public:
 
 static neograph::json one_step_graph(const std::string& node_name) {
     return {
+        {"schema_version", ng::TOPOLOGY_SCHEMA_VERSION},
         {"name", "single_work"},
         {"channels", {
             {"messages", {{"reducer", "append"}}},

--- a/examples/36_classifier_fanout.cpp
+++ b/examples/36_classifier_fanout.cpp
@@ -214,6 +214,7 @@ int main(int argc, char** argv) {
         });
 
     json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "classifier_fanout"},
         {"channels", {
             {"text",     {{"reducer", "overwrite"}}},

--- a/examples/37_a2a_client.cpp
+++ b/examples/37_a2a_client.cpp
@@ -109,6 +109,7 @@ int main(int argc, char** argv) {
         });
 
     neograph::json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "a2a_demo"},
         {"channels", {
             {"prompt",            {{"reducer", "overwrite"}}},

--- a/examples/38_a2a_server.cpp
+++ b/examples/38_a2a_server.cpp
@@ -74,6 +74,7 @@ std::shared_ptr<GraphEngine> build_demo_engine() {
             return std::make_unique<UppercaseNode>(n);
         });
     neograph::json def = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "uppercase-agent"},
         {"channels", {
             {"prompt",   {{"reducer", "overwrite"}}},

--- a/examples/39_acp_server.cpp
+++ b/examples/39_acp_server.cpp
@@ -69,6 +69,7 @@ std::shared_ptr<GraphEngine> build_demo_engine() {
             return std::make_unique<UppercaseNode>(n);
         });
     neograph::json def = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "uppercase-acp-agent"},
         {"channels", {
             {"prompt",   {{"reducer", "overwrite"}}},

--- a/examples/40_react_async_streaming.cpp
+++ b/examples/40_react_async_streaming.cpp
@@ -208,6 +208,7 @@ int main() {
         owned_tools.push_back(std::make_unique<CalculatorTool>());
         // Standard 2-node ReAct loop: llm → (has_tool_calls?) → tools → llm.
         neograph::json definition = {
+            {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
             {"name", "react_async_streaming"},
             {"channels", {{"messages", {{"reducer", "append"}}}}},
             {"nodes", {

--- a/examples/41_resume_if_exists_chat.cpp
+++ b/examples/41_resume_if_exists_chat.cpp
@@ -86,6 +86,7 @@ int main() {
     ctx.instructions = "Echo user turn count.";
 
     json definition = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "chatbot"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes",    {{"llm",       {{"type", "llm_call"}}}}},

--- a/examples/42_custom_reducer_condition.cpp
+++ b/examples/42_custom_reducer_condition.cpp
@@ -124,6 +124,7 @@ int main() {
     // the registry name is misspelled, build() throws — try changing
     // "sum" to "summ" below to see the failure mode.
     json def = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "custom_reducer_demo"},
         {"channels", {
             {"score",   {{"reducer", "sum"}}},

--- a/examples/43_store_personalization.cpp
+++ b/examples/43_store_personalization.cpp
@@ -111,6 +111,7 @@ public:
 
 static json make_graph() {
     return json{
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "personalized"},
         {"channels", {
             {"user_id",      {{"reducer", "overwrite"}}},

--- a/examples/44_request_queue_backpressure.cpp
+++ b/examples/44_request_queue_backpressure.cpp
@@ -61,6 +61,7 @@ public:
 
 static json work_graph() {
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "single_work"},
         {"channels", {{"result", {{"reducer", "overwrite"}}}}},
         {"nodes",    {{"work",   {{"type", "work"}}}}},

--- a/examples/46_cancel_token.cpp
+++ b/examples/46_cancel_token.cpp
@@ -58,6 +58,7 @@ int main() {
         });
 
     json def = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "slow_chain"},
         {"channels", {{"counter", {{"reducer", "overwrite"}}}}},
         {"nodes", {

--- a/examples/47_node_cache.cpp
+++ b/examples/47_node_cache.cpp
@@ -43,6 +43,7 @@ int main() {
         });
 
     json def = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "cache_demo"},
         {"channels", {
             {"x", {{"reducer", "overwrite"}}},

--- a/examples/48_sqlite_checkpoint.cpp
+++ b/examples/48_sqlite_checkpoint.cpp
@@ -43,6 +43,7 @@ int main() {
 
     // Two-node chain — a → b.
     json def = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "checkpoint_demo"},
         {"channels", {
             {"counter", {{"reducer", "overwrite"}}},

--- a/examples/49_openinference.cpp
+++ b/examples/49_openinference.cpp
@@ -184,6 +184,7 @@ int main() {
         });
 
     json def = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "obs_demo"},
         {"channels", {{"reply", {{"reducer", "overwrite"}}}}},
         {"nodes", {{"talk", {{"type", "talk"}}}}},

--- a/examples/51_minimal.cpp
+++ b/examples/51_minimal.cpp
@@ -43,6 +43,7 @@ int main() {
 
     // (1) 그래프 정의 — 채널 1, 노드 1, 엣지 2 (start→upper→end).
     json def = {
+        {"schema_version", TOPOLOGY_SCHEMA_VERSION},
         {"name", "minimal"},
         {"channels", {{"text", {{"reducer", "overwrite"}}}}},
         {"nodes",    {{"upper", {{"type", "upper"}}}}},

--- a/examples/61_sync_node.cpp
+++ b/examples/61_sync_node.cpp
@@ -34,6 +34,7 @@ int main() {
         });
 
     json def = {
+        {"schema_version", TOPOLOGY_SCHEMA_VERSION},
         {"name", "sync_node"},
         {"channels", {{"text", {{"reducer", "overwrite"}}}}},
         {"nodes", {{"upper", {{"type", "upper"}}}}},

--- a/examples/cookbook/ai-assembly/member_server.cpp
+++ b/examples/cookbook/ai-assembly/member_server.cpp
@@ -147,6 +147,7 @@ int main(int argc, char** argv) {
         });
 
     json def = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "member-" + persona_name},
         {"channels", {
             {"prompt",   {{"reducer", "overwrite"}}},

--- a/examples/cookbook/byo-openai/hybrid_with_tools.py
+++ b/examples/cookbook/byo-openai/hybrid_with_tools.py
@@ -173,6 +173,7 @@ def main() -> int:
 
     # Single-step graph; the agentic loop is hidden inside complete().
     graph_def = {
+        "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
         "name": "byo-openai-agentic",
         "channels": {"messages": {"reducer": "append"}},
         "nodes":    {"agent": {"type": "llm_call"}},

--- a/examples/cookbook/jarvis/bench/pybind/perturn.py
+++ b/examples/cookbook/jarvis/bench/pybind/perturn.py
@@ -25,6 +25,7 @@ if which == "neograph":
             f"n{i}", (lambda ch: (lambda name, cfg, ctx: PyNode(name, ch)))("v"))
 
     graph = {
+        "schema_version": ng.TOPOLOGY_SCHEMA_VERSION,
         "name": "chain", "channels": {"v": {"reducer": "overwrite"}},
         "nodes": {f"s{i}": {"type": f"n{i}"} for i in range(5)},
         "edges": ([{"from": "__start__", "to": "s0"}]

--- a/examples/cookbook/jarvis/config-bench-e2e/jarvis_graph.json
+++ b/examples/cookbook/jarvis/config-bench-e2e/jarvis_graph.json
@@ -1,5 +1,6 @@
 {
   "name": "jarvis",
+  "schema_version": 1,
   "_comment": [
     "자비스 메인 그래프. 음성 입력 한 턴이 들어와서 음성 출력 한 턴이 나가는 단위.",
     "voice_in / whisper_stt / supertonic_tts / mcp_dispatch / a2a_delegate 는 main.cpp 에서",

--- a/examples/cookbook/jarvis/config-bench/jarvis_graph.json
+++ b/examples/cookbook/jarvis/config-bench/jarvis_graph.json
@@ -1,5 +1,6 @@
 {
   "name": "jarvis",
+  "schema_version": 1,
   "_comment": [
     "자비스 메인 그래프. 음성 입력 한 턴이 들어와서 음성 출력 한 턴이 나가는 단위.",
     "voice_in / whisper_stt / supertonic_tts / mcp_dispatch / a2a_delegate 는 main.cpp 에서",

--- a/examples/cookbook/jarvis/config-demo/real-tools/jarvis_graph.json
+++ b/examples/cookbook/jarvis/config-demo/real-tools/jarvis_graph.json
@@ -1,5 +1,6 @@
 {
   "name": "jarvis",
+  "schema_version": 1,
   "_comment": [
     "자비스 메인 그래프. 음성 입력 한 턴이 들어와서 음성 출력 한 턴이 나가는 단위.",
     "voice_in / whisper_stt / supertonic_tts / mcp_dispatch / a2a_delegate 는 main.cpp 에서",

--- a/examples/cookbook/jarvis/config-moonshine/jarvis_graph.json
+++ b/examples/cookbook/jarvis/config-moonshine/jarvis_graph.json
@@ -1,5 +1,6 @@
 {
   "name": "jarvis",
+  "schema_version": 1,
   "_comment": [
     "자비스 메인 그래프. 음성 입력 한 턴이 들어와서 음성 출력 한 턴이 나가는 단위.",
     "voice_in / whisper_stt / supertonic_tts / mcp_dispatch / a2a_delegate 는 main.cpp 에서",

--- a/examples/cookbook/jarvis/config/jarvis_graph.json
+++ b/examples/cookbook/jarvis/config/jarvis_graph.json
@@ -1,5 +1,6 @@
 {
   "name": "jarvis",
+  "schema_version": 1,
   "_comment": [
     "자비스 메인 그래프. 음성 입력 한 턴이 들어와서 음성 출력 한 턴이 나가는 단위.",
     "voice_in / whisper_stt / supertonic_tts / mcp_dispatch / a2a_delegate 는 main.cpp 에서",

--- a/examples/cookbook/jarvis/specialists/coder/server.cpp
+++ b/examples/cookbook/jarvis/specialists/coder/server.cpp
@@ -270,6 +270,7 @@ int main(int argc, char** argv) {
 
     // 그래프 정의: persona → summary_enforcer 2단계
     json def = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "coder-specialist"},
         {"channels", {
             {"prompt",   {{"reducer", "overwrite"}}},

--- a/examples/cookbook/jarvis/specialists/researcher/server.cpp
+++ b/examples/cookbook/jarvis/specialists/researcher/server.cpp
@@ -233,6 +233,7 @@ std::shared_ptr<GraphEngine> build_engine(std::shared_ptr<Provider> provider,
         });
 
     json def = {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "researcher-agent"},
         {"channels", {
             {"prompt",   {{"reducer", "overwrite"}}},

--- a/examples/cookbook/multi_tenant_chatbot/server.cpp
+++ b/examples/cookbook/multi_tenant_chatbot/server.cpp
@@ -118,6 +118,7 @@ public:
 
 static json topology_simple() {
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "simple"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {
@@ -133,6 +134,7 @@ static json topology_simple() {
 static json topology_reflexive() {
     // 응답 → 자기 점검 → 재응답
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "reflexive"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {
@@ -152,6 +154,7 @@ static json topology_reflexive() {
 static json topology_fanout() {
     // 3 perspective 병렬 → merge
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "fanout"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {

--- a/examples/cookbook/multi_tenant_chatbot/server_live_llm.cpp
+++ b/examples/cookbook/multi_tenant_chatbot/server_live_llm.cpp
@@ -55,6 +55,7 @@ using clk = std::chrono::steady_clock;
 
 static json topology_simple() {
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "simple"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {
@@ -70,6 +71,7 @@ static json topology_simple() {
 static json topology_reflexive() {
     // draft → critique → final. 진짜 LLM 이라 3 API call/요청.
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "reflexive"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {
@@ -90,6 +92,7 @@ static json topology_fanout() {
     // 3 perspective 병렬 — 진짜 LLM 이라 3 동시 API call/요청.
     // merge 는 mock 그대로 (deterministic, LLM 불필요).
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "fanout"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {

--- a/examples/cookbook/self_evolving_chatbot/server.cpp
+++ b/examples/cookbook/self_evolving_chatbot/server.cpp
@@ -41,6 +41,7 @@ using namespace neograph::graph;
 
 static json topology_simple() {
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "simple"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {{"respond", {{"type", "llm_call"}}}}},
@@ -53,6 +54,7 @@ static json topology_simple() {
 
 static json topology_reflexive() {
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "reflexive"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {
@@ -96,6 +98,7 @@ public:
 
 static json topology_fanout() {
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "fanout"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {

--- a/examples/cookbook/self_evolving_chatbot/server_multi.cpp
+++ b/examples/cookbook/self_evolving_chatbot/server_multi.cpp
@@ -42,6 +42,7 @@ using namespace neograph::graph;
 
 static json topology_simple() {
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "simple"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {{"respond", {{"type", "llm_call"}}}}},
@@ -54,6 +55,7 @@ static json topology_simple() {
 
 static json topology_reflexive() {
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "reflexive"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {
@@ -97,6 +99,7 @@ public:
 
 static json topology_fanout() {
     return {
+        {"schema_version", neograph::graph::TOPOLOGY_SCHEMA_VERSION},
         {"name", "fanout"},
         {"channels", {{"messages", {{"reducer", "append"}}}}},
         {"nodes", {

--- a/examples/cookbook/the-beast/the_beast_apex.cpp
+++ b/examples/cookbook/the-beast/the_beast_apex.cpp
@@ -87,6 +87,11 @@ std::vector<std::unique_ptr<neograph::Tool>> make_tools() {
 struct Verdict { bool ok = false; std::string gate, report; json core; };
 
 Verdict forge(const json& dsl, const ng::NodeContext& ctx) {
+    if (!dsl.contains("schema_version")
+        || !dsl["schema_version"].is_number_integer()
+        || dsl["schema_version"].get<int>() != ng::TOPOLOGY_SCHEMA_VERSION) {
+        return {false, "schema", "schema_version must match TOPOLOGY_SCHEMA_VERSION", {}};
+    }
     json core;
     try { core = ng::Elaborator::elaborate(dsl).core; }
     catch (const std::exception& e) { return {false, "elaborate", e.what(), {}}; }
@@ -152,7 +157,7 @@ int main(int argc, char** argv) {
         "(the loop). Conditional edge form: "
         "{ \"from\": \"agent\", \"condition\": \"has_tool_calls\", "
         "\"routes\": { \"true\": \"tools\", \"false\": \"__end__\" } }.\n"
-        "- schema_version: 1.\n\n"
+        "- \"schema_version\": 1.\n\n"
         "Tools available to the agent at runtime (for your awareness; you do not "
         "wire them individually — tool_dispatch handles all): " + catalog.dump() +
         "\n\nAny dangling node, missing route branch, or undeclared channel is "

--- a/examples/cookbook/the-beast/the_beast_forge.cpp
+++ b/examples/cookbook/the-beast/the_beast_forge.cpp
@@ -44,6 +44,11 @@ namespace ng = neograph::graph;
 // ---- three coherence gates (unchanged across the whole cookbook) ----
 struct Verdict { bool ok = false; std::string gate, report; json core; };
 Verdict forge_gate(const json& dsl, const ng::NodeContext& ctx) {
+    if (!dsl.contains("schema_version")
+        || !dsl["schema_version"].is_number_integer()
+        || dsl["schema_version"].get<int>() != ng::TOPOLOGY_SCHEMA_VERSION) {
+        return {false, "schema", "schema_version must match TOPOLOGY_SCHEMA_VERSION", {}};
+    }
     json core;
     try { core = ng::Elaborator::elaborate(dsl).core; }
     catch (const std::exception& e) { return {false, "elaborate", e.what(), {}}; }
@@ -184,7 +189,7 @@ int main(int argc, char** argv) {
     std::vector<neograph::ChatMessage> hconvo = {
         {"system",
          "You author a NeoGraph agent harness — a graph TOPOLOGY in JSON. Output ONLY "
-         "one JSON object. Build a ReAct tool-calling agent: schema_version 1; channels "
+         "one JSON object. Build a ReAct tool-calling agent: \"schema_version\": 1; channels "
          "{\"messages\":{\"reducer\":\"append\"}}; a node \"agent\" of type \"llm_call\" and "
          "a node \"tools\" of type \"tool_dispatch\"; edges __start__->agent, a conditional "
          "edge {\"from\":\"agent\",\"condition\":\"has_tool_calls\",\"routes\":{\"true\":"

--- a/examples/cookbook/the-beast/the_beast_live.cpp
+++ b/examples/cookbook/the-beast/the_beast_live.cpp
@@ -77,6 +77,11 @@ json channel_of(const json& serialized, const std::string& name) {
 struct Verdict { bool ok = false; std::string gate, report; json core; };
 
 Verdict forge(const json& dsl, const ng::NodeContext& ctx) {
+    if (!dsl.contains("schema_version")
+        || !dsl["schema_version"].is_number_integer()
+        || dsl["schema_version"].get<int>() != ng::TOPOLOGY_SCHEMA_VERSION) {
+        return {false, "schema", "schema_version must match TOPOLOGY_SCHEMA_VERSION", {}};
+    }
     json core;
     try { core = ng::Elaborator::elaborate(dsl).core; }
     catch (const std::exception& e) { return {false, "elaborate", e.what(), {}}; }

--- a/include/neograph/graph/compiler.h
+++ b/include/neograph/graph/compiler.h
@@ -27,6 +27,9 @@
 
 namespace neograph::graph {
 
+/// Latest topology schema accepted by GraphCompiler.
+inline constexpr int TOPOLOGY_SCHEMA_VERSION = 1;
+
 class GraphRegistry;
 
 class GraphNode;
@@ -247,10 +250,10 @@ public:
      * @brief Upgrade a legacy (schema_version 0 / absent) topology
      *        document to the current schema version.
      *
-     * v0 → v1 is purely mechanical and **lossless**: it stamps
-     * `schema_version: 1`, removes barrier blocks whose wait_for is
-     * missing/empty (making the legacy silent drop explicit), and
-     * renames every key strict mode would refuse to
+     * v0 → v1 is purely mechanical and **lossless**: it stamps the current
+     * `schema_version`, moves barrier blocks whose wait_for is missing/empty
+     * into the annotation namespace (making the legacy silent drop explicit),
+     * and renames every key strict mode would refuse to
      * `x-upgraded-<key>` — the annotation namespace — so no user data
      * is deleted, it is just moved out of the engine's way exactly as
      * the lenient parser ignored it.

--- a/src/core/deep_research_graph.cpp
+++ b/src/core/deep_research_graph.cpp
@@ -1259,6 +1259,7 @@ std::unique_ptr<GraphEngine> create_deep_research_graph(
     }
 
     json definition = {
+        {"schema_version", TOPOLOGY_SCHEMA_VERSION},
         {"name", "deep_research_agent"},
         {"channels", channels},
         {"nodes", nodes},

--- a/src/core/graph_compiler.cpp
+++ b/src/core/graph_compiler.cpp
@@ -12,12 +12,6 @@ namespace neograph::graph {
 
 namespace {
 
-// Highest schema_version this compiler understands. Documents declaring
-// a higher version were written for a newer engine — refusing them is
-// the whole point of carrying the field (silent reinterpretation of a
-// newer document is worse than an error).
-constexpr int kSupportedSchemaVersion = 1;
-
 // Keys starting with '_' or 'x-' are annotations: for humans
 // (`_comment`, used across the cookbook corpus) and external tooling
 // (`x-studio-pos`). The engine never consumes them, strict mode never
@@ -302,11 +296,11 @@ TopologySpec GraphCompiler::parse(const json& definition,
                 + sv.dump());
         }
         topology.schema_version = sv.get<int>();
-        if (topology.schema_version > kSupportedSchemaVersion) {
+        if (topology.schema_version > TOPOLOGY_SCHEMA_VERSION) {
             throw std::runtime_error(
                 "topology schema_version " + std::to_string(topology.schema_version)
                 + " is newer than this engine supports (max "
-                + std::to_string(kSupportedSchemaVersion)
+                + std::to_string(TOPOLOGY_SCHEMA_VERSION)
                 + "). Upgrade NeoGraph or re-export the topology.");
         }
     }
@@ -857,25 +851,38 @@ json GraphCompiler::canon(const json& definition) {
 json GraphCompiler::upgrade_to_latest(const json& definition) {
     if (definition.contains("schema_version")
         && definition["schema_version"].is_number_integer()
-        && definition["schema_version"].get<int>() >= kSupportedSchemaVersion) {
+        && definition["schema_version"].get<int>() >= TOPOLOGY_SCHEMA_VERSION) {
         return definition;   // already current
     }
+
+    auto quarantine_name = [](const json& source, const json& output,
+                              const std::string& key) {
+        const std::string base = "x-upgraded-" + key;
+        std::string candidate = base;
+        for (int suffix = 2;
+             source.contains(candidate) || output.contains(candidate);
+             ++suffix) {
+            candidate = base + "-" + std::to_string(suffix);
+        }
+        return candidate;
+    };
 
     // Rebuild an object keeping `consumed` keys, renaming everything
     // else (except annotations) into the x- namespace — data preserved,
     // strict mode satisfied, semantics identical to the lenient parser
     // that ignored those keys.
-    auto quarantine = [](const json& obj, const std::set<std::string>& consumed) {
+    auto quarantine = [&](const json& obj,
+                          const std::set<std::string>& consumed) {
         json out = json::object();
         for (const auto& [k, v] : obj.items()) {
             if (consumed.count(k) || is_annotation_key(k)) out[k] = v;
-            else out["x-upgraded-" + k] = v;
+            else out[quarantine_name(obj, out, k)] = v;
         }
         return out;
     };
 
     json up = json::object();
-    up["schema_version"] = kSupportedSchemaVersion;
+    up["schema_version"] = TOPOLOGY_SCHEMA_VERSION;
 
     static const std::set<std::string> top_keys = {
         "name", "channels", "nodes", "edges", "conditional_edges",
@@ -884,7 +891,7 @@ json GraphCompiler::upgrade_to_latest(const json& definition) {
     for (const auto& [k, v] : definition.items()) {
         if (k == "schema_version") continue;   // re-stamped above
         if (!top_keys.count(k) && !is_annotation_key(k)) {
-            up["x-upgraded-" + k] = v;
+            up[quarantine_name(definition, up, k)] = v;
             continue;
         }
         if (k == "channels" && v.is_object()) {
@@ -927,6 +934,7 @@ json GraphCompiler::upgrade_to_latest(const json& definition) {
                         for (const auto& [nk, nv] : node.items()) {
                             if (nk != "barrier") cleaned[nk] = nv;
                         }
+                        cleaned[quarantine_name(node, cleaned, "barrier")] = b;
                         node = std::move(cleaned);
                     }
                 }

--- a/src/core/plan_execute_graph.cpp
+++ b/src/core/plan_execute_graph.cpp
@@ -374,6 +374,7 @@ std::unique_ptr<GraphEngine> create_plan_execute_graph(
     // the loop with plain conditional edges — including the executor's
     // self-referential "keep going" branch.
     json definition = {
+        {"schema_version", TOPOLOGY_SCHEMA_VERSION},
         {"name", "plan_execute_agent"},
         {"channels", {
             {"messages",       {{"reducer", "append"}}},

--- a/src/core/react_graph.cpp
+++ b/src/core/react_graph.cpp
@@ -12,9 +12,10 @@ std::unique_ptr<GraphEngine> create_react_graph(
     //   __start__ -> llm -> (has_tool_calls ? tools : __end__)
     //                         tools -> llm  (loop back)
     json definition = {
+        {"schema_version", TOPOLOGY_SCHEMA_VERSION},
         {"name", "react_agent"},
         {"channels", {
-            {"messages", {{"type", "list"}, {"reducer", "append"}}}
+            {"messages", {{"reducer", "append"}}}
         }},
         {"nodes", {
             {"llm",   {{"type", "llm_call"}}},

--- a/tests/test_elaborator.cpp
+++ b/tests/test_elaborator.cpp
@@ -308,9 +308,39 @@ TEST(Upgrade, LegacyDocumentUpgradesToEquivalentIR) {
     EXPECT_TRUE(up["retry_policy"].contains("x-upgraded-max_retry"));
     EXPECT_TRUE(up["channels"]["c"].contains("x-upgraded-initail"));
     EXPECT_FALSE(up["nodes"]["a"].contains("barrier"));
+    EXPECT_EQ(up["nodes"]["a"]["x-upgraded-barrier"],
+              legacy["nodes"]["a"]["barrier"]);
 
     // Already-current documents pass through unchanged.
     EXPECT_EQ(GraphCompiler::upgrade_to_latest(up), up);
+}
+
+TEST(Upgrade, QuarantinePreservesExistingAnnotationsOnNameCollision) {
+    ensure_etypes();
+    json legacy = {
+        {"conditionnal_edges", json::array()},
+        {"x-upgraded-conditionnal_edges", "existing-top-level-annotation"},
+        {"channels", {{"c", {{"reducer", "append"},
+                               {"initail", 1},
+                               {"x-upgraded-initail", "existing-channel-annotation"}}}}},
+        {"nodes", {{"a", {{"type", "enoop"},
+                            {"barrier", {{"wait_for", json::array()}}},
+                            {"x-upgraded-barrier", "existing-node-annotation"}}}}},
+    };
+
+    const json up = GraphCompiler::upgrade_to_latest(legacy);
+
+    EXPECT_EQ(up["x-upgraded-conditionnal_edges"],
+              "existing-top-level-annotation");
+    EXPECT_EQ(up["x-upgraded-conditionnal_edges-2"], json::array());
+    EXPECT_EQ(up["channels"]["c"]["x-upgraded-initail"],
+              "existing-channel-annotation");
+    EXPECT_EQ(up["channels"]["c"]["x-upgraded-initail-2"], 1);
+    EXPECT_EQ(up["nodes"]["a"]["x-upgraded-barrier"],
+              "existing-node-annotation");
+    EXPECT_EQ(up["nodes"]["a"]["x-upgraded-barrier-2"],
+              legacy["nodes"]["a"]["barrier"]);
+    EXPECT_NO_THROW(GraphCompiler::compile(up, NodeContext{}));
 }
 
 TEST(Upgrade, ExplicitDefaultRouteBecomesStrictFallback) {


### PR DESCRIPTION
## Summary
- publish the current topology schema version and a collision-safe upgrade API in C++ and Python
- migrate maintained examples and generated graph definitions to explicit strict schemas
- document the legacy compatibility timeline and add corpus, parity, and upgrader regression coverage

## Acceptance evidence
- maintained and generated definitions declare the current schema version
- troubleshooting docs define unversioned 0.x compatibility and the documented 1.0.0 default flip
- upgrader tests cover semantic preservation, annotations, barriers, ignored legacy data, and key collisions
- compiler tests distinguish permissive legacy, strict current, and upgraded documents

## Verification
- C++ CTest: 897 passed, 3 skipped
- Python tests: 265 passed, 6 skipped
- ASan/UBSan/LSan C++: 937 passed, 35 environment-dependent skipped
- TSan C++: 896 passed, 3 skipped
- issue-specific Python ASan: 29 passed
- maintained offline examples: 16 C++ and 13 Python passed
- `python3 scripts/check_docs_i18n.py --strict`
- `python3 scripts/check_runtime_doc_claims.py`
- `git diff --check`

Addresses #213