### PR TITLE
perf(bench): add OpenMP GPU offload PoC

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=CHANGELOG.md locale=ja source_sha256=4e86912fb25a078badb50fae46fb0f72e28ab1862d4c067cc88e792574a889cb -->
+<!-- neograph-i18n: source=CHANGELOG.md locale=ja source_sha256=9de7b7d962822369a007f67eaa873f442f663a4a467deb51f63196511770c04a -->
 # 変更履歴
 
 **Languages:** [English](CHANGELOG.md) | [한국어](CHANGELOG.ko.md) | [日本語](CHANGELOG.ja.md) | [简体中文](CHANGELOG.zh-CN.md)
@@ -19,6 +19,15 @@ NeoGraph の全注目すべき変更を本ファイルに文書化します。
   スキーマバージョン管理されたアーティファクト/実行の永続化で、不変のアーティファクトと
   実行-アーティファクトバインディングを提供。Harness MCP バイナリはレコードを
   `runs.db` に保存し、チェックポイントは `checkpoints.db` に残ります。
+- **AMD OpenMP GPU オフロードの概念実証。** 同じ数値ファンアウト処理で、
+  直列 CPU、OpenMP 自動スレッド化、反復ごとの GPU マッピング、GPU 上に
+  データを保持する実行を比較するオプションの `bench_openmp_offload`
+  ベンチマークを追加しました。実デバイス実行とホストフォールバック、
+  正確性、転送込みレイテンシ、カーネルのみのレイテンシ、直列 CPU 比の
+  高速化を個別に報告します。Radeon AI PRO R9700 では
+  `NEOGRAPH_OPENMP_OFFLOAD_ARCH=gfx1201` で ROCm/Clang デバイスイメージを
+  有効化します。
+
 
 ### 変更
 

--- a/CHANGELOG.ko.md
+++ b/CHANGELOG.ko.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=CHANGELOG.md locale=ko source_sha256=4e86912fb25a078badb50fae46fb0f72e28ab1862d4c067cc88e792574a889cb -->
+<!-- neograph-i18n: source=CHANGELOG.md locale=ko source_sha256=9de7b7d962822369a007f67eaa873f442f663a4a467deb51f63196511770c04a -->
 # 변경 기록
 
 **Languages:** [English](CHANGELOG.md) | [한국어](CHANGELOG.ko.md) | [日本語](CHANGELOG.ja.md) | [简体中文](CHANGELOG.zh-CN.md)
@@ -14,6 +14,14 @@ NeoGraph의 주목할 만한 모든 변경 사항을 이 파일에 기록한다.
 ### 추가
 
 - **SQLite Harness 레코드 저장소 (이슈 #147 후속).** WAL 지원, 스키마 버전 관리가 된 아티팩트/실행 영속성과 변경 불가능한 아티팩트 및 실행-아티팩트 바인딩을 제공하는 선택적 `neograph::mcp_sqlite` 대상과 `SqliteHarnessRecordStore` 추가. Harness MCP 바이너리가 이제 `runs.db`에 레코드를 저장하며, 체크포인트는 `checkpoints.db`에 남는다.
+- **AMD OpenMP GPU 이관 개념 증명.** 같은 숫자 팬아웃 작업에서 직렬 CPU,
+  OpenMP 자동 스레딩, 반복마다 데이터를 옮기는 GPU 실행, 데이터를 GPU에
+  유지하는 실행을 비교하는 선택적 `bench_openmp_offload` 벤치마크를 추가했다.
+  실제 GPU 실행과 호스트 대체 실행, 계산 정확성, 전송 포함 지연 시간,
+  커널만의 지연 시간, 직렬 CPU 대비 속도 향상을 각각 보고한다. Radeon AI PRO
+  R9700에서는 `NEOGRAPH_OPENMP_OFFLOAD_ARCH=gfx1201`로 ROCm/Clang 장치
+  이미지를 활성화한다.
+
 
 ### 변경
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   schema-versioned artifact/run persistence with immutable artifact and run-to-
   artifact bindings. The Harness MCP binary now stores records in `runs.db`,
   while checkpoints remain in `checkpoints.db`.
+- **AMD OpenMP target-offload proof of concept.** Added the opt-in
+  `bench_openmp_offload` benchmark, which compares serial CPU execution,
+  OpenMP auto-threading, per-iteration GPU mapping, and persistent GPU data on
+  the same numeric fan-out workload. It reports real-device versus host
+  fallback execution, correctness, transfer-inclusive latency, kernel-only
+  latency, and speedup. `NEOGRAPH_OPENMP_OFFLOAD_ARCH=gfx1201` enables the
+  ROCm/Clang device image for Radeon AI PRO R9700.
+
 
 ### Changed
 

--- a/CHANGELOG.zh-CN.md
+++ b/CHANGELOG.zh-CN.md
@@ -1,4 +1,4 @@
-<!-- neograph-i18n: source=CHANGELOG.md locale=zh-CN source_sha256=4e86912fb25a078badb50fae46fb0f72e28ab1862d4c067cc88e792574a889cb -->
+<!-- neograph-i18n: source=CHANGELOG.md locale=zh-CN source_sha256=9de7b7d962822369a007f67eaa873f442f663a4a467deb51f63196511770c04a -->
 # 更新日志
 
 **Languages:** [English](CHANGELOG.md) | [한국어](CHANGELOG.ko.md) | [日本語](CHANGELOG.ja.md) | [简体中文](CHANGELOG.zh-CN.md)
@@ -19,6 +19,13 @@ NeoGraph 的所有显著变更均记录于本文件。
   带模式版本的工件/运行持久化，具有不可变工件和运行到工件绑定。
   Harness MCP 二进制文件现在将记录存储在 `runs.db` 中，而检查点仍存储在
   `checkpoints.db` 中。
+- **AMD OpenMP GPU 卸载概念验证。** 新增可选的
+  `bench_openmp_offload` 基准，在相同数值扇出工作负载上比较串行 CPU、
+  OpenMP 自动线程、逐次映射 GPU 和 GPU 常驻数据四种模式。它分别报告真实
+  设备执行与主机回退、计算正确性、包含传输的延迟、仅内核延迟以及相对串行
+  CPU 的加速比。Radeon AI PRO R9700 可通过
+  `NEOGRAPH_OPENMP_OFFLOAD_ARCH=gfx1201` 启用 ROCm/Clang 设备镜像。
+
 
 ### 变更
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1499,6 +1499,40 @@ if(NEOGRAPH_BUILD_BENCHMARKS)
     add_executable(bench_neograph benchmarks/bench_neograph.cpp)
     target_link_libraries(bench_neograph PRIVATE neograph::core)
 
+    # OpenMP target-offload PoC. The target still builds without a device
+    # backend so the executable can report host fallback explicitly.
+    find_package(OpenMP QUIET COMPONENTS CXX)
+    set(NEOGRAPH_OPENMP_OFFLOAD_ARCH "" CACHE STRING
+        "GPU architecture for bench_openmp_offload (for example gfx1201)")
+    if(OpenMP_CXX_FOUND)
+        add_executable(bench_openmp_offload
+            benchmarks/bench_openmp_offload.cpp)
+        target_link_libraries(bench_openmp_offload PRIVATE OpenMP::OpenMP_CXX)
+        target_compile_features(bench_openmp_offload PRIVATE cxx_std_20)
+
+        if(NEOGRAPH_OPENMP_OFFLOAD_ARCH)
+            if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+                target_compile_options(bench_openmp_offload PRIVATE
+                    "--offload-arch=${NEOGRAPH_OPENMP_OFFLOAD_ARCH}")
+                target_link_options(bench_openmp_offload PRIVATE
+                    "-fopenmp"
+                    "--offload-arch=${NEOGRAPH_OPENMP_OFFLOAD_ARCH}")
+                message(STATUS
+                    "bench_openmp_offload device arch: "
+                    "${NEOGRAPH_OPENMP_OFFLOAD_ARCH}")
+            else()
+                message(WARNING
+                    "NEOGRAPH_OPENMP_OFFLOAD_ARCH is set, but "
+                    "${CMAKE_CXX_COMPILER_ID} does not support the "
+                    "Clang --offload-arch option; benchmark will use the "
+                    "compiler's configured OpenMP target behavior")
+            endif()
+        endif()
+    else()
+        message(STATUS
+            "OpenMP CXX not found; bench_openmp_offload will not be built")
+    endif()
+
     # Checkpoint-store load benchmark — compares InMemory / SQLite /
     # Postgres under N×M synthetic save workload. Postgres is opt-in
     # via NEOGRAPH_HAVE_POSTGRES so the binary still builds when the

--- a/benchmarks/bench_openmp_offload.cpp
+++ b/benchmarks/bench_openmp_offload.cpp
@@ -1,0 +1,280 @@
+// OpenMP target-offload PoC for NeoGraph-style fan-out workloads.
+//
+// This is intentionally not part of GraphEngine. A GPU cannot execute arbitrary
+// virtual GraphNode bodies, JSON state transitions, or blocking LLM calls. The
+// benchmark isolates the narrower case OpenMP target offload can accelerate:
+// many independent workers applying the same numeric kernel to contiguous data.
+//
+// Usage:
+//   bench_openmp_offload [fanout] [items_per_worker] [work_rounds]
+//                         [repetitions] [samples]
+
+#include <omp.h>
+
+#include <algorithm>
+#include <charconv>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string_view>
+#include <system_error>
+#include <vector>
+
+namespace {
+
+struct Config {
+    std::size_t fanout = 5;
+    std::size_t items_per_worker = 4096;
+    std::size_t work_rounds = 256;
+    std::size_t repetitions = 10;
+    std::size_t samples = 5;
+};
+
+#pragma omp declare target
+inline double numeric_kernel(double value, std::size_t rounds) {
+    for (std::size_t round = 0; round < rounds; ++round) {
+        const double bias = static_cast<double>((round & 7U) + 1U) * 1.0e-7;
+        value = value * 1.00000011920928955078125 + bias;
+    }
+    return value;
+}
+#pragma omp end declare target
+
+std::size_t parse_positive(std::string_view text, const char* name) {
+    std::size_t value = 0;
+    const auto [end, error] = std::from_chars(text.data(), text.data() + text.size(), value);
+    if (error != std::errc{} || end != text.data() + text.size() || value == 0) {
+        throw std::invalid_argument(std::string(name) + " must be a positive integer");
+    }
+    return value;
+}
+
+std::size_t checked_total_items(const Config& config) {
+    if (config.fanout > std::numeric_limits<std::size_t>::max() /
+                            config.items_per_worker) {
+        throw std::invalid_argument("fanout * items_per_worker overflows size_t");
+    }
+    const auto total = config.fanout * config.items_per_worker;
+    if (total > static_cast<std::size_t>(std::numeric_limits<std::int64_t>::max())) {
+        throw std::invalid_argument("total item count exceeds the OpenMP loop bound");
+    }
+    return total;
+}
+
+using Clock = std::chrono::steady_clock;
+
+double elapsed_ms(Clock::time_point start) {
+    return std::chrono::duration<double, std::milli>(Clock::now() - start).count();
+}
+
+template <class Run>
+double median_ms(std::size_t samples, Run&& run) {
+    std::vector<double> timings;
+    timings.reserve(samples);
+    for (std::size_t sample = 0; sample < samples; ++sample) {
+        timings.push_back(run());
+    }
+    std::sort(timings.begin(), timings.end());
+    return timings[timings.size() / 2];
+}
+
+double run_serial(const double* input, double* output, std::int64_t count,
+                  std::size_t rounds, std::size_t repetitions) {
+    const auto start = Clock::now();
+    for (std::size_t repetition = 0; repetition < repetitions; ++repetition) {
+        for (std::int64_t item = 0; item < count; ++item) {
+            output[item] = numeric_kernel(input[item], rounds);
+        }
+    }
+    return elapsed_ms(start);
+}
+
+double run_openmp_cpu(const double* input, double* output, std::int64_t count,
+                      std::size_t rounds, std::size_t repetitions) {
+    const auto start = Clock::now();
+    for (std::size_t repetition = 0; repetition < repetitions; ++repetition) {
+#pragma omp parallel for schedule(static)
+        for (std::int64_t item = 0; item < count; ++item) {
+            output[item] = numeric_kernel(input[item], rounds);
+        }
+    }
+    return elapsed_ms(start);
+}
+
+double run_target_mapped(const double* input, double* output, std::int64_t count,
+                         std::size_t rounds, std::size_t repetitions) {
+    const auto start = Clock::now();
+    for (std::size_t repetition = 0; repetition < repetitions; ++repetition) {
+#pragma omp target teams distribute parallel for map(to : input[0:count])                \
+    map(from : output[0:count]) firstprivate(rounds)
+        for (std::int64_t item = 0; item < count; ++item) {
+            output[item] = numeric_kernel(input[item], rounds);
+        }
+    }
+    return elapsed_ms(start);
+}
+
+double run_target_resident(const double* input, double* output, std::int64_t count,
+                           std::size_t rounds, std::size_t repetitions) {
+    double kernel_ms = 0.0;
+#pragma omp target data map(to : input[0:count]) map(alloc : output[0:count])
+    {
+        const auto start = Clock::now();
+        for (std::size_t repetition = 0; repetition < repetitions; ++repetition) {
+#pragma omp target teams distribute parallel for firstprivate(rounds)
+            for (std::int64_t item = 0; item < count; ++item) {
+                output[item] = numeric_kernel(input[item], rounds);
+            }
+        }
+        kernel_ms = elapsed_ms(start);
+#pragma omp target update from(output[0:count])
+    }
+    return kernel_ms;
+}
+
+bool target_uses_device() {
+    int initial_device = 1;
+#pragma omp target map(from : initial_device)
+    { initial_device = omp_is_initial_device(); }
+    return initial_device == 0;
+}
+
+double checksum(const std::vector<double>& values) {
+    long double sum = 0.0L;
+    for (const double value : values) sum += value;
+    return static_cast<double>(sum);
+}
+
+struct Accuracy {
+    double max_abs_error = 0.0;
+    bool correct = true;
+};
+
+Accuracy compare(const std::vector<double>& reference,
+                 const std::vector<double>& candidate) {
+    Accuracy result;
+    for (std::size_t index = 0; index < reference.size(); ++index) {
+        const double error = std::abs(reference[index] - candidate[index]);
+        result.max_abs_error = std::max(result.max_abs_error, error);
+        const double tolerance = 1.0e-11 * std::max(1.0, std::abs(reference[index]));
+        if (!std::isfinite(candidate[index]) || error > tolerance) {
+            result.correct = false;
+        }
+    }
+    return result;
+}
+
+void print_result(const char* mode, double median, double serial_median,
+                  std::size_t repetitions, const std::vector<double>& values,
+                  const Accuracy& accuracy, const char* timing_scope) {
+    std::cout << "result\t" << mode << '\t' << median << '\t'
+              << (median * 1000.0 / static_cast<double>(repetitions)) << '\t'
+              << (serial_median / median) << '\t' << checksum(values) << '\t'
+              << accuracy.max_abs_error << '\t' << (accuracy.correct ? 1 : 0) << '\t'
+              << timing_scope << '\n';
+}
+
+} // namespace
+
+int main(int argc, char** argv) try {
+    if (argc > 6) {
+        throw std::invalid_argument(
+            "usage: bench_openmp_offload [fanout] [items_per_worker] "
+            "[work_rounds] [repetitions] [samples]");
+    }
+
+    Config config;
+    if (argc > 1) config.fanout = parse_positive(argv[1], "fanout");
+    if (argc > 2) {
+        config.items_per_worker = parse_positive(argv[2], "items_per_worker");
+    }
+    if (argc > 3) config.work_rounds = parse_positive(argv[3], "work_rounds");
+    if (argc > 4) config.repetitions = parse_positive(argv[4], "repetitions");
+    if (argc > 5) config.samples = parse_positive(argv[5], "samples");
+
+    const std::size_t total_items = checked_total_items(config);
+    const auto loop_count = static_cast<std::int64_t>(total_items);
+
+    std::vector<double> input(total_items);
+    for (std::size_t item = 0; item < total_items; ++item) {
+        input[item] = 0.25 + static_cast<double>(item % 1024U) * 1.0e-4;
+    }
+    std::vector<double> serial_output(total_items);
+    std::vector<double> cpu_output(total_items);
+    std::vector<double> mapped_output(total_items);
+    std::vector<double> resident_output(total_items);
+
+    const bool offload_active = target_uses_device();
+
+    // Prime CPU worker creation, device runtime initialization, device image
+    // loading, and mappings before collecting samples.
+    (void)run_serial(input.data(), serial_output.data(), loop_count,
+                     config.work_rounds, 1);
+    (void)run_openmp_cpu(input.data(), cpu_output.data(), loop_count,
+                         config.work_rounds, 1);
+    (void)run_target_mapped(input.data(), mapped_output.data(), loop_count,
+                            config.work_rounds, 1);
+    (void)run_target_resident(input.data(), resident_output.data(), loop_count,
+                              config.work_rounds, 1);
+
+    const double serial_median = median_ms(config.samples, [&] {
+        return run_serial(input.data(), serial_output.data(), loop_count,
+                          config.work_rounds, config.repetitions);
+    });
+    const double cpu_median = median_ms(config.samples, [&] {
+        return run_openmp_cpu(input.data(), cpu_output.data(), loop_count,
+                              config.work_rounds, config.repetitions);
+    });
+    const double mapped_median = median_ms(config.samples, [&] {
+        return run_target_mapped(input.data(), mapped_output.data(), loop_count,
+                                 config.work_rounds, config.repetitions);
+    });
+    const double resident_median = median_ms(config.samples, [&] {
+        return run_target_resident(input.data(), resident_output.data(), loop_count,
+                                   config.work_rounds, config.repetitions);
+    });
+
+    const Accuracy serial_accuracy{};
+    const Accuracy cpu_accuracy = compare(serial_output, cpu_output);
+    const Accuracy mapped_accuracy = compare(serial_output, mapped_output);
+    const Accuracy resident_accuracy = compare(serial_output, resident_output);
+
+    std::cout << std::setprecision(12);
+    std::cout << "config\tfanout\t" << config.fanout << '\n';
+    std::cout << "config\titems_per_worker\t" << config.items_per_worker << '\n';
+    std::cout << "config\ttotal_items\t" << total_items << '\n';
+    std::cout << "config\twork_rounds\t" << config.work_rounds << '\n';
+    std::cout << "config\trepetitions\t" << config.repetitions << '\n';
+    std::cout << "config\tsamples\t" << config.samples << '\n';
+    std::cout << "runtime\topenmp_version\t" << _OPENMP << '\n';
+    std::cout << "runtime\tcpu_max_threads\t" << omp_get_max_threads() << '\n';
+    std::cout << "runtime\ttarget_devices\t" << omp_get_num_devices() << '\n';
+    std::cout << "runtime\toffload_active\t" << (offload_active ? 1 : 0) << '\n';
+    std::cout << "header\tmode\tmedian_ms\tper_repetition_us\t"
+                 "speedup_vs_serial\tchecksum\tmax_abs_error\tcorrect\t"
+                 "timing_scope\n";
+    print_result("serial_host", serial_median, serial_median, config.repetitions,
+                 serial_output, serial_accuracy, "compute");
+    print_result("openmp_cpu_auto", cpu_median, serial_median, config.repetitions,
+                 cpu_output, cpu_accuracy, "compute_plus_host_scheduling");
+    print_result("target_mapped", mapped_median, serial_median, config.repetitions,
+                 mapped_output, mapped_accuracy, "compute_plus_transfer");
+    print_result("target_resident", resident_median, serial_median,
+                 config.repetitions, resident_output, resident_accuracy,
+                 "kernel_only");
+
+    if (!cpu_accuracy.correct || !mapped_accuracy.correct ||
+        !resident_accuracy.correct) {
+        std::cerr << "benchmark output mismatch\n";
+        return 2;
+    }
+    return 0;
+} catch (const std::exception& error) {
+    std::cerr << "error: " << error.what() << '\n';
+    return 1;
+}


### PR DESCRIPTION
## Summary

- add an opt-in OpenMP target-offload benchmark for NeoGraph-style numeric fan-out
- compare serial CPU, OpenMP CPU auto-threading, transfer-inclusive target execution, and persistent target data
- detect actual GPU execution versus host fallback and validate every result against the serial output
- support target-local `NEOGRAPH_OPENMP_OFFLOAD_ARCH` configuration without changing production `GraphEngine` behavior

## Why

`set_worker_count_auto()` pays real scheduling and synchronization overhead. The existing no-I/O fan-out benchmark measured 18.91 µs per iteration with `worker_count=1` and 273.99 µs with `auto(18)` on the test host. GPU offload can beat that cost only when node work is regular, data-parallel, and large enough to amortize kernel launch and data movement.

This PR deliberately does **not** claim that arbitrary GraphNode bodies, JSON state, coroutines, LLM calls, or network I/O can execute on a GPU.

## R9700 results

AMD Radeon AI PRO R9700 (`gfx1201`), ROCm 7.2.1, 18 CPU threads. Speedup is serial CPU time divided by measured mode time.

| Workload | OpenMP CPU | GPU with transfer | GPU resident kernel |
|---|---:|---:|---:|
| 5 × 4096 items × 256 rounds | 0.90× | 4.89× | 71.21× |
| 64 × 4096 items × 256 rounds | 5.57× | 10.80× | 22.85× |

A 5-worker × 1-item case remains much slower on every parallel/offload path, demonstrating the fixed-cost boundary instead of hiding it.

## Verification

- AMD Clang 22 / ROCm 7.2.1 Release build with `--offload-arch=gfx1201`
- `OMP_TARGET_OFFLOAD=MANDATORY`: `target_devices=1`, `offload_active=1`
- all four modes: `correct=1`; maximum absolute GPU error approximately `5.66e-15`
- GCC host-only build: `target_devices=0`, `offload_active=0`
- `-Wall -Wextra -Wpedantic` clean
- `python3 scripts/check_docs_i18n.py --strict`: 126/126 translations present

Closes #258
