### PR TITLE
fix(ci): restore Pages and resolve test races

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,74 @@
+name: Deploy Doxygen to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'include/**'
+      - 'docs/**.md'
+      - 'examples/**'
+      - 'Doxyfile'
+      - 'pyproject.toml'
+      - '.github/workflows/docs.yml'
+      - 'scripts/ci_apt_install.sh'
+  pull_request:
+    branches: [master]
+    paths:
+      - 'include/**'
+      - 'docs/**.md'
+      - 'examples/**'
+      - 'Doxyfile'
+      - 'pyproject.toml'
+      - '.github/workflows/docs.yml'
+      - 'scripts/ci_apt_install.sh'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Doxygen and Graphviz
+        run: bash scripts/ci_apt_install.sh doxygen graphviz
+      - name: Generate versioned documentation
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import tomllib
+
+          version = tomllib.loads(Path('pyproject.toml').read_text())['project']['version']
+          config = Path('Doxyfile').read_text()
+          Path('Doxyfile').write_text(config + f'\nPROJECT_NUMBER = "{version}"\n')
+          PY
+          doxygen Doxyfile
+          test -s docs/api/html/index.html
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/api/html
+
+  deploy:
+    needs: build
+    if: github.ref == 'refs/heads/master' && github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/configure-pages@v5
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/bindings/python/tests/test_protocol_sdk_e2e.py
+++ b/bindings/python/tests/test_protocol_sdk_e2e.py
@@ -11,7 +11,6 @@ import os
 import runpy
 import socket
 import sys
-import tomllib
 from pathlib import Path
 from uuid import uuid4
 
@@ -22,6 +21,11 @@ from packaging.version import Version
 
 pytest.importorskip("a2a")
 pytest.importorskip("acp")
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.9 and 3.10 wheel tests.
+    import tomli as tomllib
 
 import httpx
 from a2a.client import A2ACardResolver, ClientConfig, create_client

--- a/docs/promo/package-lock.json
+++ b/docs/promo/package-lock.json
@@ -2557,9 +2557,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,7 @@ skip   = "*-musllinux_* *_i686 pp*"
 # Inside the wheel-test venv, install pytest and run the binding's
 # pytest suite plus a one-line import smoke. The {project} placeholder
 # resolves to the source tree path inside the cibw container.
-test-requires = ["pytest", "tomli; python_version < '3.11'"]
+test-requires = ["pytest", "tomli"]
 test-command  = """\
 python -c "import pathlib, sqlite3, tempfile; import neograph_engine as ng; ng.SQLiteContextStore(str(pathlib.Path(tempfile.mkdtemp()) / 'smoke.sqlite3')); print('cibw smoke version:', ng.__version__, 'preloaded sqlite:', sqlite3.sqlite_version)" && \
 python -m pytest -q {project}/bindings/python/tests/\

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,7 @@ skip   = "*-musllinux_* *_i686 pp*"
 # Inside the wheel-test venv, install pytest and run the binding's
 # pytest suite plus a one-line import smoke. The {project} placeholder
 # resolves to the source tree path inside the cibw container.
-test-requires = ["pytest"]
+test-requires = ["pytest", "tomli; python_version < '3.11'"]
 test-command  = """\
 python -c "import pathlib, sqlite3, tempfile; import neograph_engine as ng; ng.SQLiteContextStore(str(pathlib.Path(tempfile.mkdtemp()) / 'smoke.sqlite3')); print('cibw smoke version:', ng.__version__, 'preloaded sqlite:', sqlite3.sqlite_version)" && \
 python -m pytest -q {project}/bindings/python/tests/\

--- a/src/acp/server.cpp
+++ b/src/acp/server.cpp
@@ -209,7 +209,7 @@ struct ACPServer::Impl {
     std::mutex                                    workers_mu;
     std::condition_variable                       workers_cv;
     std::mutex                                    worker_threads_mu;
-    using WorkerThread = std::pair<std::jthread, std::future<void>>;
+    using WorkerThread = std::pair<std::thread, std::future<void>>;
     std::vector<WorkerThread>                      worker_threads;
     int                                           inflight_count = 0;
     std::set<std::string>                         inflight_sessions;
@@ -222,7 +222,7 @@ struct ACPServer::Impl {
     std::atomic<bool>                             fail_next_handle_message{false};
 #endif
 
-    void retain_worker(std::jthread worker, std::future<void> exited) {
+    void retain_worker(std::thread& worker, std::future<void> exited) {
         // Reap finished threads on admission so a long-lived session retains
         // only its active workers. Use a separate lock: joining a thread may
         // still need workers_mu while its captured reservation is destroyed.
@@ -615,7 +615,7 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
 #endif
         std::promise<void> exited;
         auto exit_future = exited.get_future();
-        std::jthread worker(
+        std::thread worker(
             [this, req = std::move(req), id, task_cancel, worker_reservation = reservation,
               exited = std::move(exited), resume_pending, reply_expected]() mutable {
                 exited.set_value_at_thread_exit();
@@ -809,7 +809,12 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
                 // returns. Its destructor cleans every worker exit path.
             });
 
-        retain_worker(std::move(worker), std::move(exit_future));
+        try {
+            retain_worker(worker, std::move(exit_future));
+        } catch (...) {
+            if (worker.joinable()) worker.join();
+            throw;
+        }
         reservation.reset();
     } catch (const std::exception& e) {
         // If worker launch fails, no worker owns the reservation.

--- a/src/acp/server.cpp
+++ b/src/acp/server.cpp
@@ -16,6 +16,8 @@
 #include <system_error>
 #include <thread>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace neograph::acp {
 
@@ -200,12 +202,15 @@ struct ACPServer::Impl {
     /// the engine on the same thread_id (which is what the engine's
     /// checkpoint store keys on).
     ///
-    /// Workers are spawned detached and accounted via `inflight_count`
-    /// (incremented before std::thread launches, decremented + cv
+    /// Workers are accounted via `inflight_count`
+    /// (incremented before the worker launches, decremented + cv
     /// notified at the end of the worker body). Destructor waits on
     /// the cv until inflight_count drains to zero.
     std::mutex                                    workers_mu;
     std::condition_variable                       workers_cv;
+    std::mutex                                    worker_threads_mu;
+    using WorkerThread = std::pair<std::jthread, std::future<void>>;
+    std::vector<WorkerThread>                      worker_threads;
     int                                           inflight_count = 0;
     std::set<std::string>                         inflight_sessions;
     /// Sessions currently being restored from checkpoint. Prompt admission
@@ -216,6 +221,35 @@ struct ACPServer::Impl {
     std::atomic<bool>                             fail_next_worker_launch{false};
     std::atomic<bool>                             fail_next_handle_message{false};
 #endif
+
+    void retain_worker(std::jthread worker, std::future<void> exited) {
+        // Reap finished threads on admission so a long-lived session retains
+        // only its active workers. Use a separate lock: joining a thread may
+        // still need workers_mu while its captured reservation is destroyed.
+        std::lock_guard lock(worker_threads_mu);
+        std::erase_if(worker_threads, [](auto& worker) {
+            if (worker.second.wait_for(std::chrono::seconds(0)) != std::future_status::ready)
+                return false;
+            worker.first.join();
+            return true;
+        });
+        worker_threads.emplace_back(std::move(worker), std::move(exited));
+    }
+
+    void drain_workers() {
+        {
+            std::unique_lock lock(workers_mu);
+            workers_cv.wait(lock, [this] { return inflight_count == 0; });
+        }
+        std::vector<WorkerThread> finished;
+        {
+            std::lock_guard lock(worker_threads_mu);
+            finished.swap(worker_threads);
+        }
+        // Join before destroying the readiness futures: set_value_at_thread_exit
+        // may still be releasing the promise's shared state in the thread tail.
+        for (auto& worker : finished) worker.first.join();
+    }
 
     struct WorkerReservation {
         Impl*       owner;
@@ -293,7 +327,7 @@ struct ACPServer::Impl {
             emit(jsonrpc_error(-32603, message, id));
         } catch (...) {
             // A failing transport/sink cannot be used to report its own
-            // failure, but it must never escape a detached worker.
+            // failure, but it must never escape a prompt worker.
         }
     }
 };
@@ -567,12 +601,10 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
     }
     if (pre_cancelled) task_cancel->cancel();
 
-    // Run the engine on a detached worker so the run-loop reader can
+    // Run the engine on a worker so the run-loop reader can
     // keep pumping inbound messages — including responses to fs/*
     // requests the engine issues mid-run via ACPClient::call_client.
-    // The thread is detached because completed workers don't need
-    // joining individually; the dtor / drain path waits on
-    // inflight_count via workers_cv instead.
+    // Retain its thread handle so drain also joins thread-local cleanup.
     try {
 #if defined(NEOGRAPH_ACP_TESTING)
         if (fail_next_worker_launch.exchange(false, std::memory_order_acq_rel)) {
@@ -581,9 +613,14 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
                 "injected ACP worker launch failure");
         }
 #endif
-        std::thread worker(
-            [this, req = std::move(req), id, task_cancel, reservation,
-              resume_pending, reply_expected]() mutable {
+        std::promise<void> exited;
+        auto exit_future = exited.get_future();
+        std::jthread worker(
+            [this, req = std::move(req), id, task_cancel, worker_reservation = reservation,
+              exited = std::move(exited), resume_pending, reply_expected]() mutable {
+                exited.set_value_at_thread_exit();
+                // Release accounting at body exit, before thread-local cleanup.
+                auto reservation = std::move(worker_reservation);
                 bool response_attempted = false;
                 bool terminal_committed = false;
                 auto cleanup = [&] {
@@ -772,17 +809,10 @@ ACPServer::Impl::handle_session_prompt(ACPServer& /*owner*/,
                 // returns. Its destructor cleans every worker exit path.
             });
 
-        try {
-            worker.detach();
-        } catch (...) {
-            if (worker.joinable()) {
-                worker.join();
-            }
-            throw;
-        }
+        retain_worker(std::move(worker), std::move(exit_future));
         reservation.reset();
     } catch (const std::exception& e) {
-        // If std::thread construction fails, no worker owns the reservation.
+        // If worker launch fails, no worker owns the reservation.
         reservation.reset();
         if (reply_expected) {
             emit_internal_error(id, "ACP prompt worker launch failed: ", e.what());
@@ -832,11 +862,9 @@ ACPServer::~ACPServer() {
     // Make sure no in-flight worker is mid-engine-run when the server
     // dies — that would dereference a freed engine pointer through the
     // captured shared_ptr (which is safe) but would also try to write to
-    // an output stream that's about to disappear. Workers are detached
-    // (see handle_session_prompt) so we don't join them; we wait on
-    // inflight_count via workers_cv until every worker has decremented
-    // and cleared its single-flight session.
-    // Detached workers may finish while this destructor drains. Drop their
+    // an output stream that's about to disappear. Drain reservations and
+    // join the workers, including their captured and thread-local state.
+    // Workers may finish while this destructor drains. Drop their
     // late notifications instead of invoking a sink owned by the caller.
     std::atomic_store_explicit(
         &impl_->sink_, std::shared_ptr<NotificationSink>{}, std::memory_order_release);
@@ -849,12 +877,7 @@ ACPServer::~ACPServer() {
         }
     }
     for (const auto& token : active_tokens) token->cancel();
-    {
-        std::unique_lock lk(impl_->workers_mu);
-        impl_->workers_cv.wait(lk, [this]{
-            return impl_->inflight_count == 0;
-        });
-    }
+    impl_->drain_workers();
 
     // Wake any pending outbound RPC waiters with an error so they don't
     // hang the caller forever.
@@ -1072,12 +1095,7 @@ void ACPServer::run(std::istream& in, std::ostream& out) {
     struct RunCleanupGuard {
         Impl* impl;
         ~RunCleanupGuard() {
-            {
-                std::unique_lock lk(impl->workers_mu);
-                impl->workers_cv.wait(lk, [this]{
-                    return impl->inflight_count == 0;
-                });
-            }
+            impl->drain_workers();
             std::atomic_store_explicit(
                 &impl->sink_, std::shared_ptr<NotificationSink>{},
                 std::memory_order_release);

--- a/src/core/tool_execution.cpp
+++ b/src/core/tool_execution.cpp
@@ -6,6 +6,7 @@
 #include <asio/experimental/awaitable_operators.hpp>
 #include <asio/async_result.hpp>
 #include <asio/bind_executor.hpp>
+#include <asio/executor_work_guard.hpp>
 #include <asio/error.hpp>
 #include <asio/post.hpp>
 #include <asio/redirect_error.hpp>
@@ -316,9 +317,14 @@ asio::awaitable<std::string> execute_blocking_tool_async(Tool& tool, json argume
             using Handler = std::decay_t<decltype(handler)>;
             auto completion = std::make_shared<Handler>(std::move(handler));
             const auto completion_executor = caller_executor;
+            // The completion can run before the pool thread's post() returns.
+            // Keep the caller alive until that post has stopped touching its
+            // scheduler, even if the resumed coroutine has already finished.
+            auto work = asio::make_work_guard(completion_executor);
             asio::post(blocking_tool_pool().get_executor(),
                        [&tool, arguments = std::move(arguments), result,
-                        completion = std::move(completion), completion_executor]() mutable {
+                        completion = std::move(completion), completion_executor,
+                        work = std::move(work)]() mutable {
                            try {
                                result->value = tool.execute(arguments);
                            } catch (...) {

--- a/src/program/runtime.cpp
+++ b/src/program/runtime.cpp
@@ -4393,7 +4393,17 @@ ProgramHandle ProgramRuntime::start_child(std::string_view         owner_scope,
     if (parent.control_->owner_scope != owner_scope || link.owner_scope() != owner_scope)
         throw_runtime_diagnostic("P_CHILD_OWNER", "Child owner scope is not admitted");
 
-    auto parent_record = parent.snapshot();
+    std::optional<ProgramJournalRecord> parent_journal;
+    auto parent_record = [&] {
+        // A sibling can publish completion between the run-record and journal
+        // reads. Take the same lock as child-relation publication so admission
+        // validates one generation instead of reporting a spurious CAS loss.
+        std::lock_guard lock(child_relation_publication_mutex(
+            *impl_->config.transitions, owner_scope, parent.run_id()));
+        auto record = parent.snapshot();
+        parent_journal = impl_->config.transitions->latest(owner_scope, parent.run_id());
+        return record;
+    }();
     if (parent_record.continuation().state != ContinuationState::Running)
         throw_runtime_diagnostic("P_CHILD_PARENT", "Child can only attach to a running parent");
     if (parent.control_->cancellation_cause() != detail::CancellationCause::None)
@@ -4466,7 +4476,6 @@ ProgramHandle ProgramRuntime::start_child(std::string_view         owner_scope,
     }
     RunBudget parent_budget = parent_record.remaining_budget();
     if (!existing) {
-        const auto parent_journal = impl_->config.transitions->latest(owner_scope, parent_run_id);
         if (!parent_journal || parent_journal->id != parent_record.journal_head()) {
             throw_runtime_diagnostic("P_CHILD_CONFLICT",
                                      "Parent-child admission lost the transition CAS");

--- a/tests/test_acp_server.cpp
+++ b/tests/test_acp_server.cpp
@@ -815,6 +815,58 @@ TEST(ACPServer, PromptCannotRaceSessionResumeStateRestore) {
     EXPECT_EQ(side_effects.load(), 0);
 }
 
+TEST(ACPServer, DestructorJoinsPromptThreadLocalCleanup) {
+    struct ExitState {
+        std::promise<void> entered;
+        std::promise<void> release;
+        std::shared_future<void> released = release.get_future().share();
+    };
+    struct ExitGuard {
+        std::shared_ptr<ExitState> state;
+        ~ExitGuard() {
+            if (!state) return;
+            state->entered.set_value();
+            state->released.wait();
+        }
+    };
+    class ExitAdapter final : public ACPGraphAdapter {
+    public:
+        explicit ExitAdapter(std::shared_ptr<ExitState> state) : state_(std::move(state)) {}
+        neograph::json build_initial_state(const std::vector<ContentBlock>& blocks,
+                                          const std::string& session_id) const override {
+            thread_local ExitGuard guard;
+            guard.state = state_;
+            return ACPGraphAdapter::build_initial_state(blocks, session_id);
+        }
+    private:
+        std::shared_ptr<ExitState> state_;
+    };
+
+    auto state = std::make_shared<ExitState>();
+    auto entered = state->entered.get_future();
+    CapturingSink cap;
+    auto server = std::make_unique<ACPServer>(
+        build_echo_engine(), neograph::json{{"name", "test-acp"}, {"version", "0.0.1"}},
+        std::make_shared<ExitAdapter>(state));
+    initialize_server(*server);
+    server->set_notification_sink(cap.as_sink());
+    const auto sid = new_session(*server);
+    server->handle_message(make_request(2, "session/prompt",
+        {{"sessionId", sid}, {"prompt", neograph::json::array({
+            neograph::json{{"type", "text"}, {"text", "hi"}}})}}));
+    EXPECT_TRUE(cap.wait_for_response(2).contains("result"));
+    const auto exit_started = entered.wait_for(std::chrono::seconds(5));
+    if (exit_started != std::future_status::ready) {
+        state->release.set_value();
+        FAIL() << "Prompt worker did not reach thread-local cleanup";
+    }
+    auto destroyed = std::async(std::launch::async, [&] { server.reset(); });
+    const auto before_release = destroyed.wait_for(std::chrono::milliseconds(50));
+    state->release.set_value();
+    destroyed.get();
+    EXPECT_EQ(before_release, std::future_status::timeout);
+}
+
 TEST(ACPServer, BuildInitialStateExceptionIsContained) {
     CapturingSink cap;
     auto adapter = std::make_shared<ThrowingAdapter>(

--- a/tests/test_program_runtime.cpp
+++ b/tests/test_program_runtime.cpp
@@ -8194,7 +8194,8 @@ TEST(ProgramRuntimeTest, ParallelMapLaunchesNextWindowAfterPriorCompletion) {
                                                "trace-parallel-map-windowed",
                                                {}});
 
-    ASSERT_FALSE(result.failure().has_value());
+    ASSERT_FALSE(result.failure().has_value())
+        << result.failure()->code << ": " << result.failure()->message;
     EXPECT_EQ(result.status(), ProgramTerminalStatus::Completed);
     EXPECT_EQ(window_calls.load(), 4U);
     EXPECT_EQ(window_completed.load(), 2U);


### PR DESCRIPTION
Restore the Doxygen Pages workflow deleted during documentation cleanup, and fix the failures in the current CI and Wheels runs.

- Collect optional protocol SDK tests on Python 3.9/3.10 with the TOML backport.
- Keep the caller's Asio context alive until blocking-tool completion posting returns.
- Join ACP prompt workers through thread-local teardown and reap completed threads on admission.
- Read the parent run record and journal under the child-publication lock to prevent sibling completion from producing a false admission conflict.
- Update the promo's fast-uri lock entry to 3.1.7, resolving the four current Dependabot alerts.

Validation: Doxygen HTML generation and actionlint passed; Windows Program (515), ACP (51), and Hook (23) tests passed. The parallel-map regression failed at iteration 155 before the fix and passed 2,000 iterations after it. The blocking-tool race reproduced under Linux TSan before the fix and passed 10,000 iterations after it. All 51 ACP tests passed under Linux TSan, including a new thread-local teardown regression that fails on the old implementation. Python 3.9 optional-SDK collection skips cleanly. npm audit reports zero vulnerabilities.

Repository Pages is enabled with the `workflow` build type; the existing github-pages environment allows master deployments. Pull requests validate and upload the documentation, while only master publishes the site.
