### PR TITLE
fix(runtime): stabilize Harness reads and checkpoint completion

### DIFF
--- a/include/neograph/mcp/sqlite_harness_store.h
+++ b/include/neograph/mcp/sqlite_harness_store.h
@@ -10,6 +10,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -90,6 +91,9 @@ public:
                       const program::ProgramRunRecord&     run_record) const override;
 
 #ifdef NEOGRAPH_TESTING
+    /// Run once with the next Program run read snapshot held. The callback must
+    /// use another store connection if it accesses the database.
+    void after_next_program_run_read_for_testing(std::function<void()> callback);
     /// Fail one subsequent Program transition at the requested transaction point.
     void fail_next_program_transition_for_testing(SqliteHarnessProgramFaultPoint point);
     /// Crash the current process once at the requested transition point.

--- a/src/core/graph_checkpoint.cpp
+++ b/src/core/graph_checkpoint.cpp
@@ -77,7 +77,7 @@ asio::thread_pool& blocking_checkpoint_pool() {
 }
 
 template <typename Handler>
-void post_checkpoint_completion(asio::any_io_executor caller_executor,
+void post_checkpoint_completion(asio::any_io_executor& caller_executor,
                                 std::shared_ptr<Handler> completion) {
     struct CompletionBarrier {
         std::condition_variable cv;
@@ -95,6 +95,10 @@ void post_checkpoint_completion(asio::any_io_executor caller_executor,
             (*completion)();
         });
 
+    // The resumed coroutine may finish run_sync and destroy its io_context.
+    // Release the pool worker's executor before allowing that to happen: a
+    // retained strand also touches the context's service during destruction.
+    caller_executor = {};
     {
         std::lock_guard lock(barrier->mutex);
         barrier->post_returned = true;
@@ -113,7 +117,7 @@ asio::awaitable<void> run_blocking_checkpoint(Fn fn, LegacyBridgeOperation opera
     };
     auto result = std::make_shared<Result>();
 
-    const auto caller_executor = co_await asio::this_coro::executor;
+    auto caller_executor = co_await asio::this_coro::executor;
     auto caller_work = asio::make_work_guard(caller_executor);
     auto completion_token = asio::bind_executor(caller_executor, asio::use_awaitable);
     co_await asio::async_initiate<decltype(completion_token), void()>(
@@ -148,7 +152,7 @@ asio::awaitable<T> run_blocking_checkpoint(Fn fn, LegacyBridgeOperation operatio
     };
     auto result = std::make_shared<Result>();
 
-    const auto caller_executor = co_await asio::this_coro::executor;
+    auto caller_executor = co_await asio::this_coro::executor;
     auto caller_work = asio::make_work_guard(caller_executor);
     auto completion_token = asio::bind_executor(caller_executor, asio::use_awaitable);
     co_await asio::async_initiate<decltype(completion_token), void()>(

--- a/src/mcp/sqlite_harness_store.cpp
+++ b/src/mcp/sqlite_harness_store.cpp
@@ -1046,14 +1046,12 @@ public:
     std::optional<program::ProgramJournalRecord> latest(std::string_view owner_scope,
                                                         std::string_view run_id) const override {
         if (owner_scope.empty() || run_id.empty()) return std::nullopt;
-        const auto wrapper = load_wrapper(owner_scope, run_id);
-        if (!wrapper) return std::nullopt;
         std::lock_guard lock(impl_->mutex);
         Statement       query(impl_->db,
                               "SELECT j.record_json, r.bundle_id, r.program_version_id, "
                                     "j.owner_scope, j.bundle_id, j.program_version_id "
-                                    "FROM neograph_harness_program_journal j "
-                                    "JOIN neograph_harness_runs r ON r.run_id=j.run_id "
+                                    "FROM neograph_harness_runs r "
+                                    "LEFT JOIN neograph_harness_program_journal j ON r.run_id=j.run_id "
                                     "WHERE r.owner_scope=? AND r.run_id=? AND r.program_run_id<>'' "
                                     "ORDER BY j.sequence DESC LIMIT 1");
         query.bind_text(1, std::string(owner_scope));
@@ -1061,6 +1059,12 @@ public:
         const auto result = query.step();
         if (result == SQLITE_DONE) return std::nullopt;
         if (result != SQLITE_ROW) throw_sqlite_error(impl_->db, "Program journal read failed");
+        // Keep this stepped SELECT alive while validating the wrapper. Its read
+        // snapshot includes both records even if another WAL connection commits
+        // a newer head. The LEFT JOIN also retains runs with a missing journal
+        // so the ordinary publication validation still rejects corruption.
+        const auto wrapper = load_wrapper_locked(owner_scope, run_id);
+        if (!wrapper) throw std::invalid_argument("Stored Program journal run is missing");
         auto record = program::ProgramJournalRecord::parse(query.text(0));
         if (record.id != wrapper->run_record().journal_head() || record.run_id != run_id ||
             record.bundle_id != query.text(1) || record.program_version_id != query.text(2) ||

--- a/src/mcp/sqlite_harness_store.cpp
+++ b/src/mcp/sqlite_harness_store.cpp
@@ -1022,6 +1022,9 @@ CREATE TABLE IF NOT EXISTS neograph_harness_contract_runs (
         "https://www.sqlite.org/lang_transaction.html (fetched 2026-07-31)";
     std::optional<SqliteHarnessProgramFaultPoint> program_fault;
     std::optional<SqliteHarnessProgramFaultPoint> program_crash;
+#ifdef NEOGRAPH_TESTING
+    std::function<void()> program_run_read_callback;
+#endif
 };
 
 class SqliteHarnessProgramTransitionStore final : public program::ProgramTransitionStore {
@@ -2499,6 +2502,9 @@ private:
         const auto result = query.step();
         if (result == SQLITE_DONE) return std::nullopt;
         if (result != SQLITE_ROW) throw_sqlite_error(impl_->db, "Program run read failed");
+#ifdef NEOGRAPH_TESTING
+        if (auto callback = std::exchange(impl_->program_run_read_callback, {})) callback();
+#endif
         auto wrapper = HarnessProgramRunRecord::parse(json::parse(query.text(0)));
         if (wrapper.run_record().run_id() != run_id) {
             throw std::invalid_argument("Stored Program run alias is corrupt");
@@ -2761,6 +2767,12 @@ SqliteHarnessRecordStore::SqliteHarnessRecordStore(const std::string&         db
 SqliteHarnessRecordStore::~SqliteHarnessRecordStore() = default;
 
 #ifdef NEOGRAPH_TESTING
+void SqliteHarnessRecordStore::after_next_program_run_read_for_testing(
+    std::function<void()> callback) {
+    std::lock_guard lock(impl_->mutex);
+    impl_->program_run_read_callback = std::move(callback);
+}
+
 void SqliteHarnessRecordStore::fail_next_program_transition_for_testing(
     SqliteHarnessProgramFaultPoint point) {
     std::lock_guard lock(impl_->mutex);

--- a/tests/test_checkpoint_async_default.cpp
+++ b/tests/test_checkpoint_async_default.cpp
@@ -69,6 +69,8 @@ public:
     std::atomic<bool> ran_off_thread{false};
 };
 
+class SyncFallbackStore final : public InMemoryCheckpointStore {};
+
 class CapabilityStore final : public CheckpointStoreCore,
                               public AsyncCheckpointStore,
                               public PendingWritesCheckpointStore {
@@ -290,6 +292,23 @@ TEST(CheckpointAsyncDefault, InMemorySubclassRetainsBlockingPoolFallback) {
     EXPECT_TRUE(completed);
     EXPECT_TRUE(store.ran_off_thread.load(std::memory_order_acquire));
     ASSERT_TRUE(store.load_latest("derived-sync-only").has_value());
+}
+
+TEST(CheckpointAsyncDefault, SyncFallbackReleasesStrandBeforeRunSyncReturns) {
+    // Every call owns a fresh io_context and cancellation strand. A fast
+    // completion must release the blocking worker's strand before run_sync
+    // returns and tears down the context, for both void and value operations.
+    for (int iteration = 0; iteration < 128; ++iteration) {
+        SyncFallbackStore store;
+        CancelToken cancel;
+        const auto cp = make_cp("short-lived-executor", iteration);
+        neograph::async::run_sync(store.save_async(cp), &cancel);
+        const auto loaded = neograph::async::run_sync(
+            store.load_latest_async(cp.thread_id), &cancel);
+        ASSERT_TRUE(loaded.has_value());
+        EXPECT_EQ(loaded->id, cp.id);
+        EXPECT_EQ(loaded->step, iteration);
+    }
 }
 
 TEST(CheckpointAsyncDefault, NeitherSideOverrideFailsClosed) {

--- a/tests/test_harness_program_store.cpp
+++ b/tests/test_harness_program_store.cpp
@@ -11,7 +11,9 @@
 #include <atomic>
 #include <barrier>
 #include <cstdlib>
+#include <exception>
 #include <filesystem>
+#include <functional>
 #include <future>
 #include <memory>
 #include <stdexcept>
@@ -71,6 +73,54 @@ void sqlite_exec(const std::filesystem::path& path, const char* sql) {
     }
     sqlite3_close(db);
 }
+
+// Capture only a newly opened test connection, without exposing database handles
+// through the production store API. Other auto-extensions remain registered.
+struct SqliteConnectionCapture {
+    SqliteConnectionCapture() {
+        connection = nullptr;
+        if (sqlite3_auto_extension(reinterpret_cast<void (*)()>(capture)) != SQLITE_OK) {
+            throw std::runtime_error("Could not register SQLite connection capture");
+        }
+    }
+    ~SqliteConnectionCapture() {
+        sqlite3_cancel_auto_extension(reinterpret_cast<void (*)()>(capture));
+    }
+    static int capture(sqlite3* db, char**, const sqlite3_api_routines*) {
+        connection = db;
+        return SQLITE_OK;
+    }
+    static inline thread_local sqlite3* connection = nullptr;
+};
+
+struct PublishAfterRunRead {
+    explicit PublishAfterRunRead(sqlite3* connection, std::function<void()> publish)
+        : db(connection), publish(std::move(publish)) {
+        sqlite3_trace_v2(db, SQLITE_TRACE_ROW, trace, this);
+    }
+    ~PublishAfterRunRead() { sqlite3_trace_v2(db, 0, nullptr, nullptr); }
+
+    static int trace(unsigned, void* context, void* statement, void*) noexcept {
+        auto& self = *static_cast<PublishAfterRunRead*>(context);
+        const std::string_view sql = sqlite3_sql(static_cast<sqlite3_stmt*>(statement));
+        if (self.fired || sql.find("SELECT record_json, artifact_id") == sql.npos ||
+            sql.find("FROM neograph_harness_runs") == sql.npos) {
+            return 0;
+        }
+        self.fired = true;
+        try {
+            self.publish();
+        } catch (...) {
+            self.error = std::current_exception();
+        }
+        return 0;
+    }
+
+    sqlite3* db;
+    std::function<void()> publish;
+    bool fired = false;
+    std::exception_ptr error;
+};
 
 RegistrySnapshot registry() {
     RegistrySnapshotBuilder builder;
@@ -1259,6 +1309,65 @@ TEST(HarnessProgramStoreTest, SqliteExecutionLeasePersistsAndFencesOrdinaryPubli
         fixture.artifact.owner_scope(), initial.run_record.run_id()));
 }
 
+
+TEST(HarnessProgramStoreTest, SqliteLatestKeepsOneSnapshotAcrossConcurrentPublication) {
+    TempDb db;
+    Fixture fixture;
+    auto writer_store = std::make_shared<SqliteHarnessRecordStore>(db.path.string());
+    auto writer = persist_and_bind(writer_store, fixture);
+    const auto initial = initial_publication(fixture);
+    ASSERT_EQ(writer->compare_publish(fixture.artifact.owner_scope(), {}, initial),
+              ProgramTransitionPublishResult::Published);
+    const auto completed = terminal_publication(fixture, initial, ProgramTerminalStatus::Completed,
+                                                ContinuationState::Completed, 20);
+
+    std::shared_ptr<SqliteHarnessRecordStore> reader_store;
+    sqlite3* reader_connection = nullptr;
+    {
+        SqliteConnectionCapture capture;
+        reader_store = std::make_shared<SqliteHarnessRecordStore>(db.path.string());
+        reader_connection = capture.connection;
+    }
+    ASSERT_NE(reader_connection, nullptr);
+    auto reader = reader_store->bind_program_transitions(fixture.artifact);
+    {
+        // Commit through another WAL connection while latest() holds a run row.
+        // The reader must finish on that snapshot, then see the new head on its
+        // next call. No sleeps or scheduler luck are needed to hit the race.
+        PublishAfterRunRead interleave(reader_connection, [&] {
+            EXPECT_EQ(writer->compare_publish(fixture.artifact.owner_scope(),
+                                              initial.journal_record.id, completed),
+                      ProgramTransitionPublishResult::Published);
+        });
+        const auto journal = reader->latest(fixture.artifact.owner_scope(), "run-one");
+        if (interleave.error) std::rethrow_exception(interleave.error);
+        ASSERT_TRUE(interleave.fired);
+        ASSERT_TRUE(journal);
+        EXPECT_EQ(journal->id, initial.journal_record.id);
+    }
+    const auto journal = reader->latest(fixture.artifact.owner_scope(), "run-one");
+    ASSERT_TRUE(journal);
+    EXPECT_EQ(journal->id, completed.journal_record.id);
+}
+
+TEST(HarnessProgramStoreTest, SqliteLatestRejectsMissingOrMisboundJournal) {
+    for (const auto* mutation : {
+             "DELETE FROM neograph_harness_program_journal",
+             "UPDATE neograph_harness_program_journal SET owner_scope='different-owner'"}) {
+        TempDb db;
+        Fixture fixture;
+        auto store = std::make_shared<SqliteHarnessRecordStore>(db.path.string());
+        auto transitions = persist_and_bind(store, fixture);
+        const auto initial = initial_publication(fixture);
+        ASSERT_EQ(transitions->compare_publish(fixture.artifact.owner_scope(), {}, initial),
+                  ProgramTransitionPublishResult::Published);
+        EXPECT_FALSE(transitions->latest("different-owner", "run-one"));
+        EXPECT_FALSE(transitions->latest(fixture.artifact.owner_scope(), "missing-run"));
+        sqlite_exec(db.path, mutation);
+        EXPECT_THROW((void)transitions->latest(fixture.artifact.owner_scope(), "run-one"),
+                     std::invalid_argument);
+    }
+}
 
 TEST(HarnessProgramStoreTest, TwoSqliteInstancesHaveOneCasWinnerAndRollbackInvalidBatch) {
     TempDb  db;

--- a/tests/test_harness_program_store.cpp
+++ b/tests/test_harness_program_store.cpp
@@ -11,9 +11,7 @@
 #include <atomic>
 #include <barrier>
 #include <cstdlib>
-#include <exception>
 #include <filesystem>
-#include <functional>
 #include <future>
 #include <memory>
 #include <stdexcept>
@@ -73,54 +71,6 @@ void sqlite_exec(const std::filesystem::path& path, const char* sql) {
     }
     sqlite3_close(db);
 }
-
-// Capture only a newly opened test connection, without exposing database handles
-// through the production store API. Other auto-extensions remain registered.
-struct SqliteConnectionCapture {
-    SqliteConnectionCapture() {
-        connection = nullptr;
-        if (sqlite3_auto_extension(reinterpret_cast<void (*)()>(capture)) != SQLITE_OK) {
-            throw std::runtime_error("Could not register SQLite connection capture");
-        }
-    }
-    ~SqliteConnectionCapture() {
-        sqlite3_cancel_auto_extension(reinterpret_cast<void (*)()>(capture));
-    }
-    static int capture(sqlite3* db, char**, const sqlite3_api_routines*) {
-        connection = db;
-        return SQLITE_OK;
-    }
-    static inline thread_local sqlite3* connection = nullptr;
-};
-
-struct PublishAfterRunRead {
-    explicit PublishAfterRunRead(sqlite3* connection, std::function<void()> publish)
-        : db(connection), publish(std::move(publish)) {
-        sqlite3_trace_v2(db, SQLITE_TRACE_ROW, trace, this);
-    }
-    ~PublishAfterRunRead() { sqlite3_trace_v2(db, 0, nullptr, nullptr); }
-
-    static int trace(unsigned, void* context, void* statement, void*) noexcept {
-        auto& self = *static_cast<PublishAfterRunRead*>(context);
-        const std::string_view sql = sqlite3_sql(static_cast<sqlite3_stmt*>(statement));
-        if (self.fired || sql.find("SELECT record_json, artifact_id") == sql.npos ||
-            sql.find("FROM neograph_harness_runs") == sql.npos) {
-            return 0;
-        }
-        self.fired = true;
-        try {
-            self.publish();
-        } catch (...) {
-            self.error = std::current_exception();
-        }
-        return 0;
-    }
-
-    sqlite3* db;
-    std::function<void()> publish;
-    bool fired = false;
-    std::exception_ptr error;
-};
 
 RegistrySnapshot registry() {
     RegistrySnapshotBuilder builder;
@@ -1321,27 +1271,21 @@ TEST(HarnessProgramStoreTest, SqliteLatestKeepsOneSnapshotAcrossConcurrentPublic
     const auto completed = terminal_publication(fixture, initial, ProgramTerminalStatus::Completed,
                                                 ContinuationState::Completed, 20);
 
-    std::shared_ptr<SqliteHarnessRecordStore> reader_store;
-    sqlite3* reader_connection = nullptr;
-    {
-        SqliteConnectionCapture capture;
-        reader_store = std::make_shared<SqliteHarnessRecordStore>(db.path.string());
-        reader_connection = capture.connection;
-    }
-    ASSERT_NE(reader_connection, nullptr);
+    auto reader_store = std::make_shared<SqliteHarnessRecordStore>(db.path.string());
     auto reader = reader_store->bind_program_transitions(fixture.artifact);
     {
         // Commit through another WAL connection while latest() holds a run row.
         // The reader must finish on that snapshot, then see the new head on its
         // next call. No sleeps or scheduler luck are needed to hit the race.
-        PublishAfterRunRead interleave(reader_connection, [&] {
+        bool published = false;
+        reader_store->after_next_program_run_read_for_testing([&] {
             EXPECT_EQ(writer->compare_publish(fixture.artifact.owner_scope(),
                                               initial.journal_record.id, completed),
                       ProgramTransitionPublishResult::Published);
+            published = true;
         });
         const auto journal = reader->latest(fixture.artifact.owner_scope(), "run-one");
-        if (interleave.error) std::rethrow_exception(interleave.error);
-        ASSERT_TRUE(interleave.fired);
+        ASSERT_TRUE(published);
         ASSERT_TRUE(journal);
         EXPECT_EQ(journal->id, initial.journal_record.id);
     }


### PR DESCRIPTION
Concurrent Harness reconnects could report `Stored Program journal binding is corrupt` when another SQLite connection published a new head between the run read and journal read. Keep the journal SELECT active while validating its run so both records use the same SQLite snapshot. A left join preserves rejection of missing journals.

Checkpoint bridge completion also retained a worker-side caller executor after waking `run_sync`. Destroying the caller's `io_context` could then race the retained strand's destruction, causing an ASan use-after-free or hanging ACP session restoration. Release that executor before publishing completion in both the value and void bridge paths.

Add deterministic snapshot interleaving, missing-journal/owner-binding, and repeated short-lived checkpoint context regressions. The SQLite regression failed with the original exception on all 3 runs before the fix; ASan independently reproduced the original executor lifetime failure. Snapshot injection uses a test-only hook that also works with the system SQLite on macOS.

Validation (WSL Ubuntu 24.04, GCC 13, Release):
- New snapshot regression: 20/20 repeated runs passed.
- Harness Program store suite: 20/20 passed.
- Original concurrent reconnect test: 50/50 repeated runs passed.
- Harness Program cutover suite: 31/31 passed.
- `git diff --check` passed.

Checkpoint/ACP validation:
- Checkpoint suite: 11/11 passed under MSVC and ASan.
- New checkpoint lifetime regression: 100 ASan repetitions, covering 12,800 save/load pairs.
- ACP suite: 51/51 passed on Windows, Linux, and TSan.
- Original ACP resume-race test: 10,000 independent process runs on Windows and Linux; 1,000 TSan runs passed.

Fixes the sole failure in master CI run [34173436432](https://github.com/fox1245/NeoGraph/actions/runs/34173436432/job/101898067442).
