### PR TITLE
feat(program): reconnect existing child commands after process loss

### DIFF
--- a/docs/PROGRAM_RECURSIVE_HARNESSES.md
+++ b/docs/PROGRAM_RECURSIVE_HARNESSES.md
@@ -81,6 +81,37 @@ admission path. Source proposals must match independently reviewed host template
 instances; the reference host does not approve a source merely because an agent
 included it in a checkpoint.
 
+## Recovering pre-admitted children after process loss
+
+A host that restores its admitted child bindings can explicitly allow unfinished
+JavaScript `spawn`/`await` commands to reconnect to already-published children:
+
+```cpp
+config.recover_existing_child_commands = true; // default: false
+```
+
+This works for ordinary static bindings and children inherited through a
+replacement, without a synthesis gateway. The parent relation, link receipt,
+owner, exact invocation, child depth, and persisted child run must agree. Static
+commands must derive the same child ID from their recorded command coordinate;
+inherited children retain the ID admitted in the generation-creation
+publication. The historical Program versions and host grants must still be
+available. A configured host admission resolver continues to admit the child
+attempt normally.
+
+Recovery uses a dedicated reconnect path: a child that disappears after the
+check cannot fall through to new child creation. Missing runs, changed inputs,
+or unavailable bindings leave the existing command pending for reconciliation.
+The command reservation and descendant accounting survive recovery. The flag
+does not authorize replay of unknown provider, tool, native, or other external
+effects. The separately granted synthesis recovery protocol is unchanged.
+
+The `*StaticChild*` tests cover SQLite and PostgreSQL process exit, static and
+inherited recursive children, unchanged child identities and receipts, and a
+grandchild's 32 checkpoints producing exactly 64 journal entries. They also
+exercise absent opt-in, missing runs/bindings, altered input/receipts, and a run
+disappearing between recovery admission and dispatch.
+
 ## JSON artifacts and accounting
 
 JSON is a serialized, validated Program bundle. Loading a different JSON selects

--- a/docs/PROGRAM_RECURSIVE_HARNESSES.md
+++ b/docs/PROGRAM_RECURSIVE_HARNESSES.md
@@ -114,6 +114,13 @@ interrupted child remains a dispatched, resumable relation, and its parent
 retains the in-flight command reservation instead of cancelling the relation
 or crediting that reservation twice.
 
+If result publication fails while storage remains available, the dispatched
+command's outcome and pending effect are both published as `Ambiguous`;
+cancellation cannot erase that uncertainty. Optimistic command-head read
+collisions are retried, while a permanent rejection against an unchanged parent
+head cannot block child
+completion notifications indefinitely.
+
 The `*StaticChild*` tests cover SQLite and PostgreSQL process exit, static and
 inherited recursive children, unchanged child identities and receipts, and a
 grandchild's 32 checkpoints producing exactly 64 journal entries. They also

--- a/docs/PROGRAM_RECURSIVE_HARNESSES.md
+++ b/docs/PROGRAM_RECURSIVE_HARNESSES.md
@@ -106,6 +106,14 @@ The command reservation and descendant accounting survive recovery. The flag
 does not authorize replay of unknown provider, tool, native, or other external
 effects. The separately granted synthesis recovery protocol is unchanged.
 
+Independently of this flag, replay of a running attempt completes an unfinished
+sealed `ng.checkpoint` from its exact journaled value and original command
+reservation. It performs no external dispatch.
+Other unknown effects still pause the family for reconciliation: an
+interrupted child remains a dispatched, resumable relation, and its parent
+retains the in-flight command reservation instead of cancelling the relation
+or crediting that reservation twice.
+
 The `*StaticChild*` tests cover SQLite and PostgreSQL process exit, static and
 inherited recursive children, unchanged child identities and receipts, and a
 grandchild's 32 checkpoints producing exactly 64 journal entries. They also

--- a/include/neograph/program/runtime.h
+++ b/include/neograph/program/runtime.h
@@ -151,6 +151,10 @@ struct ProgramChildQuotaConfig {
       /// Retaining the lease pauses this generation. Destroying it releases the generator.
       /// Explicit next_handoff requests take precedence. Programs cannot install this handler.
       std::function<void(ProgramHandle, ProgramHandoff)> checkpoint_handler;
+      /// Opt in to reconnecting exact, already-published child runs when a
+      /// recorded spawn/await command is unfinished after process loss. This
+      /// never authorizes a new child or replay of an unknown external effect.
+      bool recover_existing_child_commands = false;
   };
 class NEOGRAPH_PROGRAM_API ProgramRuntime {
 public:

--- a/src/mcp/sqlite_harness_store.cpp
+++ b/src/mcp/sqlite_harness_store.cpp
@@ -132,7 +132,9 @@ bool valid_effect_outbox_binding(
     const std::vector<program::ProgramEffectOutboxEntry>& effects) {
     if (effects.empty()) return true;
     const auto pending = run.pending_effect();
-    return pending && pending->state() == program::ProgramPendingState::Awaiting &&
+    return pending && (pending->state() == program::ProgramPendingState::Awaiting ||
+                       (pending->state() == program::ProgramPendingState::Ambiguous &&
+                        run.continuation().state == program::ContinuationState::AmbiguousEffect)) &&
            effects.size() == 1 && effects.front().effect() == *pending;
 }
 bool has_blocking_hook_obligation(const std::vector<HookOutboxEntry>& entries) noexcept {

--- a/src/program/postgres_transition_store.cpp
+++ b/src/program/postgres_transition_store.cpp
@@ -504,7 +504,10 @@ bool valid_effect_outbox_binding(const ProgramRunRecord& run,
                                  const std::vector<ProgramEffectOutboxEntry>& effects) {
     if (effects.empty()) return true;
     const auto pending = run.pending_effect();
-    return pending && pending->state() == ProgramPendingState::Awaiting && effects.size() == 1 &&
+    return pending && (pending->state() == ProgramPendingState::Awaiting ||
+                       (pending->state() == ProgramPendingState::Ambiguous &&
+                        run.continuation().state == ContinuationState::AmbiguousEffect)) &&
+           effects.size() == 1 &&
            effects.front().effect() == *pending;
 }
 

--- a/src/program/run_attempt.cpp
+++ b/src/program/run_attempt.cpp
@@ -3200,14 +3200,15 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
 
             using JsCommandExecutor = std::function<asio::awaitable<PlanExecution>(
                 const JavaScriptCommand&, std::string, std::shared_ptr<graph::CancelToken>,
-                std::shared_ptr<JavaScriptScopeState>, std::size_t, bool)>;
+                std::shared_ptr<JavaScriptScopeState>, std::size_t, bool, bool)>;
             JsCommandExecutor execute_command;
 
             execute_command = [&](const JavaScriptCommand& command, std::string operation_id,
                                   std::shared_ptr<graph::CancelToken>   operation_token,
                                   std::shared_ptr<JavaScriptScopeState> scope,
                                   std::size_t                           scope_depth,
-                                  bool reserve_budget) -> asio::awaitable<PlanExecution> {
+                                  bool reserve_budget,
+                                  bool reconnect_child_only) -> asio::awaitable<PlanExecution> {
                 if (scope_depth > kMaxJavaScriptStructuredScopeDepth)
                     co_return plan_failure(
                         ProgramTerminalStatus::Failed, "P_JS_SCOPE_LIMIT",
@@ -3437,8 +3438,11 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
 
                 if (command.kind() == JavaScriptCommandKind::Spawn) {
                     const auto binding = arguments.at("child_binding").get<std::string>();
-                    auto child = control->launch_child(binding, arguments.at("input"), operation_id,
-                                                       operation_id);
+                    auto child = reconnect_child_only
+                                     ? control->reconnect_existing_child(
+                                           binding, arguments.at("input"), operation_id)
+                                     : control->launch_child(binding, arguments.at("input"),
+                                                             operation_id, operation_id);
                     scope->attach(child);
                     PlanExecution result;
                     result.output        = json{{"child_run_id", child->run_id},
@@ -3459,7 +3463,8 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                         -> asio::awaitable<PlanExecution> {
                         auto launched = co_await execute_command(child, operation_id + "/await",
                                                                  std::move(token), scope,
-                                                                 scope_depth + 1, false);
+                                                                 scope_depth + 1, false,
+                                                                 reconnect_child_only);
                         if (launched.status != ProgramTerminalStatus::Completed) co_return launched;
                         if (!launched.spawned_child) co_return std::move(launched);
                         co_return plan_result_from_child(
@@ -3670,7 +3675,8 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                         completion_executor,
                         execute_command(
                             members[index], operation_id + "/member/" + std::to_string(index),
-                            state->tokens[index], state->scopes[index], scope_depth + 1, false),
+                            state->tokens[index], state->scopes[index], scope_depth + 1, false,
+                            false),
                         asio::bind_executor(
                             completion_executor,
                             [state, index, launch_member, &members, mode, collect, required, cap,
@@ -3996,17 +4002,20 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                 const auto prior_commands = control->transitions->load_javascript_commands(
                     control->owner_scope, control->run_id);
                 bool       child_resume_authorized      = false;
-                const auto can_resume_synthesized_child = [&] {
+                auto       child_recovery_mode = ChildRecoveryMode::None;
+                const auto can_resume_child = [&] {
                     auto        candidate       = command_value;
                     auto        child_operation = operation_id;
                     std::size_t depth           = 0;
                     while (candidate.kind() == JavaScriptCommandKind::Await) {
-                        if (++depth > kMaxJavaScriptStructuredScopeDepth) return false;
+                        if (++depth > kMaxJavaScriptStructuredScopeDepth)
+                            return ChildRecoveryMode::None;
                         candidate =
                             JavaScriptCommand::from_json(candidate.arguments().at("command"));
                         child_operation += "/await";
                     }
-                    if (candidate.kind() != JavaScriptCommandKind::Spawn) return false;
+                    if (candidate.kind() != JavaScriptCommandKind::Spawn)
+                        return ChildRecoveryMode::None;
                     const auto args = candidate.arguments();
                     return control->can_recover_child(args.at("child_binding").get<std::string>(),
                                                       args.at("input"), child_operation);
@@ -4059,7 +4068,8 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                         continue;
                     }
 
-                    if (can_resume_synthesized_child()) {
+                    child_recovery_mode = can_resume_child();
+                    if (child_recovery_mode != ChildRecoveryMode::None) {
                         if (auto failure =
                                 validate_javascript_command(command_value, operation_id, 0))
                             co_return std::move(*failure);
@@ -4173,7 +4183,8 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                 PlanExecution command_result;
                 try {
                     command_result = co_await execute_command(
-                        command_value, operation_id, control->cancel_token, root_scope, 0, false);
+                        command_value, operation_id, control->cancel_token, root_scope, 0, false,
+                        child_recovery_mode == ChildRecoveryMode::Existing);
                 } catch (const EventSinkError& error) {
                     command_result = plan_failure(ProgramTerminalStatus::Failed, "P_EVENT_SINK",
                                                   error.what(), operation_id);
@@ -4182,9 +4193,22 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                         plan_failure(ProgramTerminalStatus::Cancelled, "P_RUNTIME_CANCELLED",
                                      error.what(), operation_id);
                 } catch (const ProgramDiagnosticError& error) {
-                    command_result =
-                        plan_failure(ProgramTerminalStatus::Failed, error.diagnostic().code,
-                                     error.diagnostic().message, operation_id);
+                    if (child_recovery_mode == ChildRecoveryMode::Existing &&
+                        error.diagnostic().code == "P_CHILD_RECOVERY") {
+                        if (const auto pending = control->transitions->load(
+                                control->owner_scope, control->run_id))
+                            unreconciled_javascript_remaining = pending->remaining_budget();
+                        active_javascript_command.reset();
+                        command_result.status = ProgramTerminalStatus::Interrupted;
+                        command_result.interrupt = ProgramInterrupt{
+                            "javascript", command_value.to_json(), std::nullopt,
+                            javascript_command_pending_effect(*control, ordinal, command_value,
+                                                              effect_id)};
+                    } else {
+                        command_result =
+                            plan_failure(ProgramTerminalStatus::Failed, error.diagnostic().code,
+                                         error.diagnostic().message, operation_id);
+                    }
                 } catch (const std::exception& error) {
                     command_result =
                         plan_failure(ProgramTerminalStatus::Failed, "P_RUNTIME_CORE_FAILURE",

--- a/src/program/run_attempt.cpp
+++ b/src/program/run_attempt.cpp
@@ -1148,7 +1148,8 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                 "javascript", active_javascript_command->command.to_json(), std::nullopt,
                 javascript_command_pending_effect(*control, active_javascript_command->ordinal,
                                                   active_javascript_command->command,
-                                                  active_javascript_command->effect_identity)};
+                                                  active_javascript_command->effect_identity)
+                    .mark_outcome_unknown(static_cast<std::uint64_t>(latest->timestamp_ms)).value};
         } catch (...) {
             // The already-published reservation remains durable when the
             // transition store itself cannot be read during terminalization.

--- a/src/program/run_attempt.cpp
+++ b/src/program/run_attempt.cpp
@@ -4024,6 +4024,7 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                     prior_commands.rbegin(), prior_commands.rend(),
                     [&](const auto& entry) { return entry.command_ordinal() == ordinal; });
                 bool      exact_resume_authorized = false;
+                bool      checkpoint_resume_authorized = false;
                 RunBudget resource_reservation;
 
                 if (prior != prior_commands.rend()) {
@@ -4069,7 +4070,15 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                     }
 
                     child_recovery_mode = can_resume_child();
-                    if (child_recovery_mode != ChildRecoveryMode::None) {
+                    if (command_value.kind() == JavaScriptCommandKind::Checkpoint) {
+                        if (auto failure =
+                                validate_javascript_command(command_value, operation_id, 0))
+                            co_return std::move(*failure);
+                        // A checkpoint only returns its journaled value and
+                        // stages internal events. No external dispatch needs
+                        // reconciliation when its result publication was lost.
+                        checkpoint_resume_authorized = true;
+                    } else if (child_recovery_mode != ChildRecoveryMode::None) {
                         if (auto failure =
                                 validate_javascript_command(command_value, operation_id, 0))
                             co_return std::move(*failure);
@@ -4107,7 +4116,8 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                         co_return result;
                     }
                 }
-                if (exact_resume_authorized || child_resume_authorized) {
+                if (exact_resume_authorized || child_resume_authorized ||
+                    checkpoint_resume_authorized) {
                     const auto durable_resumed =
                         control->transitions->latest(control->owner_scope, control->run_id);
                     if (!durable_resumed ||
@@ -4117,6 +4127,7 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                             "Exact Core resume has no durable command resource reservation");
                     }
                     resource_reservation = durable_resumed->inflight_reservation;
+                    unreconciled_javascript_remaining = durable_resumed->remaining_budget;
                     active_javascript_command =
                         ActiveJavaScriptCommand{ordinal, command_value, effect_id};
                 }
@@ -4127,7 +4138,8 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                     operations_before = operation_count;
                 }
                 std::size_t command_count = 0;
-                if (!exact_resume_authorized && !child_resume_authorized) {
+                if (!exact_resume_authorized && !child_resume_authorized &&
+                    !checkpoint_resume_authorized) {
                     try {
                         command_count = javascript_command_tree_size(command_value);
                     } catch (const ProgramDiagnosticError& error) {

--- a/src/program/run_attempt.cpp
+++ b/src/program/run_attempt.cpp
@@ -999,10 +999,16 @@ void cancel_deadline_timer(const asio::any_io_executor&        executor,
     });
 }
 asio::awaitable<void> cancel_after_timer(std::shared_ptr<asio::steady_timer> timer,
-                                         std::shared_ptr<graph::CancelToken> token) {
+                                         std::shared_ptr<graph::CancelToken> token,
+                                         std::shared_ptr<std::atomic<bool>> expired) {
     asio::error_code wait_error;
     co_await         timer->async_wait(asio::redirect_error(asio::use_awaitable, wait_error));
-    if (!wait_error) token->cancel();
+    if (!wait_error) {
+        // Cancelling the child can complete its branch before this timer's
+        // co_spawn completion is delivered. Record the cause first.
+        expired->store(true, std::memory_order_release);
+        token->cancel();
+    }
 }
 
 constexpr std::string_view PROGRAM_PENDING_KIND_FIELD = "__neograph_program_pending_kind";
@@ -3122,7 +3128,8 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                 auto timeout        = std::make_shared<asio::steady_timer>(executor);
                 timeout->expires_after(std::chrono::milliseconds(*operation.timeout_ms()));
                 auto child_token       = operation_token->fork();
-                auto timeout_operation = cancel_after_timer(timeout, child_token);
+                auto timeout_expired   = std::make_shared<std::atomic<bool>>(false);
+                auto timeout_operation = cancel_after_timer(timeout, child_token, timeout_expired);
                 // Await races the child completion (including a child error)
                 // against the timeout.  The awaitable `||` operator waits for
                 // one *successful* operation, which would mask an immediate
@@ -3138,7 +3145,7 @@ asio::awaitable<void> execute_run_attempt(std::shared_ptr<RunControl> control,
                                        asio::deferred),
                         asio::co_spawn(executor, std::move(timeout_operation), asio::deferred))
                         .async_wait(asio::experimental::wait_for_one(), asio::use_awaitable);
-                if (order[0] == 0) {
+                if (order[0] == 0 && !timeout_expired->load(std::memory_order_acquire)) {
                     if (child_error) std::rethrow_exception(child_error);
                     co_return std::move(child_result);
                 }

--- a/src/program/run_control.h
+++ b/src/program/run_control.h
@@ -59,7 +59,11 @@ using ChildLaunchCallback =
                                               std::string_view,
                                               std::optional<TaskGraphBudget>)>;
 using ChildBindingValidationCallback = std::function<void(std::string_view, std::string_view)>;
-using ChildRecoveryCallback = std::function<bool(std::string_view, const json&, std::string_view)>;
+enum class ChildRecoveryMode { None, Synthesis, Existing };
+using ChildRecoveryCallback =
+    std::function<ChildRecoveryMode(std::string_view, const json&, std::string_view)>;
+using ExistingChildReconnectCallback =
+    std::function<std::shared_ptr<RunControl>(std::string_view, const json&, std::string_view)>;
 
 struct AsyncWaiter {
     std::weak_ptr<asio::steady_timer> timer;
@@ -121,7 +125,11 @@ public:
         std::string_view expansion_operation_id) const;
     void set_child_binding_validation_callback(ChildBindingValidationCallback callback) noexcept;
     void set_child_recovery_callback(ChildRecoveryCallback callback) noexcept;
-    bool can_recover_child(std::string_view binding,
+    void set_existing_child_reconnect_callback(ExistingChildReconnectCallback callback) noexcept;
+    std::shared_ptr<RunControl> reconnect_existing_child(std::string_view binding,
+                                                        const json& input,
+                                                        std::string_view operation) const;
+    ChildRecoveryMode can_recover_child(std::string_view binding,
                            const json&      input,
                            std::string_view operation) const;
     void set_hook_runtime(std::shared_ptr<HookRuntime> runtime) noexcept;
@@ -261,6 +269,7 @@ private:
     bool                                          follow_successor_ = false;
     ChildLaunchCallback                     child_launch_callback_;
     ChildRecoveryCallback                         child_recovery_callback_;
+    ExistingChildReconnectCallback                existing_child_reconnect_callback_;
     ChildBindingValidationCallback           child_binding_validation_callback_;
     std::shared_ptr<HookRuntime>               hook_runtime_;
     std::atomic<bool>                          hook_runtime_enabled_{false};

--- a/src/program/runtime.cpp
+++ b/src/program/runtime.cpp
@@ -1427,6 +1427,10 @@ bool publish_child_completion(const std::shared_ptr<ProgramTransitionStore>& tra
             const auto current = load_active_agent_run(transitions, owner_scope, parent_run_id);
             if (!current || current->continuation().state != ContinuationState::Running)
                 return false;
+            // A rejection against an unchanged head is a validation/storage
+            // failure, not competing publication. Do not strand completion
+            // waiters in an infinite retry loop for a permanent rejection.
+            if (current->journal_head() == record->journal_head()) return false;
             std::this_thread::yield();
         }
     } catch (...) {
@@ -3595,6 +3599,10 @@ ProgramTransitionPublishResult RunControl::publish_javascript_command(
 
     for (int retry = 0; retry < 3; ++retry) {
         const auto head = transitions->load_command_publication_head(owner_scope, run_id);
+        // The default store implementation reads optimistically. A child join
+        // can advance its head between reads; retry that miss before treating
+        // a command-result publication as an unresolved external outcome.
+        if (!head) continue;
         const auto* previous = head ? &head->run_record : nullptr;
         const auto* previous_journal = head ? &head->journal_record : nullptr;
         if (!previous || !previous_journal || previous->journal_head() != previous_journal->id ||

--- a/src/program/runtime.cpp
+++ b/src/program/runtime.cpp
@@ -1663,7 +1663,10 @@ TerminalPublicationResult publish_terminal_record(const detail::RunControl& cont
             data.binding_fingerprint = previous->binding_fingerprint();
             data.invocation          = previous->invocation();
             data.child_depth         = previous->child_depth();
-            data.children            = terminal_children(previous->children());
+            const bool resumable = result.status() == ProgramTerminalStatus::Interrupted ||
+                                   result.status() == ProgramTerminalStatus::AmbiguousEffect;
+            data.children            = resumable ? previous->children()
+                                                : terminal_children(previous->children());
             data.continuation        = journal.continuation;
             data.remaining_budget    = result.remaining_budget();
             data.exact_checkpoint    = result.checkpoint();
@@ -2513,8 +2516,12 @@ void RunControl::complete(RunOutcome outcome) noexcept {
             return;
         }
         const auto current_cause = cancellation_cause();
-        cancel_children(current_cause == CancellationCause::None ? CancellationCause::ParentTerminal
-                                                                 : current_cause);
+        const bool retained_children = current_cause == CancellationCause::None &&
+            (outcome.status == ProgramTerminalStatus::Interrupted ||
+             outcome.status == ProgramTerminalStatus::AmbiguousEffect);
+        if (!retained_children)
+            cancel_children(current_cause == CancellationCause::None
+                                ? CancellationCause::ParentTerminal : current_cause);
         ensure_terminal_checkpoint(*this, outcome);
 
         std::vector<ProgramEvent> terminal_events;
@@ -2572,6 +2579,9 @@ void RunControl::complete(RunOutcome outcome) noexcept {
                                     terminal_events.back(), outcome.status, false);
             } catch (...) {}
         }
+        if (retained_children && outcome.status != ProgramTerminalStatus::Interrupted &&
+            outcome.status != ProgramTerminalStatus::AmbiguousEffect)
+            cancel_children(CancellationCause::ParentTerminal);
         auto       result       = make_result(outcome);
         const auto publication  = publish_terminal_record(*this, result);
         const bool is_published = publication == TerminalPublicationResult::Published;

--- a/src/program/runtime.cpp
+++ b/src/program/runtime.cpp
@@ -1939,7 +1939,7 @@ void RunControl::set_child_recovery_callback(ChildRecoveryCallback callback) noe
     std::lock_guard lock(mutex_);
     child_recovery_callback_ = std::move(callback);
 }
-bool RunControl::can_recover_child(std::string_view binding,
+ChildRecoveryMode RunControl::can_recover_child(std::string_view binding,
                                    const json&      input,
                                    std::string_view operation) const {
     ChildRecoveryCallback callback;
@@ -1947,7 +1947,23 @@ bool RunControl::can_recover_child(std::string_view binding,
         std::lock_guard lock(mutex_);
         callback = child_recovery_callback_;
     }
-    return callback && callback(binding, input, operation);
+    return callback ? callback(binding, input, operation) : ChildRecoveryMode::None;
+}
+void RunControl::set_existing_child_reconnect_callback(
+    ExistingChildReconnectCallback callback) noexcept {
+    std::lock_guard lock(mutex_);
+    existing_child_reconnect_callback_ = std::move(callback);
+}
+std::shared_ptr<RunControl> RunControl::reconnect_existing_child(
+    std::string_view binding, const json& input, std::string_view operation) const {
+    ExistingChildReconnectCallback callback;
+    {
+        std::lock_guard lock(mutex_);
+        callback = existing_child_reconnect_callback_;
+    }
+    if (!callback)
+        throw_runtime_diagnostic("P_CHILD_RECOVERY", "Existing child reconnect is not configured");
+    return callback(binding, input, operation);
 }
 void RunControl::set_child_binding_validation_callback(
     ChildBindingValidationCallback callback) noexcept {
@@ -4050,27 +4066,127 @@ struct ProgramRuntime::Impl {
                    : std::nullopt;
     }
 
+    std::optional<ProgramChildRecord> recoverable_existing_child(
+        const std::shared_ptr<detail::RunControl>& parent, std::string_view binding,
+        const json& input, std::string_view operation) const {
+        const auto run = parent->snapshot();
+        if (run.owner_scope() != parent->owner_scope ||
+            run.logical_run_id() != parent->logical_run_id ||
+            run.continuation().state != ContinuationState::Running ||
+            parent->cancellation_cause() != detail::CancellationCause::None)
+            return std::nullopt;
+        const auto resolved = resolve_child_binding(parent, binding);
+        if (!resolved) return std::nullopt;
+        const auto& link = resolved->receipt;
+        if (link.owner_scope() != parent->owner_scope || link.child_name() != binding ||
+            link.child_program_version_id() != resolved->version.id())
+            return std::nullopt;
+
+        auto child = inherited_child(parent, binding);
+        if (child) {
+            const auto inherited = std::find_if(
+                parent->inherited_children.begin(), parent->inherited_children.end(),
+                [&](const auto& admitted) { return same_child_metadata(admitted, *child); });
+            if (inherited == parent->inherited_children.end()) return std::nullopt;
+        } else {
+            const auto expected_id = detail::sha256_identity(
+                "program-dsl-child/v1",
+                detail::canonical_json_bytes(
+                    json{{"owner_scope", parent->owner_scope},
+                         {"parent_run_id", parent->run_id},
+                         {"parent_program_version_id", parent->program_version_id},
+                         {"link_id", link.id()},
+                         {"operation_id", std::string(operation)},
+                         {"execution_key", std::string(operation)}}));
+            child = find_child(run, expected_id);
+        }
+        if (!child || child->link_id != link.id() ||
+            child->link_receipt != link.serialize_canonical() ||
+            child->invocation.parent_run_id != parent->logical_run_id ||
+            child->invocation.child_depth != parent->persisted_invocation.child_depth + 1 ||
+            detail::canonical_json_bytes(child->invocation.input) !=
+                detail::canonical_json_bytes(input))
+            return std::nullopt;
+        const auto persisted = config.transitions->load(parent->owner_scope, child->child_run_id);
+        if (!persisted || persisted->owner_scope() != parent->owner_scope ||
+            persisted->run_id() != child->child_run_id ||
+            persisted->program_version_id() != resolved->version.id() ||
+            persisted->bundle_id() != resolved->version.bundle_id() ||
+            persisted->child_depth() != child->invocation.child_depth)
+            return std::nullopt;
+        ProgramInvocation invocation{
+            child->invocation.input, child->invocation.granted_budget,
+            child->invocation.trace_id, {}, child->child_run_id,
+            child->invocation.parent_run_id, child->invocation.child_depth};
+        if (persisted->invocation() != bind_runtime_invocation(
+                invocation, parent->owner_scope, resolved->version.id(), child->child_run_id))
+            return std::nullopt;
+        return child;
+    }
+
     void configure_child_launcher(const std::shared_ptr<detail::RunControl>& control) {
         if (!owner) return;
-        if (!config.child_binding_resolver && !config.child_synthesis_gateway) {
+        if (!config.child_binding_resolver && !config.child_synthesis_gateway &&
+            !config.recover_existing_child_commands) {
             if (config.task_graph_fragments && config.task_graph_policy_resolver)
                 control->set_task_graph_expansion_context(config.task_graph_fragments,
                                                           config.task_graph_policy_resolver);
             return;
         }
         const auto weak_control = std::weak_ptr<detail::RunControl>(control);
-        if (config.child_synthesis_gateway) {
+        if (config.recover_existing_child_commands) {
+            control->set_existing_child_reconnect_callback(
+                [this, weak_control](std::string_view binding, const json& input,
+                                     std::string_view operation) {
+                    const auto parent = weak_control.lock();
+                    const auto child = parent
+                                           ? recoverable_existing_child(parent, binding, input,
+                                                                         operation)
+                                           : std::nullopt;
+                    if (!child)
+                        throw_runtime_diagnostic("P_CHILD_RECOVERY",
+                                                 "Existing child recovery binding changed");
+                    // Reconnect cannot create a missing run. Do not fall through
+                    // to start_child if publication disappears after validation.
+                    auto reconnected = [&] {
+                        try {
+                            return owner->reconnect(parent->owner_scope, child->child_run_id);
+                        } catch (const ProgramDiagnosticError& error) {
+                            if (error.diagnostic().code == "P_RUN_NOT_FOUND")
+                                throw_runtime_diagnostic("P_CHILD_RECOVERY",
+                                                         "Existing child run disappeared");
+                            throw;
+                        }
+                    }();
+                    bind_budgeted_child_completion(reconnected.control_, parent->owner_scope,
+                                                     parent->logical_run_id, child->child_run_id);
+                    parent->attach_child(reconnected.control_);
+                    if (const auto result = reconnected.try_result())
+                        publish_child_completion(config.transitions, parent->owner_scope,
+                                                 parent->logical_run_id, child->child_run_id, *result);
+                    return reconnected.control_;
+                });
+        }
+        if (config.child_synthesis_gateway || config.recover_existing_child_commands) {
             control->set_child_recovery_callback([this, weak_control](std::string_view binding,
                                                                       const json&      input,
                                                                       std::string_view operation) {
                 const auto parent = weak_control.lock();
-                if (!parent) return false;
+                using Mode = detail::ChildRecoveryMode;
+                if (!parent) return Mode::None;
+                if (config.recover_existing_child_commands &&
+                    recoverable_existing_child(parent, binding, input, operation))
+                    return Mode::Existing;
+                if (!config.child_synthesis_gateway) return Mode::None;
                 if (const auto child = inherited_child(parent, binding))
-                    return detail::canonical_json_bytes(child->invocation.input) ==
-                           detail::canonical_json_bytes(input);
+                    return !config.recover_existing_child_commands &&
+                                   detail::canonical_json_bytes(child->invocation.input) ==
+                                       detail::canonical_json_bytes(input)
+                               ? Mode::Synthesis : Mode::None;
                 const auto synthesis = synthesis_binding(parent, binding);
-                if (!synthesis) return false;
-                if (synthesis->data().state == ProgramChildSynthesisState::Bound) return true;
+                if (!synthesis) return Mode::None;
+                if (synthesis->data().state == ProgramChildSynthesisState::Bound)
+                    return Mode::Synthesis;
                 const auto& artifacts = synthesis->data().artifacts;
                 const auto  link =
                     ModuleLinkReceipt::parse(detail::canonical_json_bytes(artifacts.at("link")));
@@ -4084,8 +4200,9 @@ struct ProgramRuntime::Impl {
                              {"operation_id", std::string(operation)},
                              {"execution_key", std::string(operation)}}));
                 return artifacts.at("child_run_id") == expected_id &&
-                       detail::canonical_json_bytes(artifacts.at("child_input")) ==
-                           detail::canonical_json_bytes(input);
+                               detail::canonical_json_bytes(artifacts.at("child_input")) ==
+                                   detail::canonical_json_bytes(input)
+                           ? Mode::Synthesis : Mode::None;
             });
         }
 

--- a/src/program/sqlite_transition_store.cpp
+++ b/src/program/sqlite_transition_store.cpp
@@ -502,7 +502,10 @@ bool valid_effect_outbox_binding(const ProgramRunRecord& run,
                                  const std::vector<ProgramEffectOutboxEntry>& effects) {
     if (effects.empty()) return true;
     const auto pending = run.pending_effect();
-    return pending && pending->state() == ProgramPendingState::Awaiting && effects.size() == 1 &&
+    return pending && (pending->state() == ProgramPendingState::Awaiting ||
+                       (pending->state() == ProgramPendingState::Ambiguous &&
+                        run.continuation().state == ContinuationState::AmbiguousEffect)) &&
+           effects.size() == 1 &&
            effects.front().effect() == *pending;
 }
 

--- a/src/program/transition_store.cpp
+++ b/src/program/transition_store.cpp
@@ -66,7 +66,10 @@ bool valid_effect_outbox_binding(const ProgramRunRecord& run,
     // the run interrupted; a caller cannot smuggle a second effect through a
     // transition publication.
     const auto pending = run.pending_effect();
-    if (!pending || pending->state() != ProgramPendingState::Awaiting || effects.size() != 1 ||
+    if (!pending ||
+        (pending->state() != ProgramPendingState::Awaiting &&
+         !(pending->state() == ProgramPendingState::Ambiguous &&
+           run.continuation().state == ContinuationState::AmbiguousEffect)) || effects.size() != 1 ||
         effects.front().effect() != *pending) {
         return false;
     }

--- a/tests/test_harness_program_store.cpp
+++ b/tests/test_harness_program_store.cpp
@@ -458,8 +458,13 @@ ProgramPendingEffect pending_effect() {
 }
 
 ProgramTransitionPublication publication_with_effect(
-    const Fixture& fixture, const ProgramTransitionPublication& initial) {
+    const Fixture& fixture, const ProgramTransitionPublication& initial, bool ambiguous = false) {
     auto pending = pending_effect();
+    if (ambiguous) pending = pending.mark_outcome_unknown(10).value;
+    const auto status = ambiguous ? ProgramTerminalStatus::AmbiguousEffect
+                                  : ProgramTerminalStatus::Interrupted;
+    const auto state = ambiguous ? ContinuationState::AmbiguousEffect
+                                 : ContinuationState::Interrupted;
     const CoreCheckpointIdentity checkpoint{
         "main", digest('5'),
         program_root_core_thread_id(initial.run_record.run_id(), digest('5')),
@@ -469,14 +474,14 @@ ProgramTransitionPublication publication_with_effect(
                                                  fixture.version_value.id(),
                                                  fixture.bundle_value.id(),
                                                  2,
-                                                 {"root", ContinuationState::Interrupted, 1},
+                                                 {"root", state, 1},
                                                  budget(),
                                                  {},
                                                  checkpoint,
                                                  10});
 
     ProgramResultData result_data;
-    result_data.status             = ProgramTerminalStatus::Interrupted;
+    result_data.status             = status;
     result_data.run_id             = initial.run_record.run_id();
     result_data.program_version_id = fixture.version_value.id();
     result_data.bundle_id          = fixture.bundle_value.id();
@@ -510,7 +515,7 @@ ProgramTransitionPublication publication_with_effect(
     publication.journal_record = std::move(journal);
     publication.events = {event(fixture, initial.run_record.run_id(), 2,
                                  ProgramEventKind::Terminal,
-                                 ProgramTerminalEvent{ProgramTerminalStatus::Interrupted}, 10)};
+                                 ProgramTerminalEvent{status}, 10)};
     publication.effects.emplace_back(1, std::move(pending));
     return publication;
 }
@@ -1259,6 +1264,28 @@ TEST(HarnessProgramStoreTest, SqliteExecutionLeasePersistsAndFencesOrdinaryPubli
         fixture.artifact.owner_scope(), initial.run_record.run_id()));
 }
 
+
+TEST(HarnessProgramStoreTest, SqlitePublishesAnInitiallyAmbiguousEffect) {
+    TempDb db;
+    Fixture fixture;
+    auto store = std::make_shared<SqliteHarnessRecordStore>(db.path.string());
+    auto transitions = persist_and_bind(store, fixture);
+    const auto initial = initial_publication(fixture);
+    ASSERT_EQ(transitions->compare_publish(fixture.artifact.owner_scope(), {}, initial),
+              ProgramTransitionPublishResult::Published);
+    const auto ambiguous = publication_with_effect(fixture, initial, true);
+    ASSERT_EQ(transitions->compare_publish(fixture.artifact.owner_scope(),
+                                           initial.journal_record.id, ambiguous),
+              ProgramTransitionPublishResult::Published);
+    const auto run = transitions->load(fixture.artifact.owner_scope(), "run-one");
+    ASSERT_TRUE(run);
+    EXPECT_EQ(run->continuation().state, ContinuationState::AmbiguousEffect);
+    ASSERT_TRUE(run->pending_effect());
+    EXPECT_EQ(run->pending_effect()->state(), ProgramPendingState::Ambiguous);
+    const auto effects = transitions->load_effects(fixture.artifact.owner_scope(), "run-one");
+    ASSERT_EQ(effects.size(), 1U);
+    EXPECT_EQ(effects.front().effect().state(), ProgramPendingState::Ambiguous);
+}
 
 TEST(HarnessProgramStoreTest, SqliteLatestKeepsOneSnapshotAcrossConcurrentPublication) {
     TempDb db;

--- a/tests/test_program_runtime.cpp
+++ b/tests/test_program_runtime.cpp
@@ -1506,9 +1506,19 @@ public:
     std::mutex                                               synthesis_observation_mutex;
     std::optional<ProgramChildSynthesisState> fail_synthesis_after;
     std::function<void(const ProgramTransitionPublication&)> after_publication;
+    std::function<void(const ProgramTransitionPublication&)> before_publication;
     std::function<std::optional<ProgramRunRecord>(std::string_view,
                                                  std::optional<ProgramRunRecord>)> filter_run_read;
     mutable std::atomic<unsigned>                            synthesis_read_failures{0};
+    mutable std::atomic<unsigned>                            command_head_misses{0};
+    std::optional<ProgramCommandPublicationHead> load_command_publication_head(
+        std::string_view owner, std::string_view run) const override {
+        auto remaining = command_head_misses.load();
+        while (remaining &&
+               !command_head_misses.compare_exchange_weak(remaining, remaining - 1)) {}
+        if (remaining) return std::nullopt;
+        return ProgramTransitionStore::load_command_publication_head(owner, run);
+    }
     std::optional<ProgramRunRecord> load(std::string_view owner,
                                          std::string_view run_id) const override {
         if (throw_next_load_.exchange(false)) {
@@ -1586,6 +1596,7 @@ public:
         std::string_view             owner,
         std::string_view             expected,
         ProgramTransitionPublication publication) override {
+        if (before_publication) before_publication(publication);
         const bool command_result =
             !publication.commands.empty() && publication.commands.back().completed();
         const bool replacement =
@@ -1636,6 +1647,7 @@ public:
         ProgramTransitionPublication publication,
         std::optional<ProgramExecutionLease> expected_lease,
         std::optional<ProgramExecutionLease> next_lease) override {
+        if (before_publication) before_publication(publication);
         const bool replacement =
             publication.run_generation && publication.run_generation->replacement_receipt();
         if (replacement && throw_before_replacement_.exchange(false)) {
@@ -10771,6 +10783,85 @@ TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryCompletesPendingChec
 }
 TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryPreservesUnknownDescendantEffect) {
     check_static_child_recovery(true, true, "unknown_effect");
+}
+#endif
+#if defined(NEOGRAPH_PROGRAM_TESTS_HAVE_QUICKJS)
+TEST_P(ProgramChildSynthesisPersistence, CommandResultRetriesAnOptimisticSnapshotMiss) {
+    auto journal = std::make_shared<BlockAfterJavaScriptResultJournal>(backend());
+    journal->release_result();
+    journal->after_publication = [weak = std::weak_ptr(journal)](const auto& publication) {
+        if (!publication.commands.empty() && !publication.commands.back().completed())
+            if (const auto store = weak.lock()) store->command_head_misses.store(1);
+    };
+    AdmittedRuntime host(2, checkpoint_backend(), journal, {}, ExecutionGuarantee::Unmanaged, true);
+    const auto version = host.admit_javascript(javascript_runtime_source("runtime-completed",
+        "return yield ng.checkpoint({done:true},'snapshot:checkpoint');"));
+    const auto result = host.runtime->run("tenant:runtime", version,
+        ProgramInvocation{json::object(), javascript_budget(1), "snapshot-miss", {}});
+    journal->after_publication = {};
+    EXPECT_EQ(result.status(), ProgramTerminalStatus::Completed) << result.serialize_canonical();
+    EXPECT_EQ(result.output(), (json{{"done", true}}));
+    EXPECT_EQ(journal->load_javascript_commands("tenant:runtime", result.run_id(), 0).size(), 2U);
+}
+
+TEST_P(ProgramChildSynthesisPersistence, FailedResultPublicationPersistsAmbiguousEffect) {
+    auto journal = std::make_shared<BlockAfterJavaScriptResultJournal>(backend());
+    journal->release_result();
+    std::atomic<bool> failed{false};
+    journal->before_publication = [&](const auto& publication) {
+        if (!publication.commands.empty() && publication.commands.back().completed() &&
+            !failed.exchange(true))
+            throw std::runtime_error("injected command result publication failure");
+    };
+    AdmittedRuntime host(2, checkpoint_backend(), journal, {}, ExecutionGuarantee::Unmanaged, true);
+    const auto version = host.admit_javascript(javascript_runtime_source("runtime-completed",
+        "yield ng.emit({effect:'once'},'ambiguous:emit');return {};"));
+    const auto result = host.runtime->run("tenant:runtime", version,
+        ProgramInvocation{json::object(), javascript_budget(1), "ambiguous-publication", {}});
+    journal->before_publication = {};
+    EXPECT_TRUE(failed.load());
+    ASSERT_EQ(result.status(), ProgramTerminalStatus::AmbiguousEffect) << result.serialize_canonical();
+    ASSERT_TRUE(result.interrupt());
+    ASSERT_TRUE(result.interrupt()->pending_effect);
+    EXPECT_EQ(result.interrupt()->pending_effect->state(), ProgramPendingState::Ambiguous);
+    const auto stored = journal->load("tenant:runtime", result.run_id());
+    ASSERT_TRUE(stored);
+    EXPECT_EQ(stored->continuation().state, ContinuationState::AmbiguousEffect);
+    EXPECT_EQ(journal->load_effects("tenant:runtime", result.run_id(), 0).size(), 1U);
+    EXPECT_EQ(journal->load_javascript_commands("tenant:runtime", result.run_id(), 0).size(), 1U);
+    auto recovered = host.runtime->reconnect("tenant:runtime", result.run_id());
+    EXPECT_FALSE(recovered.cancel());
+    EXPECT_EQ(recovered.wait().id(), result.id());
+}
+
+TEST_P(ProgramChildSynthesisPersistence, AmbiguousDescendantDoesNotStrandFamilyCompletion) {
+    StaticChildRecoveryFixture test(backend(), checkpoint_backend(), true, false, false, true);
+    std::atomic<bool> failed{false};
+    test.journal->before_publication = [&](const auto& publication) {
+        if (publication.run_record.program_version_id() == test.grand_version->id() &&
+            !publication.commands.empty() && publication.commands.back().completed() &&
+            publication.commands.back().command().kind() == JavaScriptCommandKind::Emit &&
+            !failed.exchange(true))
+            throw std::runtime_error("injected descendant result publication failure");
+    };
+    test.root = test.host.runtime->start("tenant:runtime", *test.root_version,
+        ProgramInvocation{json::object(), test.root_budget, "ambiguous-family", {}});
+    const auto result = test.root->wait();
+    test.journal->before_publication = {};
+    EXPECT_TRUE(failed.load());
+    ASSERT_EQ(result.status(), ProgramTerminalStatus::AmbiguousEffect) << result.serialize_canonical();
+    const auto root = test.root->snapshot();
+    ASSERT_EQ(root.children().size(), 1U);
+    EXPECT_EQ(root.children().front().state, ProgramChildState::Dispatched);
+    const auto child = test.journal->load("tenant:runtime", root.children().front().child_run_id);
+    ASSERT_TRUE(child);
+    ASSERT_EQ(child->children().size(), 1U);
+    EXPECT_EQ(child->continuation().state, ContinuationState::AmbiguousEffect);
+    EXPECT_EQ(child->children().front().state, ProgramChildState::Dispatched);
+    const auto grand = test.journal->load("tenant:runtime", child->children().front().child_run_id);
+    ASSERT_TRUE(grand);
+    EXPECT_EQ(grand->continuation().state, ContinuationState::AmbiguousEffect);
+    EXPECT_FALSE(test.root->cancel());
 }
 #endif
 #if defined(NEOGRAPH_PROGRAM_TESTS_HAVE_QUICKJS)

--- a/tests/test_program_runtime.cpp
+++ b/tests/test_program_runtime.cpp
@@ -1506,13 +1506,16 @@ public:
     std::mutex                                               synthesis_observation_mutex;
     std::optional<ProgramChildSynthesisState> fail_synthesis_after;
     std::function<void(const ProgramTransitionPublication&)> after_publication;
+    std::function<std::optional<ProgramRunRecord>(std::string_view,
+                                                 std::optional<ProgramRunRecord>)> filter_run_read;
     mutable std::atomic<unsigned>                            synthesis_read_failures{0};
     std::optional<ProgramRunRecord> load(std::string_view owner,
                                          std::string_view run_id) const override {
         if (throw_next_load_.exchange(false)) {
             throw std::runtime_error("simulated Program run read failure");
         }
-        return inner_->load(owner, run_id);
+        auto record = inner_->load(owner, run_id);
+        return filter_run_read ? filter_run_read(run_id, std::move(record)) : std::move(record);
     }
     std::optional<ProgramJournalRecord> latest(std::string_view owner,
                                                std::string_view run_id) const override {
@@ -9065,6 +9068,8 @@ TEST(ProgramSynthesisGateway, SemanticRejectionConsumesReservationAndPreventsAdm
 namespace {
 class ProgramChildSynthesisPersistence : public ::testing::TestWithParam<std::string> {
 protected:
+    void check_static_child_recovery(bool replace, bool recover = true,
+                                     std::string_view fault = {});
     std::string database;
     void        SetUp() override {
         if (GetParam() == "PostgreSQL" && !std::getenv("NEOGRAPH_TEST_POSTGRES_URL"))
@@ -10420,6 +10425,304 @@ TEST_P(ProgramChildSynthesisPersistence, RecursiveCancellationFollowsTheReplacem
     EXPECT_EQ(test.replacement->wait().status(), ProgramTerminalStatus::Cancelled);
     EXPECT_EQ(test.grandchild->wait().status(), ProgramTerminalStatus::Cancelled);
     EXPECT_EQ(test.replacement->wait().remaining_budget().max_dynamic_compiles, 1U);
+}
+
+namespace {
+struct StaticChildRecoveryFixture {
+    std::shared_ptr<BlockAfterJavaScriptResultJournal> journal;
+    AdmittedRuntime                                    host;
+    std::optional<ProgramVersion> root_version, child_version, grand_version, successor_version;
+    std::optional<ProgramHandle>  root;
+    std::mutex                    mutex;
+    std::condition_variable       ready;
+    std::optional<ProgramHandoff> root_hold, grand_hold;
+    RunBudget                     root_budget{60000, 1000, 1000, 4, 128, 100, 1, 3, 8};
+    RunBudget                     child_budget{45000, 500, 500, 2, 64, 50, 0, 2, 4};
+    RunBudget                     grand_budget{30000, 100, 100, 1, 32, 20, 0, 0, 0};
+    std::function<void()>         binding_observer;
+
+    StaticChildRecoveryFixture(std::shared_ptr<ProgramTransitionStore> transitions,
+                               std::shared_ptr<CheckpointStore>        checkpoints,
+                               bool                                    recover,
+                               bool                                    hold,
+                               bool                                    replace)
+        : journal(std::make_shared<BlockAfterJavaScriptResultJournal>(std::move(transitions))),
+          host(4, std::move(checkpoints), journal, {}, ExecutionGuarantee::Unmanaged, true) {
+        journal->release_result();
+        PolicySnapshotBuilder policy;
+        policy.id("static-recovery-policy")
+            .semantic_version("1.0.0")
+            .owner_scope("tenant:runtime")
+            .admission_profile(host.profile)
+            .budget_ceiling(BudgetLimits{60000, 10000, 1000000, 4, 256, 100, 4, 4, 32})
+            .minimum_execution_guarantee(ExecutionGuarantee::Unmanaged);
+        host.policy      = std::move(policy).build();
+        const auto admit = [&](int topology, std::string body, RunBudget budget) {
+            ProgramCompiler compiler(host.registry, {"program-runtime-test/v1"});
+            auto            bundle = compiler.compile(
+                ProgramSource::from_javascript("static-child-recovery.js",
+                                                          recursive_graph_source(topology, std::move(body))),
+                ProgramBudgetBounds{RunBudget{1, 0, 0, 1, 1, 1, 0, 0, 0}, budget});
+            return host.catalog->admit(
+                bundle, ProgramAdmission{"tenant:runtime", host.profile, host.policy, {}});
+        };
+        grand_version =
+            admit(3,
+                  "for(let i=0;i<32;i++)yield ng.checkpoint({cursor:i},'auditor:checkpoint');"
+                  "return {answer:42};",
+                  grand_budget);
+        child_version = admit(2,
+                              "return yield ng.await(ng.spawn('child',{marker:2},'child:spawn'),"
+                              "40000,'child:await');",
+                              child_budget);
+        root_version =
+            admit(1,
+                  replace ? "yield ng.spawn('child',{marker:1},'root:spawn');"
+                            "yield ng.checkpoint({cursor:1},'root:swap');return {};"
+                          : "return yield ng.await(ng.spawn('child',{marker:1},'root:spawn'),"
+                            "55000,'root:await');",
+                  root_budget);
+        successor_version =
+            admit(4,
+                  "return yield ng.await(ng.spawn('child',{marker:1},'successor:spawn'),"
+                  "55000,'successor:await');",
+                  root_budget);
+        const auto limits = [](const RunBudget& b) {
+            return BudgetLimits{b.wall_time_ms,
+                                b.model_tokens,
+                                b.monetary_microunits,
+                                b.max_concurrency,
+                                b.max_program_operations,
+                                b.max_core_steps,
+                                static_cast<std::uint32_t>(b.max_dynamic_compiles),
+                                b.max_child_depth,
+                                b.max_total_children};
+        };
+        link_child_versions(host, *root_version, *child_version, limits(child_budget),
+                            ExecutionGuarantee::Unmanaged);
+        link_child_versions(host, *child_version, *grand_version, limits(grand_budget),
+                            ExecutionGuarantee::Unmanaged);
+        RuntimeConfig config{
+            host.catalog,
+            host.checkpoints,
+            {},
+            journal,
+            4,
+            [this, bindings = host.child_bindings](std::string_view owner, std::string_view version,
+                                                   std::string_view name) {
+                if (binding_observer) binding_observer();
+                return bindings->resolve(owner, version, name);
+            }};
+        config.recover_existing_child_commands = recover;
+        if (hold)
+            config.checkpoint_handler = [this](ProgramHandle handle, ProgramHandoff point) {
+                std::lock_guard lock(mutex);
+                if (handle.program_version_id() == grand_version->id())
+                    grand_hold.emplace(std::move(point));
+                else
+                    root_hold.emplace(std::move(point));
+                ready.notify_all();
+            };
+        host.runtime = std::make_unique<ProgramRuntime>(std::move(config));
+    }
+    ~StaticChildRecoveryFixture() {
+        journal->after_publication = {};
+        if (root) root->cancel();
+        root_hold.reset();
+        grand_hold.reset();
+        host.runtime.reset();
+    }
+    void start(bool replace) {
+        root = host.runtime->start(
+            "tenant:runtime", *root_version,
+            ProgramInvocation{json::object(), root_budget, "static-family", {}});
+        std::unique_lock lock(mutex);
+        if (!ready.wait_for(lock, std::chrono::seconds(10),
+                            [&] { return grand_hold && (!replace || root_hold); }))
+            throw std::runtime_error("Static family did not reach its held checkpoints");
+    }
+};
+}  // namespace
+#endif
+#if defined(NEOGRAPH_PROGRAM_TESTS_HAVE_QUICKJS) && !defined(_WIN32)
+void ProgramChildSynthesisPersistence::check_static_child_recovery(bool             replace,
+                                                                   bool             recover,
+                                                                   std::string_view fault) {
+    if (GetParam() == "Memory") GTEST_SKIP() << "Process recovery requires durable stores";
+    if (const auto* inherited = std::getenv("NEOGRAPH_STATIC_CHILD_DB")) database = inherited;
+    setenv("NEOGRAPH_STATIC_CHILD_DB", database.c_str(), 1);
+    ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+    ASSERT_EXIT(
+        ([&] {
+            StaticChildRecoveryFixture test(backend(), checkpoint_backend(), true, true, replace);
+            test.start(replace);
+            const auto save = [&](const ProgramRunRecord& active) {
+                const auto    child      = active.children().front();
+                const auto    descendant = test.journal->load("tenant:runtime", child.child_run_id);
+                std::ofstream saved(database + ".static-family");
+                saved << json{{"root", test.root->run_id()},
+                              {"active", active.run_id()},
+                              {"child", child.child_run_id},
+                              {"child_record_id", descendant->id()},
+                              {"grandchild", descendant->children().front().child_run_id},
+                              {"root_children", active.children().size()},
+                              {"child_record", json::parse(child.link_receipt)},
+                              {"dynamic_compiles", active.remaining_budget().max_dynamic_compiles},
+                              {"root_budget",
+                               active.remaining_budget().model_tokens +
+                                   test.journal->latest("tenant:runtime", active.run_id())
+                                       ->inflight_reservation.model_tokens}}
+                             .dump();
+                saved.close();
+                std::_Exit(77);
+            };
+            if (!replace) save(test.root->snapshot());
+            test.journal->after_publication = [&](const auto& publication) {
+                if (publication.run_record.program_version_id() == test.successor_version->id() &&
+                    !publication.commands.empty() && !publication.commands.back().completed())
+                    save(publication.run_record);
+            };
+            const auto state     = test.root_hold->value();
+            auto       successor = test.host.runtime->replace(
+                "tenant:runtime", std::move(*test.root_hold), *test.successor_version,
+                ProgramInvocation{
+                    json{{"handoff", state}, {"previous_run_id", test.root->run_id()}},
+                    test.root->snapshot().remaining_budget(),
+                    "static-family:replacement",
+                          {}});
+            (void)successor.wait();
+            std::_Exit(78);
+        }()),
+        ::testing::ExitedWithCode(77), "");
+    unsetenv("NEOGRAPH_STATIC_CHILD_DB");
+    std::ifstream saved_file(database + ".static-family");
+    const auto    saved = json::parse(std::string(std::istreambuf_iterator<char>(saved_file), {}));
+    saved_file.close();
+    StaticChildRecoveryFixture recovered(backend(), checkpoint_backend(), recover, false, replace);
+    const auto                 child_id = saved.at("child").get<std::string>();
+    if (fault == "missing_run" || fault == "disappearing_run") {
+        auto hidden = std::make_shared<std::atomic<bool>>(fault == "missing_run");
+        recovered.journal->filter_run_read = [child_id, hidden](auto id, auto record) {
+            return id == child_id && hidden->load() ? std::nullopt : record;
+        };
+        if (fault == "disappearing_run") {
+            auto resolutions           = std::make_shared<unsigned>(0);
+            recovered.binding_observer = [hidden, resolutions] {
+                // The second binding read is command preflight, after the
+                // existing-child recovery decision but before dispatch.
+                if (++*resolutions == 2) hidden->store(true);
+            };
+        }
+    } else if (fault == "changed_link") {
+        recovered.host.clear_child_bindings();
+    } else if (fault == "changed_receipt") {
+        auto binding = recovered.host.child_bindings->resolve(
+            "tenant:runtime", recovered.root_version->id(), "child");
+        const auto& old  = binding->receipt;
+        binding->receipt = ModuleLinkReceipt::create(ModuleLinkReceiptData{
+            old.owner_scope(), digest('9'), old.dependency_merkle_root(), old.child_name(),
+            old.child_program_version_id(), old.child_bundle_id(),
+            old.child_input_contract_fingerprint(), old.child_output_contract_fingerprint(),
+            old.granted_capabilities(), old.granted_effects(), old.budget(),
+            old.minimum_execution_guarantee()});
+        recovered.host.bind_child(*recovered.root_version, "child", std::move(*binding));
+    } else if (fault == "changed_input") {
+        recovered.journal->filter_run_read = [child_id](auto id, auto record) {
+            if (id != child_id || !record) return record;
+            ProgramRunRecordData d;
+            d.owner_scope         = record->owner_scope();
+            d.run_id              = record->run_id();
+            d.logical_run_id      = record->logical_run_id();
+            d.program_version_id  = record->program_version_id();
+            d.bundle_id           = record->bundle_id();
+            d.binding_fingerprint = record->binding_fingerprint();
+            d.invocation          = record->invocation();
+            d.invocation.input    = json{{"marker", "changed"}};
+            d.child_depth         = record->child_depth();
+            d.continuation        = record->continuation();
+            d.remaining_budget    = record->remaining_budget();
+            d.children            = record->children();
+            d.journal_head        = record->journal_head();
+            d.event_sequence      = record->event_sequence();
+            d.effect_sequence     = record->effect_sequence();
+            d.created_at_ms       = record->created_at_ms();
+            d.updated_at_ms       = record->updated_at_ms();
+            return std::optional<ProgramRunRecord>(ProgramRunRecord::create(std::move(d)));
+        };
+    }
+    recovered.root =
+        recovered.host.runtime->reconnect("tenant:runtime", saved.at("root").get<std::string>());
+    const auto result = recovered.root->wait();
+    if (!recover || !fault.empty()) {
+        EXPECT_EQ(result.status(), ProgramTerminalStatus::Interrupted)
+            << result.serialize_canonical();
+        ASSERT_TRUE(result.interrupt());
+        EXPECT_TRUE(result.interrupt()->pending_effect);
+        const auto storage = backend();
+        ASSERT_TRUE(storage->load("tenant:runtime", child_id));
+        EXPECT_EQ(storage->load("tenant:runtime", child_id)->id(),
+                  saved.at("child_record_id").get<std::string>());
+        EXPECT_EQ(storage
+                      ->load_javascript_commands("tenant:runtime",
+                                                 saved.at("grandchild").get<std::string>())
+                      .size(),
+                  2U);
+        EXPECT_EQ(recovered.root->snapshot().children().size(), 1U);
+        std::filesystem::remove(database + ".static-family");
+        return;
+    }
+    ASSERT_EQ(result.status(), ProgramTerminalStatus::Completed) << result.serialize_canonical();
+    EXPECT_EQ(result.output(), (json{{"answer", 42}}));
+    EXPECT_EQ(result.remaining_budget().max_dynamic_compiles,
+              saved.at("dynamic_compiles").get<std::uint64_t>());
+    EXPECT_EQ(recovered.root->run_id(), saved.at("active").get<std::string>());
+    const auto active = recovered.root->snapshot();
+    ASSERT_EQ(active.children().size(), 1U);
+    EXPECT_EQ(active.children().front().child_run_id, saved.at("child").get<std::string>());
+    EXPECT_EQ(json::parse(active.children().front().link_receipt), saved.at("child_record"));
+    EXPECT_EQ(active.remaining_budget().model_tokens, saved.at("root_budget").get<std::uint64_t>());
+    const auto child =
+        recovered.journal->load("tenant:runtime", saved.at("child").get<std::string>());
+    ASSERT_TRUE(child);
+    ASSERT_EQ(child->children().size(), 1U);
+    EXPECT_EQ(child->children().front().child_run_id, saved.at("grandchild").get<std::string>());
+    EXPECT_EQ(recovered.journal
+                  ->load_javascript_commands("tenant:runtime",
+                                             saved.at("grandchild").get<std::string>(), 0)
+                  .size(),
+              64U);
+    std::filesystem::remove(database + ".static-family");
+}
+TEST_P(ProgramChildSynthesisPersistence, StaticChildCommandsRecoverAfterProcessLoss) {
+    check_static_child_recovery(false);
+}
+TEST_P(ProgramChildSynthesisPersistence, InheritedStaticChildCommandsRecoverAfterReplacement) {
+    check_static_child_recovery(true);
+}
+TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryRequiresHostOptIn) {
+    EXPECT_FALSE(RuntimeConfig{}.recover_existing_child_commands);
+    check_static_child_recovery(false, false);
+}
+TEST_P(ProgramChildSynthesisPersistence, InheritedStaticChildRecoveryRequiresHostOptIn) {
+    check_static_child_recovery(true, false);
+}
+TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryRejectsMissingRun) {
+    check_static_child_recovery(false, true, "missing_run");
+}
+TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryRejectsChangedInput) {
+    check_static_child_recovery(false, true, "changed_input");
+}
+TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryRejectsMissingBinding) {
+    check_static_child_recovery(false, true, "changed_link");
+}
+TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryRejectsChangedReceipt) {
+    check_static_child_recovery(false, true, "changed_receipt");
+}
+TEST_P(ProgramChildSynthesisPersistence, InheritedStaticChildRecoveryRejectsMissingRun) {
+    check_static_child_recovery(true, true, "missing_run");
+}
+TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryCannotCreateAfterRunDisappears) {
+    check_static_child_recovery(false, true, "disappearing_run");
 }
 #endif
 #if defined(NEOGRAPH_PROGRAM_TESTS_HAVE_QUICKJS)

--- a/tests/test_program_runtime.cpp
+++ b/tests/test_program_runtime.cpp
@@ -7121,22 +7121,23 @@ TEST(ProgramRuntimeTest, MapExecutesItemsSerially) {
 }
 
 TEST(ProgramRuntimeTest, AwaitTimeoutCancelsTheChildOperation) {
-    AdmittedRuntime fixture(2);
-    const auto      started = std::chrono::steady_clock::now();
-    const auto      result  = run_orchestration(
-        fixture,
-        orchestration_document(
-            json{{"op", "await"}, {"timeout_ms", 10}, {"body", json{{"op", "call_core"}}}},
-            "runtime-blocking"),
-        json::object(), "trace-await");
+    for (const auto threads : {1U, 2U, 4U}) {
+        SCOPED_TRACE(threads);
+        AdmittedRuntime fixture(threads);
+        const auto      started = std::chrono::steady_clock::now();
+        const auto      result  = run_orchestration(
+            fixture,
+            orchestration_document(
+                json{{"op", "await"}, {"timeout_ms", 10}, {"body", json{{"op", "call_core"}}}},
+                "runtime-blocking"),
+            json::object(), "trace-await");
 
-    EXPECT_EQ(result.status(), ProgramTerminalStatus::TimedOut);
-    ASSERT_TRUE(result.failure().has_value());
-    EXPECT_EQ(result.failure()->code, "P_AWAIT_TIMEOUT");
-    EXPECT_LT(
-        std::chrono::duration_cast<std::chrono::seconds>(std::chrono::steady_clock::now() - started)
-            .count(),
-        2);
+        EXPECT_EQ(result.status(), ProgramTerminalStatus::TimedOut);
+        ASSERT_TRUE(result.failure().has_value());
+        EXPECT_EQ(result.failure()->code, "P_AWAIT_TIMEOUT");
+        EXPECT_LT(std::chrono::duration_cast<std::chrono::seconds>(
+                      std::chrono::steady_clock::now() - started).count(), 2);
+    }
 }
 
 TEST(ProgramRuntimeTest, AwaitPropagatesChildFailureBeforeTimeout) {

--- a/tests/test_program_runtime.cpp
+++ b/tests/test_program_runtime.cpp
@@ -10440,12 +10440,14 @@ struct StaticChildRecoveryFixture {
     RunBudget                     child_budget{45000, 500, 500, 2, 64, 50, 0, 2, 4};
     RunBudget                     grand_budget{30000, 100, 100, 1, 32, 20, 0, 0, 0};
     std::function<void()>         binding_observer;
+    std::atomic<bool>             hold_checkpoints{true};
 
     StaticChildRecoveryFixture(std::shared_ptr<ProgramTransitionStore> transitions,
                                std::shared_ptr<CheckpointStore>        checkpoints,
                                bool                                    recover,
                                bool                                    hold,
-                               bool                                    replace)
+                               bool                                    replace,
+                               bool                                    external_effect = false)
         : journal(std::make_shared<BlockAfterJavaScriptResultJournal>(std::move(transitions))),
           host(4, std::move(checkpoints), journal, {}, ExecutionGuarantee::Unmanaged, true) {
         journal->release_result();
@@ -10466,11 +10468,11 @@ struct StaticChildRecoveryFixture {
             return host.catalog->admit(
                 bundle, ProgramAdmission{"tenant:runtime", host.profile, host.policy, {}});
         };
-        grand_version =
-            admit(3,
-                  "for(let i=0;i<32;i++)yield ng.checkpoint({cursor:i},'auditor:checkpoint');"
-                  "return {answer:42};",
-                  grand_budget);
+        grand_version = admit(3, external_effect
+            ? "for(let i=0;i<11;i++)yield ng.checkpoint({cursor:i},'auditor:checkpoint');"
+              "yield ng.emit({unknown:true},'auditor:external');return {answer:42};"
+            : "for(let i=0;i<32;i++)yield ng.checkpoint({cursor:i},'auditor:checkpoint');"
+              "return {answer:42};", grand_budget);
         child_version = admit(2,
                               "return yield ng.await(ng.spawn('child',{marker:2},'child:spawn'),"
                               "40000,'child:await');",
@@ -10516,6 +10518,7 @@ struct StaticChildRecoveryFixture {
         config.recover_existing_child_commands = recover;
         if (hold)
             config.checkpoint_handler = [this](ProgramHandle handle, ProgramHandoff point) {
+                if (!hold_checkpoints.load()) return;
                 std::lock_guard lock(mutex);
                 if (handle.program_version_id() == grand_version->id())
                     grand_hold.emplace(std::move(point));
@@ -10549,12 +10552,15 @@ void ProgramChildSynthesisPersistence::check_static_child_recovery(bool         
                                                                    bool             recover,
                                                                    std::string_view fault) {
     if (GetParam() == "Memory") GTEST_SKIP() << "Process recovery requires durable stores";
+    const bool checkpoint_crash = fault == "pending_checkpoint";
+    const bool effect_crash = fault == "unknown_effect";
     if (const auto* inherited = std::getenv("NEOGRAPH_STATIC_CHILD_DB")) database = inherited;
     setenv("NEOGRAPH_STATIC_CHILD_DB", database.c_str(), 1);
     ::testing::FLAGS_gtest_death_test_style = "threadsafe";
     ASSERT_EXIT(
         ([&] {
-            StaticChildRecoveryFixture test(backend(), checkpoint_backend(), true, true, replace);
+            StaticChildRecoveryFixture test(backend(), checkpoint_backend(), true, true, replace,
+                                            effect_crash);
             test.start(replace);
             const auto save = [&](const ProgramRunRecord& active) {
                 const auto    child      = active.children().front();
@@ -10577,20 +10583,32 @@ void ProgramChildSynthesisPersistence::check_static_child_recovery(bool         
                 std::_Exit(77);
             };
             if (!replace) save(test.root->snapshot());
+            std::optional<ProgramHandle> successor;
             test.journal->after_publication = [&](const auto& publication) {
+                if (checkpoint_crash || effect_crash) {
+                    if (publication.run_record.program_version_id() == test.grand_version->id() &&
+                        !publication.commands.empty() && !publication.commands.back().completed() &&
+                        publication.commands.back().command_ordinal() == 12)
+                        save(*test.journal->load("tenant:runtime", successor->run_id()));
+                    return;
+                }
                 if (publication.run_record.program_version_id() == test.successor_version->id() &&
                     !publication.commands.empty() && !publication.commands.back().completed())
                     save(publication.run_record);
             };
             const auto state     = test.root_hold->value();
-            auto       successor = test.host.runtime->replace(
+            successor = test.host.runtime->replace(
                 "tenant:runtime", std::move(*test.root_hold), *test.successor_version,
                 ProgramInvocation{
                     json{{"handoff", state}, {"previous_run_id", test.root->run_id()}},
                     test.root->snapshot().remaining_budget(),
                     "static-family:replacement",
                           {}});
-            (void)successor.wait();
+            if (checkpoint_crash || effect_crash) {
+                test.hold_checkpoints.store(false);
+                test.grand_hold.reset();
+            }
+            (void)successor->wait();
             std::_Exit(78);
         }()),
         ::testing::ExitedWithCode(77), "");
@@ -10598,7 +10616,8 @@ void ProgramChildSynthesisPersistence::check_static_child_recovery(bool         
     std::ifstream saved_file(database + ".static-family");
     const auto    saved = json::parse(std::string(std::istreambuf_iterator<char>(saved_file), {}));
     saved_file.close();
-    StaticChildRecoveryFixture recovered(backend(), checkpoint_backend(), recover, false, replace);
+    StaticChildRecoveryFixture recovered(backend(), checkpoint_backend(), recover, false, replace,
+                                          effect_crash);
     const auto                 child_id = saved.at("child").get<std::string>();
     if (fault == "missing_run" || fault == "disappearing_run") {
         auto hidden = std::make_shared<std::atomic<bool>>(fault == "missing_run");
@@ -10653,7 +10672,29 @@ void ProgramChildSynthesisPersistence::check_static_child_recovery(bool         
     recovered.root =
         recovered.host.runtime->reconnect("tenant:runtime", saved.at("root").get<std::string>());
     const auto result = recovered.root->wait();
-    if (!recover || !fault.empty()) {
+    if (effect_crash) {
+        EXPECT_EQ(result.status(), ProgramTerminalStatus::Interrupted) << result.serialize_canonical();
+        const auto child = recovered.journal->load("tenant:runtime", child_id);
+        const auto grand = recovered.journal->load("tenant:runtime",
+                                                   saved.at("grandchild").get<std::string>());
+        ASSERT_TRUE(child);
+        ASSERT_TRUE(grand);
+        EXPECT_EQ(child->continuation().state, ContinuationState::Interrupted);
+        EXPECT_EQ(grand->continuation().state, ContinuationState::Interrupted);
+        ASSERT_EQ(child->children().size(), 1U);
+        EXPECT_EQ(child->children().front().state, ProgramChildState::Dispatched);
+        ASSERT_EQ(recovered.root->snapshot().children().size(), 1U);
+        EXPECT_EQ(recovered.root->snapshot().children().front().state, ProgramChildState::Dispatched);
+        EXPECT_EQ(recovered.journal->load_javascript_commands("tenant:runtime", grand->run_id(), 0)
+                      .size(), 23U);
+        const auto events = recovered.journal->load_events("tenant:runtime", grand->run_id(), 0);
+        EXPECT_TRUE(std::none_of(events.begin(), events.end(), [](const auto& event) {
+            return event.kind == ProgramEventKind::Emit;
+        }));
+        std::filesystem::remove(database + ".static-family");
+        return;
+    }
+    if (!recover || (!fault.empty() && !checkpoint_crash)) {
         EXPECT_EQ(result.status(), ProgramTerminalStatus::Interrupted)
             << result.serialize_canonical();
         ASSERT_TRUE(result.interrupt());
@@ -10723,6 +10764,12 @@ TEST_P(ProgramChildSynthesisPersistence, InheritedStaticChildRecoveryRejectsMiss
 }
 TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryCannotCreateAfterRunDisappears) {
     check_static_child_recovery(false, true, "disappearing_run");
+}
+TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryCompletesPendingCheckpoint) {
+    check_static_child_recovery(true, true, "pending_checkpoint");
+}
+TEST_P(ProgramChildSynthesisPersistence, StaticChildRecoveryPreservesUnknownDescendantEffect) {
+    check_static_child_recovery(true, true, "unknown_effect");
 }
 #endif
 #if defined(NEOGRAPH_PROGRAM_TESTS_HAVE_QUICKJS)


### PR DESCRIPTION
An unfinished JavaScript spawn/await currently becomes an external pending effect after process loss when its child came from a static host binding. This also prevents a replacement generation from rejoining an already-running inherited child without a synthesis gateway.

Add the explicit, default-off `RuntimeConfig::recover_existing_child_commands` option. Recovery requires the exact parent relation, admitted receipt, invocation, derived or inherited child identity, and persisted child run. It uses a dedicated reconnect path, so a child disappearing after validation cannot fall through to a new spawn. Missing or changed evidence leaves the original pending effect and reservation available for reconciliation. Unknown external commands and the separately granted synthesis protocol retain their existing behavior.

Complete a pending sealed checkpoint from its journaled value and original reservation, without external dispatch. When an awaited descendant still needs reconciliation, retain the parent's reserved remainder and resumable child relation; double credit and a fabricated cancelled relation previously caused terminal publication conflicts.

Preserve the cause of inline await timeouts when the cancelled child's completion is delivered before the timer coroutine's completion. The child-cancellation result must not turn a timeout into a user cancellation.

Retry optimistic command-head snapshot misses and persist uncertain outcomes with matching `Ambiguous` result/effect states across all stores. A permanent child-completion rejection against an unchanged parent head must not spin forever or strand completion waiters.

SQLite and PostgreSQL process-exit tests cover a static three-level tree and root replacement followed by inherited rejoin. They verify the result, child identities, receipts, unchanged accounting, and exactly 64 journal entries for 32 grandchild checkpoints. Negative cases cover absent host opt-in, missing child runs/bindings, changed input/receipts, and disappearance between recovery admission and dispatch.

Validation: GCC 13 Release with SQLite and PostgreSQL, 713 Program tests passed; 14 memory-only process-loss cases were inapplicable and skipped. All 24 new durable backend cases also passed under ASan, UBSan, and leak detection, including process exit immediately after a checkpoint's pending publication and an unknown external effect. The Harness SQLite suite passed 21/21. `git diff --check` passed.

Timeout validation: 12,000 timeout executions across scheduler widths 1/2/4 and eight parallel test processes passed. Timeout and early-child-failure tests also passed 100 repetitions under ASan/UBSan/leak detection.

Cancellation validation: the original family cancellation hang was reproduced with a gdb stack in child completion's retry loop. After the fix, 400 concurrent test executions passed. Cancellation, snapshot-miss, and result-publication-failure cases passed 10 repetitions across Memory/SQLite/PostgreSQL under ASan/UBSan/leak detection; nested ambiguous-family completion also passed all three backends under the sanitizers.

Builds on the independent SQLite read-snapshot and checkpoint executor-lifetime fixes merged in #286.
